### PR TITLE
Removes IE11 support for Monitor Analytics Image Capture

### DIFF
--- a/app/javascript/components/dashboard/MonitorAnalytics.js
+++ b/app/javascript/components/dashboard/MonitorAnalytics.js
@@ -43,8 +43,8 @@ class MonitorAnalytics extends React.Component {
   exportAsPNG() {
     // The two datatables in the cdc-maps cause the export to fail
     // remove them before the export then reload the page so that they come back
-    document.getElementsByClassName('data-table')[0].remove();
-    document.getElementsByClassName('data-table')[0].remove();
+    document.getElementsByClassName('data-table')[0].outerHTML = '';
+    document.getElementsByClassName('data-table')[0].outerHTML = '';
     var node = document.getElementById('sara-alert-body');
     domtoimage
       .toPng(node)

--- a/app/javascript/components/dashboard/MonitorAnalytics.js
+++ b/app/javascript/components/dashboard/MonitorAnalytics.js
@@ -44,7 +44,7 @@ class MonitorAnalytics extends React.Component {
     // The two datatables in the cdc-maps cause the export to fail
     // remove them before the export then reload the page so that they come back
     if (window.document.documentMode) {
-      alert('Capturing a screenshot is not supported by Internet Explorer. Please use a local image capture software instead.');
+      alert('Analytics export is not availale using the Internet Explorer web browser. Please use an alternative browser or a local image capture application instead.');
     } else {
       document.getElementsByClassName('data-table')[0].remove();
       document.getElementsByClassName('data-table')[0].remove();

--- a/app/javascript/components/dashboard/MonitorAnalytics.js
+++ b/app/javascript/components/dashboard/MonitorAnalytics.js
@@ -43,28 +43,31 @@ class MonitorAnalytics extends React.Component {
   exportAsPNG() {
     // The two datatables in the cdc-maps cause the export to fail
     // remove them before the export then reload the page so that they come back
-    document.getElementsByClassName('data-table')[0].outerHTML = '';
-    document.getElementsByClassName('data-table')[0].outerHTML = '';
-    var node = document.getElementById('sara-alert-body');
-    domtoimage
-      .toPng(node)
-      .then(dataUrl => {
-        var img = new Image();
-        img.src = dataUrl;
-        let link = document.createElement('a');
-        let email = this.props.current_user.email;
-        let currentDate = moment().format('YYYY_MM_DD');
-        let imageName = `SaraAlert_Analytics_${email}_${currentDate}.png`;
-        link.download = imageName;
-        link.href = dataUrl;
-        link.click();
-        location.reload();
-      })
-      .catch(error => {
-        alert('An error occured.');
-        console.error(error);
-        location.reload();
-      });
+    if (window.document.documentMode) {
+      alert('Capturing a screenshot is not supported by Internet Explorer. Please use a local image capture software instead.');
+    } else {
+      document.getElementsByClassName('data-table')[0].remove();
+      document.getElementsByClassName('data-table')[0].remove();
+      var node = document.getElementById('sara-alert-body');
+      domtoimage
+        .toPng(node)
+        .then(dataUrl => {
+          var img = new Image();
+          img.src = dataUrl;
+          let link = document.createElement('a');
+          let email = this.props.current_user.email;
+          let currentDate = moment().format('YYYY_MM_DD');
+          let imageName = `SaraAlert_Analytics_${email}_${currentDate}.png`;
+          link.download = imageName;
+          link.href = dataUrl;
+          link.click();
+          location.reload();
+        })
+        .catch(error => {
+          alert('An error occured. Please refresh the page.');
+          console.error(error);
+        });
+    }
   }
 
   toggleBetweenActiveAndTotal = viewTotal => this.setState({ viewTotal });


### PR DESCRIPTION
On the Analytics Dashboard, the User may download a screencapture of the dashboard. The CDC Maps component use by Sara has Tables of data beneath it that cause this to fail. These tables are removed just prior to the screencapture and then the page is re-loaded. The manner in which these tables were removed created an error with earlier versions of Internet Explorer. This PR changes that removal to use a legacy method that works across all browsers.