### PR TITLE
SARAALERT-336: Add asymptomatic recovery definition

### DIFF
--- a/app/models/laboratory.rb
+++ b/app/models/laboratory.rb
@@ -7,15 +7,15 @@ class Laboratory < ApplicationRecord
   validates :result, inclusion: { in: ['positive', 'negative', 'indeterminate', 'other', nil, ''] }
 
   scope :last_ten_days_positive, lambda {
-    where('created_at > ?', 10.days.ago).where(result: 'positive')
+    where('report > ?', 10.days.ago).where(result: 'positive')
   }
 
   scope :before_ten_days_positive, lambda {
-    where('created_at <= ?', 10.days.ago).where(result: 'positive')
+    where('report <= ?', 10.days.ago).where(result: 'positive')
   }
 
   scope :last_ten_days_negative, lambda {
-    where('created_at > ?', 10.days.ago).where(result: 'negative')
+    where('report > ?', 10.days.ago).where(result: 'negative')
   }
 
   # Information about this laboratory

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -229,7 +229,7 @@ class Patient < ApplicationRecord # rubocop:todo Metrics/ClassLength
       .where('laboratories.patient_id = patients.id')
       .left_outer_joins(:assessments)
       .where('assessments.patient_id = patients.id')
-      .where_assoc_not_exists(:assessments, 'assessments.symptomatic = true AND assessments.created_at > laboratories.created_at')
+      .where_assoc_not_exists(:assessments, 'assessments.symptomatic = true AND assessments.created_at > laboratories.report')
       .distinct
   }
 
@@ -403,9 +403,9 @@ class Patient < ApplicationRecord # rubocop:todo Metrics/ClassLength
       return :asymptomatic if asymptomatic?
       return :non_reporting if non_reporting?
     end
+    return :isolation_asymp_non_test_based if Patient.where(id: id).asymp_non_test_based.exists?
     return :isolation_test_based if Patient.where(id: id).test_based.exists?
     return :isolation_non_test_based if Patient.where(id: id).non_test_based.exists?
-    return :isolation_asymp_non_test_based if Patient.where(id: id).asymp_non_test_based.exists?
     return :isolation_non_reporting if Patient.where(id: id).isolation_non_reporting.exists?
     return :isolation_reporting if Patient.where(id: id).isolation_reporting.exists?
     return :purged if purged?


### PR DESCRIPTION
JIRA: [https://jira.mitre.org/browse/SARAALERT-336](https://jira.mitre.org/browse/SARAALERT-336)

Current description from JIRA ticket:
If they have not had a test to determine if they are still contagious, they can leave home after these two things have happened:
At least 10 days have passed since the date of their first positive test
AND
they continue to have no symptoms since the test.

[CDC description](https://www.cdc.gov/coronavirus/2019-ncov/hcp/disposition-in-home-patients.html):

At least 10 days have passed since the date of their first positive COVID-19 diagnostic test assuming they have not subsequently developed symptoms since their positive test. If they develop symptoms, then the symptom-based or test-based strategy should be used. Note, because symptoms cannot be used to gauge where these individuals are in the course of their illness, it is possible that the duration of viral shedding could be longer or shorter than 10 days after their first positive test.