### PR TITLE
Excel individual export bug

### DIFF
--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -23,7 +23,7 @@ class ExportController < ApplicationController
     # Build CSV
     csv_result = CSV.generate(headers: true) do |csv|
       csv << headers
-      patients.find_each(batch_size: 1000) do |patient|
+      patients.find_each(batch_size: 500) do |patient|
         p = params[:type] == 'linelist' ? patient.linelist.values : patient.comprehensive_details.values
         p[0] = p[0][:name] if params[:type] == 'linelist'
         csv << p
@@ -48,7 +48,7 @@ class ExportController < ApplicationController
       p.workbook.add_worksheet(name: 'Monitorees') do |sheet|
         headers = COMPREHENSIVE_HEADERS
         sheet.add_row headers
-        patients.find_each(batch_size: 1000) do |patient|
+        patients.find_each(batch_size: 500) do |patient|
           sheet.add_row patient.comprehensive_details.values, { types: Array.new(headers.length, :string) }
         end
       end
@@ -60,36 +60,37 @@ class ExportController < ApplicationController
     redirect_to(root_url) && return unless current_user.can_export?
 
     patients = params[:scope] == 'purgeable' ? current_user.viewable_patients.purge_eligible : current_user.viewable_patients
-    patient_ids = patients.pluck(:id)
-    send_data build_excel_export_for_patients(patient_ids)
+    send_data build_excel_export_for_patients(patients)
   end
 
   def excel_full_history_patient
     redirect_to(root_url) && return unless current_user.can_export?
     return unless current_user.viewable_patients.exists?(params[:patient_id])
 
+    patient = current_user.viewable_patients.where(id: params[:patient_id])
+    return if patient.nil?
+
     history = History.new
     history.created_by = current_user.email
     comment = 'User downloaded monitoree\'s data in Excel Export.'
     history.comment = comment
-    history.patient = current_user.viewable_patients.find(params[:patient_id])
+    history.patient = patient
     history.history_type = 'Monitoree Data Downloaded'
     history.save
-    send_data build_excel_export_for_patients([params[:patient_id]])
+    send_data build_excel_export_for_patients(patient)
   end
 
-  def build_excel_export_for_patients(patient_ids)
-    patients = current_user.viewable_patients.where(id: patient_ids)
+  def build_excel_export_for_patients(patients)
     Axlsx::Package.new do |p|
       p.workbook.add_worksheet(name: 'Monitorees List') do |sheet|
         headers = MONITOREES_LIST_HEADERS
         sheet.add_row headers
-        patients.find_each(batch_size: 1000) do |patient|
+        patients.find_each(batch_size: 500) do |patient|
           sheet.add_row [patient.id] + patient.comprehensive_details.values, { types: Array.new(headers.length, :string) }
         end
       end
       p.workbook.add_worksheet(name: 'Assessments') do |sheet|
-        assessment_ids = Assessment.where(patient_id: patient_ids).pluck(:id)
+        assessment_ids = Assessment.where(patient_id: patients.last&.id).pluck(:id)
         condition_ids = ReportedCondition.where(assessment_id: assessment_ids).pluck(:id)
         # Need to get ALL symptom names and labels (human readable and computer-queryable) since
         # Symptoms may differ over time and bettween sub-jurisdictions but each monitoree columns still need to line up
@@ -101,7 +102,7 @@ class ExportController < ApplicationController
         patient_info_headers = %w[patient_id symptomatic who_reported created_at updated_at]
         human_readable_headers = ['Patient ID', 'Symptomatic', 'Who Reported', 'Created At', 'Updated At'] + symptom_labels
         sheet.add_row human_readable_headers
-        patients.find_each(batch_size: 1000) do |patient|
+        patients.find_each(batch_size: 500) do |patient|
           patient_assessments = patient.assessmenmts_summary_array(patient_info_headers, symptom_names)
           patient_assessments.each do |assessment|
             sheet.add_row assessment, { types: Array.new(human_readable_headers.length, :string) }
@@ -109,18 +110,18 @@ class ExportController < ApplicationController
         end
       end
       p.workbook.add_worksheet(name: 'Lab Results') do |sheet|
-        labs = Laboratory.where(patient_id: patient_ids)
+        labs = Laboratory.where(patient_id: patients.pluck(:id))
         lab_headers = ['Patient ID', 'Lab Type', 'Specimen Collection Date', 'Report Date', 'Result Date', 'Created At', 'Updated At']
         sheet.add_row lab_headers
-        labs.find_each(batch_size: 1000) do |lab|
+        labs.find_each(batch_size: 500) do |lab|
           sheet.add_row lab.details.values, { types: Array.new(lab_headers.length, :string) }
         end
       end
       p.workbook.add_worksheet(name: 'Edit Histories') do |sheet|
-        histories = History.where(patient_id: patient_ids)
+        histories = History.where(patient_id: patients.pluck(:id))
         history_headers = ['Patient ID', 'Comment', 'Created By', 'History Type', 'Created At', 'Updated At']
         sheet.add_row history_headers
