### PR TITLE
Fix double render route on password change

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,11 +12,14 @@ class ApplicationController < ActionController::Base
     current_user.lock_access! if current_user.password_changed_at < 3.days.ago
 
     if request.url == edit_user_registration_url || request.url == user_registration_url ||
-       request.url == destroy_user_session_url || request.url == user_enable_authy_url
+       request.url == destroy_user_session_url || request.url == user_enable_authy_url || request.url == user_verify_authy_url
       return
     end
 
-    redirect_to edit_user_registration_url if current_user&.force_password_change
-    redirect_to user_enable_authy_url if current_user&.authy_id.nil? && current_user&.authy_enabled && !current_user&.force_password_change
+    if current_user&.force_password_change
+      redirect_to edit_user_registration_url
+      return
+    end
+    redirect_to user_enable_authy_url if current_user&.authy_id.nil? && current_user&.authy_enabled
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,6 @@ class ApplicationController < ActionController::Base
     end
 
     redirect_to edit_user_registration_url if current_user&.force_password_change
-    redirect_to user_enable_authy_url if current_user&.authy_id.nil? && current_user&.authy_enabled
+    redirect_to user_enable_authy_url if current_user&.authy_id.nil? && current_user&.authy_enabled && !current_user&.force_password_change
   end
 end

--- a/app/javascript/components/admin/Admin.js
+++ b/app/javascript/components/admin/Admin.js
@@ -41,6 +41,7 @@ class Admin extends React.Component {
       if (success) {
         row['failed_attempts'] = 0;
         row['locked'] = 'Unlocked';
+        row['configured_2fa'] = 'No';
         this.props.data.push(row);
         this.setState({ data: this.props.data });
       } else {


### PR DESCRIPTION
This PR contains a quick fix for a bug that caused a double rendering call when a user must both reset their password and also setup 2FA. The fix, forces a password change followed by 2FA creation.