### PR TITLE
189 record purge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,9 @@ gem 'faker'
 # Gem for scheduling ActiveJobs to run
 gem 'whenever', require: false
 
+# Time parser for managing scheduled jobs
+gem 'chronic'
+
 # Store sessions in DB
 gem 'activerecord-session_store'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,6 +337,7 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   caxlsx
+  chronic
   devise
   devise-authy
   devise-security

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ bundle exec whenever --update-crontab
     - Active job that closes cases that meet duration/symptomatic conditions
   * `PurgeJob`
       - Active job that redacts PII of cases that have been closed for N many days
+  * `rake mailers:send_purge_warning`
+      - Send warning to users of upcoming PurgeJob containing N many records
   * `rake analytics:cache_current_analytics`
       - Caches analytics information for faster retrieval 
   * `rake mailers:send_assessments`

--- a/app/jobs/purge_job.rb
+++ b/app/jobs/purge_job.rb
@@ -5,7 +5,7 @@ class PurgeJob < ApplicationJob
   queue_as :default
 
   def perform(*_args)
-    Patient.purgeable.find_each(batch_size: 5000) do |monitoree|
+    Patient.marked_for_purge.find_each(batch_size: 5000) do |monitoree|
       # Whitelist attributes to keep
       attributes = Patient.new.attributes.keys
       whitelist = %w[id created_at updated_at responder_id creator_id jurisdiction_id

--- a/app/jobs/purge_job.rb
+++ b/app/jobs/purge_job.rb
@@ -5,7 +5,7 @@ class PurgeJob < ApplicationJob
   queue_as :default
 
   def perform(*_args)
-    Patient.marked_for_purge.find_each(batch_size: 5000) do |monitoree|
+    Patient.purge_eligible.find_each(batch_size: 5000) do |monitoree|
       # Whitelist attributes to keep
       attributes = Patient.new.attributes.keys
       whitelist = %w[id created_at updated_at responder_id creator_id jurisdiction_id

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -18,7 +18,7 @@ class UserMailer < ApplicationMailer
 
     receipients.each do |user|
       @user = user
-      @num_purgeable_records = user.viewable_patients.purgeable.length
+      @num_purgeable_records = user.viewable_patients.purge_eligible.length
 
       mail(to: user.email, subject: 'Sara Alert User Records Expiring Soon')
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'chronic'
+
 # UserMailer: mailers for users
 class UserMailer < ApplicationMailer
   default from: 'notifications@saraalert.org'
@@ -9,4 +11,17 @@ class UserMailer < ApplicationMailer
     @password = password
     mail(to: user.email, subject: 'Welcome to the Sara Alert system')
   end
+
+  def purge_notification()
+    receipients = User.with_any_role(:public_health, :public_health_enroller)
+    @expiration_date = Chronic.parse(ADMIN_OPTIONS['weekly_purge_date']).strftime("%A %B %d, at %l:%M %p %Z")
+
+    receipients.each do |user|
+      @user = user
+      @num_purgeable_records = user.viewable_patients.purgeable.length
+
+      mail(to: user.email, subject: 'Sara Alert User Records Expiring Soon')
+    end
+  end
+
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -12,9 +12,9 @@ class UserMailer < ApplicationMailer
     mail(to: user.email, subject: 'Welcome to the Sara Alert system')
   end
 
-  def purge_notification()
+  def purge_notification
     receipients = User.with_any_role(:public_health, :public_health_enroller)
-    @expiration_date = Chronic.parse(ADMIN_OPTIONS['weekly_purge_date']).strftime("%A %B %d, at %l:%M %p %Z")
+    @expiration_date = Chronic.parse(ADMIN_OPTIONS['weekly_purge_date']).strftime('%A %B %d, at %l:%M %p %Z')
 
     receipients.each do |user|
       @user = user
@@ -23,5 +23,4 @@ class UserMailer < ApplicationMailer
       mail(to: user.email, subject: 'Sara Alert User Records Expiring Soon')
     end
   end
-
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -13,12 +13,12 @@ class UserMailer < ApplicationMailer
   end
 
   def purge_notification
-    receipients = User.with_any_role(:public_health, :public_health_enroller)
+    recipients = User.with_any_role(:public_health, :public_health_enroller)
     @expiration_date = Chronic.parse(ADMIN_OPTIONS['weekly_purge_date']).strftime('%A %B %d, at %l:%M %p %Z')
 
-    receipients.each do |user|
+    recipients.each do |user|
       @user = user
-      @num_purgeable_records = user.viewable_patients.purge_eligible.length
+      @num_purgeable_records = user.viewable_patients.purge_eligible.size
 
       mail(to: user.email, subject: 'Sara Alert User Records Expiring Soon')
     end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -20,7 +20,9 @@ class UserMailer < ApplicationMailer
       @user = user
       @num_purgeable_records = user.viewable_patients.purge_eligible.size
 
-      mail(to: user.email, subject: 'Sara Alert User Records Expiring Soon')
+      @subject = @num_purgeable_records.zero? ? 'Sara Alert Notification' : 'Sara Alert User Records Expirng Soon'
+
+      mail(to: user.email, subject: @subject)
     end
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -20,7 +20,7 @@ class UserMailer < ApplicationMailer
       @user = user
       @num_purgeable_records = user.viewable_patients.purge_eligible.size
 
-      @subject = @num_purgeable_records.zero? ? 'Sara Alert Notification' : 'Sara Alert User Records Expirng Soon'
+      @subject = @num_purgeable_records.zero? ? 'Sara Alert Notification' : 'Sara Alert User Records Expiring Soon'
 
       mail(to: user.email, subject: @subject)
     end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -91,7 +91,7 @@ class Patient < ApplicationRecord
       .where('purged = ?', true)
   }
 
-  # Purgeable records
+  # Purgeable records right now
   scope :purgeable, lambda {
     where('monitoring = ?', false)
       .where('purged = ?', false)
@@ -104,6 +104,13 @@ class Patient < ApplicationRecord
     where('monitoring = ?', false)
       .where('purged = ?', false)
       .where('patients.updated_at < ?', ((ADMIN_OPTIONS['purgeable_after']).minutes + 1.week.minutes).ago)
+  }
+
+  # Purgeable records at the time of the last purge warning message
+  scope :marked_for_purge, lambda {
+    where('monitoring = ?', false)
+      .where('purged = ?', false)
+      .where('updated_at < ?', ADMIN_OPTIONS['purgeable_after'].minutes.before(Chronic.parse('last ' + ADMIN_OPTIONS['weekly_purge_warning_date'], :now => Chronic.parse(ADMIN_OPTIONS['weekly_purge_date']))))
   }
 
   # Purged monitoree records

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'chronic'
+
 # Patient: patient model
 class Patient < ApplicationRecord
   columns.each do |column|
@@ -104,7 +106,12 @@ class Patient < ApplicationRecord
   scope :purge_eligible, lambda {
     where('monitoring = ?', false)
       .where('purged = ?', false)
-      .where('patients.updated_at < ?', ADMIN_OPTIONS['purgeable_after'].minutes.before(Chronic.parse('last ' + ADMIN_OPTIONS['weekly_purge_warning_date'], :now => Chronic.parse('this ' + ADMIN_OPTIONS['weekly_purge_date'], :now => Chronic.parse('yesterday')))))
+      .where('patients.updated_at < ?',
+             ADMIN_OPTIONS['purgeable_after'].minutes.before(
+               Chronic.parse('last ' + ADMIN_OPTIONS['weekly_purge_warning_date'], now:
+                 Chronic.parse('this ' + ADMIN_OPTIONS['weekly_purge_date'], now:
+                   Chronic.parse('yesterday')))
+             ))
   }
 
   # Purgeable records at the time of the last purge warning message

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -93,13 +93,6 @@ class Patient < ApplicationRecord
       .where('purged = ?', true)
   }
 