-        histories.find_each(batch_size: 1000) do |history|
+        histories.find_each(batch_size: 500) do |history|
           sheet.add_row history.details.values, { types: Array.new(history_headers.length, :string) }
         end
       end

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -67,17 +67,17 @@ class ExportController < ApplicationController
     redirect_to(root_url) && return unless current_user.can_export?
     return unless current_user.viewable_patients.exists?(params[:patient_id])
 
-    patient = current_user.viewable_patients.where(id: params[:patient_id])
-    return if patient.nil?
+    patients = current_user.viewable_patients.where(id: params[:patient_id])
+    return if patients.empty?
 
     history = History.new
     history.created_by = current_user.email
     comment = 'User downloaded monitoree\'s data in Excel Export.'
     history.comment = comment
-    history.patient = patient
+    history.patient = patients.first
     history.history_type = 'Monitoree Data Downloaded'
     history.save
-    send_data build_excel_export_for_patients(patient)
+    send_data build_excel_export_for_patients(patients)
   end
 
   def build_excel_export_for_patients(patients)

--- a/app/helpers/import_export_helper.rb
+++ b/app/helpers/import_export_helper.rb
@@ -2,9 +2,9 @@
 
 # Helper methods for the import controller
 module ImportExportHelper # rubocop:todo Metrics/ModuleLength
