### PR TITLE
Authy redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,10 +3,11 @@
 # ApplicationController: base controller, handles password changes
 class ApplicationController < ActionController::Base
   before_action :user_must_change_password
+  before_action :ensure_authy_enabled
   protect_from_forgery prepend: true
 
   def user_must_change_password
-    return unless current_user&.force_password_change || (current_user && !current_user&.authy_enabled && current_user&.authy_enforced)
+    return unless current_user&.force_password_change
 
     # First login (and first password change) must occur within three days
     current_user.lock_access! if current_user.password_changed_at < 3.days.ago && current_user&.force_password_change
@@ -17,13 +18,12 @@ class ApplicationController < ActionController::Base
       redirect_to edit_user_registration_url
       return
     end
+  end
 
-    if !current_user&.authy_enforced || request.url == user_enable_authy_url || request.url == user_verify_authy_url ||
-       request.url == user_verify_authy_installation_url || request.url == user_request_sms_url || request.url == user_request_phone_call_url
-      return
+  def ensure_authy_enabled
+    return if params[:controller] == "devise_authy" || params[:controller] == "users/registrations" || (params[:controller] == "devise/sessions" && params[:action] == 'destroy')
+    if current_user and !current_user.authy_enabled? and current_user.authy_enforced
+      redirect_to user_enable_authy_url
     end
-
-    redirect_to user_enable_authy_url unless current_user&.authy_enabled || !current_user&.authy_id.nil?
-    redirect_to user_verify_authy_installation_url unless current_user&.authy_enabled || current_user&.authy_id.nil?
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,16 +14,17 @@ class ApplicationController < ActionController::Base
 
     return if request.url == edit_user_registration_url || request.url == user_registration_url || request.url == destroy_user_session_url
 
-    if current_user&.force_password_change
-      redirect_to edit_user_registration_url
-      return
-    end
+    return unless current_user&.force_password_change
+
+    redirect_to edit_user_registration_url
   end
 
   def ensure_authy_enabled
-    return if params[:controller] == "devise_authy" || params[:controller] == "users/registrations" || (params[:controller] == "devise/sessions" && params[:action] == 'destroy')
-    if current_user and !current_user.authy_enabled? and current_user.authy_enforced
-      redirect_to user_enable_authy_url
-    end
+    return if params[:controller] == 'devise_authy' || params[:controller] == 'users/registrations' ||
+              (params[:controller] == 'devise/sessions' && params[:action] == 'destroy')
+
+    return unless current_user && !current_user.authy_enabled? && current_user.authy_enforced
+
+    redirect_to user_enable_authy_url
   end
 end

--- a/app/controllers/devise_authy_controller.rb
+++ b/app/controllers/devise_authy_controller.rb
@@ -1,8 +1,12 @@
-class DeviseAuthyController < Devise::DeviseAuthyController
-    before_action :verify_enforcement
+# frozen_string_literal: true
 
-    def verify_enforcement
-      return unless current_user
-      redirect_to root_url unless current_user&.authy_enforced
-    end
+# DeviseAuthyController: for customizing devise-authy gem routing
+class DeviseAuthyController < Devise::DeviseAuthyController
+  before_action :verify_enforcement
+
+  def verify_enforcement
+    return unless current_user
+
+    redirect_to root_url unless current_user&.authy_enforced
   end
+end

--- a/app/controllers/devise_authy_controller.rb
+++ b/app/controllers/devise_authy_controller.rb
@@ -1,9 +1,8 @@
 class DeviseAuthyController < Devise::DeviseAuthyController
-    before_action :check_enforcement
+    before_action :verify_enforcement
 
-    def check_enforcement
+    def verify_enforcement
       return unless current_user
-
       redirect_to root_url unless current_user&.authy_enforced
     end
   end

--- a/app/controllers/devise_authy_controller.rb
+++ b/app/controllers/devise_authy_controller.rb
@@ -1,0 +1,9 @@
+class DeviseAuthyController < Devise::DeviseAuthyController
+    before_action :check_enforcement
+
+    def check_enforcement
+      return unless current_user
+
+      redirect_to root_url unless current_user&.authy_enforced
+    end
+  end

--- a/config/initializers/authy.rb
+++ b/config/initializers/authy.rb
@@ -1,2 +1,12 @@
 Authy.api_key = ENV["AUTHY_API_KEY"]
 Authy.api_uri = "https://api.authy.com/"
+
+Devise::Models::AuthyAuthenticatable.module_eval do
+    def with_authy_authentication?(request)
+        if self.authy_id.present? && self.authy_enabled && self.authy_enforced
+            return true
+        end
+
+        return false
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     root to: 'home#index'
   end
 
-  devise_for :users, only: [:sessions, :authy], :path_names => {
+  devise_for :users, only: [:sessions, :authy], controllers: {devise_authy: 'devise_authy'}, :path_names => {
     verify_authy: "/verify-token",
     enable_authy: "/enable-two-factor",
     verify_authy_installation: "/verify-installation"


### PR DESCRIPTION
**Overview**
This PR attempts to address an issue where a user who does not have authy enforced is able to access the 2FA registration screen. The system will now redirect them away from it. This is a niche case only seen in testing.

Additionally, this PR cleans up some of the authy application filter logic, making it far more clear when rerouting is happening.

Lastly, this PR overrides a function in the `devise-authy` gem in order to add our `authy_enforced` logic into the processing of devise. Now if a user has `authy_enforced` set to false but `authy_enabled` set to true. They should still be able to bypass the 2FA screen.

**Simplified Console Commmand**
As a result the new console command to allow bypass of 2FA can be simplified to:
`User.where(email: 'username@example.com').first.update(authy_enforced: false)`