### PR TITLE
Add new SMTP_AUTHENTICATION environment variable to provide better co…

### DIFF
--- a/.env-prod-enrollment-example
+++ b/.env-prod-enrollment-example
@@ -19,6 +19,7 @@ ACTION_MAILER_SMTP_ADDRESS=<address of smtp server>
 ACTION_MAILER_SMTP_PORT=25
 ACTION_MAILER_SMTP_USERNAME=
 ACTION_MAILER_SMTP_PASSWORD=
+ACTION_MAILER_SMTP_AUTHENTICATION=<authentication method (e.g., plain, login>
 
 SECRET_KEY_BASE=<result of running `rake secret`>
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,7 +76,7 @@ Rails.application.configure do
     port: ENV['ACTION_MAILER_SMTP_PORT'] || 25,
     user_name: !ENV['ACTION_MAILER_SMTP_USERNAME'].blank? ? ENV['ACTION_MAILER_SMTP_USERNAME'] : nil,
     password: !ENV['ACTION_MAILER_SMTP_PASSWORD'].blank? ? ENV['ACTION_MAILER_SMTP_PASSWORD'] : nil,
-    authentication: !ENV['ACTION_MAILER_SMTP_USERNAME'].blank? ? 'login' : nil
+    authentication: !ENV['ACTION_MAILER_SMTP_AUTHENTICATION'].blank? ? ENV['ACTION_MAILER_SMTP_AUTHENTICATION'] : nil
   }
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -73,10 +73,11 @@ Rails.application.configure do
 
   config.action_mailer.smtp_settings = {
     address: ENV['ACTION_MAILER_SMTP_ADDRESS'] || 'localhost',
-    port: ENV['ACTION_MAILER_SMTP_PORT'] || 25,
+    port: ENV['ACTION_MAILER_SMTP_PORT'].to_i || 25,
     user_name: !ENV['ACTION_MAILER_SMTP_USERNAME'].blank? ? ENV['ACTION_MAILER_SMTP_USERNAME'] : nil,
     password: !ENV['ACTION_MAILER_SMTP_PASSWORD'].blank? ? ENV['ACTION_MAILER_SMTP_PASSWORD'] : nil,
-    authentication: !ENV['ACTION_MAILER_SMTP_AUTHENTICATION'].blank? ? ENV['ACTION_MAILER_SMTP_AUTHENTICATION'] : nil
+    authentication: !ENV['ACTION_MAILER_SMTP_AUTHENTICATION'].blank? ? ENV['ACTION_MAILER_SMTP_AUTHENTICATION'].to_sym : nil,
+    domain: ENV['ACTION_MAILER_SMTP_DOMAIN'].blank? ? ENV['ACTION_MAILER_SMTP_DOMAIN'] : nil
   }
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
…ntrol of authentication method when using SaraAlert with various relay providers.

Our deployment partners will probably need to ensure this variable is set to `login` which was the previous value if a username was provided.