### PR TITLE
Fix: Viewable patients by epi enrollers

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -106,10 +106,7 @@ class PatientsController < ApplicationController
     patient.creator = current_user
 
     # Set the subject jurisdiction to the creator's jurisdiction if jurisdiction is not assigned or not assignable by the current user
-    unless patient.jurisdiction_id.nil?
-      valid_jurisdiction = (current_user.can_assign_any_jurisdiction? && !Jurisdiction.find(patient.jurisdiction_id).nil?) ||
-                           current_user.jurisdiction.subtree_ids.include?(patient.jurisdiction_id)
-    end
+    valid_jurisdiction = current_user.jurisdiction.subtree_ids.include?(patient.jurisdiction_id) unless patient.jurisdiction_id.nil?
     patient.jurisdiction = current_user.jurisdiction unless valid_jurisdiction
 
     # Create a secure random token to act as the monitoree's password when they submit assessments; this gets
@@ -175,8 +172,7 @@ class PatientsController < ApplicationController
 
     # If the assigned jurisdiction is updated, verify that the jurisdiction exists and that it is assignable by the current user
     if content[:jurisdiction_id] && content[:jurisdiction_id] != patient.jurisdiction_id
-      if current_user.can_assign_any_jurisdiction? && Jurisdiction.find(content[:jurisdiction_id]).any? ||
-         current_user.jurisdiction.subtree_ids.include?(content[:jurisdiction_id])
+      if current_user.jurisdiction.subtree_ids.include?(content[:jurisdiction_id])
         history = History.new
         history.created_by = current_user.email
         old_jurisdiction = patient.jurisdiction.jurisdiction_path_string

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,7 @@ class User < ApplicationRecord
     elsif has_role?(:public_health)
       viewable_patients.find_by_id(id)
     elsif has_role?(:public_health_enroller)
-      enrolled_patients.find_by_id(id) || viewable_patients.find_by_id(id)
+      viewable_patients.find_by_id(id)
     elsif has_role?(:admin)
       Patient.find_by_id(id)
     end
@@ -82,11 +82,6 @@ class User < ApplicationRecord
 
   # Can this user import?
   def can_import?
-    has_role?(:public_health) || has_role?(:public_health_enroller)
-  end
-
-  # Can this user assign a Patient to any jurisdiction?
-  def can_assign_any_jurisdiction?
     has_role?(:public_health) || has_role?(:public_health_enroller)
   end
 

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -8,5 +8,5 @@
   authenticity_token: form_authenticity_token,
   can_add_group: current_user.can_create_patient?,
   has_group_members: @group_members.count.positive?, 
-  jurisdiction_paths: current_user.can_assign_any_jurisdiction? ? Jurisdiction.all.collect{ |jur| { value: jur.id, label: jur.jurisdiction_path_string } } : Jurisdiction.find(current_user.jurisdiction.subtree_ids).collect{ |jur| { value: jur.id, label: jur.jurisdiction_path_string } }
+  jurisdiction_paths: Jurisdiction.find(current_user.jurisdiction.subtree_ids).collect{ |jur| { value: jur.id, label: jur.jurisdiction_path_string } }
   }) %>

--- a/app/views/patients/new.html.erb
+++ b/app/views/patients/new.html.erb
@@ -8,7 +8,7 @@
   authenticity_token: form_authenticity_token, 
   can_add_group: current_user.can_create_patient?, 
   has_group_members: false,
-  jurisdiction_paths: current_user.can_assign_any_jurisdiction? ? Jurisdiction.all.collect{ |jur| { value: jur.id, label: jur.jurisdiction_path_string } } : Jurisdiction.find(current_user.jurisdiction.subtree_ids).collect{ |jur| { value: jur.id, label: jur.jurisdiction_path_string } }
+  jurisdiction_paths: Jurisdiction.find(current_user.jurisdiction.subtree_ids).collect{ |jur| { value: jur.id, label: jur.jurisdiction_path_string } }
   }) %>
 
 <div class="pb-4"></div>

--- a/app/views/patients/new_group_member.html.erb
+++ b/app/views/patients/new_group_member.html.erb
@@ -9,7 +9,7 @@
   authenticity_token: form_authenticity_token,
   can_add_group: current_user.can_create_patient?,
   has_group_members: false,