-  LINELIST_HEADERS = ['Monitoree', 'Jurisdiction', 'State/Local ID', 'Sex', 'Date of Birth', 'End of Monitoring', 'Risk Level', 'Monitoring Plan',
-                      'Latest Report', 'Transferred At', 'Reason For Closure', 'Latest Public Health Action', 'Status', 'Closed At', 'Transferred From',
-                      'Transferred To', 'Expected Purge Date'].freeze
+  LINELIST_HEADERS = ['Monitoree', 'Jurisdiction', 'Assigned User', 'State/Local ID', 'Sex', 'Date of Birth', 'End of Monitoring', 'Risk Level',
+                      'Monitoring Plan', 'Latest Report', 'Transferred At', 'Reason For Closure', 'Latest Public Health Action', 'Status', 'Closed At',
+                      'Transferred From', 'Transferred To', 'Expected Purge Date'].freeze
 
   COMPREHENSIVE_HEADERS = ['First Name', 'Middle Name', 'Last Name', 'Date of Birth', 'Sex at Birth', 'White', 'Black or African American',
                            'American Indian or Alaska Native', 'Asian', 'Native Hawaiian or Other Pacific Islander', 'Ethnicity', 'Primary Language',

--- a/app/javascript/components/subject/DownloadMonitoreeExcel.js
+++ b/app/javascript/components/subject/DownloadMonitoreeExcel.js
@@ -27,7 +27,7 @@ class DownloadMonitoreeExcel extends React.Component {
             base64StringToBlob(response.data.replace(/(\r\n|\n|\r)/gm, ''), 'application/xlsx'),
             'Sara-Alert-Full-History-Monitoree-' + this.props.patient.id + '-' + fileDate + '.xlsx'
           );
-          location.reload(true);
+          this.setState({ loading: false });
         })
         .catch(error => {
           reportError(error);

--- a/test/system/lib/public_health_monitoring/export_verifier.rb
+++ b/test/system/lib/public_health_monitoring/export_verifier.rb
@@ -6,61 +6,33 @@ require 'roo'
 require_relative '../system_test_utils'
 
 class PublicHealthMonitoringExportVerifier < ApplicationSystemTestCase
+  include ImportExportHelper
   @@system_test_utils = SystemTestUtils.new(nil)
     
   DOWNLOAD_TIMEOUT = 10
   DOWNLOAD_CHECK_INTERVAL = 0.1
-
-  LINELIST_HEADERS = ['Monitoree', 'Jurisdiction', 'State/Local ID', 'Sex', 'Date of Birth', 'End of Monitoring', 'Risk Level', 'Monitoring Plan',
-                      'Latest Report', 'Transferred At', 'Reason For Closure', 'Latest Public Health Action', 'Status', 'Closed At', 'Transferred From',
-                      'Transferred To', 'Expected Purge Date'].freeze
-
-  COMPREHENSIVE_HEADERS = ['First Name', 'Middle Name', 'Last Name', 'Date of Birth', 'Sex at Birth', 'White', 'Black or African American',
-                           'American Indian or Alaska Native', 'Asian', 'Native Hawaiian or Other Pacific Islander', 'Ethnicity', 'Primary Language',
-                           'Secondary Language', 'Interpretation Required?', 'Nationality', 'Identifier (STATE/LOCAL)', 'Identifier (CDC)',
-                           'Identifier (NNDSS)', 'Address Line 1', 'Address City', 'Address State', 'Address Line 2', 'Address Zip', 'Address County',
-                           'Foreign Address Line 1', 'Foreign Address City', 'Foreign Address Country', 'Foreign Address Line 2', 'Foreign Address Zip',
-                           'Foreign Address Line 3', 'Foreign Address State', 'Monitored Address Line 1', 'Monitored Address City', 'Monitored Address State',
-                           'Monitored Address Line 2', 'Monitored Address Zip', 'Monitored Address County', 'Foreign Monitored Address Line 1',
-                           'Foreign Monitored Address City', 'Foreign Monitored Address State', 'Foreign Monitored Address Line 2',
-                           'Foreign Monitored Address Zip', 'Foreign Monitored Address County', 'Preferred Contact Method', 'Primary Telephone',
-                           'Primary Telephone Type', 'Secondary Telephone', 'Secondary Telephone Type', 'Preferred Contact Time', 'Email', 'Port of Origin',
-                           'Date of Departure', 'Source of Report', 'Flight or Vessel Number', 'Flight or Vessel Carrier', 'Port of Entry Into USA',
-                           'Date of Arrival', 'Travel Related Notes', 'Additional Planned Travel Type', 'Additional Planned Travel Destination',
-                           'Additional Planned Travel Destination State', 'Additional Planned Travel Destination Country',
-                           'Additional Planned Travel Port of Departure', 'Additional Planned Travel Start Date', 'Additional Planned Travel End Date',
-                           'Additional Planned Travel Related Notes', 'Last Date of Exposure', 'Potential Exposure Location', 'Potential Exposure Country',
-                           'Contact of Known Case?', 'Contact of Known Case ID', 'Travel from Affected Country or Area?',
-                           'Was in Health Care Facility With Known Cases?', 'Health Care Facility with Known Cases Name', 'Laboratory Personnel?',
-                           'Laboratory Personnel Facility Name', 'Health Care Personnel?', 'Health Care Personnel Facility Name',
-                           'Crew on Passenger or Cargo Flight?', 'Member of a Common Exposure Cohort?', 'Common Exposure Cohort Name',
-                           'Exposure Risk Assessment', 'Monitoring Plan', 'Exposure Notes', 'Status', 'Symptom Onset Date', 'Case Status', 'Lab 1 Test Type',
-                           'Lab 1 Specimen Collection Date', 'Lab 1 Report Date', 'Lab 1 Result', 'Lab 2 Test Type', 'Lab 2 Specimen Collection Date',
-                           'Lab 2 Report Date', 'Lab 2 Result'].freeze
-
-  MONITOREES_LIST_HEADERS = ['Patient ID'] + COMPREHENSIVE_HEADERS.freeze
   
   def verify_line_list_csv(jurisdiction_id, workflow)
     csv = get_csv("Sara-Alert-#{workflow == :isolation ? 'Isolation' : 'Exposure'}-Linelist-????-??-??T??_??_?????_??.csv")
-    patients = Jurisdiction.find(jurisdiction_id).all_patients.where(isolation: workflow == :isolation)
+    patients = Jurisdiction.find(jurisdiction_id).all_patients.where(isolation: workflow == :isolation).order(:id)
     verify_csv_export(csv, :line_list, LINELIST_HEADERS, patients)
   end
   
   def verify_sara_alert_format(jurisdiction_id, workflow)
     xlsx = get_xlsx("Sara-Alert-Format-#{workflow == :isolation ? 'Isolation' : 'Exposure'}-????-??-??T??_??_?????_??.xlsx")
-    patients = Jurisdiction.find(jurisdiction_id).all_patients.where(isolation: workflow == :isolation)
+    patients = Jurisdiction.find(jurisdiction_id).all_patients.where(isolation: workflow == :isolation).order(:id)
     verify_sara_alert_format_export(xlsx, patients)
   end
 
   def verify_excel_purge_eligible_monitorees(jurisdiction_id)
     xlsx = get_xlsx('Sara-Alert-Full-History-Purgeable-Monitorees-????-??-??T??_??_?????_??.xlsx')
-    patients = Jurisdiction.find(jurisdiction_id).all_patients.purge_eligible
+    patients = Jurisdiction.find(jurisdiction_id).all_patients.purge_eligible.order(:id)
     verify_excel_export(xlsx, patients)
   end
 
   def verify_excel_all_monitorees(jurisdiction_id)
     xlsx = get_xlsx('Sara-Alert-Full-History-All-Monitorees-????-??-??T??_??_?????_??.xlsx')
-    patients = Jurisdiction.find(jurisdiction_id).all_patients
+    patients = Jurisdiction.find(jurisdiction_id).all_patients.order(:id)
     verify_excel_export(xlsx, patients)
   end
 


### PR DESCRIPTION
to recreate:
While using the Public Health role in Safari when I go to an individual record and click download Excel file of record the Safari browser has an icon spin as if it is trying to download, but then no file is downloaded. 

fix: set loading bool to false instead of reloading the entire page