-  # Purgeable records right now
-  scope :purgeable, lambda {
-    where('monitoring = ?', false)
-      .where('purged = ?', false)
-      .where('updated_at < ?', ADMIN_OPTIONS['purgeable_after'].minutes.ago)
-  }
-
   # Purgeable eligible (records that could be purged in the next purge run if they aren't edited again)
   # By using chronic to determine the date of the next purge, the last warning date can be determined from that context
   # The use of `yesterday` in the context of the next purge date ensures that it includes the same day when using `this` keyword

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -99,11 +99,12 @@ class Patient < ApplicationRecord
   }
 
   # Purgeable eligible (records that could be purged in the next purge run if they aren't edited again)
-  # This assumes that the purge interval configured in schedule.rb is set to run weekly
+  # By using chronic to determine the date of the next purge, the last warning date can be determined from that context
+  # The use of `yesterday` in the context of the next purge date ensures that it includes the same day when using `this` keyword
   scope :purge_eligible, lambda {
     where('monitoring = ?', false)
       .where('purged = ?', false)
-      .where('patients.updated_at < ?', ((ADMIN_OPTIONS['purgeable_after']).minutes + 1.week.minutes).ago)
+      .where('patients.updated_at < ?', ADMIN_OPTIONS['purgeable_after'].minutes.before(Chronic.parse('last ' + ADMIN_OPTIONS['weekly_purge_warning_date'], :now => Chronic.parse('this ' + ADMIN_OPTIONS['weekly_purge_date'], :now => Chronic.parse('yesterday')))))
   }
 
   # Purgeable records at the time of the last purge warning message

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -114,13 +114,6 @@ class Patient < ApplicationRecord
              ))
   }
 
