### PR TITLE
Browser recalls most recent dashboard tab

### DIFF
--- a/app/views/public_health/index.html.erb
+++ b/app/views/public_health/index.html.erb
@@ -36,27 +36,27 @@
 
   <ul class="nav nav-tabs">
     <li class="nav-item">
-      <a class="nav-link active" id="symptomatic-tab" data-toggle="tab" href="#symptomatic">
+      <a class="nav-link active" id="symptomatic-tab" data-toggle="tab" href="#symptomatic" role="tab">
         Symptomatic <span class="badge badge-danger badge-larger-font"><%= @symptomatic_count %></span>
       </a>
     </li>
     <li class="nav-item">
-      <a class="nav-link" id="non-reporting-tab" data-toggle="tab" href="#non-reporting">
+      <a class="nav-link" id="non-reporting-tab" data-toggle="tab" href="#non-reporting" role="tab">
         Non-Reporting <span class="badge badge-warning badge-larger-font"><%= @non_reporting_count %></span>
       </a>
     </li>
     <li class="nav-item">
-      <a class="nav-link" id="asymptomatic-tab" data-toggle="tab" href="#asymptomatic">
+      <a class="nav-link" id="asymptomatic-tab" data-toggle="tab" href="#asymptomatic" role="tab">
         Asymptomatic <span class="badge badge-success badge-larger-font"><%= @asymptomatic_count %></span>
       </a>
     </li>
     <li class="nav-item">
-      <a class="nav-link" id="closed-tab" data-toggle="tab" href="#closed">
+      <a class="nav-link" id="closed-tab" data-toggle="tab" href="#closed" role="tab">
         Closed <span class="badge badge-secondary badge-larger-font"><%= @closed_count %></span>
       </a>
     </li>
     <li class="nav-item">
-      <a class="nav-link" id="closed-tab" data-toggle="tab" href="#transferred">
+      <a class="nav-link" id="transferred-tab" data-toggle="tab" href="#transferred" role="tab">
         Transferred <span class="badge badge-secondary badge-larger-font"><%= @transferred_count %></span>
       </a>
     </li>
@@ -101,3 +101,18 @@
   </div>
 
 </div>
+
+<script>
+  $(document).ready(function() {
+    if (localStorage.getItem('dashboardCurrentTab') !== null) {
+      $(localStorage.getItem('dashboardCurrentTab') + '-tab').find('span').trigger('click')
+    }
+    $('a[data-toggle="tab"]').on('click', function(e) {
+      if ($(e.target).attr('href') === undefined) {
+        localStorage.setItem('dashboardCurrentTab', $(e.target).parent().attr('href'))
+      } else {
+        localStorage.setItem('dashboardCurrentTab', $(e.target).attr('href'))
+      }
+    })
+  });
+</script>

--- a/test/system/components/public_health_monitoring/actions.rb
+++ b/test/system/components/public_health_monitoring/actions.rb
@@ -10,7 +10,6 @@ class PublicHealthMonitoringActions < ApplicationSystemTestCase
   def update_monitoring_status(monitoring_status, status_change_reason, reasoning)
     if monitoring_status != find('#monitoring_status')['value']
       select monitoring_status, from: 'monitoring_status'
-      @@system_test_utils.wait_for_modal_animation
       select status_change_reason, from: 'monitoring_status_option'
       fill_in 'reasoning', with: reasoning
       click_on 'Submit'
@@ -20,7 +19,6 @@ class PublicHealthMonitoringActions < ApplicationSystemTestCase
   def update_exposure_risk_assessment(exposure_risk_assessment, reasoning)
     if exposure_risk_assessment != find('#exposure_risk_assessment')['value']
       select exposure_risk_assessment, from: 'exposure_risk_assessment'
-      @@system_test_utils.wait_for_modal_animation
       fill_in 'reasoning', with: reasoning
       click_on 'Submit'
     end
@@ -29,7 +27,6 @@ class PublicHealthMonitoringActions < ApplicationSystemTestCase
   def update_monitoring_plan(monitoring_plan, reasoning)
     if monitoring_plan != find('#monitoring_plan')['value']
       select monitoring_plan, from: 'monitoring_plan'
-      @@system_test_utils.wait_for_modal_animation
       fill_in 'reasoning', with: reasoning
       click_on 'Submit'
     end
