### PR TITLE
Adds Info Tooltip to UI

### DIFF
--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -17,7 +17,6 @@ class Exposure extends React.Component {
       jurisdictionPath: this.props.jurisdictionPaths[this.props.currentState.patient.jurisdiction_id],
       originalJurisdictionId: this.props.currentState.patient.jurisdiction_id,
     };
-    this.lastDOETooltip = 'Used by the system to automatically calculate the monitoring period.';
     this.handleChange = this.handleChange.bind(this);
     this.handlePropagatedFieldChange = this.handlePropagatedFieldChange.bind(this);
     this.validate = this.validate.bind(this);
@@ -99,7 +98,7 @@ class Exposure extends React.Component {
                 <Form.Group as={Col} md="7" controlId="last_date_of_exposure">
                   <Form.Label className="nav-input-label">
                     LAST DATE OF EXPOSURE{schema?.fields?.last_date_of_exposure?._exclusive?.required && ' *'}
-                    <InfoTooltip tooltipText={this.lastDOETooltip} location="right"></InfoTooltip>
+                    <InfoTooltip tooltipTextKey="lastDateOfExposure" location="right"></InfoTooltip>
                   </Form.Label>
                   <Form.Control
                     isInvalid={this.state.errors['last_date_of_exposure']}

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -4,6 +4,7 @@ import { countryOptions } from '../../data';
 import { PropTypes } from 'prop-types';
 import * as yup from 'yup';
 import confirmDialog from '../../util/ConfirmDialog';
+import InfoTooltip from '../../util/InfoTooltip';
 
 class Exposure extends React.Component {
   constructor(props) {
@@ -16,6 +17,7 @@ class Exposure extends React.Component {
       jurisdictionPath: this.props.jurisdictionPaths[this.props.currentState.patient.jurisdiction_id],
       originalJurisdictionId: this.props.currentState.patient.jurisdiction_id,
     };
+    this.lastDOETooltip = 'Used by the system to automatically calculate the monitoring period.';
     this.handleChange = this.handleChange.bind(this);
     this.handlePropagatedFieldChange = this.handlePropagatedFieldChange.bind(this);
     this.validate = this.validate.bind(this);
@@ -97,6 +99,7 @@ class Exposure extends React.Component {
                 <Form.Group as={Col} md="7" controlId="last_date_of_exposure">
                   <Form.Label className="nav-input-label">
                     LAST DATE OF EXPOSURE{schema?.fields?.last_date_of_exposure?._exclusive?.required && ' *'}
+                    <InfoTooltip tooltipText={this.lastDOETooltip} location="right"></InfoTooltip>
                   </Form.Label>
                   <Form.Control
                     isInvalid={this.state.errors['last_date_of_exposure']}

--- a/app/javascript/components/subject/CaseStatus.js
+++ b/app/javascript/components/subject/CaseStatus.js
@@ -27,9 +27,9 @@ class CaseStatus extends React.Component {
   caseStatusTooltip() {
     return (
       <div>
-        Used to move records into the appropriate workflow after investigating a report of symptoms. If an individual meets the <i>confirmed</i> or{' '}
-        <i>probable</i> case definition, a user can choose to move the record to the isolation workflow or to end monitoring in Sara Alert. If the individual
-        meets another case definition, the record will be returned to the appropriate exposure monitoring line list.
+        Used to move records into the appropriate workflow after investigating a report of symptoms. If <i>confirmed</i> or <i>probable</i> is selected, the
+        user is prompted to choose between moving the record to the isolation workflow or to end monitoring. If the user selects another case status, the record
+        will be returned to the appropriate exposure monitoring line list.
       </div>
     );
   }

--- a/app/javascript/components/subject/CaseStatus.js
+++ b/app/javascript/components/subject/CaseStatus.js
@@ -3,6 +3,7 @@ import { Button, Modal, Form } from 'react-bootstrap';
 import { PropTypes } from 'prop-types';
 import axios from 'axios';
 import reportError from '../util/ReportError';
+import InfoTooltip from '../util/InfoTooltip';
 
 class CaseStatus extends React.Component {
   constructor(props) {
@@ -21,6 +22,16 @@ class CaseStatus extends React.Component {
     this.toggleCaseStatusModal = this.toggleCaseStatusModal.bind(this);
     this.submit = this.submit.bind(this);
     this.handleChange = this.handleChange.bind(this);
+  }
+
+  caseStatusTooltip() {
+    return (
+      <div>
+        Used to move records into the appropriate workflow after investigating a report of symptoms. If an individual meets the <i>confirmed</i> or{' '}
+        <i>probable</i> case definition, a user can choose to move the record to the isolation workflow or to end monitoring in Sara Alert. If the individual
+        meets another case definition, the record will be returned to the appropriate exposure monitoring line list.
+      </div>
+    );
   }
 
   handleChange(event) {
@@ -164,7 +175,10 @@ class CaseStatus extends React.Component {
     return (
       <React.Fragment>
         <div className="disabled">
-          <Form.Label className="nav-input-label">CASE STATUS</Form.Label>
+          <Form.Label className="nav-input-label">
+            CASE STATUS
+            <InfoTooltip tooltipText={this.caseStatusTooltip()} location="right"></InfoTooltip>
+          </Form.Label>
           <Form.Control as="select" className="form-control-lg" id="case_status" onChange={this.handleChange} value={this.state.case_status}>
             <option></option>
             <option>Confirmed</option>

--- a/app/javascript/components/subject/CaseStatus.js
+++ b/app/javascript/components/subject/CaseStatus.js
@@ -24,16 +24,6 @@ class CaseStatus extends React.Component {
     this.handleChange = this.handleChange.bind(this);
   }
 
-  caseStatusTooltip() {
-    return (
-      <div>
-        Used to move records into the appropriate workflow after investigating a report of symptoms. If <i>confirmed</i> or <i>probable</i> is selected, the
-        user is prompted to choose between moving the record to the isolation workflow or to end monitoring. If the user selects another case status, the record
-        will be returned to the appropriate exposure monitoring line list.
-      </div>
-    );
-  }
-
   handleChange(event) {
     event.persist();
     this.setState({ [event.target.id]: event.target.type === 'checkbox' ? event.target.checked : event.target.value, showCaseStatusModal: true }, () => {
@@ -177,7 +167,7 @@ class CaseStatus extends React.Component {
         <div className="disabled">
           <Form.Label className="nav-input-label">
             CASE STATUS
-            <InfoTooltip tooltipText={this.caseStatusTooltip()} location="right"></InfoTooltip>
+            <InfoTooltip tooltipTextKey="caseStatus" location="right"></InfoTooltip>
           </Form.Label>
           <Form.Control as="select" className="form-control-lg" id="case_status" onChange={this.handleChange} value={this.state.case_status}>
             <option></option>

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -5,6 +5,7 @@ import axios from 'axios';
 import ContactAttempt from './ContactAttempt';
 import CaseStatus from './CaseStatus';
 import reportError from '../util/ReportError';
+import InfoTooltip from '../util/InfoTooltip';
 
 class MonitoringStatus extends React.Component {
   constructor(props) {
@@ -44,6 +45,33 @@ class MonitoringStatus extends React.Component {
     this.togglePublicHealthAction = this.togglePublicHealthAction.bind(this);
     this.toggleIsolation = this.toggleIsolation.bind(this);
     this.toggleNotifications = this.toggleNotifications.bind(this);
+  }
+
+  monitoringStatusTooltip() {
+    return (
+      <div>
+        If set to{' '}
+        <i>
+          <b>Actively Monitoring</b>
+        </i>
+        , the system will move the record to the appropriate monitoring line list based on reporting history and latest public health actions. The system will
+        send daily report reminders if the record is not on the <i>PUI</i> (exposure workflow) or <i>Records Requiring Review</i> (isolation workflow) line
+        lists. If set to{' '}
+        <i>
+          <b>Not Monitoring</b>
+        </i>
+        , the records will be moved to the <i>Closed</i> line list and the system will stop sending daily report reminders.
+      </div>
+    );
+  }
+
+  caseStatusTooltip() {
+    return (
+      <div>
+        Used to move records from the symptomatic line list to the Person Under Investigation (PUI) line list in the exposure workflow. To move a record off of
+        the PUI line list in the exposure workflow, update <i>Case Status</i> based on the findings of the investigation.
+      </div>
+    );
   }
 
   handleChange(event) {
@@ -317,7 +345,10 @@ class MonitoringStatus extends React.Component {
             <Col>
               <Form.Row>
                 <Form.Group as={Col}>
-                  <Form.Label className="nav-input-label">MONITORING STATUS</Form.Label>
+                  <Form.Label className="nav-input-label">
+                    MONITORING STATUS
+                    <InfoTooltip tooltipText={this.monitoringStatusTooltip()} location="right"></InfoTooltip>
+                  </Form.Label>
                   <Form.Control
                     as="select"
                     className="form-control-lg"
@@ -363,7 +394,10 @@ class MonitoringStatus extends React.Component {
                   />
                 </Form.Group>
                 <Form.Group as={Col} md="8">
-                  <Form.Label className="nav-input-label">LATEST PUBLIC HEALTH ACTION</Form.Label>
+                  <Form.Label className="nav-input-label">
+                    LATEST PUBLIC HEALTH ACTION
+                    <InfoTooltip tooltipText={this.caseStatusTooltip()} location="right"></InfoTooltip>
+                  </Form.Label>
                   <Form.Control
                     as="select"
                     className="form-control-lg"

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -46,31 +46,6 @@ class MonitoringStatus extends React.Component {
     this.toggleIsolation = this.toggleIsolation.bind(this);
     this.toggleNotifications = this.toggleNotifications.bind(this);
   }
-  monitoringStatusTooltip() {
-    return (
-      <div>
-        If set to{' '}
-        <i>
-          <b>Actively Monitoring</b>
-        </i>
-        , the system moves the record to the appropriate line list based on reporting history and latest public health actions. The system will send daily
-        report reminders if the record is not on the <i>PUI</i> (exposure) or <i>Records Requiring Review</i> (isolation) line lists. If set to{' '}
-        <i>
-          <b>Not Monitoring</b>
-        </i>
-        , the system moves the record to the <i>Closed</i> line list and stops sending daily reminders.
-      </div>
-    );
-  }
-
-  latestPublicHealthActionTooltip() {
-    return (
-      <div>
-        Selecting any option other than <i>none</i> moves record from the symptomatic line list to the Person Under Investigation (PUI) line list in the
-        exposure workflow. To move a record off the PUI line list, update <i>Case Status</i> based on the findings of the investigation.
-      </div>
-    );
-  }
 
   handleChange(event) {
     if (event?.target?.name && event.target.name === 'jurisdictionId') {
@@ -345,7 +320,7 @@ class MonitoringStatus extends React.Component {
                 <Form.Group as={Col}>
                   <Form.Label className="nav-input-label">
                     MONITORING STATUS
-                    <InfoTooltip tooltipText={this.monitoringStatusTooltip()} location="right"></InfoTooltip>
+                    <InfoTooltip tooltipTextKey="monitoringStatus" location="right"></InfoTooltip>
                   </Form.Label>
                   <Form.Control
                     as="select"
@@ -394,7 +369,7 @@ class MonitoringStatus extends React.Component {
                 <Form.Group as={Col} md="8">
                   <Form.Label className="nav-input-label">
                     LATEST PUBLIC HEALTH ACTION
-                    <InfoTooltip tooltipText={this.latestPublicHealthActionTooltip()} location="right"></InfoTooltip>
+                    <InfoTooltip tooltipTextKey="latestPublicHealthAction" location="right"></InfoTooltip>
                   </Form.Label>
                   <Form.Control
                     as="select"

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -46,7 +46,6 @@ class MonitoringStatus extends React.Component {
     this.toggleIsolation = this.toggleIsolation.bind(this);
     this.toggleNotifications = this.toggleNotifications.bind(this);
   }
-
   monitoringStatusTooltip() {
     return (
       <div>
@@ -54,22 +53,21 @@ class MonitoringStatus extends React.Component {
         <i>
           <b>Actively Monitoring</b>
         </i>
-        , the system will move the record to the appropriate monitoring line list based on reporting history and latest public health actions. The system will
-        send daily report reminders if the record is not on the <i>PUI</i> (exposure workflow) or <i>Records Requiring Review</i> (isolation workflow) line
-        lists. If set to{' '}
+        , the system moves the record to the appropriate line list based on reporting history and latest public health actions. The system will send daily
+        report reminders if the record is not on the <i>PUI</i> (exposure) or <i>Records Requiring Review</i> (isolation) line lists. If set to{' '}
         <i>
           <b>Not Monitoring</b>
         </i>
-        , the records will be moved to the <i>Closed</i> line list and the system will stop sending daily report reminders.
+        , the system moves the record to the <i>Closed</i> line list and stops sending daily reminders.
       </div>
     );
   }
 
-  caseStatusTooltip() {
+  latestPublicHealthActionTooltip() {
     return (
       <div>
-        Used to move records from the symptomatic line list to the Person Under Investigation (PUI) line list in the exposure workflow. To move a record off of
-        the PUI line list in the exposure workflow, update <i>Case Status</i> based on the findings of the investigation.
+        Selecting any option other than <i>none</i> moves record from the symptomatic line list to the Person Under Investigation (PUI) line list in the
+        exposure workflow. To move a record off the PUI line list, update <i>Case Status</i> based on the findings of the investigation.
       </div>
     );
   }
@@ -396,7 +394,7 @@ class MonitoringStatus extends React.Component {
                 <Form.Group as={Col} md="8">
                   <Form.Label className="nav-input-label">
                     LATEST PUBLIC HEALTH ACTION
-                    <InfoTooltip tooltipText={this.caseStatusTooltip()} location="right"></InfoTooltip>
+                    <InfoTooltip tooltipText={this.latestPublicHealthActionTooltip()} location="right"></InfoTooltip>
                   </Form.Label>
                   <Form.Control
                     as="select"

--- a/app/javascript/components/subject/SymptomOnset.js
+++ b/app/javascript/components/subject/SymptomOnset.js
@@ -4,6 +4,7 @@ import { PropTypes } from 'prop-types';
 import axios from 'axios';
 import confirmDialog from '../util/ConfirmDialog';
 import reportError from '../util/ReportError';
+import InfoTooltip from '../util/InfoTooltip';
 
 class SymptomOnset extends React.Component {
   constructor(props) {
@@ -14,6 +15,9 @@ class SymptomOnset extends React.Component {
     this.handleSubmit = this.handleSubmit.bind(this);
     this.submit = this.submit.bind(this);
     this.handleChange = this.handleChange.bind(this);
+    this.systemOnsetToolTip = `Used by the system to determine if the non-test based recovery definition
+    in the isolation monitoring workflow has been met. This field will be auto-populated with the date
+    of the earliest symptomatic report in the system unless an earlier date is entered by a user.`;
   }
 
   handleChange(event) {
@@ -45,7 +49,10 @@ class SymptomOnset extends React.Component {
       <React.Fragment>
         <Row>
           <Form.Group as={Col} md="6">
-            <Form.Label className="nav-input-label">SYMPTOM ONSET</Form.Label>
+            <Form.Label className="nav-input-label">
+              SYMPTOM ONSET
+              <InfoTooltip tooltipText={this.systemOnsetToolTip} location="right"></InfoTooltip>
+            </Form.Label>
             <Form.Control
               size="lg"
               id="symptom_onset"

--- a/app/javascript/components/subject/SymptomOnset.js
+++ b/app/javascript/components/subject/SymptomOnset.js
@@ -15,9 +15,6 @@ class SymptomOnset extends React.Component {
     this.handleSubmit = this.handleSubmit.bind(this);
     this.submit = this.submit.bind(this);
     this.handleChange = this.handleChange.bind(this);
-    this.symptomOnsetTooltip = `Used by the system to determine if the non-test based recovery definition
-    in the isolation monitoring workflow has been met. This field is auto-populated with the date
-    of the earliest symptomatic report in the system unless a user enters an earlier date.`;
   }
 
   handleChange(event) {
@@ -51,7 +48,7 @@ class SymptomOnset extends React.Component {
           <Form.Group as={Col} md="6">
             <Form.Label className="nav-input-label">
               SYMPTOM ONSET
-              <InfoTooltip tooltipText={this.symptomOnsetTooltip} location="right"></InfoTooltip>
+              <InfoTooltip tooltipTextKey="symptomOnset" location="right"></InfoTooltip>
             </Form.Label>
             <Form.Control
               size="lg"

--- a/app/javascript/components/subject/SymptomOnset.js
+++ b/app/javascript/components/subject/SymptomOnset.js
@@ -15,9 +15,9 @@ class SymptomOnset extends React.Component {
     this.handleSubmit = this.handleSubmit.bind(this);
     this.submit = this.submit.bind(this);
     this.handleChange = this.handleChange.bind(this);
-    this.systemOnsetToolTip = `Used by the system to determine if the non-test based recovery definition
-    in the isolation monitoring workflow has been met. This field will be auto-populated with the date
-    of the earliest symptomatic report in the system unless an earlier date is entered by a user.`;
+    this.symptomOnsetTooltip = `Used by the system to determine if the non-test based recovery definition
+    in the isolation monitoring workflow has been met. This field is auto-populated with the date
+    of the earliest symptomatic report in the system unless a user enters an earlier date.`;
   }
 
   handleChange(event) {
@@ -51,7 +51,7 @@ class SymptomOnset extends React.Component {
           <Form.Group as={Col} md="6">
             <Form.Label className="nav-input-label">
               SYMPTOM ONSET
-              <InfoTooltip tooltipText={this.systemOnsetToolTip} location="right"></InfoTooltip>
+              <InfoTooltip tooltipText={this.symptomOnsetTooltip} location="right"></InfoTooltip>
             </Form.Label>
             <Form.Control
               size="lg"

--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import ReactTooltip from 'react-tooltip';
+
+class InfoTooltip extends React.Component {
+  constructor(props) {
+    super(props);
+    // If multiple instances of the Tooltip Exist on a page, the <ReactTooltip/> cannnot find
+    // the correct instance (due to the lack of `data-for`/`id` pairs). Therefore we generate
+    // custom string for each instance
+    this.customID = this.makeid(this.props.tooltipText.length || 10).substring(0, 6);
+  }
+
+  makeid = length => {
+    let result = '';
+    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    for (let i = 0; i < length; ++i) {
+      result += characters.charAt(Math.floor(Math.random() * characters.length));
+    }
+    return result;
+  };
+
+  render() {
+    return (
+      <div style={{ display: 'inline' }}>
+        <span data-for={this.customID} data-tip="" className="ml-1">
+          <i className="fas fa-question-circle"></i>
+        </span>
+        <ReactTooltip id={this.customID} multiline={true} place={this.props.location} type="dark" effect="solid" className="tooltip-container">
+          <span>{this.props.tooltipText}</span>
+        </ReactTooltip>
+      </div>
+    );
+  }
+}
+
+InfoTooltip.propTypes = {
+  tooltipText: PropTypes.oneOfType([
+    PropTypes.string, // Can pass in a string (eg "some helpful info")
+    PropTypes.object, // Or JSX (eg <div> some <i> helpful </i> info </div>)
+  ]),
+  location: PropTypes.string, // top, right, bottom, left
+};
+
+export default InfoTooltip;

--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -2,13 +2,66 @@ import React from 'react';
 import { PropTypes } from 'prop-types';
 import ReactTooltip from 'react-tooltip';
 
+// When adding a new tooltip in the UI create an entry in this object, and pass in the entry `key` as props
+const TOOLTIP_TEXT = {
+  caseStatus: (
+    <div>
+      Used to move records into the appropriate workflow after investigating a report of symptoms. If <i>confirmed</i> or <i>probable</i> is selected, the user
+      is prompted to choose between moving the record to the isolation workflow or to end monitoring. If the user selects another case status, the record will
+      be returned to the appropriate exposure monitoring line list.
+    </div>
+  ),
+
+  monitoringStatus: (
+    <div>
+      If set to{' '}
+      <i>
+        <b>Actively Monitoring</b>
+      </i>
+      , the system moves the record to the appropriate line list based on reporting history and latest public health actions. The system will send daily report
+      reminders if the record is not on the <i>PUI</i> (exposure) or <i>Records Requiring Review</i> (isolation) line lists. If set to{' '}
+      <i>
+        <b>Not Monitoring</b>
+      </i>
+      , the system moves the record to the <i>Closed</i> line list and stops sending daily reminders.
+    </div>
+  ),
+
+  latestPublicHealthAction: (
+    <div>
+      Selecting any option other than <i>none</i> moves record from the symptomatic line list to the Person Under Investigation (PUI) line list in the exposure
+      workflow. To move a record off the PUI line list, update <i>Case Status</i> based on the findings of the investigation.
+    </div>
+  ),
+
+  symptomOnset: (
+    <div>
+      {' '}
+      Used by the system to determine if the non-test based recovery definition in the isolation monitoring workflow has been met. This field is auto-populated
+      with the date of the earliest symptomatic report in the system unless a user enters an earlier date.{' '}
+    </div>
+  ),
+
+  purgeDate: (
+    <div>
+      {' '}
+      In order to minimize the amount of identifiable information stored on the production servers, Sara Alert will purge identifiers in records for which there
+      have been no updates for a defined time period, provided that monitoree is no longer being actively monitored. An update includes any action on the
+      record, including adding comments or updating any fields. Local administrators are sent weekly email reminders about records that meet this definition.
+      See User Guide for list of fields that are not purged for use in the analytics summary.{' '}
+    </div>
+  ),
+
+  lastDateOfExposure: <div> Used by the system to automatically calculate the monitoring period. </div>,
+};
+
 class InfoTooltip extends React.Component {
   constructor(props) {
     super(props);
     // If multiple instances of the Tooltip Exist on a page, the <ReactTooltip/> cannnot find
     // the correct instance (due to the lack of `data-for`/`id` pairs). Therefore we generate
     // custom string for each instance
-    this.customID = this.makeid(this.props.tooltipText.length || 10).substring(0, 6);
+    this.customID = this.makeid(this.props.tooltipTextKey.length || 10).substring(0, 6);
   }
 
   makeid = length => {
@@ -27,7 +80,7 @@ class InfoTooltip extends React.Component {
           <i className="fas fa-question-circle"></i>
         </span>
         <ReactTooltip id={this.customID} multiline={true} place={this.props.location} type="dark" effect="solid" className="tooltip-container">
-          <span>{this.props.tooltipText}</span>
+          <span>{TOOLTIP_TEXT[this.props.tooltipTextKey]}</span>
         </ReactTooltip>
       </div>
     );
@@ -35,10 +88,7 @@ class InfoTooltip extends React.Component {
 }
 
 InfoTooltip.propTypes = {
-  tooltipText: PropTypes.oneOfType([
-    PropTypes.string, // Can pass in a string (eg "some helpful info")
-    PropTypes.object, // Or JSX (eg <div> some <i> helpful </i> info </div>)
-  ]),
+  tooltipTextKey: PropTypes.string,
   location: PropTypes.string, // top, right, bottom, left
 };
 

--- a/app/javascript/packs/stylesheets/layout.scss
+++ b/app/javascript/packs/stylesheets/layout.scss
@@ -7,3 +7,7 @@
 .collapse-hover {
   cursor: grab;
 }
+
+.tooltip-container {
+  width: 300px;
+}

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -3,7 +3,7 @@
 require 'chronic'
 
 # Patient: patient model
-class Patient < ApplicationRecord # rubocop:todo Metrics/ClassLength
+class Patient < ApplicationRecord
   include PatientHelper
 
   columns.each do |column|

--- a/app/views/public_health/_patients.html.erb
+++ b/app/views/public_health/_patients.html.erb
@@ -8,7 +8,17 @@
           <th class="DataTable-table-header">State&#47;Local ID</th>
           <th class="DataTable-table-header">Sex</th>
           <th class="DataTable-table-header">Date of Birth</th>
-          <% if type == 'closed_patients' %><th class="DataTable-table-header">Expected Purge Date</th><% end %>
+          <% if type == 'closed_patients' %>
+            <th class="DataTable-table-header">
+              Expected Purge Date
+              <%= react_component("util/InfoTooltip", { tooltipText: 'In order to minimize the amount of identifiable information stored
+              on the production servers, Sara Alert will purge identifiers in records for which there have been no updates for a defined
+              time period, provided that monitoree is no longer being actively monitored. An update includes any action on the record,
+              including adding comments or updating any fields. Local administrators are sent weekly email reminders about records that
+              meet this definition.See User Guide for list of fields that are not purged for use in the analytics summary.',
+              location: 'right' }, {style: "display:inline"}) %>
+            </th>
+          <% end %>
           <th class="DataTable-table-header"><% if type == 'closed_patients' %>Reason for Closure<% elsif type == 'pui_patients' %>Latest Public Health Action<% else %>Monitoring Plan<% end %></th>
           <th class="DataTable-table-header"><% if type.include? 'transferred' %>Transferred At<% elsif type == 'closed_patients' %>Closed At<% else %>Latest Report<% end %></th>
           <% if type == 'all_patients' %><th class="DataTable-table-header">Status</th><% end %>

--- a/app/views/public_health/_patients.html.erb
+++ b/app/views/public_health/_patients.html.erb
@@ -11,7 +11,7 @@
           <% if type == 'closed_patients' %>
             <th class="DataTable-table-header">
               Expected Purge Date
-              <%= react_component("util/InfoTooltip", { tooltipTextKey: 'purgeDate', location: 'right' }, {style: "display:inline"}) %>
+              <%= react_component("util/InfoTooltip", { tooltipTextKey: 'purgeDate', location: 'right' }, { style: 'display:inline' }) %>
             </th>
           <% end %>
           <th class="DataTable-table-header"><% if type == 'closed_patients' %>Reason for Closure<% elsif type == 'pui_patients' %>Latest Public Health Action<% else %>Monitoring Plan<% end %></th>

--- a/app/views/public_health/_patients.html.erb
+++ b/app/views/public_health/_patients.html.erb
@@ -11,12 +11,7 @@
           <% if type == 'closed_patients' %>
             <th class="DataTable-table-header">
               Expected Purge Date
-              <%= react_component("util/InfoTooltip", { tooltipText: 'In order to minimize the amount of identifiable information stored
-              on the production servers, Sara Alert will purge identifiers in records for which there have been no updates for a defined
-              time period, provided that monitoree is no longer being actively monitored. An update includes any action on the record,
-              including adding comments or updating any fields. Local administrators are sent weekly email reminders about records that
-              meet this definition.See User Guide for list of fields that are not purged for use in the analytics summary.',
-              location: 'right' }, {style: "display:inline"}) %>
+              <%= react_component("util/InfoTooltip", { tooltipTextKey: 'purgeDate', location: 'right' }, {style: "display:inline"}) %>
             </th>
           <% end %>
           <th class="DataTable-table-header"><% if type == 'closed_patients' %>Reason for Closure<% elsif type == 'pui_patients' %>Latest Public Health Action<% else %>Monitoring Plan<% end %></th>

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-simple-maps": "^1.0.0-beta.0",
     "react-switch": "^5.0.1",
     "react-toastify": "^5.5.0",
-    "react-tooltip": "^3.11.4",
+    "react-tooltip": "^4.2.6",
     "react_ujs": "^2.6.1",
     "recharts": "^2.0.0-beta.1",
     "yup": "^0.28.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2108,6 +2108,7 @@ cdc-map@SaraAlert/CDC-Maps#build_adjustments:
     react-app-polyfill "^1.0.1"
     react-csv "^1.1.1"
     react-html-parser "^2.0.2"
+    react-scripts "3.1.1"
     react-select "^3.0.4"
     react-simple-maps "^0.12.1"
     react-sortable-hoc "^1.9.1"
@@ -7550,12 +7551,20 @@ react-toastify@^5.5.0:
     prop-types "^15.7.2"
     react-transition-group "^4"
 
-react-tooltip@^3.10.0, react-tooltip@^3.11.4:
+react-tooltip@^3.10.0:
   version "3.11.6"
   resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-3.11.6.tgz#4f9735a2a4aa50580af351ce23e74a56f41afc0c"
   integrity sha512-nTc1yHHaPCHHURvMpf/VNF17pIZiU4zwUGFJBUVr1fZkezFC7E0VPMMVrCfDjt+IpwTHICyzlyx+1FiQ7lw5LQ==
   dependencies:
     prop-types "^15.6.0"
+
+react-tooltip@^4.2.6:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.6.tgz#a3d5f0d1b0c597c0852ba09c5e2af0019b7cfc70"
+  integrity sha512-KX/zCsPFCI8RuulzBX86U+Ur7FvgGNRBdb7dUu0ndo8Urinn48nANq9wfq4ABlehweQjPzLl7XdNAtLKza+I3w==
+  dependencies:
+    prop-types "^15.7.2"
+    uuid "^7.0.3"
 
 react-transition-group@2.5.3:
   version "2.5.3"
@@ -9130,6 +9139,11 @@ uuid@^3.0.1, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 v8-compile-cache@2.0.3:
   version "2.0.3"


### PR DESCRIPTION
The functionality behind some parts of the SaraAlert Tool might not be immediately clear to the user. Based on User feedback, this PR adds hover-able Question Marks that provide helpful tips, tutorials, and explanations for certain labels/buttons. An example of a tooltip is shown here:

![image](https://user-images.githubusercontent.com/17532163/81895086-6d93a800-957f-11ea-8cb6-9c1d6dc62c06.png)