-  jurisdiction_paths: current_user.can_assign_any_jurisdiction? ? Jurisdiction.all.collect{ |jur| { value: jur.id, label: jur.jurisdiction_path_string } } : Jurisdiction.find(current_user.jurisdiction.subtree_ids).collect{ |jur| { value: jur.id, label: jur.jurisdiction_path_string } }
+  jurisdiction_paths: Jurisdiction.find(current_user.jurisdiction.subtree_ids).collect{ |jur| { value: jur.id, label: jur.jurisdiction_path_string } }
   }) %>
 
 <div class="pb-4"></div>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -180,20 +180,6 @@ class UserTest < ActiveSupport::TestCase
     assert_not analyst.can_import?
   end
 
-  test 'can assign any jurisdiction' do
-    admin = create(:admin_user)
-    enroller = create(:enroller_user)
-    public_health_enroller = create(:public_health_enroller_user)
-    public_health = create(:public_health_user)
-    analyst = create(:analyst_user)
-
-    assert_not admin.can_assign_any_jurisdiction?
-    assert public_health.can_assign_any_jurisdiction?
-    assert_not enroller.can_assign_any_jurisdiction?
-    assert public_health_enroller.can_assign_any_jurisdiction?
-    assert_not analyst.can_assign_any_jurisdiction?
-  end
-
   test 'can edit patient' do
     admin = create(:admin_user)
     enroller = create(:enroller_user)

--- a/test/system/workflow_test.rb
+++ b/test/system/workflow_test.rb
@@ -36,32 +36,31 @@ class WorkflowTest < ApplicationSystemTestCase
 
   test 'epi enroll monitoree, complete assessment, update monitoring actions, jurisdiction, workflow' do
     # enroll monitoree, should be asymptomatic
-    enroller_user_label = 'state1_epi_enroller'
+    epi_enroller_user_label = 'state1_epi_enroller'
     monitoree_label = 'monitoree_3'
-    @@monitoree_enrollment_helper.enroll_monitoree(enroller_user_label, monitoree_label, true)
-    @@system_test_utils.login(enroller_user_label)
+    @@monitoree_enrollment_helper.enroll_monitoree(epi_enroller_user_label, monitoree_label, true)
+    @@system_test_utils.login(epi_enroller_user_label)
     @@public_health_monitoring_dashboard.search_for_and_view_monitoree('asymptomatic', monitoree_label)
     @@public_health_monitoring_reports_verifier.verify_current_status('asymptomatic')
 
     # add symptomatic report, should be symptomatic
-    @@public_health_monitoring_reports.add_report(enroller_user_label, ASSESSMENTS['assessment_1'])
+    @@public_health_monitoring_reports.add_report(epi_enroller_user_label, ASSESSMENTS['assessment_1'])
     @@public_health_monitoring_reports_verifier.verify_current_status('symptomatic')
     @@system_test_utils.return_to_dashboard('exposure')
     @@public_health_monitoring_dashboard.search_for_and_view_monitoree('symptomatic', monitoree_label)
 
     # mark all reports as reviewed, should be symptomatic again
-    @@public_health_monitoring_reports.mark_all_as_reviewed(enroller_user_label, 'reason', true)
+    @@public_health_monitoring_reports.mark_all_as_reviewed(epi_enroller_user_label, 'reason', true)
     @@system_test_utils.return_to_dashboard('exposure')
     @@public_health_monitoring_dashboard.search_for_and_view_monitoree('asymptomatic', monitoree_label)
 
     # add PUI, should be listed under PUI tab
-    @@public_health_monitoring_actions.update_latest_public_health_action(enroller_user_label, 'Recommended medical evaluation of symptoms', 'reason')
+    @@public_health_monitoring_actions.update_latest_public_health_action(epi_enroller_user_label, 'Recommended medical evaluation of symptoms', 'reason')
     @@system_test_utils.return_to_dashboard('exposure')
     @@public_health_monitoring_dashboard.search_for_and_view_monitoree('pui', monitoree_label)
 
     # update assigned jurisdiction, should be transferred out of old jurisdiction and transferred into new one
-    @@public_health_monitoring_actions.update_assigned_jurisdiction(enroller_user_label, 'USA, State 2', 'reason')
-    @@system_test_utils.return_to_dashboard('exposure')
+    @@public_health_monitoring_actions.update_assigned_jurisdiction(epi_enroller_user_label, 'USA, State 2', 'reason', true, false)
     @@public_health_monitoring_dashboard_verifier.verify_monitoree_under_tab('transferred-out', monitoree_label)
     @@system_test_utils.logout
     @@system_test_utils.login('state2_epi')


### PR DESCRIPTION
- Epi enrollers can only assign patients to jurisdictions within their hierarchy during enrollment
- Epi enrollers can no longer view patients outside of hierarchy even if they enrolled them