### PR TITLE
Demo script and cache analytics improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console', '>= 3.3.0'
+  gem 'activerecord-import'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,9 @@ gem 'phonelib'
 # Email address validation
 gem 'valid_email2'
 
+# Bulk db inserts
+gem 'activerecord-import'
+
 group :development, :test do
   gem 'brakeman'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
@@ -90,7 +93,6 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console', '>= 3.3.0'
-  gem 'activerecord-import'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,8 @@ GEM
     activerecord (6.0.3.1)
       activemodel (= 6.0.3.1)
       activesupport (= 6.0.3.1)
+    activerecord-import (1.0.4)
+      activerecord (>= 3.2)
     activerecord-session_store (1.1.3)
       actionpack (>= 4.0)
       activerecord (>= 4.0)
@@ -341,6 +343,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import
   activerecord-session_store
   activerecord_where_assoc
   ancestry

--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -29,16 +29,12 @@ class CacheAnalyticsJob < ApplicationJob
         jurisdiction_analytic_map[root_node_path].symptomatic_state_map = symp_by_state.to_s
         jurisdiction_analytic_map[root_node_path].monitoree_state_map = monitored_by_state.to_s
       end
-      monitoree_counts = []
-      monitoree_snapshots = []
       jurisdiction_analytic_map.each do |_jur_path, analytic|
         analytic.save!
         patients = Jurisdiction.find(analytic.jurisdiction_id).all_patients
-        monitoree_counts.concat(self.class.all_monitoree_counts(analytic.id, patients))
-        monitoree_snapshots.concat(self.class.all_monitoree_snapshots(analytic.id, patients, analytic.jurisdiction_id))
+        MonitoreeCount.import! self.class.all_monitoree_counts(analytic.id, patients)
+        MonitoreeSnapshot.import! self.class.all_monitoree_snapshots(analytic.id, patients, analytic.jurisdiction_id)
       end
-      MonitoreeCount.import! monitoree_counts
-      MonitoreeSnapshot.import! monitoree_snapshots
     end
   end
 

--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -28,9 +28,16 @@ class CacheAnalyticsJob < ApplicationJob
       jurisdiction_analytic_map[root_node_path].symptomatic_state_map = symp_by_state.to_s
       jurisdiction_analytic_map[root_node_path].monitoree_state_map = monitored_by_state.to_s
     end
+    monitoree_counts = []
+    monitoree_snapshots = []
     jurisdiction_analytic_map.each do |_jur_path, analytic|
       analytic.save!
+      patients = Jurisdiction.find(analytic.jurisdiction_id).all_patients
+      monitoree_counts.concat(self.class.all_monitoree_counts(analytic.id, patients))
+      monitoree_snapshots.concat(self.class.all_monitoree_snapshots(analytic.id, patients, analytic.jurisdiction_id))
     end
+    MonitoreeCount.import! monitoree_counts
+    MonitoreeSnapshot.import! monitoree_snapshots
   end
 
   MONITORING_STATUSES ||= %w[Symptomatic Non-Reporting Asymptomatic].freeze
@@ -59,8 +66,6 @@ class CacheAnalyticsJob < ApplicationJob
     analytic.closed_cases_count = jurisdiction_monitorees.monitoring_closed_with_purged.size
     analytic.open_cases_count = jurisdiction_monitorees.monitoring_open.size
     analytic.non_reporting_monitorees_count = jurisdiction_monitorees.non_reporting.size
-    analytic.monitoree_counts = all_monitoree_counts(jurisdiction.all_patients)
-    analytic.monitoree_snapshots = all_monitoree_snapshots(jurisdiction.all_patients, jurisdiction.id)
     analytic
   end
 
@@ -89,50 +94,50 @@ class CacheAnalyticsJob < ApplicationJob
   end
 
   # Compute all monitoree counts
-  def self.all_monitoree_counts(monitorees)
+  def self.all_monitoree_counts(analytic_id, monitorees)
     counts = []
 
     # Active and overall total counts
-    counts.concat(monitoree_counts_by_total(monitorees, true))
-    counts.concat(monitoree_counts_by_total(monitorees, false))
+    counts.concat(monitoree_counts_by_total(analytic_id, monitorees, true))
+    counts.concat(monitoree_counts_by_total(analytic_id, monitorees, false))
 
     # Monitoring status counts for today's reporting summary
-    counts.concat(monitoree_counts_by_monitoring_status(monitorees))
+    counts.concat(monitoree_counts_by_monitoring_status(analytic_id, monitorees))
 
     # Active and overall counts for epidemiological summary
-    counts.concat(monitoree_counts_by_age_group(monitorees, true))
-    counts.concat(monitoree_counts_by_age_group(monitorees, false))
-    counts.concat(monitoree_counts_by_sex(monitorees, true))
-    counts.concat(monitoree_counts_by_sex(monitorees, false))
-    counts.concat(monitoree_counts_by_risk_factor(monitorees, true))
-    counts.concat(monitoree_counts_by_risk_factor(monitorees, false))
-    counts.concat(monitoree_counts_by_exposure_country(monitorees, true))
-    counts.concat(monitoree_counts_by_exposure_country(monitorees, false))
+    counts.concat(monitoree_counts_by_age_group(analytic_id, monitorees, true))
+    counts.concat(monitoree_counts_by_age_group(analytic_id, monitorees, false))
+    counts.concat(monitoree_counts_by_sex(analytic_id, monitorees, true))
+    counts.concat(monitoree_counts_by_sex(analytic_id, monitorees, false))
+    counts.concat(monitoree_counts_by_risk_factor(analytic_id, monitorees, true))
+    counts.concat(monitoree_counts_by_risk_factor(analytic_id, monitorees, false))
+    counts.concat(monitoree_counts_by_exposure_country(analytic_id, monitorees, true))
+    counts.concat(monitoree_counts_by_exposure_country(analytic_id, monitorees, false))
 
     # Active and overall counts for date of last exposure
-    counts.concat(monitoree_counts_by_last_exposure_date(monitorees, true))
-    counts.concat(monitoree_counts_by_last_exposure_date(monitorees, false))
-    counts.concat(monitoree_counts_by_last_exposure_week(monitorees, true))
-    counts.concat(monitoree_counts_by_last_exposure_week(monitorees, false))
-    counts.concat(monitoree_counts_by_last_exposure_month(monitorees, true))
-    counts.concat(monitoree_counts_by_last_exposure_month(monitorees, false))
+    counts.concat(monitoree_counts_by_last_exposure_date(analytic_id, monitorees, true))
+    counts.concat(monitoree_counts_by_last_exposure_date(analytic_id, monitorees, false))
+    counts.concat(monitoree_counts_by_last_exposure_week(analytic_id, monitorees, true))
+    counts.concat(monitoree_counts_by_last_exposure_week(analytic_id, monitorees, false))
+    counts.concat(monitoree_counts_by_last_exposure_month(analytic_id, monitorees, true))
+    counts.concat(monitoree_counts_by_last_exposure_month(analytic_id, monitorees, false))
 
     counts
   end
 
   # Total monitoree counts
