### PR TITLE
Authy Enforced Per User

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery prepend: true
 
   def user_must_change_password
-    return unless current_user&.force_password_change || (current_user && !current_user&.authy_enabled)
+    return unless current_user&.force_password_change || (current_user && !current_user&.authy_enabled && current_user&.authy_enforced)
 
     # First login (and first password change) must occur within three days
     current_user.lock_access! if current_user.password_changed_at < 3.days.ago && current_user&.force_password_change
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
       return
     end
 
-    if !current_user&.devise_modules&.include?(:authy_authenticatable) || request.url == user_enable_authy_url || request.url == user_verify_authy_url ||
+    if !current_user&.authy_enforced || request.url == user_enable_authy_url || request.url == user_verify_authy_url ||
        request.url == user_verify_authy_installation_url || request.url == user_request_sms_url || request.url == user_request_phone_call_url
       return
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,11 +6,7 @@ class User < ApplicationRecord
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  if ADMIN_OPTIONS['two_factor_auth_enabled']
-    devise :authy_authenticatable, :database_authenticatable, :registerable, :validatable, :lockable, :password_expirable, :password_archivable
-  else
-    devise :database_authenticatable, :registerable, :validatable, :lockable, :password_expirable, :password_archivable
-  end
+  devise :authy_authenticatable, :database_authenticatable, :registerable, :validatable, :lockable, :password_expirable, :password_archivable
 
   # Validate password complexity
   validate :password_complexity

--- a/config/sara/sara.yml
+++ b/config/sara/sara.yml
@@ -36,6 +36,3 @@ report_mode: <%= ENV["SARA_ALERT_REPORT_MODE"] || false %>
 
 # Optional Sentry URL for application monitoring and error reporting
 sentry_url: <%= ENV["SENTRY_URL"] || '' %>
-
-# Globally Enable or Disable the use of two factor authentication
-two_factor_auth_enabled: <%= ENV["AUTHY_API_KEY"] || false %>

--- a/db/migrate/20200511151627_add_authy_enforced_to_user.rb
+++ b/db/migrate/20200511151627_add_authy_enforced_to_user.rb
@@ -1,0 +1,13 @@
+class AddAuthyEnforcedToUser < ActiveRecord::Migration[6.0]
+  def self.up
+    change_table :users do |t|
+      t.boolean :authy_enforced, :default => true
+    end
+  end
+
+  def self.down
+    change_table :users do |t|
+      t.remove :authy_enforced
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_08_203548) do
+ActiveRecord::Schema.define(version: 2020_05_11_151627) do
 
   create_table "analytics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "jurisdiction_id"
@@ -320,6 +320,7 @@ ActiveRecord::Schema.define(version: 2020_05_08_203548) do
     t.string "authy_id"
     t.datetime "last_sign_in_with_authy"
     t.boolean "authy_enabled", default: false
+    t.boolean "authy_enforced", default: true
     t.index ["authy_id"], name: "index_users_on_authy_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["jurisdiction_id"], name: "index_users_on_jurisdiction_id"

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -23,27 +23,27 @@ namespace :demo do
 
     print 'Creating enroller users...'
 
-    enroller1 = User.new(email: 'state1_enroller@example.com', password: '1234567ab!', jurisdiction: state1, force_password_change: false, authy_enabled: false)
+    enroller1 = User.new(email: 'state1_enroller@example.com', password: '1234567ab!', jurisdiction: state1, force_password_change: false, authy_enabled: false, authy_enforced: false)
     enroller1.add_role :enroller
     enroller1.save
 
-    enroller2 = User.new(email: 'localS1C1_enroller@example.com', password: '1234567ab!', jurisdiction: county1, force_password_change: false, authy_enabled: false)
+    enroller2 = User.new(email: 'localS1C1_enroller@example.com', password: '1234567ab!', jurisdiction: county1, force_password_change: false, authy_enabled: false, authy_enforced: false)
     enroller2.add_role :enroller
     enroller2.save
 
-    enroller3 = User.new(email: 'localS1C2_enroller@example.com', password: '1234567ab!', jurisdiction: county2, force_password_change: false, authy_enabled: false)
+    enroller3 = User.new(email: 'localS1C2_enroller@example.com', password: '1234567ab!', jurisdiction: county2, force_password_change: false, authy_enabled: false, authy_enforced: false)
     enroller3.add_role :enroller
     enroller3.save
 
