### PR TITLE
Update email generation to use #email instead of #safe_email because …

### DIFF
--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :user do
-    email { Faker::Internet.safe_email }
+    email { Faker::Internet.email }
     password { Faker::Internet.password(min_length: 8, max_length: 128, mix_case: true) }
     jurisdiction { create(:jurisdiction) }
 


### PR DESCRIPTION
…the tests were sometimes duplicating emails, which must be unique. This change increases the number of unique emails.