-  def self.monitoree_counts_by_total(monitorees, active_monitoring)
+  def self.monitoree_counts_by_total(analytic_id, monitorees, active_monitoring)
     monitorees.monitoring_active(active_monitoring)
               .group(:exposure_risk_assessment)
               .order(:exposure_risk_assessment)
               .size
               .map do |risk_level, total|
-                monitoree_count(active_monitoring, 'Overall Total', 'Total', risk_level, total)
+                monitoree_count(analytic_id, active_monitoring, 'Overall Total', 'Total', risk_level, total)
               end
   end
 
   # Monitoree counts by monitoring status (symptomatic, non-reporting, asymptomatic)
-  def self.monitoree_counts_by_monitoring_status(monitorees)
+  def self.monitoree_counts_by_monitoring_status(analytic_id, monitorees)
     counts = []
     MONITORING_STATUSES.each do |monitoring_status|
       monitorees.monitoring_status(monitoring_status)
@@ -140,14 +145,14 @@ class CacheAnalyticsJob < ApplicationJob
                 .order(:exposure_risk_assessment)
                 .size
                 .each do |risk_level, total|
-                  counts.append(monitoree_count(true, 'Monitoring Status', monitoring_status, risk_level, total))
+                  counts.append(monitoree_count(analytic_id, true, 'Monitoring Status', monitoring_status, risk_level, total))
                 end
     end
     counts
   end
 
   # Monitoree counts by age group
-  def self.monitoree_counts_by_age_group(monitorees, active_monitoring)
+  def self.monitoree_counts_by_age_group(analytic_id, monitorees, active_monitoring)
     age_groups = <<-SQL
       CASE
         WHEN TIMESTAMPDIFF(YEAR, date_of_birth, CURDATE()) < 20 THEN '0-19'
@@ -165,23 +170,23 @@ class CacheAnalyticsJob < ApplicationJob
               .order(Arel.sql(age_groups), :exposure_risk_assessment)
               .size
               .map do |fields, total|
-                monitoree_count(active_monitoring, 'Age Group', fields[0], fields[1], total)
+                monitoree_count(analytic_id, active_monitoring, 'Age Group', fields[0], fields[1], total)
               end
   end
 
   # Monitoree counts by sex
-  def self.monitoree_counts_by_sex(monitorees, active_monitoring)
+  def self.monitoree_counts_by_sex(analytic_id, monitorees, active_monitoring)
     monitorees.monitoring_active(active_monitoring)
               .group(:sex, :exposure_risk_assessment)
               .order(:sex, :exposure_risk_assessment)
               .size
               .map do |fields, total|
-                monitoree_count(active_monitoring, 'Sex', fields[0].nil? ? 'Missing' : fields[0], fields[1], total)
+                monitoree_count(analytic_id, active_monitoring, 'Sex', fields[0].nil? ? 'Missing' : fields[0], fields[1], total)
               end
   end
 
   # Monitoree counts by exposure risk factors
-  def self.monitoree_counts_by_risk_factor(monitorees, active_monitoring)
+  def self.monitoree_counts_by_risk_factor(analytic_id, monitorees, active_monitoring)
     counts = []
     # Individual risk factors
     RISK_FACTORS.each do |risk_factor, label|
@@ -191,7 +196,7 @@ class CacheAnalyticsJob < ApplicationJob
                 .order(:exposure_risk_assessment)
                 .size
                 .map do |fields, total|
-                  counts.append(monitoree_count(active_monitoring, 'Risk Factor', label, fields[1], total))
+                  counts.append(monitoree_count(analytic_id, active_monitoring, 'Risk Factor', label, fields[1], total))
                 end
     end
     # Total
@@ -201,13 +206,13 @@ class CacheAnalyticsJob < ApplicationJob
               .order(:exposure_risk_assessment)
               .size
               .map do |risk_level, total|
-                counts.append(monitoree_count(active_monitoring, 'Risk Factor', 'Total', risk_level, total))
+                counts.append(monitoree_count(analytic_id, active_monitoring, 'Risk Factor', 'Total', risk_level, total))
               end
     counts
   end
 
   # Monitoree counts by exposure country
-  def self.monitoree_counts_by_exposure_country(monitorees, active_monitoring)
+  def self.monitoree_counts_by_exposure_country(analytic_id, monitorees, active_monitoring)
     counts = []
     # Individual countries
     exposure_countries = monitorees.monitoring_active(active_monitoring)
@@ -223,7 +228,7 @@ class CacheAnalyticsJob < ApplicationJob
               .order(:potential_exposure_country, :exposure_risk_assessment)
               .size
               .map do |fields, total|
-                counts.append(monitoree_count(active_monitoring, 'Exposure Country', fields[0], fields[1], total))
+                counts.append(monitoree_count(analytic_id, active_monitoring, 'Exposure Country', fields[0], fields[1], total))
               end
     # Total
     monitorees.monitoring_active(active_monitoring)
@@ -231,25 +236,25 @@ class CacheAnalyticsJob < ApplicationJob
               .group(:exposure_risk_assessment).order(:exposure_risk_assessment)
               .size
               .map do |risk_level, total|
-                counts.append(monitoree_count(active_monitoring, 'Exposure Country', 'Total', risk_level, total))
+                counts.append(monitoree_count(analytic_id, active_monitoring, 'Exposure Country', 'Total', risk_level, total))
               end
     counts
   end
 
   # Monitoree counts by last date of exposure by days
-  def self.monitoree_counts_by_last_exposure_date(monitorees, active_monitoring)
+  def self.monitoree_counts_by_last_exposure_date(analytic_id, monitorees, active_monitoring)
     monitorees.monitoring_active(active_monitoring)
               .exposed_in_time_frame(NUM_PAST_EXPOSURE_DAYS.days.ago.to_date.to_datetime)
               .group(:last_date_of_exposure, :exposure_risk_assessment)
               .order(:last_date_of_exposure, :exposure_risk_assessment)
               .size
               .map do |fields, total|
-                monitoree_count(active_monitoring, 'Last Exposure Date', fields[0], fields[1], total)
+                monitoree_count(analytic_id, active_monitoring, 'Last Exposure Date', fields[0], fields[1], total)
               end
   end
 
   # Monitoree counts by last date of exposure by weeks
-  def self.monitoree_counts_by_last_exposure_week(monitorees, active_monitoring)
+  def self.monitoree_counts_by_last_exposure_week(analytic_id, monitorees, active_monitoring)
     exposure_weeks = <<-SQL
       DATE_ADD(last_date_of_exposure, INTERVAL(1 - DAYOFWEEK(last_date_of_exposure)) DAY)
     SQL
@@ -259,12 +264,12 @@ class CacheAnalyticsJob < ApplicationJob
               .order(Arel.sql(exposure_weeks), :exposure_risk_assessment)
               .size
               .map do |fields, total|
-                monitoree_count(active_monitoring, 'Last Exposure Week', fields[0], fields[1], total)
+                monitoree_count(analytic_id, active_monitoring, 'Last Exposure Week', fields[0], fields[1], total)
               end
   end
 
   # Monitoree counts by last date of exposure by months
