### PR TITLE
Adds STOP IMPORT to Import Page

### DIFF
--- a/app/javascript/components/import/Import.js
+++ b/app/javascript/components/import/Import.js
@@ -159,7 +159,7 @@ class Import extends React.Component {
                   `This will import all records listed below that you did not manually accept or reject.If potential duplicates have been detected, check the box if you would like to import them.`
                 )
               }>
-              Accept
+              Import All
             </Button>
             {this.state.acceptedAllStarted && (
               <Button variant="primary" className="btn-lg my-2 ml-2" onClick={() => this.stopImport()}>

--- a/app/javascript/components/import/Import.js
+++ b/app/javascript/components/import/Import.js
@@ -87,26 +87,30 @@ class Import extends React.Component {
   }
 
   stopImport = async () => {
-    this.setState({ isPaused: true });
-    let confirmText = `This will stop the  creation of new records from the list below. Records that were imported prior to clicking “Stop Import” will not be deleted from the system.`;
-    if (await confirmDialog(confirmText, { title: 'Stop Import Process' })) {
-      this.setState({ isPaused: false });
-      location.href = '/';
-    } else {
-      this.setState({ isPaused: false });
-      if (this.state.acceptedAllStarted) {
-        this.submit(this.state.phased[this.state.progress], this.state.progress, true);
+    this.setState({ isPaused: true }, async () => {
+      let confirmText = `This will stop the  creation of new records from the list below. Records that were imported prior to clicking “Stop Import” will not be deleted from the system.`;
+      if (await confirmDialog(confirmText, { title: 'Stop Import Process' })) {
+        this.setState({ isPaused: false });
+        location.href = '/';
+      } else {
+        this.setState({ isPaused: false });
+        if (this.state.acceptedAllStarted) {
+          this.submit(this.state.phased[this.state.progress + 1], this.state.progress + 1, true);
+        }
       }
-    }
+    });
   };
 
   handleConfirm = async confirmText => {
-    this.setState({ acceptedAllStarted: true });
-    let duplicateCount = this.state.patients.filter(pat => pat.appears_to_be_duplicate == true).length;
-    let duplicatePrompt = duplicateCount != 0 ? `Include the ${duplicateCount} detected duplicate monitorees` : undefined;
-    if (await confirmDialog(confirmText, { title: 'Import Monitorees', extraOption: duplicatePrompt, extraOptionChange: this.handleExtraOptionToggle })) {
-      this.importAll();
-    }
+    this.setState({ acceptedAllStarted: true }, async () => {
+      let duplicateCount = this.state.patients.filter(pat => pat.appears_to_be_duplicate == true).length;
+      let duplicatePrompt = duplicateCount != 0 ? `Include the ${duplicateCount} detected duplicate monitorees` : undefined;
+      if (await confirmDialog(confirmText, { title: 'Import Monitorees', extraOption: duplicatePrompt, extraOptionChange: this.handleExtraOptionToggle })) {
+        this.importAll();
+      } else {
+        this.setState({ acceptedAllStarted: false });
+      }
+    });
   };
 
   render() {
@@ -157,9 +161,11 @@ class Import extends React.Component {
               }>
               Accept
             </Button>
-            <Button variant="primary" className="btn-lg my-2 ml-2" onClick={() => this.stopImport()}>
-              Stop Import
-            </Button>
+            {this.state.acceptedAllStarted && (
+              <Button variant="primary" className="btn-lg my-2 ml-2" onClick={() => this.stopImport()}>
+                Stop Import
+              </Button>
+            )}
             {this.state.patients.map((patient, index) => {
               return (
                 <Card

--- a/app/javascript/components/import/Import.js
+++ b/app/javascript/components/import/Import.js
@@ -148,8 +148,8 @@ class Import extends React.Component {
               </div>
             )}
             <h5>
-              Please review the monitoree records that are about to be imported. You can individually accept or reject each record below. You can choose to
-              import all unique records or all records (including duplicates) by selecting Accept.
+              Please review the monitoree records that are about to be imported. You can individually accept or reject each record below. You can also choose to
+              import all unique records or all records (including duplicates) by clicking the &quot;Import All&quot; button.
             </h5>
             <Button
               variant="primary"

--- a/app/javascript/components/import/Import.js
+++ b/app/javascript/components/import/Import.js
@@ -14,6 +14,7 @@ class Import extends React.Component {
     this.rejectSub = this.rejectSub.bind(this);
     this.handleExtraOptionToggle = this.handleExtraOptionToggle.bind(this);
     this.handleConfirm = this.handleConfirm.bind(this);
+    this.finishImport = this.finishImport.bind(this);
     this.submit = this.submit.bind(this);
   }
 
@@ -74,6 +75,13 @@ class Import extends React.Component {
     this.setState({ importDuplicates: value });
   }
 
+  finishImport = async () => {
+    let confirmText = `Ending the Import process will not undo any records imported, but no new records will be created.`;
+    if (await confirmDialog(confirmText, { title: 'Finish Import Process' })) {
+      window.history.go(-1);
+    }
+  };
+
   handleConfirm = async confirmText => {
     let duplicateCount = this.state.patients.filter(pat => pat.appears_to_be_duplicate == true).length;
     let duplicatePrompt = duplicateCount != 0 ? `Include the ${duplicateCount} detected duplicate monitorees` : undefined;
@@ -126,6 +134,9 @@ class Import extends React.Component {
                 )
               }>
               Accept All
+            </Button>
+            <Button variant="primary" className="btn-lg my-2 ml-2" onClick={() => this.finishImport()}>
+              Finish Import
             </Button>
             {this.state.patients.map((patient, index) => {
               return (

--- a/test/system/lib/public_health_monitoring/dashboard.rb
+++ b/test/system/lib/public_health_monitoring/dashboard.rb
@@ -133,7 +133,7 @@ class PublicHealthMonitoringDashboard < ApplicationSystemTestCase
 
   def select_monitorees_to_import(rejects, accept_duplicates)
     if rejects.nil?
-      click_on 'Accept'
+      click_on 'Import All'
       find(:css, '.form-check-input').set(true) if accept_duplicates
       click_on 'OK'
     else

--- a/test/system/lib/public_health_monitoring/dashboard.rb
+++ b/test/system/lib/public_health_monitoring/dashboard.rb
@@ -12,10 +12,10 @@ class PublicHealthMonitoringDashboard < ApplicationSystemTestCase
   @@public_health_import_verifier = PublicHealthMonitoringImportVerifier.new(nil)
   @@public_health_monitoring_reports = PublicHealthMonitoringReports.new(nil)
   @@system_test_utils = SystemTestUtils.new(nil)
-  
+
   PATIENTS = @@system_test_utils.get_patients
   MONITOREES = @@system_test_utils.get_monitorees
-  
+
   def search_for_and_view_patient(tab, patient_label)
     @@system_test_utils.go_to_tab(tab)
     fill_in 'Search:', with: PATIENTS[patient_label]['last_name']
@@ -133,7 +133,7 @@ class PublicHealthMonitoringDashboard < ApplicationSystemTestCase
 
   def select_monitorees_to_import(rejects, accept_duplicates)
     if rejects.nil?
-      click_on 'Accept All'
+      click_on 'Accept'
       find(:css, '.form-check-input').set(true) if accept_duplicates
       click_on 'OK'
     else


### PR DESCRIPTION
Clarified some of the text Import section. Now, during the Import process, the user has the ability to stop the process. This will not add any more records. The already-imported records will remain in the system. This functionality has been made plain with descriptive text.