### PR TITLE
fixes weird padding issue for datatables tooltip svg

### DIFF
--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -77,7 +77,7 @@ class InfoTooltip extends React.Component {
     return (
       <div style={{ display: 'inline' }}>
         <span data-for={this.customID} data-tip="" className="ml-1">
-          <i className="fas fa-question-circle"></i>
+          <i className="fas fa-question-circle px-0"></i>
         </span>
         <ReactTooltip id={this.customID} multiline={true} place={this.props.location} type="dark" effect="solid" className="tooltip-container">
           <span>{TOOLTIP_TEXT[this.props.tooltipTextKey]}</span>

--- a/app/javascript/components/util/ReportError.js
+++ b/app/javascript/components/util/ReportError.js
@@ -20,7 +20,7 @@ export default function reportError(error, reportToSentry = true) {
 
   if (reportToSentry) {
     Sentry.captureException(error);
-    if (error.hasOwnProperty('toJSON')) {
+    if (Object.prototype.hasOwnProperty.call(error, 'toJSON')) {
       Sentry.captureMessage(error.toJSON());
     }
   }

--- a/app/views/public_health/_patients.html.erb
+++ b/app/views/public_health/_patients.html.erb
@@ -11,6 +11,7 @@
           <% if type == 'closed_patients' %>
             <th class="DataTable-table-header">
               Expected Purge Date
+              <%= react_component("util/InfoTooltip", { tooltipTextKey: 'purgeDate', location: 'right' }, { style: 'display:inline' }) %>
             </th>
           <% end %>
           <th class="DataTable-table-header"><% if type == 'closed_patients' %>Reason for Closure<% elsif type == 'pui_patients' %>Latest Public Health Action<% else %>Monitoring Plan<% end %></th>


### PR DESCRIPTION
Datatables was adding a `20px padding-right` which was blowing up the font-awesome question-circle svg. Adding bootstrap's `px-0` class forces that to zero, making the icon not blow up
![image](https://user-images.githubusercontent.com/17532163/82067957-62d03480-969f-11ea-999d-8c163a7caee9.png)