-  def self.monitoree_counts_by_last_exposure_month(monitorees, active_monitoring)
+  def self.monitoree_counts_by_last_exposure_month(analytic_id, monitorees, active_monitoring)
     exposure_months = <<-SQL
       DATE_FORMAT(last_date_of_exposure ,'%Y-%m-01')
     SQL
@@ -274,13 +279,14 @@ class CacheAnalyticsJob < ApplicationJob
               .order(Arel.sql(exposure_months), :exposure_risk_assessment)
               .size
               .map do |fields, total|
-                monitoree_count(active_monitoring, 'Last Exposure Month', fields[0], fields[1], total)
+                monitoree_count(analytic_id, active_monitoring, 'Last Exposure Month', fields[0], fields[1], total)
               end
   end
 
   # New monitoree count with given fields
-  def self.monitoree_count(active_monitoring, category_type, category, risk_level, total)
+  def self.monitoree_count(analytic_id, active_monitoring, category_type, category, risk_level, total)
     MonitoreeCount.new(
+      analytic_id: analytic_id,
       active_monitoring: active_monitoring,
       category_type: category_type,
       category: category,
@@ -290,10 +296,11 @@ class CacheAnalyticsJob < ApplicationJob
   end
 
   # Monitoree flow over time and monitoree action summary
-  def self.all_monitoree_snapshots(monitorees, jurisdiction_id)
+  def self.all_monitoree_snapshots(analytic_id, monitorees, jurisdiction_id)
     # rubocop:disable Layout/LineLength
     MONITOREE_SNAPSHOT_TIME_FRAMES.map do |time_frame|
       MonitoreeSnapshot.new(
+        analytic_id: analytic_id,
         time_frame: time_frame,
         new_enrollments: monitorees.enrolled_in_time_frame(time_frame).size,
         transferred_in: Transfer.with_incoming_jurisdiction_id(jurisdiction_id).in_time_frame(time_frame).size,

--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -7,7 +7,7 @@ class CacheAnalyticsJob < ApplicationJob
   def perform(*_args)
     jurisdiction_analytic_map = {}
 
-    leaf_nodes = Jurisdiction.leaf_nodes
+    leaf_nodes = Jurisdiction.all.select { |jur| jur.has_children? == false }
     leaf_nodes.each do |leaf_jurisdiction|
       leaf_analytic = self.class.calculate_analytic_local_to_jurisdiction(leaf_jurisdiction)
       jurisdiction_analytic_map[leaf_jurisdiction[:path]] = leaf_analytic

--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -304,7 +304,7 @@ class CacheAnalyticsJob < ApplicationJob
         time_frame: time_frame,
         new_enrollments: monitorees.enrolled_in_time_frame(time_frame).size,
         transferred_in: Transfer.with_incoming_jurisdiction_id(jurisdiction_id).in_time_frame(time_frame).size,
-        closed: monitorees.monitoring_closed.joins(:histories).merge(History.not_monitoring.in_time_frame(time_frame)).size,
+        closed: monitorees.monitoring_closed.closed_in_time_frame(time_frame).size,
         transferred_out: Transfer.with_outgoing_jurisdiction_id(jurisdiction_id).in_time_frame(time_frame).size,
         referral_for_medical_evaluation: monitorees.joins(:histories).merge(History.referral_for_medical_evaluation.in_time_frame(time_frame)).size,
         document_completed_medical_evaluation: monitorees.joins(:histories).merge(History.document_completed_medical_evaluation.in_time_frame(time_frame)).size,

--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -284,7 +284,7 @@ class CacheAnalyticsJob < ApplicationJob
   end
 
   # New monitoree count with given fields
-  def self.monitoree_count(analytic_id, active_monitoring, category_type, category, risk_level, total)
+  def self.monitoree_count(analytic_id, active_monitoring, category_type, category, risk_level, total) # rubocop:todo Metrics/ParameterLists
     MonitoreeCount.new(
       analytic_id: analytic_id,
       active_monitoring: active_monitoring,

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -2,6 +2,8 @@
 
 # Assessment: assessment model
 class Assessment < ApplicationRecord
+  has_one :reported_condition
+  
   columns.each do |column|
     case column.type
     when :text

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -2,8 +2,6 @@
 
 # Assessment: assessment model
 class Assessment < ApplicationRecord
-  has_one :reported_condition
-  
   columns.each do |column|
     case column.type
     when :text

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -44,11 +44,6 @@ class History < ApplicationRecord
     end
   }
 
-  # All histories that are monitoring changes in which a patient is no longer monitored
-  scope :not_monitoring, lambda {
-    where('comment LIKE \'%Not Monitoring%\'')
-  }
-
   # All histories that are public health actions for medical evaluation referrals
   scope :referral_for_medical_evaluation, lambda {
     where('comment LIKE \'%Recommended medical evaluation of symptoms%\'')

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -13,14 +13,6 @@ class Jurisdiction < ApplicationRecord
 
   has_many :analytics, class_name: 'Analytic'
 
-  scope :leaf_nodes, lambda {
-    Jurisdiction.all.select { |jur| jur.has_children? == false }
-  }
-
-  scope :non_leaf_nodes, lambda {
-    Jurisdiction.all.select { |jur| jur.has_children? == true }
-  }
-
   # All patients are all those in this or descendent jurisdictions
   def all_patients
     Patient.includes([:jurisdiction]).where(jurisdiction_id: subtree_ids)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -296,6 +296,20 @@ class Patient < ApplicationRecord # rubocop:todo Metrics/ClassLength
     end
   }
 
+  # All individuals closed within the given time frame
+  scope :closed_in_time_frame, lambda { |time_frame|
+    case time_frame
+    when 'Last 24 Hours'
+      where('patients.closed_at >= ?', 24.hours.ago)
+    when 'Last 14 Days'
+      where('patients.closed_at >= ? AND patients.closed_at < ?', 14.days.ago.to_date.to_datetime, Date.today.to_datetime)
+    when 'Total'
+      all
+    else
+      none
+    end
+  }
+
   # Order individuals based on their public health assigned risk assessment
   def self.order_by_risk(asc = true)
     order_by = ["WHEN exposure_risk_assessment='High' THEN 0",

--- a/app/models/reported_condition.rb
+++ b/app/models/reported_condition.rb
@@ -2,8 +2,8 @@
 
 # ReportedCondition
 class ReportedCondition < Condition
-  belongs_to :assessment
-  
+  belongs_to :assessment, optional: true
+
   def threshold_condition
     # Because threshold_condition_hash is calculated based on jurisdiction_path and edit_count
     # there should never be multiple threshold_condition_hash with the same non-nil value.

--- a/app/models/reported_condition.rb
+++ b/app/models/reported_condition.rb
@@ -2,6 +2,8 @@
 
 # ReportedCondition
 class ReportedCondition < Condition
+  belongs_to :assessment
+  
   def threshold_condition
     # Because threshold_condition_hash is calculated based on jurisdiction_path and edit_count
     # there should never be multiple threshold_condition_hash with the same non-nil value.

--- a/app/models/reported_condition.rb
+++ b/app/models/reported_condition.rb
@@ -2,7 +2,7 @@
 
 # ReportedCondition
 class ReportedCondition < Condition
-  belongs_to :assessment, optional: true
+  belongs_to :assessment
 
   def threshold_condition
     # Because threshold_condition_hash is calculated based on jurisdiction_path and edit_count

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -254,11 +254,11 @@ namespace :demo do
         Patient.update(patient_symptom_onset_date_updates.keys, patient_symptom_onset_date_updates.values)
         printf(" done.\n")
 
-        # Create laboratories for 10-20% of isolation patients on any given day
+        # Create laboratories for 20-30% of isolation patients on any given day
         printf("Generating laboratories...")
         laboratories = []
         isolation_patients = existing_patients.where(isolation: true)
-        patient_ids_lab = isolation_patients.pluck(:id).sample(isolation_patients.count * rand(20..25) / 100)
+        patient_ids_lab = isolation_patients.pluck(:id).sample(isolation_patients.count * rand(20..30) / 100)
         patient_ids_lab.each_with_index do |patient_id, index|
           printf("\rGenerating laboratory #{index+1} of #{patient_ids_lab.length}...")
           timestamp = Faker::Time.between_dates(from: today, to: today, period: :day)
@@ -268,7 +268,7 @@ namespace :demo do
             lab_type: ['PCR', 'Antigen', 'Total Antibody', 'IgG Antibody', 'IgM Antibody', 'IgA Antibody', 'Other'].sample,
             specimen_collection: Faker::Time.between_dates(from: 2.weeks.ago, to: report_date, period: :day),
             report: report_date,
-            result: ['positive', 'negative', 'indeterminate', 'other'].sample,
+            result: (Array.new(3, 'positive') + Array.new(5, 'negative') + ['indeterminate', 'other']).sample,
             created_at: timestamp,
             updated_at: timestamp
           )

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -237,7 +237,7 @@ namespace :demo do
         printf("Generating transfers...")
         transfers = []
         patient_updates = {}
-        patient_and_jur_ids_transfer = existing_patients.pluck(:id, :jurisdiction_id).sample(existing_patients.count * rand(0..10) / 100)
+        patient_and_jur_ids_transfer = existing_patients.pluck(:id, :jurisdiction_id).sample(existing_patients.count * rand(5..15) / 100)
         patient_and_jur_ids_transfer.each_with_index do |(patient_id, jur_id), index|
           printf("\rGenerating transfer #{index+1} of #{patient_and_jur_ids_transfer.length}...")
           timestamp = Faker::Time.between_dates(from: today, to: today, period: :day)

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -166,7 +166,7 @@ namespace :demo do
         # Histories to be created today
         histories = []
       
-        # Create assessments for 80-90% of patients on any given day
+        # Create assessments
         printf("Generating assessments...")
 
         # Get symptoms for each jurisdiction
@@ -176,7 +176,7 @@ namespace :demo do
         end
         
         # Generate unpopulated assessments
-        patient_and_jur_ids_assessment = existing_patients.pluck(:id, :jurisdiction_id).sample(existing_patients.count * rand(80..90) / 100)
+        patient_and_jur_ids_assessment = existing_patients.pluck(:id, :jurisdiction_id).sample(existing_patients.count * rand(70..75) / 100)
         patient_and_jur_ids_assessment.each_with_index do |(patient_id, jur_id), index|
           printf("\rGenerating assessment #{index+1} of #{patient_and_jur_ids_assessment.length}...")
           timestamp = Faker::Time.between_dates(from: today, to: today, period: :day)
@@ -249,7 +249,7 @@ namespace :demo do
         printf("Generating transfers...")
         transfers = []
         patient_updates = {}
-        patient_and_jur_ids_transfer = existing_patients.pluck(:id, :jurisdiction_id).sample(existing_patients.count * rand(5..15) / 100)
+        patient_and_jur_ids_transfer = existing_patients.pluck(:id, :jurisdiction_id).sample(existing_patients.count * rand(5..10) / 100)
         patient_and_jur_ids_transfer.each_with_index do |(patient_id, jur_id), index|
           printf("\rGenerating transfer #{index+1} of #{patient_and_jur_ids_transfer.length}...")
           timestamp = Faker::Time.between_dates(from: today, to: today, period: :day)
@@ -337,7 +337,7 @@ namespace :demo do
             pause_notifications: rand < 0.1,
             submission_token: SecureRandom.hex(20),
             created_at: timestamp,
-            updated_at: timestamp
+            updated_at: Faker::Time.between_dates(from: timestamp, to: today, period: :day)
           )
 
           patient[%i[white black_or_african_american american_indian_or_alaska_native asian native_hawaiian_or_other_pacific_islander].sample] = true
@@ -374,7 +374,7 @@ namespace :demo do
           patient[:monitoring_plan] = ['Self-monitoring with delegated supervision', 'Daily active monitoring',
                                        'Self-monitoring with public health supervision', 'Self-observation', 'None', nil].sample
           
-          if !isol && rand < 0.1
+          if !isol && rand < 0.075
             patient[:public_health_action] = [
               'Recommended medical evaluation of symptoms',
               'Document results of medical evaluation',
@@ -397,7 +397,7 @@ namespace :demo do
             patient_id: patient[:id],
             history_type: 'Enrollment',
             created_at: patient[:created_at],
-            updated_at: patient[:updated_at],
+            updated_at: patient[:created_at],
           )
           # monitoring status
           histories << History.new(
@@ -405,7 +405,7 @@ namespace :demo do
             comment: "User changed monitoring status to \"Not Monitoring\". Reason: #{patient[:monitoring_reason]}",
             patient_id: patient[:id],
             history_type: 'Monitoring Change',
-            created_at: patient[:created_at],
+            created_at: patient[:updated_at],
             updated_at: patient[:updated_at],
           ) unless patient[:monitoring]
           # exposure risk assessment
@@ -414,7 +414,7 @@ namespace :demo do
             comment: "User changed exposure risk assessment to \"#{patient[:exposure_risk_assessment]}\".",
             patient_id: patient[:id],
             history_type: 'Monitoring Change',
-            created_at: patient[:created_at],
+            created_at: patient[:updated_at],
             updated_at: patient[:updated_at],
           ) unless patient[:exposure_risk_assessment].nil?
           # case status