@@ -38,7 +35,6 @@ class PublicHealthMonitoringActions < ApplicationSystemTestCase
   def update_jurisdiction(jurisdiction, reasoning)
     fill_in 'jurisdictionList', with: jurisdiction
     click_on 'Change Jurisdiction'
-    @@system_test_utils.wait_for_modal_animation
     fill_in 'reasoning', with: reasoning
     click_on 'Submit'
   end

--- a/test/system/components/public_health_monitoring/reports.rb
+++ b/test/system/components/public_health_monitoring/reports.rb
@@ -38,7 +38,6 @@ class PublicHealthMonitoringReports < ApplicationSystemTestCase
 
   def mark_all_as_reviewed(reasoning)
     click_on 'Mark All As Reviewed'
-    @@system_test_utils.wait_for_modal_animation
     fill_in 'reasoning', with: reasoning
     click_on 'Submit'
   end

--- a/test/system/lib/system_test_utils.rb
+++ b/test/system/lib/system_test_utils.rb
@@ -14,11 +14,11 @@ class SystemTestUtils < ApplicationSystemTestCase
   SIGN_IN_URL = '/users/sign_in'
   USER_PASSWORD = '123456ab'
 
-  ENROLLMENT_PAGE_TRANSITION_DELAY = 0.8 # wait for carousel animation to finish loading
   ENROLLMENT_SUBMISSION_DELAY = 4 # wait for submission alert animation to finish
+  ENROLLMENT_PAGE_TRANSITION_DELAY = 0.8 # wait for carousel animation to finish loading
   POP_UP_ALERT_ANIMATION_DELAY = 0.5 # wait for alert to pop up or dismiss
   CHECKBOX_ANIMATION_DELAY = 0.5 # wait for checkbox to load
-  MODAL_ANIMATION_DELAY = 0 # wait for modal to load
+  DASHBOARD_LOAD_DELAY = 0.2 # wait for dashboard to load saved tab
 
   def login(user_name)
     visit '/'
@@ -26,6 +26,7 @@ class SystemTestUtils < ApplicationSystemTestCase
     fill_in 'user_email', with: USERS[user_name]['email']
     fill_in 'user_password', with: USER_PASSWORD
     click_on 'login'
+    wait_for_dashboard_load
   end
 
   def login_with_custom_password(email, password)
@@ -42,6 +43,7 @@ class SystemTestUtils < ApplicationSystemTestCase
 
   def return_to_dashboard
     click_on 'Return To Dashboard'
+    wait_for_dashboard_load
   end
 
   def go_to_next_page
@@ -54,12 +56,12 @@ class SystemTestUtils < ApplicationSystemTestCase
     click_on 'Previous'
   end
 
-  def wait_for_enrollment_page_transition
-    sleep(inspection_time = ENROLLMENT_PAGE_TRANSITION_DELAY)
-  end
-
   def wait_for_enrollment_submission
     sleep(inspection_time = ENROLLMENT_SUBMISSION_DELAY)
+  end
+
+  def wait_for_enrollment_page_transition
+    sleep(inspection_time = ENROLLMENT_PAGE_TRANSITION_DELAY)
   end
 
   def wait_for_pop_up_alert
@@ -70,8 +72,8 @@ class SystemTestUtils < ApplicationSystemTestCase
     sleep(inspection_time = CHECKBOX_ANIMATION_DELAY)
   end
 
-  def wait_for_modal_animation
-    sleep(inspection_time = MODAL_ANIMATION_DELAY)
+  def wait_for_dashboard_load
+    sleep(inspection_time = DASHBOARD_LOAD_DELAY)
   end
 
   def get_dashboard_display_name(monitoree)
@@ -95,7 +97,6 @@ class SystemTestUtils < ApplicationSystemTestCase
   end
 
   def get_reports
-    # REPORTS.each{|k,v| v['reported_condition'] = ReportedCondition.new(symptoms: [FloatSymptom.new(name: 'temperature', label: 'Temperature', float_value: 101.1)])}
     REPORTS
   end
 


### PR DESCRIPTION
Browser recalls most recent dashboard tab by saving it as a local storage variable

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: SARAALERT-125
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)

**Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] You have tried to break the code