-    enroller4 = User.new(email: 'state2_enroller@example.com', password: '1234567ab!', jurisdiction: state2, force_password_change: false, authy_enabled: false)
+    enroller4 = User.new(email: 'state2_enroller@example.com', password: '1234567ab!', jurisdiction: state2, force_password_change: false, authy_enabled: false, authy_enforced: false)
     enroller4.add_role :enroller
     enroller4.save
 
-    enroller5 = User.new(email: 'localS2C3_enroller@example.com', password: '1234567ab!', jurisdiction: county3, force_password_change: false, authy_enabled: false)
+    enroller5 = User.new(email: 'localS2C3_enroller@example.com', password: '1234567ab!', jurisdiction: county3, force_password_change: false, authy_enabled: false, authy_enforced: false)
     enroller5.add_role :enroller
     enroller5.save
 
-    enroller6 = User.new(email: 'localS2C4_enroller@example.com', password: '1234567ab!', jurisdiction: county4, force_password_change: false, authy_enabled: false)
+    enroller6 = User.new(email: 'localS2C4_enroller@example.com', password: '1234567ab!', jurisdiction: county4, force_password_change: false, authy_enabled: false, authy_enforced: false)
     enroller6.add_role :enroller
     enroller6.save
 
@@ -53,27 +53,27 @@ namespace :demo do
 
     print 'Creating public health users...'
 
-    ph1 = User.new(email: 'state1_epi@example.com', password: '1234567ab!', jurisdiction: state1, force_password_change: false, authy_enabled: false)
+    ph1 = User.new(email: 'state1_epi@example.com', password: '1234567ab!', jurisdiction: state1, force_password_change: false, authy_enabled: false, authy_enforced: false)
     ph1.add_role :public_health
     ph1.save
 
-    ph2 = User.new(email: 'localS1C1_epi@example.com', password: '1234567ab!', jurisdiction: county1, force_password_change: false, authy_enabled: false)
+    ph2 = User.new(email: 'localS1C1_epi@example.com', password: '1234567ab!', jurisdiction: county1, force_password_change: false, authy_enabled: false, authy_enforced: false)
     ph2.add_role :public_health
     ph2.save
 
-    ph3 = User.new(email: 'localS1C2_epi@example.com', password: '1234567ab!', jurisdiction: county2, force_password_change: false, authy_enabled: false)
+    ph3 = User.new(email: 'localS1C2_epi@example.com', password: '1234567ab!', jurisdiction: county2, force_password_change: false, authy_enabled: false, authy_enforced: false)
     ph3.add_role :public_health
     ph3.save
 
-    ph4 = User.new(email: 'state2_epi@example.com', password: '1234567ab!', jurisdiction: state2, force_password_change: false, authy_enabled: false)
+    ph4 = User.new(email: 'state2_epi@example.com', password: '1234567ab!', jurisdiction: state2, force_password_change: false, authy_enabled: false, authy_enforced: false)
     ph4.add_role :public_health
     ph4.save
 
-    ph5 = User.new(email: 'localS2C3_epi@example.com', password: '1234567ab!', jurisdiction: county3, force_password_change: false, authy_enabled: false)
+    ph5 = User.new(email: 'localS2C3_epi@example.com', password: '1234567ab!', jurisdiction: county3, force_password_change: false, authy_enabled: false, authy_enforced: false)
     ph5.add_role :public_health
     ph5.save
 
-    ph6 = User.new(email: 'localS2C4_epi@example.com', password: '1234567ab!', jurisdiction: county4, force_password_change: false, authy_enabled: false)
+    ph6 = User.new(email: 'localS2C4_epi@example.com', password: '1234567ab!', jurisdiction: county4, force_password_change: false, authy_enabled: false, authy_enforced: false)
     ph6.add_role :public_health
     ph6.save
 
@@ -83,7 +83,7 @@ namespace :demo do
 
     print 'Creating public health enroller users...'
 
-    phe1 = User.new(email: 'state1_epi_enroller@example.com', password: '1234567ab!', jurisdiction: state1, force_password_change: false, authy_enabled: false)
+    phe1 = User.new(email: 'state1_epi_enroller@example.com', password: '1234567ab!', jurisdiction: state1, force_password_change: false, authy_enabled: false, authy_enforced: false)
     phe1.add_role :public_health_enroller
     phe1.save
 