@@ -423,7 +423,7 @@ namespace :demo do
             comment: "User changed case status to \"#{patient[:case_status]}\", and chose to \"Continue Monitoring in Isolation Workflow\".",
             patient_id: patient[:id],
             history_type: 'Monitoring Change',
-            created_at: patient[:created_at],
+            created_at: patient[:updated_at],
             updated_at: patient[:updated_at],
           ) unless patient[:case_status].nil?
           # public health action
@@ -432,7 +432,7 @@ namespace :demo do
             comment: "User changed latest public health action to \"#{patient[:public_health_action]}\".",
             patient_id: patient[:id],
             history_type: 'Monitoring Change',
-            created_at: patient[:created_at],
+            created_at: patient[:updated_at],
             updated_at: patient[:updated_at],
           ) unless patient[:public_health_action] == 'None'
           # pause notifications
@@ -441,7 +441,7 @@ namespace :demo do
             comment: "User paused notifications for this monitoree.",
             patient_id: patient[:id],
             history_type: 'Monitoring Change',
-            created_at: patient[:created_at],
+            created_at: patient[:updated_at],
             updated_at: patient[:updated_at],
           ) unless patient[:public_health_action] == 'None'
         end

--- a/test/factories/assessment.rb
+++ b/test/factories/assessment.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :assessment do
+    patient { create(:patient) }
+  end
+end