-  # Purgeable records at the time of the last purge warning message
-  scope :marked_for_purge, lambda {
-    where('monitoring = ?', false)
-      .where('purged = ?', false)
-      .where('updated_at < ?', ADMIN_OPTIONS['purgeable_after'].minutes.before(Chronic.parse('last ' + ADMIN_OPTIONS['weekly_purge_warning_date'])))
-  }
-
   # Purged monitoree records
   scope :purged, lambda {
     where('purged = ?', true)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -110,7 +110,7 @@ class Patient < ApplicationRecord
   scope :marked_for_purge, lambda {
     where('monitoring = ?', false)
       .where('purged = ?', false)
-      .where('updated_at < ?', ADMIN_OPTIONS['purgeable_after'].minutes.before(Chronic.parse('last ' + ADMIN_OPTIONS['weekly_purge_warning_date'], :now => Chronic.parse(ADMIN_OPTIONS['weekly_purge_date']))))
+      .where('updated_at < ?', ADMIN_OPTIONS['purgeable_after'].minutes.before(Chronic.parse('last ' + ADMIN_OPTIONS['weekly_purge_warning_date'])))
   }
 
   # Purged monitoree records

--- a/app/views/user_mailer/purge_notification.html.erb
+++ b/app/views/user_mailer/purge_notification.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta name="viewport" content="width=device-width">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>Sara Alert Records Expiring Soon</title>
+    <title><%= @subject %></title>
     <style>
 @media only screen and (max-width: 620px) {
   table[class=body] h1 {
@@ -98,7 +98,13 @@ table[class=body] .article {
 </style>
   </head>
   <body class="" style="background-color: #f6f6f6; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
-    <span class="preheader" style="color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;">Please log into Sara Alert and export the data your wish to save.</span>
+    <span class="preheader" style="color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;">
+      <% if @num_purgeable_records.zero? %>
+        No action is required at this time.
+      <% else %>
+        Please log into Sara Alert and export the data your wish to save.
+      <% end %>
+    </span>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #f6f6f6; width: 100%;" width="100%" bgcolor="#f6f6f6">
       <tr>
         <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">&nbsp;</td>
@@ -125,11 +131,21 @@ table[class=body] .article {
                     <tr>
                       <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">
                         <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">Dear <%= @user.email[/[^@]+/] %>,</p>
-                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">Several user records within your juristdiction will be expiring soon. Please be sure to export the data before it is deleted as these records are unrecoverable.</p>
-                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
-                        <b>Number of Patient Records:</b> <%= @num_purgeable_records %><br>
-                        <b>Expiration Date:</b> <%= @expiration_date %>
-                        </p>
+
+                        <% if @num_purgeable_records.zero? %>
+                          <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">There are no user records within your jurisdiction that are expiring this week. No action is required at this time, however you will receive this message every week for your records. Please be on the lookout for future Sara Alert notifications.</p>
+                          <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
+                          <b>No Records Expiring</b><br>
+                          <b>Expiration Date:</b> <%= @expiration_date %>
+                          </p>
+                        <% else %>
+                          <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">Several user records within your jurisdiction will be expiring soon. Please be sure to export the data before it is deleted as these records are unrecoverable.</p>
+                          <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
+                          <b>Number of Patient Records:</b> <%= @num_purgeable_records %><br>
+                          <b>Expiration Date:</b> <%= @expiration_date %>
+                          </p>
+                        <% end %>
+
                         <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; box-sizing: border-box; width: 100%;" width="100%">
                           <tbody>
                             <tr>

--- a/app/views/user_mailer/purge_notification.html.erb
+++ b/app/views/user_mailer/purge_notification.html.erb
@@ -1,0 +1,174 @@
+<!doctype html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Sara Alert Records Expiring Soon</title>
+    <style>
+@media only screen and (max-width: 620px) {
+  table[class=body] h1 {
+    font-size: 28px !important;
+    margin-bottom: 10px !important;
+  }
+
+  table[class=body] p,
+table[class=body] ul,
+table[class=body] ol,
+table[class=body] td,
+table[class=body] span,
+table[class=body] a {
+    font-size: 16px !important;
+  }
+
+  table[class=body] .wrapper,
+table[class=body] .article {
+    padding: 10px !important;
+  }
+
+  table[class=body] .content {
+    padding: 0 !important;
+  }
+
+  table[class=body] .container {
+    padding: 0 !important;
+    width: 100% !important;
+  }
+
+  table[class=body] .main {
+    border-left-width: 0 !important;
+    border-radius: 0 !important;
+    border-right-width: 0 !important;
+  }
+
+  table[class=body] .btn table {
+    width: 100% !important;
+  }
+
+  table[class=body] .btn a {
+    width: 100% !important;
+  }
+
+  table[class=body] .img-responsive {
+    height: auto !important;
+    max-width: 100% !important;
+    width: auto !important;
+  }
+}
+@media all {
+  .ExternalClass {
+    width: 100%;
+  }
+
+  .ExternalClass,
+.ExternalClass p,
+.ExternalClass span,
+.ExternalClass font,
+.ExternalClass td,
+.ExternalClass div {
+    line-height: 100%;
+  }
+
+  .apple-link a {
+    color: inherit !important;
+    font-family: inherit !important;
+    font-size: inherit !important;
+    font-weight: inherit !important;
+    line-height: inherit !important;
+    text-decoration: none !important;
+  }
+
+  #MessageViewBody a {
+    color: inherit;
+    text-decoration: none;
+    font-size: inherit;
+    font-family: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+  }
+
+  .btn-primary table td:hover {
+    background-color: #34495e !important;
+  }
+
+  .btn-primary a:hover {
+    background-color: #34495e !important;
+    border-color: #34495e !important;
+  }
+}
+</style>
+  </head>
+  <body class="" style="background-color: #f6f6f6; font-family: sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+    <span class="preheader" style="color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; mso-hide: all; visibility: hidden; width: 0;">Please log into Sara Alert and export the data your wish to save.</span>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background-color: #f6f6f6; width: 100%;" width="100%" bgcolor="#f6f6f6">
+      <tr>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">&nbsp;</td>
+        <td class="container" style="font-family: sans-serif; font-size: 14px; vertical-align: top; display: block; max-width: 580px; padding: 10px; width: 580px; margin: 0 auto;" width="580" valign="top">
+          <div class="content" style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 580px; padding: 10px;">
+
+            <!-- START HEADER -->
+            <div class="header" style="clear: both; text-align: center; width: 100%;">
+              <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;" width="100%">
+                <tr>
+                    <%= render partial: 'devise/shared/logo' %>
+                </tr>
+              </table>
+            </div>
+            <!-- END HEADER -->
+
+            <!-- START CENTERED WHITE CONTAINER -->
+            <table role="presentation" class="main" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; background: #ffffff; border-radius: 3px; width: 100%;" width="100%">
+
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper" style="font-family: sans-serif; font-size: 14px; vertical-align: top; box-sizing: border-box; padding: 20px;" valign="top">
+                  <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;" width="100%">
+                    <tr>
+                      <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">
+                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">Dear <%= @user.email[/[^@]+/] %>,</p>
+                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">Several user records within your juristdiction will be expiring soon. Please be sure to export the data before it is deleted as these records are unrecoverable.</p>
+                        <p style="font-family: sans-serif; font-size: 14px; font-weight: normal; margin: 0; margin-bottom: 15px;">
+                        <b>Number of Patient Records:</b> <%= @num_purgeable_records %><br>
+                        <b>Expiration Date:</b> <%= @expiration_date %>
+                        </p>
+                        <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; box-sizing: border-box; width: 100%;" width="100%">
+                          <tbody>
+                            <tr>
+                              <td align="center" style="font-family: sans-serif; font-size: 14px; vertical-align: top; padding-bottom: 0px;" valign="top">
+                                <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
+                                  <tbody>
+                                    <tr>
+                                      <td style="font-family: sans-serif; font-size: 14px; vertical-align: top; border-radius: 5px; text-align: center; background-color: #3498db;" valign="top" align="center" bgcolor="#3498db"> <a href="<%= root_url %>" target="_blank" style="border: solid 1px #3498db; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-decoration: none; text-transform: capitalize; background-color: #3498db; border-color: #3498db; color: #ffffff;">Sara Alert</a> </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+
+            <!-- END MAIN CONTENT AREA -->
+            </table>
+            <!-- END CENTERED WHITE CONTAINER -->
+
+            <!-- START FOOTER -->
+            <div class="footer" style="clear: both; margin-top: 10px; text-align: center; width: 100%;">
+              <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 100%;" width="100%">
+                <tr>
+                    <p style="font-family: sans-serif; font-weight: normal; margin: 0; margin-bottom: 15px; color: #999999; font-size: 12px; text-align: center;">This message was automatically generated by the Sara Alert system. If you wish to stop recieving these notifications or believe that it was a mistake, please contact your system administrator.</p>
+                </tr>
+              </table>
+            </div>
+            <!-- END FOOTER -->
+
+          </div>
+        </td>
+        <td style="font-family: sans-serif; font-size: 14px; vertical-align: top;" valign="top">&nbsp;</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/app/views/user_mailer/unformatted_html/purge_notification.html.erb
+++ b/app/views/user_mailer/unformatted_html/purge_notification.html.erb
@@ -1,0 +1,423 @@
+<!doctype html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Sara Alert Records Expiring Soon</title>
+    <style>
+      /* -------------------------------------
+          GLOBAL RESETS
+      ------------------------------------- */
+      
+      /*All the styling goes here*/
+      
+      img {
+        border: none;
+        -ms-interpolation-mode: bicubic;
+        max-width: 100%; 
+      }
+
+      body {
+        background-color: #f6f6f6;
+        font-family: sans-serif;
+        -webkit-font-smoothing: antialiased;
+        font-size: 14px;
+        line-height: 1.4;
+        margin: 0;
+        padding: 0;
+        -ms-text-size-adjust: 100%;
+        -webkit-text-size-adjust: 100%; 
+      }
+
+      table {
+        border-collapse: separate;
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+        width: 100%; }
+        table td {
+          font-family: sans-serif;
+          font-size: 14px;
+          vertical-align: top; 
+      }
+
+      /* -------------------------------------
+          BODY & CONTAINER
+      ------------------------------------- */
+
+      .body {
+        background-color: #f6f6f6;
+        width: 100%; 
+      }
+
+      /* Set a max-width, and make it display as block so it will automatically stretch to that width, but will also shrink down on a phone or something */
+      .container {
+        display: block;
+        margin: 0 auto !important;
+        /* makes it centered */
+        max-width: 580px;
+        padding: 10px;
+        width: 580px; 
+      }
+
+      /* This should also be a block element, so that it will fill 100% of the .container */
+      .content {
+        box-sizing: border-box;
+        display: block;
+        margin: 0 auto;
+        max-width: 580px;
+        padding: 10px; 
+      }
+
+      /* -------------------------------------
+          HEADER, FOOTER, MAIN
+      ------------------------------------- */
+      .main {
+        background: #ffffff;
+        border-radius: 3px;
+        width: 100%; 
+      }
+
+      .wrapper {
+        box-sizing: border-box;
+        padding: 20px; 
+      }
+
+      .content-block {
+        padding-bottom: 10px;
+        padding-top: 10px;
+      }
+
+      .footer {
+        clear: both;
+        margin-top: 10px;
+        text-align: center;
+        width: 100%; 
+      }
+        .footer td,
+        .footer p,
+        .footer span,
+        .footer a {
+          color: #999999;
+          font-size: 12px;
+          text-align: center; 
+      }
+
+      .header {
+        clear: both;
+        text-align: center;
+        width: 100%; 
+      }
+        .header td,
+        .header p,
+        .header span,
+        .header a {
+          color: #999999;
+          font-size: 12px;
+          text-align: center; 
+      }
+
+      /* -------------------------------------
+          TYPOGRAPHY
+      ------------------------------------- */
+      h1,
+      h2,
+      h3,
+      h4 {
+        color: #000000;
+        font-family: sans-serif;
+        font-weight: 400;
+        line-height: 1.4;
+        margin: 0;
+        margin-bottom: 30px; 
+      }
+
+      h1 {
+        font-size: 35px;
+        font-weight: 300;
+        text-align: center;
+        text-transform: capitalize; 
+      }
+
+      p,
+      ul,
+      ol {
+        font-family: sans-serif;
+        font-size: 14px;
+        font-weight: normal;
+        margin: 0;
+        margin-bottom: 15px; 
+      }
+        p li,
+        ul li,
+        ol li {
+          list-style-position: inside;
+          margin-left: 5px; 
+      }
+
+      a {
+        color: #3498db;
+        text-decoration: underline; 
+      }
+
+      /* -------------------------------------
+          BUTTONS
+      ------------------------------------- */
+      .btn {
+        box-sizing: border-box;
+        width: 100%; }
+        .btn > tbody > tr > td {
+          padding-bottom: 0px; }
+        .btn table {
+          width: auto; 
+      }
+        .btn table td {
+          background-color: #ffffff;
+          border-radius: 5px;
+          text-align: center; 
+      }
+        .btn a {
+          background-color: #ffffff;
+          border: solid 1px #3498db;
+          border-radius: 5px;
+          box-sizing: border-box;
+          color: #3498db;
+          cursor: pointer;
+          display: inline-block;
+          font-size: 14px;
+          font-weight: bold;
+          margin: 0;
+          padding: 12px 25px;
+          text-decoration: none;
+          text-transform: capitalize; 
+      }
+
+      .btn-primary table td {
+        background-color: #3498db; 
+      }
+
+      .btn-primary a {
+        background-color: #3498db;
+        border-color: #3498db;
+        color: #ffffff; 
+      }
+
+      /* -------------------------------------
+          OTHER STYLES THAT MIGHT BE USEFUL
+      ------------------------------------- */
+      .last {
+        margin-bottom: 0; 
+      }
+
+      .first {
+        margin-top: 0; 
+      }
+
+      .align-center {
+        text-align: center; 
+      }
+
+      .align-right {
+        text-align: right; 
+      }
+
+      .align-left {
+        text-align: left; 
+      }
+
+      .clear {
+        clear: both; 
+      }
+
+      .mt0 {
+        margin-top: 0; 
+      }
+
+      .mb0 {
+        margin-bottom: 0; 
+      }
+
+      .preheader {
+        color: transparent;
+        display: none;
+        height: 0;
+        max-height: 0;
+        max-width: 0;
+        opacity: 0;
+        overflow: hidden;
+        mso-hide: all;
+        visibility: hidden;
+        width: 0; 
+      }
+
+      .powered-by a {
+        text-decoration: none; 
+      }
+
+      hr {
+        border: 0;
+        border-bottom: 1px solid #f6f6f6;
+        margin: 20px 0; 
+      }
+
+      /* -------------------------------------
+          RESPONSIVE AND MOBILE FRIENDLY STYLES
+      ------------------------------------- */
+      @media only screen and (max-width: 620px) {
+        table[class=body] h1 {
+          font-size: 28px !important;
+          margin-bottom: 10px !important; 
+        }
+        table[class=body] p,
+        table[class=body] ul,
+        table[class=body] ol,
+        table[class=body] td,
+        table[class=body] span,
+        table[class=body] a {
+          font-size: 16px !important; 
+        }
+        table[class=body] .wrapper,
+        table[class=body] .article {
+          padding: 10px !important; 
+        }
+        table[class=body] .content {
+          padding: 0 !important; 
+        }
+        table[class=body] .container {
+          padding: 0 !important;
+          width: 100% !important; 
+        }
+        table[class=body] .main {
+          border-left-width: 0 !important;
+          border-radius: 0 !important;
+          border-right-width: 0 !important; 
+        }
+        table[class=body] .btn table {
+          width: 100% !important; 
+        }
+        table[class=body] .btn a {
+          width: 100% !important; 
+        }
+        table[class=body] .img-responsive {
+          height: auto !important;
+          max-width: 100% !important;
+          width: auto !important; 
+        }
+      }
+
+      /* -------------------------------------
+          PRESERVE THESE STYLES IN THE HEAD
+      ------------------------------------- */
+      @media all {
+        .ExternalClass {
+          width: 100%; 
+        }
+        .ExternalClass,
+        .ExternalClass p,
+        .ExternalClass span,
+        .ExternalClass font,
+        .ExternalClass td,
+        .ExternalClass div {
+          line-height: 100%; 
+        }
+        .apple-link a {
+          color: inherit !important;
+          font-family: inherit !important;
+          font-size: inherit !important;
+          font-weight: inherit !important;
+          line-height: inherit !important;
+          text-decoration: none !important; 
+        }
+        #MessageViewBody a {
+          color: inherit;
+          text-decoration: none;
+          font-size: inherit;
+          font-family: inherit;
+          font-weight: inherit;
+          line-height: inherit;
+        }
+        .btn-primary table td:hover {
+          background-color: #34495e !important; 
+        }
+        .btn-primary a:hover {
+          background-color: #34495e !important;
+          border-color: #34495e !important; 
+        } 
+      }
+
+    </style>
+  </head>
+  <body class="">
+    <span class="preheader">Please log into Sara Alert and export the data your wish to save.</span>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
+      <tr>
+        <td>&nbsp;</td>
+        <td class="container">
+          <div class="content">
+
+            <!-- START HEADER -->
+            <div class="header">
+              <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                <tr>
+                    <%= render partial: 'devise/shared/logo' %>
+                </tr>
+              </table>
+            </div>
+            <!-- END HEADER -->
+
+            <!-- START CENTERED WHITE CONTAINER -->
+            <table role="presentation" class="main">
+
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper">
+                  <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                    <tr>
+                      <td>
+                        <p>Dear <%= @user.email[/[^@]+/] %>,</p>
+                        <p>Several user records within your juristdiction will be expiring soon. Please be sure to export the data before it is deleted as these records are unrecoverable.</p>
+                        <p>
+                        <b>Number of Patient Records:</b> <%= @num_purgeable_records %><br/>
+                        <b>Expiration Date:</b> <%= @expiration_date %>
+                        </p>
+                        <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
+                          <tbody>
+                            <tr>
+                              <td align="center">
+                                <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                                  <tbody>
+                                    <tr>
+                                      <td> <a href="<%= root_url %>" target="_blank">Sara Alert</a> </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+
+            <!-- END MAIN CONTENT AREA -->
+            </table>
+            <!-- END CENTERED WHITE CONTAINER -->
+
+            <!-- START FOOTER -->
+            <div class="footer">
+              <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                <tr>
+                    <p>This message was automatically generated by the Sara Alert system. If you wish to stop recieving these notifications or believe that it was a mistake, please contact your system administrator.</p>
+                </tr>
+              </table>
+            </div>
+            <!-- END FOOTER -->
+
+          </div>
+        </td>
+        <td>&nbsp;</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/app/views/user_mailer/unformatted_html/purge_notification.html.erb
+++ b/app/views/user_mailer/unformatted_html/purge_notification.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta name="viewport" content="width=device-width" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title>Sara Alert Records Expiring Soon</title>
+    <title><%= @subject %></title>
     <style>
       /* -------------------------------------
           GLOBAL RESETS
@@ -347,7 +347,13 @@
     </style>
   </head>
   <body class="">
-    <span class="preheader">Please log into Sara Alert and export the data your wish to save.</span>
+    <span class="preheader">
+      <% if @num_purgeable_records.zero? %>
+        No action is required at this time.
+      <% else %>
+        Please log into Sara Alert and export the data your wish to save.
+      <% end %>
+    </span>
     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body">
       <tr>
         <td>&nbsp;</td>
@@ -374,11 +380,21 @@
                     <tr>
                       <td>
                         <p>Dear <%= @user.email[/[^@]+/] %>,</p>
-                        <p>Several user records within your juristdiction will be expiring soon. Please be sure to export the data before it is deleted as these records are unrecoverable.</p>
-                        <p>
-                        <b>Number of Patient Records:</b> <%= @num_purgeable_records %><br/>
-                        <b>Expiration Date:</b> <%= @expiration_date %>
-                        </p>
+
+                        <% if @num_purgeable_records.zero? %>
+                          <p>There are no user records within your jurisdiction that are expiring this week. No action is required at this time, however you will receive this message every week for your records. Please be on the lookout for future Sara Alert notifications.</p>
+                          <p>
+                          <b>No Records Expiring</b><br/>
+                          <b>Expiration Date:</b> <%= @expiration_date %>
+                          </p>
+                        <% else %>
+                          <p>Several user records within your jurisdiction will be expiring soon. Please be sure to export the data before it is deleted as these records are unrecoverable.</p>
+                          <p>
+                          <b>Number of Patient Records:</b> <%= @num_purgeable_records %><br/>
+                          <b>Expiration Date:</b> <%= @expiration_date %>
+                          </p>
+                        <% end %>
+
                         <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
                           <tbody>
                             <tr>

--- a/config/sara/sara.yml
+++ b/config/sara/sara.yml
@@ -14,7 +14,7 @@ reporting_period_minutes: <%= ENV["SARA_ALERT_REPORTING_PERIOD_MINUTES"] || 1440
 purgeable_after: <%= ENV["SARA_ALERT_PURGEABLE_AFTER_MINUTES"] || 20160 %>
 
 # The day and time of week to run the purge user records job
-weekly_purge_date: <%= ENV["SARA_ALERT_WEEKLY_PURGE_DATE"] || 'saturday 11:59pm' %>
+weekly_purge_date: <%= ENV["SARA_ALERT_WEEKLY_PURGE_DATE"] || 'sunday 12:00am' %>
 
 # The day and time of week to warn users of records that will soon be purged
 weekly_purge_warning_date: <%= ENV["SARA_ALERT_WEEKLY_PURGE_WARNING_DATE"] || 'thursday 12:00pm' %>

--- a/config/sara/sara.yml
+++ b/config/sara/sara.yml
@@ -13,6 +13,12 @@ reporting_period_minutes: <%= ENV["SARA_ALERT_REPORTING_PERIOD_MINUTES"] || 1440
 # How many minutes after a closed record last_update it can be purged
 purgeable_after: <%= ENV["SARA_ALERT_PURGEABLE_AFTER_MINUTES"] || 20160 %>
 
+# The day and time of week to run the purge user records job
+weekly_purge_date: <%= ENV["SARA_ALERT_WEEKLY_PURGE_DATE"] || 'saturday 11:59pm' %>
+
+# The day and time of week to warn users of records that will soon be purged
+weekly_purge_warning_date: <%= ENV["SARA_ALERT_WEEKLY_PURGE_WARNING_DATE"] || 'thursday 12:00pm' %>
+
 # How many minutes after a report was received the monitoree can re-report
 reporting_limit: <%= ENV["SARA_ALERT_REPORTING_LIMIT_MINUTES"] || 15 %>
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,12 +6,20 @@ every 24.hours do
   runner "CloseSubjectsJob.perform_now"
 end
 
-every :sunday do
+every ADMIN_OPTIONS['weekly_purge_date'] do
   runner "PurgeJob.perform_now"
 end
 
 every 1.hours do
   runner "CacheAnalyticsJob.perform_now"
+end
+
+every ADMIN_OPTIONS['weekly_purge_warning_date'] do
+  rake "mailers:send_purge_warning"
+end
+
+every 30.minutes do
+  rake "analytics:cache_current_analytics"
 end
 
 every 1.hours do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,21 +1,26 @@
 # For information about how to use this file see https://github.com/javan/whenever
 
+# Load rails environment to provide application control/knowledge of job timings
+require File.expand_path(File.dirname(__FILE__) + "/environment")
+
 set :output, "/tmp/cronlog.log"
 
 every 24.hours do
   runner "CloseSubjectsJob.perform_now"
 end
 
-every ADMIN_OPTIONS['weekly_purge_date'] do
+weekly_purge_date = Chronic.parse(ADMIN_OPTIONS['weekly_purge_date'])
+every weekly_purge_date.strftime("%A"), at: weekly_purge_date.strftime("%I:%M %p") do
   runner "PurgeJob.perform_now"
+end
+
+weekly_purge_warning_date = Chronic.parse(ADMIN_OPTIONS['weekly_purge_warning_date'])
+every weekly_purge_warning_date.strftime("%A"), at: weekly_purge_warning_date.strftime("%I:%M %p") do
+  rake "mailers:send_purge_warning  RAILS_ENV=development"
 end
 
 every 1.hours do
   runner "CacheAnalyticsJob.perform_now"
-end
-
-every ADMIN_OPTIONS['weekly_purge_warning_date'] do
-  rake "mailers:send_purge_warning"
 end
 
 every 30.minutes do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -16,15 +16,11 @@ end
 
 weekly_purge_warning_date = Chronic.parse(ADMIN_OPTIONS['weekly_purge_warning_date'])
 every weekly_purge_warning_date.strftime("%A"), at: weekly_purge_warning_date.strftime("%I:%M %p") do
-  rake "mailers:send_purge_warning"
+  runner "UserMailer.purge_notification().deliver_now"
 end
 
 every 1.hours do
   runner "CacheAnalyticsJob.perform_now"
-end
-
-every 30.minutes do
-  rake "analytics:cache_current_analytics"
 end
 
 every 1.hours do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -16,7 +16,7 @@ end
 
 weekly_purge_warning_date = Chronic.parse(ADMIN_OPTIONS['weekly_purge_warning_date'])
 every weekly_purge_warning_date.strftime("%A"), at: weekly_purge_warning_date.strftime("%I:%M %p") do
-  runner "UserMailer.purge_notification().deliver_now"
+  runner "UserMailer.purge_notification.deliver_now"
 end
 
 every 1.hours do

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -16,7 +16,7 @@ end
 
 weekly_purge_warning_date = Chronic.parse(ADMIN_OPTIONS['weekly_purge_warning_date'])
 every weekly_purge_warning_date.strftime("%A"), at: weekly_purge_warning_date.strftime("%I:%M %p") do
-  rake "mailers:send_purge_warning  RAILS_ENV=development"
+  rake "mailers:send_purge_warning"
 end
 
 every 1.hours do

--- a/lib/tasks/mailers.rake
+++ b/lib/tasks/mailers.rake
@@ -64,4 +64,9 @@ namespace :mailers do
   task send_assessments: :environment do
     SendAssessmentsJob.perform_now
   end
+
+  desc "Sends data purge warning to users"
+  task send_purge_warning: :environment do
+    UserMailer.purge_notification().deliver_now
+  end
 end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -12,7 +12,7 @@ class PatientTest < ActiveSupport::TestCase
   end
 
   test 'purge eligible' do
-    jur = Jurisdiction.create()
+    jur = Jurisdiction.create
     user = User.create!(
       email: 'foobar@example.com',
       password: '123456ab',
@@ -24,10 +24,10 @@ class PatientTest < ActiveSupport::TestCase
     patient.save
     assert Patient.count == 1
     # Updated at of today, still monitoring, should not be purgeable
-    assert Patient.purge_eligible.count == 0
+    assert Patient.purge_eligible.count.zero?
     patient.update!(monitoring: false)
     # Updated at of today, not monitoring, should not be purgeable
-    assert Patient.purge_eligible.count == 0
+    assert Patient.purge_eligible.count.zero?
     # Updated at of 2x purgeable_after, not monitoring, should obviously be purgeable regardless of weekly_purge_date and weekly_purge_warning_date
     patient.update!(updated_at: (2 * ADMIN_OPTIONS['purgeable_after']).minutes.ago)
     assert Patient.purge_eligible.count == 1
@@ -36,31 +36,30 @@ class PatientTest < ActiveSupport::TestCase
     # These tests reset the weekly_purge_warning_date and weekly_purge_date, and set the times to 1 minute from Time.now to avoid timing issues
     # caused by the duration of time it takes to run the test
     ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
-    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + (2.5).days + 1.minute).strftime('%A %l:%M%p')
+    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + 2.5.days + 1.minute).strftime('%A %l:%M%p')
     patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after']).minutes.ago)
     assert Patient.purge_eligible.count == 1
     # However, if the test email was going out in 1 minute from now and the patient was last updated purgeable_after - 2 minutes ago, no purge
     ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
-    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + (2.5).days + 1.minute).strftime('%A %l:%M%p')
+    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + 2.5.days + 1.minute).strftime('%A %l:%M%p')
     patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after'] - 2).minutes.ago)
-    assert Patient.purge_eligible.count == 0
+    assert Patient.purge_eligible.count.zero?
     # Now test the boundry conditions that exist between the purge_warning and the purging
     # ADMIN_OPTIONS['weekly_purge_warning_date'] is 2.5 days before ADMIN_OPTIONS['weekly_purge_date']
     ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
-    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute - (2.5).days).strftime('%A %l:%M%p')
+    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute - 2.5.days).strftime('%A %l:%M%p')
     # If the email is going out in 1 minute, and the patient was modified purgeable_after minutes ago, they should not be purgeable
     patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after']).minutes.ago)
-    assert Patient.purge_eligible.count == 0
+    assert Patient.purge_eligible.count.zero?
     # However, if the email is going out in 1 minute and the patient was modified right before the warning (2.5 days ago), they should be purgable
     ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
-    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute - (2.5).days).strftime('%A %l:%M%p')
-    patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after'] + ((2.5).days/1.minute)).minutes.ago)
+    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute - 2.5.days).strftime('%A %l:%M%p')
+    patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after'] + (2.5.days / 1.minute)).minutes.ago)
     assert Patient.purge_eligible.count == 1
     # Anything less than the 2.5 days ago means the patient was modified between the warning and the purging and should not be purged
     ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
-    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute - (2.5).days).strftime('%A %l:%M%p')
-    patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after'] + ((2.5).days/1.minute) - 2).minutes.ago)
-    assert Patient.purge_eligible.count == 0
+    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute - 2.5.days).strftime('%A %l:%M%p')
+    patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after'] + (2.5.days / 1.minute) - 2).minutes.ago)
+    assert Patient.purge_eligible.count.zero?
   end
-
 end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -10,4 +10,57 @@ class PatientTest < ActiveSupport::TestCase
   test 'create patient' do
     assert create(:patient)
   end
+
+  test 'purge eligible' do
+    jur = Jurisdiction.create()
+    user = User.create!(
+      email: 'foobar@example.com',
+      password: '123456ab',
+      jurisdiction: jur,
+      force_password_change: true # Require user to change password on first login
+    )
+    patient = Patient.new(creator: user, jurisdiction: jur)
+    patient.responder = patient
+    patient.save
+    assert Patient.count == 1
+    # Updated at of today, still monitoring, should not be purgeable
+    assert Patient.purge_eligible.count == 0
+    patient.update!(monitoring: false)
+    # Updated at of today, not monitoring, should not be purgeable
+    assert Patient.purge_eligible.count == 0
+    # Updated at of 2x purgeable_after, not monitoring, should obviously be purgeable regardless of weekly_purge_date and weekly_purge_warning_date
+    patient.update!(updated_at: (2 * ADMIN_OPTIONS['purgeable_after']).minutes.ago)
+    assert Patient.purge_eligible.count == 1
+    # ADMIN_OPTIONS['weekly_purge_warning_date'] is 2.5 days before ADMIN_OPTIONS['weekly_purge_date']
+    # Test if the email was going out in 1 minute and patient was updated purgeable_after minutes ago, patient should be purgeable
+    # These tests reset the weekly_purge_warning_date and weekly_purge_date, and set the times to 1 minute from Time.now to avoid timing issues
+    # caused by the duration of time it takes to run the test
+    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
+    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + (2.5).days.minutes + 1.minute).strftime('%A %l:%M%p')
+    patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after']).minutes.ago)
+    assert Patient.purge_eligible.count == 1
+    # However, if the test email was going out in 1 minute from now and the patient was last updated purgeable_after - 2 minutes ago, no purge
+    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
+    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + (2.5).days.minutes + 1.minute).strftime('%A %l:%M%p')
+    patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after'] - 2).minutes.ago)
+    assert Patient.purge_eligible.count == 0
+    # Now test the boundry conditions that exist between the purge_warning and the purging
+    # ADMIN_OPTIONS['weekly_purge_warning_date'] is 2.5 days before ADMIN_OPTIONS['weekly_purge_date']
+    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
+    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute - (2.5).days.minutes).strftime('%A %l:%M%p')
+    # If the email is going out in 1 minute, and the patient was modified purgeable_after minutes ago, they should not be purgeable
+    patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after']).minutes.ago)
+    assert Patient.purge_eligible.count == 0
+    # However, if the email is going out in 1 minute and the patient was modified right before the warning (2.5 days ago), they should be purgable
+    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
+    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute - (2.5).days.minutes).strftime('%A %l:%M%p')
+    patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after'] + (2.5).days.minutes).minutes.ago)
+    assert Patient.purge_eligible.count == 1
+    # Anything less than the 2.5 days ago means the patient was modified between the warning and the purging and should not be purged
+    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
+    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute - (2.5).days.minutes).strftime('%A %l:%M%p')
+    patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after'] + 72.minutes).minutes.ago)
+    assert Patient.purge_eligible.count == 0
+  end
+
 end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -36,30 +36,30 @@ class PatientTest < ActiveSupport::TestCase
     # These tests reset the weekly_purge_warning_date and weekly_purge_date, and set the times to 1 minute from Time.now to avoid timing issues
     # caused by the duration of time it takes to run the test
     ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
-    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + (2.5).days.minutes + 1.minute).strftime('%A %l:%M%p')
+    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + (2.5).days + 1.minute).strftime('%A %l:%M%p')
     patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after']).minutes.ago)
     assert Patient.purge_eligible.count == 1
     # However, if the test email was going out in 1 minute from now and the patient was last updated purgeable_after - 2 minutes ago, no purge
     ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
-    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + (2.5).days.minutes + 1.minute).strftime('%A %l:%M%p')
+    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + (2.5).days + 1.minute).strftime('%A %l:%M%p')
     patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after'] - 2).minutes.ago)
     assert Patient.purge_eligible.count == 0
     # Now test the boundry conditions that exist between the purge_warning and the purging
     # ADMIN_OPTIONS['weekly_purge_warning_date'] is 2.5 days before ADMIN_OPTIONS['weekly_purge_date']
     ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
-    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute - (2.5).days.minutes).strftime('%A %l:%M%p')
+    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute - (2.5).days).strftime('%A %l:%M%p')
     # If the email is going out in 1 minute, and the patient was modified purgeable_after minutes ago, they should not be purgeable
     patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after']).minutes.ago)
     assert Patient.purge_eligible.count == 0
     # However, if the email is going out in 1 minute and the patient was modified right before the warning (2.5 days ago), they should be purgable
     ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
-    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute - (2.5).days.minutes).strftime('%A %l:%M%p')
-    patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after'] + (2.5).days.minutes).minutes.ago)
+    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute - (2.5).days).strftime('%A %l:%M%p')
+    patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after'] + ((2.5).days/1.minute)).minutes.ago)
     assert Patient.purge_eligible.count == 1
     # Anything less than the 2.5 days ago means the patient was modified between the warning and the purging and should not be purged
     ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
-    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute - (2.5).days.minutes).strftime('%A %l:%M%p')
-    patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after'] + 72.minutes).minutes.ago)
+    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute - (2.5).days).strftime('%A %l:%M%p')
+    patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after'] + ((2.5).days/1.minute) - 2).minutes.ago)
     assert Patient.purge_eligible.count == 0
   end
 

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -19,6 +19,7 @@ class PatientTest < ActiveSupport::TestCase
       jurisdiction: jur,
       force_password_change: true # Require user to change password on first login
     )
+    Patient.destroy_all
     patient = Patient.new(creator: user, jurisdiction: jur)
     patient.responder = patient
     patient.save


### PR DESCRIPTION
**Summary**
This PR contains changes to the user record purging job. The job now takes place once per week, defaulting to Saturday at 11:59pm. A notification will go out to all public health users several days before, again defaulting to Thursday at 12:00pm.

The email contains the number of user records that are currently marked as purgeable. At the time of the purge, the system will only purge the records that were considered purgeable at the time of the last warning (marked_for_purge).

**Design Decisions**
The email notification uses inline html styling to provide a professional feel for a critical email that users will be receiving weekly. Currently the Sara Alert logo is added as a header to the email, however not all email platforms will properly display the logo, which shouldn't cause errors, just no logo will be displayed. If there is a better way to include it, please add as a suggestion.

Sample Email:
![Screen Shot 2020-04-24 at 3 37 15 PM](https://user-images.githubusercontent.com/15388200/80250372-b079f400-8641-11ea-9e5b-e771982901fe.png)

In order to provide knowledge and control of the purge times to the system, the whenever scheduler has been setup to load the rails environment. Doing so, allows both whenever and Sara Alert access to the same Admin Option from sara.yaml.