### PR TITLE
Condition model tests

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -5,11 +5,16 @@ class Condition < ApplicationRecord
   has_many :symptoms
 
   def self.build_symptoms(symptoms_array)
+    raise TypeError, "no conversion of #{symptoms_array.class} to Symptoms Array" unless symptoms_array.is_a?(Array)
+
     typed_symptoms = []
 
     symptoms_array.each do |symp|
       symptom = Symptom.new(symp)
       typed_symptoms.push(symptom)
+    rescue ActiveRecord::ActiveRecordError => e
+      Rails.logger.error("Attempting to create Symptom with `#{symp}` caused the following: #{e}")
+      next
     end
     typed_symptoms
   end

--- a/test/factories/condition.rb
+++ b/test/factories/condition.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :condition do
+    transient do
+      symptoms_count { 0 }
+    end
+
+    after(:create) do |condition, evaluator|
+      evaluator.symptoms_count.times do
+        condition.symptoms << create(:symptom)
+      end
+    end
+  end
+end

--- a/test/factories/symptom.rb
+++ b/test/factories/symptom.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :symptom do
-    type { Symptom.valid_types.select }
+    type { Symptom.valid_types.sample }
 
     after(:build) do |symptom|
       if symptom.type == 'IntegerSymptom' && symptom.int_value.nil?

--- a/test/models/condition_test.rb
+++ b/test/models/condition_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'test_case'
+require_relative '../test_helpers/symptom_test_helper'
+
+class ConditionTest < ActiveSupport::TestCase
+  def setup; end
+
+  def teardown; end
+
+  test 'create condition' do
+    assert create(:condition)
+    assert create(:condition, symptoms_count: Faker::Number.between(from: 1, to: 5))
+  end
+
+  test 'build symptoms' do
+    symptoms_array = []
+    Faker::Number.between(from: 1, to: 5).times do
+      temp_symptom = build(:symptom)
+      symptoms_array.push(SymptomTestHelper.create_symptom_as_hash(
+                            kname: Faker::Alphanumeric.alpha,
+                            value: SymptomTestHelper.get_value(temp_symptom),
+                            type: temp_symptom.type,
+                            label: Faker::Alphanumeric.alpha,
+                            notes: Faker::Alphanumeric.alpha
+                          ))
+    end
+    typed_symptoms = ::Condition.build_symptoms(symptoms_array)
+    symptoms_array.each_with_index do |symptom, idx|
+      symptom.each_key do |key|
+        assert_equal(typed_symptoms[idx].send(key), symptom[key])
+      end
+    end
+  end
+end

--- a/test/models/condition_test.rb
+++ b/test/models/condition_test.rb
@@ -31,5 +31,37 @@ class ConditionTest < ActiveSupport::TestCase
         assert_equal(typed_symptoms[idx].send(key), symptom[key])
       end
     end
+
+    assert_equal([], ::Condition.build_symptoms([]))
+
+    assert_raises(TypeError) do
+      ::Condition.build_symptoms(SymptomTestHelper.create_symptom_as_hash)
+    end
+
+    assert_raises(ArgumentError) do
+      ::Condition.build_symptoms(['v'])
+    end
+
+    symptoms_array = []
+    temp_symptom = build(:symptom)
+    symptoms_array.push(SymptomTestHelper.create_symptom_as_hash(
+                          kname: Faker::Alphanumeric.alpha,
+                          value: SymptomTestHelper.get_value(temp_symptom),
+                          type: temp_symptom.type,
+                          label: Faker::Alphanumeric.alpha,
+                          notes: Faker::Alphanumeric.alpha
+                        ))
+    symptoms_array.push(SymptomTestHelper.create_symptom_as_hash(
+                          kname: Faker::Alphanumeric.alpha,
+                          value: SymptomTestHelper.get_value(temp_symptom),
+                          type: 'Invalid',
+                          label: Faker::Alphanumeric.alpha,
+                          notes: Faker::Alphanumeric.alpha
+                        ))
+    typed_symptoms = ::Condition.build_symptoms(symptoms_array)
+    assert_equal 1, typed_symptoms.length
+    symptoms_array.first.each_key do |key|
+      assert_equal(typed_symptoms.first.send(key), symptoms_array.first[key])
+    end
   end
 end

--- a/test/test_helpers/symptom_test_helper.rb
+++ b/test/test_helpers/symptom_test_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module SymptomTestHelper
+  def self.create_symptom_as_hash(kname: 'Name', value: 1, type: 'IntegerSymptom', label: 'Label', notes: 'Notes')
+    {
+      "name": kname,
+      "value": value,
+      "type": type,
+      "label": label,
+      "notes": notes
+    }
+  end
+
+  def self.get_value(symptom)
+    return nil unless symptom.is_a?(::Symptom)
+
+    case symptom.type
+    when 'IntegerSymptom'
+      symptom.int_value
+    when 'BoolSymptom'
+      symptom.bool_value
+    when 'FloatSymptom'
+      symptom.float_value
+    end
+  end
+end


### PR DESCRIPTION
This PR also adds some error checking to `Condition#build_symptoms` and adds a new feature to the method that will create symptoms even given that at least one symptom provided is valid. 