--- a/test/factories/reported_condition.rb
+++ b/test/factories/reported_condition.rb
@@ -3,5 +3,6 @@
 FactoryBot.define do
   factory :reported_condition, parent: :condition, class: 'ReportedCondition' do
     type { 'ReportedCondition' }
+    assessment { create(:assessment) }
   end
 end

--- a/test/fixtures/histories.yml
+++ b/test/fixtures/histories.yml
@@ -1,27 +1,3 @@
-close_patient_5:
-  id: 1005
-  patient_id: 5
-  comment: 'User changed monitoring status to "Not Monitoring". Reason: Lost to follow-up during monitoring period, notes'
-  created_by: 'state1_epi_enroller@example.com'
-  history_type: 'Monitoring Change'
-  created_at: '<%= 20.days.ago %>'
-  updated_at: '<%= 20.days.ago %>'
-close_patient_14:
-  id: 1014
-  patient_id: 14
-  comment: 'User changed monitoring status to "Not Monitoring". Reason: Lost to follow-up during monitoring period, notes'
-  created_by: 'state1_epi_enroller@example.com'
-  history_type: 'Monitoring Change'
-  created_at: '<%= 3.days.ago %>'
-  updated_at: '<%= 3.days.ago %>'
-close_patient_18:
-  id: 1018
-  patient_id: 18
-  comment: 'User changed monitoring status to "Not Monitoring". Reason: Lost to follow-up during monitoring period, notes'
-  created_by: 'state1_epi_enroller@example.com'
-  history_type: 'Monitoring Change'
-  created_at: '<%= 5.hours.ago %>'
-  updated_at: '<%= 5.hours.ago %>'
 public_health_action_patient_6:
   id: 2006
   patient_id: 6

--- a/test/fixtures/patients.yml
+++ b/test/fixtures/patients.yml
@@ -144,6 +144,7 @@ patient_5:
   jurisdiction_id: 2
   submission_token: "746fb25b5d6b2eb7b3cc8c1eae2862900e39759f"
   monitoring: false
+  closed_at: "<%= 1.hour.ago %>"
   first_name: "Nicolas00"
   last_name: "McClure72"
   date_of_birth: "<%= 14.years.ago %>"
@@ -351,6 +352,7 @@ patient_14:
   updated_at: "<%= 4.days.ago %>"
   jurisdiction_id: 1
   monitoring: false
+  closed_at: "<%= 5.hours.ago %>"
   first_name: "Sarah"
   last_name: "Chung"
   sex: "Female"
@@ -436,6 +438,7 @@ patient_18:
   updated_at: "<%= 23.hours.ago %>"
   jurisdiction_id: 1
   monitoring: false
+  closed_at: "<%= 5.days.ago %>"
   first_name: "Theon"
   last_name: "Greyjoy"
   sex: "Unknown"
@@ -510,12 +513,14 @@ patient_23:
   id: 23
   jurisdiction_id: 8
   monitoring: false
+  closed_at: "<%= 9.hours.ago %>"
   exposure_risk_assessment: 'Low'
   last_date_of_exposure: "<%= 3.weeks.ago %>"
 patient_24:
   id: 24
   jurisdiction_id: 8
   monitoring: false
+  closed_at: "<%= 1.week.ago %>"
   exposure_risk_assessment: 'Medium'
   last_date_of_exposure: "<%= 11.weeks.ago %>"
 patient_25:
@@ -528,6 +533,7 @@ patient_26:
   id: 26
   jurisdiction_id: 8
   monitoring: false
+  closed_at: "<%= 1.day.ago %>"
   exposure_risk_assessment: 'No Identified Risk'
   last_date_of_exposure: "<%= 21.weeks.ago %>"
 patient_27:
@@ -568,6 +574,7 @@ patient_33:
   id: 33
   jurisdiction_id: 9
   monitoring: false
+  closed_at: "<%= 3.weeks.ago %>"
   exposure_risk_assessment: 'Medium'
   last_date_of_exposure: '<%= 2.months.ago %>'
 patient_34:
@@ -598,6 +605,7 @@ patient_38:
   id: 38
   jurisdiction_id: 9
   monitoring: false
+  closed_at: "<%= 5.days.ago %>"
   exposure_risk_assessment: 'Medium'
   last_date_of_exposure: '<%= 11.months.ago %>'
 patient_39:

--- a/test/jobs/analytics_job_test.rb
+++ b/test/jobs/analytics_job_test.rb
@@ -12,7 +12,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     MonitoreeSnapshot.delete_all
     CacheAnalyticsJob.perform_now()
     assert_equal(8, Analytic.all.size)
-    assert_equal(593, MonitoreeCount.all.size)
+    assert_equal(589, MonitoreeCount.all.size)
     assert_equal(24, MonitoreeSnapshot.all.size)
   end
   
@@ -47,7 +47,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
   
   test 'all monitoree counts' do
     counts = CacheAnalyticsJob.all_monitoree_counts(1, @@monitorees)
-    assert_equal(244, counts.length)
+    assert_equal(241, counts.length)
   end
   
   test 'monitoree counts by total' do

--- a/test/jobs/analytics_job_test.rb
+++ b/test/jobs/analytics_job_test.rb
@@ -12,7 +12,19 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     MonitoreeSnapshot.delete_all
     CacheAnalyticsJob.perform_now()
     assert_equal(8, Analytic.all.size)
-    assert_equal(587, MonitoreeCount.all.size)
+    assert_equal(38, MonitoreeCount.where(category_type: 'Overall Total').size)
+    assert_equal(17, MonitoreeCount.where(category_type: 'Monitoring Status').size)
+    assert_equal(95, MonitoreeCount.where(category_type: 'Age Group').size)
+    assert_equal(79, MonitoreeCount.where(category_type: 'Sex').size)
+    assert_equal(53, MonitoreeCount.where(category_type: 'Risk Factor').size)
+    assert_equal(63, MonitoreeCount.where(category_type: 'Exposure Country').size)
+    assert_not_equal(0, MonitoreeCount.where(category_type: 'Last Exposure Date').size)
+    assert_not_equal(0, MonitoreeCount.where(category_type: 'Last Exposure Week').size)
+    assert_not_equal(0, MonitoreeCount.where(category_type: 'Last Exposure Month').size)
+    assert_not_equal(0, MonitoreeCount.all.size)
+    assert_equal(8, MonitoreeSnapshot.where(time_frame: 'Last 24 Hours').size)
+    assert_equal(8, MonitoreeSnapshot.where(time_frame: 'Last 14 Days').size)
+    assert_equal(8, MonitoreeSnapshot.where(time_frame: 'Total').size)
     assert_equal(24, MonitoreeSnapshot.all.size)
   end
   