@@ -93,7 +93,7 @@ namespace :demo do
 
     print 'Creating admin users...'
 
-    admin1 = User.new(email: 'admin1@example.com', password: '1234567ab!', jurisdiction: usa, force_password_change: false, authy_enabled: false)
+    admin1 = User.new(email: 'admin1@example.com', password: '1234567ab!', jurisdiction: usa, force_password_change: false, authy_enabled: false, authy_enforced: false)
     admin1.add_role :admin
     admin1.save
 
@@ -103,7 +103,7 @@ namespace :demo do
 
     print 'Creating analyst users...'
 
-    analyst1 = User.new(email: 'analyst_all@example.com', password: '1234567ab!', jurisdiction: usa, force_password_change: false, authy_enabled: false)
+    analyst1 = User.new(email: 'analyst_all@example.com', password: '1234567ab!', jurisdiction: usa, force_password_change: false, authy_enabled: false, authy_enforced: false)
     analyst1.add_role :analyst
     analyst1.save
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -10,6 +10,7 @@ state1_enroller:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 locals1c1_enroller:
   id: 2
   email: "locals1c1_enroller@example.com"
@@ -22,6 +23,7 @@ locals1c1_enroller:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 locals1c2_enroller:
   id: 3
   email: "locals1c2_enroller@example.com"
@@ -34,6 +36,7 @@ locals1c2_enroller:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 state2_enroller:
   id: 4
   email: "state2_enroller@example.com"
@@ -46,6 +49,7 @@ state2_enroller:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 locals2c3_enroller:
   id: 5
   email: "locals2c3_enroller@example.com"
@@ -58,6 +62,7 @@ locals2c3_enroller:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 locals2c4_enroller:
   id: 6
   email: "locals2c4_enroller@example.com"
@@ -70,6 +75,7 @@ locals2c4_enroller:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 state1_epi:
   id: 7
   email: "state1_epi@example.com"
@@ -82,6 +88,7 @@ state1_epi:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 locals1c1_epi:
   id: 8
   email: "locals1c1_epi@example.com"
@@ -94,6 +101,7 @@ locals1c1_epi:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 locals1c2_epi:
   id: 9
   email: "locals1c2_epi@example.com"
@@ -106,6 +114,7 @@ locals1c2_epi:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 state2_epi:
   id: 10
   email: "state2_epi@example.com"
@@ -118,6 +127,7 @@ state2_epi:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 locals2c3_epi:
   id: 11
   email: "locals2c3_epi@example.com"
@@ -130,6 +140,7 @@ locals2c3_epi:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 locals2c4_epi:
   id: 12
   email: "locals2c4_epi@example.com"
@@ -142,6 +153,7 @@ locals2c4_epi:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 state1_epi_enroller:
   id: 13
   email: "state1_epi_enroller@example.com"
@@ -154,6 +166,7 @@ state1_epi_enroller:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 admin1:
   id: 14
   email: "admin1@example.com"
@@ -166,6 +179,7 @@ admin1:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 analyst_all:
   id: 15
   email: "analyst_all@example.com"
@@ -178,6 +192,7 @@ analyst_all:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 usa_epi:
   id: 16
   email: "usa_epi@example.com"
@@ -190,6 +205,7 @@ usa_epi:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 forced_password_change_user:
   id: 17
   email: "forced_password_change_user@example.com"
@@ -202,6 +218,7 @@ forced_password_change_user:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false
 locked_user:
   id: 18
   email: "locked_user@example.com"
@@ -214,3 +231,4 @@ locked_user:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   authy_enabled: false
+  authy_enforced: false


### PR DESCRIPTION
This PR removes the use of environment variable `two_factor_auth_enabled` and replaces it with a new db column `authy_enforced`. It is important to note that `authy_enforced` is only applicable to users who do not have `authy_enabled`. If a user has `authy_enabled` they will still be presented with the 2FA screen as this routing is done by the authy gem itself.

To setup an Authy by-passable account, use the following commands in rails console:
```
user = User.find_by(email: 'username@example.com')
user.authy_enforced = false
user.authy_enabled = false      // If authy account already setup
user.authy_id = nil             // If authy account already setup
user.save!
```