@@ -47,7 +59,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
   
   test 'all monitoree counts' do
     counts = CacheAnalyticsJob.all_monitoree_counts(1, @@monitorees)
-    assert_equal(241, counts.length)
+    assert_not_equal(0, counts.length)
   end
   
   test 'monitoree counts by total' do

--- a/test/jobs/analytics_job_test.rb
+++ b/test/jobs/analytics_job_test.rb
@@ -12,7 +12,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     MonitoreeSnapshot.delete_all
     CacheAnalyticsJob.perform_now()
     assert_equal(8, Analytic.all.size)
-    assert_equal(589, MonitoreeCount.all.size)
+    assert_equal(587, MonitoreeCount.all.size)
     assert_equal(24, MonitoreeSnapshot.all.size)
   end
   

--- a/test/jobs/analytics_job_test.rb
+++ b/test/jobs/analytics_job_test.rb
@@ -7,14 +7,14 @@ class AnalyticsJobTest < ActiveSupport::TestCase
   @@monitorees_by_exposure_month = Patient.where(jurisdiction_id: 9)
 
   test 'monitoree counts by total' do
-    active_counts = CacheAnalyticsJob.monitoree_counts_by_total(@@monitorees, true)
+    active_counts = CacheAnalyticsJob.monitoree_counts_by_total(1, @@monitorees, true)
     verify_monitoree_count(active_counts, 0, true, 'Overall Total', 'Total', 'Missing', 14)
     verify_monitoree_count(active_counts, 1, true, 'Overall Total', 'Total', 'High', 3)
     verify_monitoree_count(active_counts, 2, true, 'Overall Total', 'Total', 'Low', 2)
     verify_monitoree_count(active_counts, 3, true, 'Overall Total', 'Total', 'Medium', 4)
     verify_monitoree_count(active_counts, 4, true, 'Overall Total', 'Total', 'No Identified Risk', 4)
     assert_equal(5, active_counts.length)
-    overall_counts = CacheAnalyticsJob.monitoree_counts_by_total(@@monitorees, false)
+    overall_counts = CacheAnalyticsJob.monitoree_counts_by_total(1, @@monitorees, false)
     verify_monitoree_count(overall_counts, 0, false, 'Overall Total', 'Total', 'Missing', 14)
     verify_monitoree_count(overall_counts, 1, false, 'Overall Total', 'Total', 'High', 3)
     verify_monitoree_count(overall_counts, 2, false, 'Overall Total', 'Total', 'Low', 4)
@@ -24,7 +24,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
   end
 
   test 'monitoree counts by monitoring status' do
-    active_counts = CacheAnalyticsJob.monitoree_counts_by_monitoring_status(@@monitorees)
+    active_counts = CacheAnalyticsJob.monitoree_counts_by_monitoring_status(1, @@monitorees)
     verify_monitoree_count(active_counts, 0, true, 'Monitoring Status', 'Symptomatic', 'Missing', 2)
     verify_monitoree_count(active_counts, 1, true, 'Monitoring Status', 'Non-Reporting', 'Missing', 10)
     verify_monitoree_count(active_counts, 2, true, 'Monitoring Status', 'Asymptomatic', 'Missing', 2)
@@ -32,7 +32,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
   end
 
   test 'monitoree counts by age group' do
-    active_counts = CacheAnalyticsJob.monitoree_counts_by_age_group(@@monitorees, true)
+    active_counts = CacheAnalyticsJob.monitoree_counts_by_age_group(1, @@monitorees, true)
     verify_monitoree_count(active_counts, 0, true, 'Age Group', '0-19', 'Missing', 3)
     verify_monitoree_count(active_counts, 1, true, 'Age Group', '0-19', 'High', 1)
     verify_monitoree_count(active_counts, 2, true, 'Age Group', '0-19', 'Low', 1)
@@ -52,7 +52,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     verify_monitoree_count(active_counts, 16, true, 'Age Group', '70-79', 'Missing', 1)
     verify_monitoree_count(active_counts, 17, true, 'Age Group', '>=80', 'No Identified Risk', 1)
     assert_equal(18, active_counts.length)
-    overall_counts = CacheAnalyticsJob.monitoree_counts_by_age_group(@@monitorees, false)
+    overall_counts = CacheAnalyticsJob.monitoree_counts_by_age_group(1, @@monitorees, false)
     verify_monitoree_count(overall_counts, 0, false, 'Age Group', '0-19', 'Missing', 3)
     verify_monitoree_count(overall_counts, 1, false, 'Age Group', '0-19', 'High', 1)
     verify_monitoree_count(overall_counts, 2, false, 'Age Group', '0-19', 'Low', 1)
@@ -77,7 +77,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
   end
 
   test 'monitoree counts by sex' do
-    active_counts = CacheAnalyticsJob.monitoree_counts_by_sex(@@monitorees, true)
+    active_counts = CacheAnalyticsJob.monitoree_counts_by_sex(1, @@monitorees, true)
     verify_monitoree_count(active_counts, 0, true, 'Sex', 'Missing', 'Medium', 1)
     verify_monitoree_count(active_counts, 1, true, 'Sex', 'Missing', 'No Identified Risk', 1)
     verify_monitoree_count(active_counts, 2, true, 'Sex', 'Female', 'Missing', 5)
@@ -95,7 +95,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     verify_monitoree_count(active_counts, 14, true, 'Sex', 'Unknown', 'Medium', 1)
     verify_monitoree_count(active_counts, 15, true, 'Sex', 'Unknown', 'No Identified Risk', 1)
     assert_equal(16, active_counts.length)
-    overall_counts = CacheAnalyticsJob.monitoree_counts_by_sex(@@monitorees, false)
+    overall_counts = CacheAnalyticsJob.monitoree_counts_by_sex(1, @@monitorees, false)
     verify_monitoree_count(overall_counts, 0, false, 'Sex', 'Missing', 'Medium', 1)
     verify_monitoree_count(overall_counts, 1, false, 'Sex', 'Missing', 'No Identified Risk', 1)
     verify_monitoree_count(overall_counts, 2, false, 'Sex', 'Female', 'Missing', 5)
@@ -117,7 +117,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
   end
 
   test 'monitoree counts by risk factor' do
-    active_counts = CacheAnalyticsJob.monitoree_counts_by_risk_factor(@@monitorees, true)
+    active_counts = CacheAnalyticsJob.monitoree_counts_by_risk_factor(1, @@monitorees, true)
     verify_monitoree_count(active_counts, 0, true, 'Risk Factor', 'Close Contact with Known Case', 'High', 1)
     verify_monitoree_count(active_counts, 1, true, 'Risk Factor', 'Close Contact with Known Case', 'Medium', 1)
     verify_monitoree_count(active_counts, 2, true, 'Risk Factor', 'Travel from Affected Country or Area', 'Missing', 1)
@@ -139,7 +139,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     verify_monitoree_count(active_counts, 18, true, 'Risk Factor', 'Total', 'Medium', 2)
     verify_monitoree_count(active_counts, 19, true, 'Risk Factor', 'Total', 'No Identified Risk', 2)
     assert_equal(20, active_counts.length)
-    overall_counts = CacheAnalyticsJob.monitoree_counts_by_risk_factor(@@monitorees, false)
+    overall_counts = CacheAnalyticsJob.monitoree_counts_by_risk_factor(1, @@monitorees, false)
     verify_monitoree_count(overall_counts, 0, false, 'Risk Factor', 'Close Contact with Known Case', 'High', 1)
     verify_monitoree_count(overall_counts, 1, false, 'Risk Factor', 'Close Contact with Known Case', 'Low', 1)
     verify_monitoree_count(overall_counts, 2, false, 'Risk Factor', 'Close Contact with Known Case', 'Medium', 1)
@@ -171,7 +171,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
   end
 
   test 'monitoree counts by exposure country' do
-    active_counts = CacheAnalyticsJob.monitoree_counts_by_exposure_country(@@monitorees, true)
+    active_counts = CacheAnalyticsJob.monitoree_counts_by_exposure_country(1, @@monitorees, true)
     verify_monitoree_count(active_counts, 0, true, 'Exposure Country', 'China', 'No Identified Risk', 1)
     verify_monitoree_count(active_counts, 1, true, 'Exposure Country', 'Faroe Islands', 'High', 1)
     verify_monitoree_count(active_counts, 2, true, 'Exposure Country', 'Faroe Islands', 'No Identified Risk', 1)
@@ -185,7 +185,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     verify_monitoree_count(active_counts, 10, true, 'Exposure Country', 'Total', 'Medium', 2)
     verify_monitoree_count(active_counts, 11, true, 'Exposure Country', 'Total', 'No Identified Risk', 2)
     assert_equal(12, active_counts.length)
-    overall_counts = CacheAnalyticsJob.monitoree_counts_by_exposure_country(@@monitorees, false)
+    overall_counts = CacheAnalyticsJob.monitoree_counts_by_exposure_country(1, @@monitorees, false)
     verify_monitoree_count(overall_counts, 0, false, 'Exposure Country', 'Brazil', 'Low', 1)
     verify_monitoree_count(overall_counts, 1, false, 'Exposure Country', 'China', 'No Identified Risk', 1)
     verify_monitoree_count(overall_counts, 2, false, 'Exposure Country', 'Faroe Islands', 'High', 1)
@@ -204,7 +204,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
   end
 
   test 'monitoree counts by last exposure date' do
-    active_counts = CacheAnalyticsJob.monitoree_counts_by_last_exposure_date(@@monitorees, true)
+    active_counts = CacheAnalyticsJob.monitoree_counts_by_last_exposure_date(1, @@monitorees, true)
     verify_monitoree_count(active_counts, 0, true, 'Last Exposure Date', days_ago(27), 'Missing', 1)
     verify_monitoree_count(active_counts, 1, true, 'Last Exposure Date', days_ago(27), 'Medium', 1)
     verify_monitoree_count(active_counts, 2, true, 'Last Exposure Date', days_ago(26), 'High', 1)
@@ -218,7 +218,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     verify_monitoree_count(active_counts, 10, true, 'Last Exposure Date', days_ago(3), 'Missing', 1)
     verify_monitoree_count(active_counts, 11, true, 'Last Exposure Date', days_ago(1), 'High', 1)
     assert_equal(12, active_counts.length)
-    overall_counts = CacheAnalyticsJob.monitoree_counts_by_last_exposure_date(@@monitorees, false)
+    overall_counts = CacheAnalyticsJob.monitoree_counts_by_last_exposure_date(1, @@monitorees, false)
     verify_monitoree_count(overall_counts, 0, false, 'Last Exposure Date', days_ago(27), 'Missing', 1)
     verify_monitoree_count(overall_counts, 1, false, 'Last Exposure Date', days_ago(27), 'Medium', 1)
     verify_monitoree_count(overall_counts, 2, false, 'Last Exposure Date', days_ago(26), 'High', 1)
@@ -235,14 +235,14 @@ class AnalyticsJobTest < ActiveSupport::TestCase
   end
 
   test 'monitoree counts by last exposure week' do
-    active_counts = CacheAnalyticsJob.monitoree_counts_by_last_exposure_week(@@monitorees_by_exposure_week, true)
+    active_counts = CacheAnalyticsJob.monitoree_counts_by_last_exposure_week(1, @@monitorees_by_exposure_week, true)
     verify_monitoree_count(active_counts, 0, true, 'Last Exposure Week', weeks_ago(52), 'Missing', 1)
     verify_monitoree_count(active_counts, 1, true, 'Last Exposure Week', weeks_ago(25), 'Low', 2)
     verify_monitoree_count(active_counts, 2, true, 'Last Exposure Week', weeks_ago(19), 'Medium', 1)
     verify_monitoree_count(active_counts, 3, true, 'Last Exposure Week', weeks_ago(3), 'High', 1)
     verify_monitoree_count(active_counts, 4, true, 'Last Exposure Week', weeks_ago(1), 'High', 1)
     assert_equal(5, active_counts.length)
-    overall_counts = CacheAnalyticsJob.monitoree_counts_by_last_exposure_week(@@monitorees_by_exposure_week, false)
+    overall_counts = CacheAnalyticsJob.monitoree_counts_by_last_exposure_week(1, @@monitorees_by_exposure_week, false)
     verify_monitoree_count(overall_counts, 0, false, 'Last Exposure Week', weeks_ago(52), 'Missing', 1)
     verify_monitoree_count(overall_counts, 1, false, 'Last Exposure Week', weeks_ago(25), 'Low', 2)
     verify_monitoree_count(overall_counts, 2, false, 'Last Exposure Week', weeks_ago(21), 'No Identified Risk', 1)
@@ -255,7 +255,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
   end
 
   test 'monitoree counts by last exposure month' do
-    active_counts = CacheAnalyticsJob.monitoree_counts_by_last_exposure_month(@@monitorees_by_exposure_month, true)
+    active_counts = CacheAnalyticsJob.monitoree_counts_by_last_exposure_month(1, @@monitorees_by_exposure_month, true)
     verify_monitoree_count(active_counts, 0, true, 'Last Exposure Month', months_ago(13), 'Low', 1)
     verify_monitoree_count(active_counts, 1, true, 'Last Exposure Month', months_ago(11), 'No Identified Risk', 1)
     verify_monitoree_count(active_counts, 2, true, 'Last Exposure Month', months_ago(5), 'Low', 1)
@@ -264,7 +264,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     verify_monitoree_count(active_counts, 5, true, 'Last Exposure Month', months_ago(1), 'High', 1)
     verify_monitoree_count(active_counts, 6, true, 'Last Exposure Month', months_ago(1), 'Low', 1)
     assert_equal(7, active_counts.length)
-    overall_counts = CacheAnalyticsJob.monitoree_counts_by_last_exposure_month(@@monitorees_by_exposure_month, false)
+    overall_counts = CacheAnalyticsJob.monitoree_counts_by_last_exposure_month(1, @@monitorees_by_exposure_month, false)
     verify_monitoree_count(overall_counts, 0, false, 'Last Exposure Month', months_ago(13), 'Low', 1)
     verify_monitoree_count(overall_counts, 1, false, 'Last Exposure Month', months_ago(11), 'Medium', 1)
     verify_monitoree_count(overall_counts, 2, false, 'Last Exposure Month', months_ago(11), 'No Identified Risk', 1)
@@ -277,23 +277,25 @@ class AnalyticsJobTest < ActiveSupport::TestCase
   end
 
   test 'monitoree snapshots' do
-    snapshots = CacheAnalyticsJob.all_monitoree_snapshots(@@monitorees, 1)
-    verify_snapshot(snapshots, 0, 'Last 24 Hours', 5, 0, 1, 0)
+    snapshots = CacheAnalyticsJob.all_monitoree_snapshots(1, @@monitorees, 1)
+    verify_snapshot(snapshots, 0, 'Last 24 Hours', 5, 0, 2, 0)
     verify_snapshot(snapshots, 2, 'Total', 30, 0, 3, 0)
-    snapshots = CacheAnalyticsJob.all_monitoree_snapshots(Patient.where(jurisdiction_id: 2), 2)
-    verify_snapshot(snapshots, 0, 'Last 24 Hours', 2, 1, 0, 1)
+    snapshots = CacheAnalyticsJob.all_monitoree_snapshots(1, Patient.where(jurisdiction_id: 2), 2)
+    verify_snapshot(snapshots, 0, 'Last 24 Hours', 2, 1, 1, 1)
     verify_snapshot(snapshots, 2, 'Total', 12, 2, 1, 2)
   end
 
-  def verify_monitoree_count(monitoree_counts, index, active_monitoring, category_type, category, risk_level, count)
-    assert_equal(active_monitoring, monitoree_counts[index].active_monitoring, monitoree_count_err_msg(index, active_monitoring, category_type))
-    assert_equal(category_type, monitoree_counts[index].category_type, monitoree_count_err_msg(index, active_monitoring, category_type))
-    assert_equal(category, monitoree_counts[index].category, monitoree_count_err_msg(index, active_monitoring, category_type))
-    assert_equal(risk_level, monitoree_counts[index].risk_level, monitoree_count_err_msg(index, active_monitoring, category_type))
-    assert_equal(count, monitoree_counts[index].total, monitoree_count_err_msg(index, active_monitoring, category_type))
+  def verify_monitoree_count(counts, index, active_monitoring, category_type, category, risk_level, count)
+    assert_equal(1, counts[index].analytic_id, monitoree_count_err_msg(index, active_monitoring, category_type))
+    assert_equal(active_monitoring, counts[index].active_monitoring, monitoree_count_err_msg(index, active_monitoring, category_type))
+    assert_equal(category_type, counts[index].category_type, monitoree_count_err_msg(index, active_monitoring, category_type))
+    assert_equal(category, counts[index].category, monitoree_count_err_msg(index, active_monitoring, category_type))
+    assert_equal(risk_level, counts[index].risk_level, monitoree_count_err_msg(index, active_monitoring, category_type))
+    assert_equal(count, counts[index].total, monitoree_count_err_msg(index, active_monitoring, category_type))
   end
 
   def verify_snapshot(snapshots, index, time_frame, new_enrollments, transferred_in, closed, transferred_out)
+    assert_equal(1, snapshots[index].analytic_id, 'Analytic ID')
     assert_equal(time_frame, snapshots[index].time_frame, 'Time frame')
     assert_equal(new_enrollments, snapshots[index].new_enrollments, 'New enrollments')
     assert_equal(transferred_in, snapshots[index].transferred_in, 'Incoming transfers')

--- a/test/models/history_test.rb
+++ b/test/models/history_test.rb
@@ -76,16 +76,6 @@ class HistoryTest < ActiveSupport::TestCase
     end
   end
 
-  test 'not monitoring' do
-    assert_difference('History.not_monitoring.size', 1) do
-      create(:history, history_type: 'Monitoring Change', comment: 'Not Monitoring')
-    end
-
-    assert_no_difference('History.not_monitoring.size') do
-      create(:history, history_type: 'Monitoring Change', comment: 'Monitoring')
-    end
-  end
-
   test 'referral for medical evaluation' do
     assert_difference('History.referral_for_medical_evaluation.size', 1) do
       create(:history, history_type: 'Monitoring Change', comment: 'Recommended medical evaluation of symptoms')

--- a/test/models/reported_condition_test.rb
+++ b/test/models/reported_condition_test.rb
@@ -10,6 +10,11 @@ class ReportedConditionTest < ActiveSupport::TestCase
   test 'create reported condition' do
     assert create(:reported_condition)
     assert create(:reported_condition, threshold_condition_hash: Faker::Alphanumeric.alphanumeric(number: 64))
+
+    error = assert_raises(ActiveRecord::RecordInvalid) do
+      create(:reported_condition, assessment: nil)
+    end
+    assert_includes(error.message, 'Assessment')
   end
 
   test 'threshold condition' do


### PR DESCRIPTION
Demo script data population and cache analytics job are improved by using the bulk import function from the [activerecord-import](https://github.com/zdennis/activerecord-import) gem. Beforehand, individual queries to the db were made for every insert of:
- patients, laboratories (demo:populate task)
- monitoree_counts, monitoree_snapshots (cache_analytics job)

Although the [insert_all](https://apidock.com/rails/v6.0.0/ActiveRecord/Persistence/ClassMethods/insert_all) function does bulk inserts as well, it only accepts hashes for the insert and not ActiveRecord models. Neither the insert_all nor activerecord-import import functions support bulk inserts with associated records as well. This feature only works for postgres unfortunately, which means doing bulk inserts on records with associated records becomes more complicated, but is still doable.

This PR includes improvements to:
- [x] demo:populate task
  - [x] generate transfers
  - [x] generate histories for assessments, laboratories, transfers, monitoring changes
  - [x] generate all data via bulk import instead of individual saves
  - [x] add households to enrollments
  - [x] even out line list distributions
  - [x] populate monitoree fields with more realistic data
- [x] cache_analytics job
  - [x] bulk inserts for monitoree_counts and monitoree_snapshots
  - [x] use closed_at field from patient to determine num closed patients in monitoree_snapshot instead of history
  - [x] improve test coverage
  - [ ] revisit monitoree_snapshots schema (the lookup of public health actions here is one of the slowest parts of the job, public health actions have also changed since schema was created, do we still need these? they currently aren't being used on the analytics page and even if we do want to keep them, we should update them to the latest list of public health actions)

Previously, it would take about 3:30 on average to run the following command to do a fresh setup of the dev environment, but with these changes, it takes under 1:30 to complete
```
time bundle exec rake db:drop db:create db:migrate db:setup admin:import_or_update_jurisdictions demo:setup demo:populate
```