### PR TITLE
SQL performance improvements for isolation scopes

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -13,20 +13,12 @@ class Assessment < ApplicationRecord
   has_one :reported_condition, class_name: 'ReportedCondition'
   belongs_to :patient
 
-  scope :twenty_four_hours_fever, lambda {
-    where('created_at >= ?', 24.hours.ago).where_assoc_exists(:reported_condition, &:fever)
+  scope :twenty_four_hours_fever_or_fever_medication, lambda {
+    where('created_at >= ?', 24.hours.ago).where_assoc_exists(:reported_condition, &:fever_or_fever_medication)
   }
 
-  scope :twenty_four_hours_fever_medication, lambda {
-    where('created_at >= ?', 24.hours.ago).where_assoc_exists(:reported_condition, &:fever_medication)
-  }
-
-  scope :seventy_two_hours_fever, lambda {
-    where('created_at >= ?', 72.hours.ago).where_assoc_exists(:reported_condition, &:fever)
-  }
-
-  scope :seventy_two_hours_fever_medication, lambda {
-    where('created_at >= ?', 72.hours.ago).where_assoc_exists(:reported_condition, &:fever_medication)
+  scope :seventy_two_hours_fever_or_fever_medication, lambda {
+    where('created_at >= ?', 72.hours.ago).where_assoc_exists(:reported_condition, &:fever_or_fever_medication)
   }
 
   scope :ten_days_symptomatic, lambda {

--- a/app/models/reported_condition.rb
+++ b/app/models/reported_condition.rb
@@ -12,11 +12,7 @@ class ReportedCondition < Condition
     ThresholdCondition.find_by(threshold_condition_hash: threshold_condition_hash)
   end
 
-  scope :fever_medication, lambda {
-    where_assoc_exists(:symptoms, &:fever_medication)
-  }
-
-  scope :fever, lambda {
-    where_assoc_exists(:symptoms, &:fever)
+  scope :fever_or_fever_medication, lambda {
+    where_assoc_exists(:symptoms, &:fever_or_fever_medication)
   }
 end

--- a/app/models/symptom.rb
+++ b/app/models/symptom.rb
@@ -17,12 +17,8 @@ class Symptom < ApplicationRecord
 
   validates :type, inclusion: valid_types, presence: true
 
-  scope :fever, lambda {
-    where(['name = ? and bool_value = ?', 'fever', true])
-  }
-
-  scope :fever_medication, lambda {
-    where(['name = ? and bool_value = ?', 'used-a-fever-reducer', true])
+  scope :fever_or_fever_medication, lambda {
+    where(['(name = ? OR name = ?) AND bool_value = ?', 'fever', 'used-a-fever-reducer', true])
   }
 
   def bool_based_prompt(lang = :en)

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -64,72 +64,307 @@ class PatientTest < ActiveSupport::TestCase
     assert Patient.purge_eligible.count.zero?
   end
 
+  test 'test based' do
+    # setup
+    Patient.destroy_all
+    patient = create(:patient, monitoring: true, purged: false, isolation: true)
+    assert_equal 0, Patient.test_based.count
+
+    # meets definition: has at least 1 assessment and 2 negative test results
+    create(:assessment, patient: patient, created_at: 50.days.ago)
+    create(:laboratory, patient: patient, result: 'negative', report: 50.days.ago)
+    create(:laboratory, patient: patient, result: 'negative', report: 50.days.ago)
+    assert_equal 1, Patient.test_based.count
+    Assessment.destroy_all
+    Laboratory.destroy_all
+
+    # does not meet definition: no assessments
+    create(:laboratory, patient: patient, result: 'negative')
+    create(:laboratory, patient: patient, result: 'negative')
+    assert_equal 0, Patient.test_based.count
+    Laboratory.destroy_all
+
+    # does not meet definition: only 1 negative test result
+    create(:assessment, patient: patient)
+    create(:laboratory, patient: patient, result: 'negative')
+    assert_equal 0, Patient.test_based.count
+    Assessment.destroy_all
+    Laboratory.destroy_all
+  end
+
+  test 'symp non test based' do
+    # setup
+    Patient.destroy_all
+    patient = create(:patient, monitoring: true, purged: false, isolation: true, symptom_onset: 12.days.ago)
+    assert_equal 0, Patient.symp_non_test_based.count
+
+    # meets definition: assessment older than 72 hours
+    create(:assessment, patient: patient, created_at: 80.hours.ago)
+    assert_equal 1, Patient.symp_non_test_based.count
+    Assessment.destroy_all
+
+    # does not meet definition: assessment not older than 72 hours
+    create(:assessment, patient: patient, created_at: 70.hours.ago)
+    assert_equal 0, Patient.symp_non_test_based.count
+    Assessment.destroy_all
+
+    # does not meet definition: had a fever within the past 72 hours
+    create(:assessment, patient: patient, created_at: 80.hours.ago)
+    assessment_2 = create(:assessment, patient: patient, created_at: 70.hours.ago)
+    reported_condition = create(:reported_condition, assessment: assessment_2)
+    create(:symptom, condition_id: reported_condition.id, type: 'BoolSymptom', name: 'fever', bool_value: true)
+    assert_equal 0, Patient.symp_non_test_based.count
+    Assessment.destroy_all
+
+    # does not meet definition: used a fever reducer within the past 72 hours
+    create(:assessment, patient: patient, created_at: 80.hours.ago)
+    assessment_2 = create(:assessment, patient: patient, created_at: 70.hours.ago)
+    reported_condition = create(:reported_condition, assessment: assessment_2)
+    create(:symptom, condition_id: reported_condition.id, type: 'BoolSymptom', name: 'used-a-fever-reducer', bool_value: true)
+    assert_equal 0, Patient.symp_non_test_based.count
+    Assessment.destroy_all
+
+    # meets definition: had an assessment with no fever
+    create(:assessment, patient: patient, created_at: 80.hours.ago)
+    assessment_2 = create(:assessment, patient: patient, created_at: 70.hours.ago)
+    reported_condition = create(:reported_condition, assessment: assessment_2)
+    create(:symptom, condition_id: reported_condition.id, type: 'BoolSymptom', name: 'fever', bool_value: false)
+    assert_equal 1, Patient.symp_non_test_based.count
+    Assessment.destroy_all
+
+    # meets definition: had a fever more than 72 hours ago
+    assessment = create(:assessment, patient: patient, created_at: 80.hours.ago)
+    reported_condition = create(:reported_condition, assessment: assessment)
+    create(:symptom, condition_id: reported_condition.id, type: 'BoolSymptom', name: 'fever', bool_value: true)
+    assert_equal 1, Patient.symp_non_test_based.count
+    Assessment.destroy_all
+  end
+
   test 'asymp non test based' do
     # setup
     Patient.destroy_all
     patient = create(:patient, monitoring: true, purged: false, isolation: true)
-    assert_equal 1, Patient.count
     assert_equal 0, Patient.asymp_non_test_based.count
 
     # meets definition: asymptomatic after positive test result
-    Laboratory.create(patient_id: patient.id, result: 'positive', report: 15.days.ago)
-    Assessment.create(patient_id: patient.id, symptomatic: false, created_at: 8.days.ago)
+    create(:laboratory, patient: patient, result: 'positive', report: 15.days.ago)
+    create(:assessment, patient: patient, symptomatic: false, created_at: 8.days.ago)
     assert_equal 1, Patient.asymp_non_test_based.count
-    Laboratory.destroy_all
     Assessment.destroy_all
+    Laboratory.destroy_all
 
     # meets definition: only symptomatic before positive test result but not afterwards
-    Laboratory.create(patient_id: patient.id, result: 'positive', report: 11.days.ago)
-    Assessment.create(patient_id: patient.id, symptomatic: true, created_at: 12.days.ago)
+    create(:assessment, patient: patient, symptomatic: true, created_at: 12.days.ago)
+    create(:laboratory, patient: patient, result: 'positive', report: 11.days.ago)
     assert_equal 1, Patient.asymp_non_test_based.count
-    Laboratory.destroy_all
     Assessment.destroy_all
+    Laboratory.destroy_all
 
     # does not meet defiition: has positive test result less than 10 days ago
-    Laboratory.create(patient_id: patient.id, result: 'positive', report: 8.days.ago)
+    create(:laboratory, patient: patient, result: 'positive', report: 8.days.ago)
     assert_equal 0, Patient.asymp_non_test_based.count
     Laboratory.destroy_all
 
     # does not meet defiition: has positive test result more than 10 days ago, but also has positive test result less than 10 days ago
-    Laboratory.create(patient_id: patient.id, result: 'positive', report: 11.days.ago)
-    Laboratory.create(patient_id: patient.id, result: 'positive', report: 9.days.ago)
+    create(:laboratory, patient: patient, result: 'positive', report: 11.days.ago)
+    create(:laboratory, patient: patient, result: 'positive', report: 9.days.ago)
+    assert_equal 0, Patient.asymp_non_test_based.count
+    Laboratory.destroy_all
+
+    # does not meet defiition: has negative test result more than 10 days ago, but also has positive test result less than 10 days ago
+    create(:laboratory, patient: patient, result: 'negative', report: 11.days.ago)
+    create(:laboratory, patient: patient, result: 'positive', report: 9.days.ago)
+    assert_equal 0, Patient.asymp_non_test_based.count
+    Laboratory.destroy_all
+
+    # does not meet defiition: has positive test result more than 10 days ago, but also has positive test result less than 10 days ago
+    create(:laboratory, patient: patient, result: 'positive', report: 11.days.ago)
+    create(:laboratory, patient: patient, result: 'negative', report: 9.days.ago)
     assert_equal 0, Patient.asymp_non_test_based.count
     Laboratory.destroy_all
 
     # does not meet definition: symptomatic after positive test result
-    Laboratory.create(patient_id: patient.id, result: 'positive', report: 15.days.ago)
-    Assessment.create(patient_id: patient.id, symptomatic: true, created_at: 8.days.ago)
+    create(:laboratory, patient: patient, result: 'positive', report: 15.days.ago)
+    create(:assessment, patient: patient, symptomatic: true, created_at: 8.days.ago)
     assert_equal 0, Patient.asymp_non_test_based.count
-    Laboratory.destroy_all
     Assessment.destroy_all
+    Laboratory.destroy_all
 
     # does not meet definition: symptomatic after positive test result even though symptomatic more than 10 days ago
-    Laboratory.create(patient_id: patient.id, result: 'positive', report: 13.days.ago)
-    Assessment.create(patient_id: patient.id, symptomatic: true, created_at: 12.days.ago)
+    create(:laboratory, patient: patient, result: 'positive', report: 13.days.ago)
+    create(:assessment, patient: patient, symptomatic: true, created_at: 12.days.ago)
     assert_equal 0, Patient.asymp_non_test_based.count
-    Laboratory.destroy_all
     Assessment.destroy_all
+    Laboratory.destroy_all
 
     # does not meet definition: symptomatic after positive test result even though symptomatic more than 10 days ago
-    Laboratory.create(patient_id: patient.id, result: 'positive', report: 12.days.ago)
-    Laboratory.create(patient_id: patient.id, result: 'negative', report: 3.days.ago)
-    Assessment.create(patient_id: patient.id, symptomatic: true, created_at: 6.days.ago)
-    Assessment.create(patient_id: patient.id, symptomatic: false, created_at: 5.days.ago)
+    create(:laboratory, patient: patient, result: 'positive', report: 12.days.ago)
+    create(:assessment, patient: patient, symptomatic: true, created_at: 6.days.ago)
+    create(:assessment, patient: patient, symptomatic: false, created_at: 5.days.ago)
+    create(:laboratory, patient: patient, result: 'negative', report: 3.days.ago)
     assert_equal 0, Patient.asymp_non_test_based.count
-    Laboratory.destroy_all
     Assessment.destroy_all
+    Laboratory.destroy_all
 
     # does not meet definition: symptomatic after positive test result even though symptomatic more than 10 days ago
-    Laboratory.create(patient_id: patient.id, result: 'positive', report: 15.days.ago)
-    Laboratory.create(patient_id: patient.id, result: 'negative', report: 12.days.ago)
-    Assessment.create(patient_id: patient.id, symptomatic: true, created_at: 14.days.ago)
-    Assessment.create(patient_id: patient.id, symptomatic: false, created_at: 13.days.ago)
+    create(:laboratory, patient: patient, result: 'positive', report: 15.days.ago)
+    create(:assessment, patient: patient, symptomatic: true, created_at: 14.days.ago)
+    create(:assessment, patient: patient, symptomatic: false, created_at: 13.days.ago)
+    create(:laboratory, patient: patient, result: 'negative', report: 12.days.ago)
     assert_equal 0, Patient.asymp_non_test_based.count
-    Laboratory.destroy_all
     Assessment.destroy_all
+    Laboratory.destroy_all
   end
 
-  test 'get timezone offset' do
+  test 'isolation requiring review' do
+    # setup for test based case
+    Patient.destroy_all
+    patient = create(:patient, monitoring: true, purged: false, isolation: true)
+    assert_equal 0, Patient.isolation_requiring_review.count
+
+    # meets definition: has at least 1 assessment and 2 negative test results
+    create(:assessment, patient: patient, created_at: 50.days.ago)
+    create(:laboratory, patient: patient, result: 'negative', report: 50.days.ago)
+    create(:laboratory, patient: patient, result: 'negative', report: 50.days.ago)
+    assert_equal 1, Patient.isolation_requiring_review.count
+    Assessment.destroy_all
+    Laboratory.destroy_all
+
+    # does not meet definition: no assessments
+    create(:laboratory, patient: patient, result: 'negative')
+    create(:laboratory, patient: patient, result: 'negative')
+    assert_equal 0, Patient.isolation_requiring_review.count
+    Laboratory.destroy_all
+
+    # does not meet definition: only 1 negative test result
+    create(:assessment, patient: patient)
+    create(:laboratory, patient: patient, result: 'negative')
+    assert_equal 0, Patient.isolation_requiring_review.count
+    Assessment.destroy_all
+    Laboratory.destroy_all
+
+    # setup for non test based case
+    Patient.destroy_all
+    patient = create(:patient, monitoring: true, purged: false, isolation: true, symptom_onset: 12.days.ago)
+    assert_equal 0, Patient.isolation_requiring_review.count
+
+    # meets definition: assessment older than 72 hours
+    create(:assessment, patient: patient, created_at: 80.hours.ago)
+    assert_equal 1, Patient.isolation_requiring_review.count
+    Assessment.destroy_all
+
+    # does not meet definition: assessment not older than 72 hours
+    create(:assessment, patient: patient, created_at: 70.hours.ago)
+    assert_equal 0, Patient.isolation_requiring_review.count
+    Assessment.destroy_all
+
+    # does not meet definition: had a fever within the past 72 hours
+    create(:assessment, patient: patient, created_at: 80.hours.ago)
+    assessment_2 = create(:assessment, patient: patient, created_at: 70.hours.ago)
+    reported_condition = create(:reported_condition, assessment: assessment_2)
+    create(:symptom, condition_id: reported_condition.id, type: 'BoolSymptom', name: 'fever', bool_value: true)
+    assert_equal 0, Patient.isolation_requiring_review.count
+    Assessment.destroy_all
+
+    # does not meet definition: used a fever reducer within the past 72 hours
+    create(:assessment, patient: patient, created_at: 80.hours.ago)
+    assessment_2 = create(:assessment, patient: patient, created_at: 70.hours.ago)
+    reported_condition = create(:reported_condition, assessment: assessment_2)
+    create(:symptom, condition_id: reported_condition.id, type: 'BoolSymptom', name: 'used-a-fever-reducer', bool_value: true)
+    assert_equal 0, Patient.isolation_requiring_review.count
+    Assessment.destroy_all
+
+    # meets definition: had an assessment with no fever
+    create(:assessment, patient: patient, created_at: 80.hours.ago)
+    assessment_2 = create(:assessment, patient: patient, created_at: 70.hours.ago)
+    reported_condition = create(:reported_condition, assessment: assessment_2)
+    create(:symptom, condition_id: reported_condition.id, type: 'BoolSymptom', name: 'fever', bool_value: false)
+    assert_equal 1, Patient.isolation_requiring_review.count
+    Assessment.destroy_all
+
+    # meets definition: had a fever more than 72 hours ago
+    assessment = create(:assessment, patient: patient, created_at: 80.hours.ago)
+    reported_condition = create(:reported_condition, assessment: assessment)
+    create(:symptom, condition_id: reported_condition.id, type: 'BoolSymptom', name: 'fever', bool_value: true)
+    assert_equal 1, Patient.isolation_requiring_review.count
+    Assessment.destroy_all
+
+    # setup for asymp non test based case
+    Patient.destroy_all
+    patient = create(:patient, monitoring: true, purged: false, isolation: true)
+    assert_equal 0, Patient.isolation_requiring_review.count
+
+    # meets definition: asymptomatic after positive test result
+    create(:laboratory, patient: patient, result: 'positive', report: 15.days.ago)
+    create(:assessment, patient: patient, symptomatic: false, created_at: 8.days.ago)
+    assert_equal 1, Patient.isolation_requiring_review.count
+    Assessment.destroy_all
+    Laboratory.destroy_all
+
+    # meets definition: only symptomatic before positive test result but not afterwards
+    create(:assessment, patient: patient, symptomatic: true, created_at: 12.days.ago)
+    create(:laboratory, patient: patient, result: 'positive', report: 11.days.ago)
+    assert_equal 1, Patient.isolation_requiring_review.count
+    Assessment.destroy_all
+    Laboratory.destroy_all
+
+    # does not meet defiition: has positive test result less than 10 days ago
+    create(:laboratory, patient: patient, result: 'positive', report: 8.days.ago)
+    assert_equal 0, Patient.isolation_requiring_review.count
+    Laboratory.destroy_all
+
+    # does not meet defiition: has positive test result more than 10 days ago, but also has positive test result less than 10 days ago
+    create(:laboratory, patient: patient, result: 'positive', report: 11.days.ago)
+    create(:laboratory, patient: patient, result: 'positive', report: 9.days.ago)
+    assert_equal 0, Patient.isolation_requiring_review.count
+    Laboratory.destroy_all
+
+    # does not meet defiition: has negative test result more than 10 days ago, but also has positive test result less than 10 days ago
+    create(:laboratory, patient: patient, result: 'negative', report: 11.days.ago)
+    create(:laboratory, patient: patient, result: 'positive', report: 9.days.ago)
+    assert_equal 0, Patient.isolation_requiring_review.count
+    Laboratory.destroy_all
+
+    # does not meet defiition: has positive test result more than 10 days ago, but also has positive test result less than 10 days ago
+    create(:laboratory, patient: patient, result: 'positive', report: 11.days.ago)
+    create(:laboratory, patient: patient, result: 'negative', report: 9.days.ago)
+    assert_equal 0, Patient.isolation_requiring_review.count
+    Laboratory.destroy_all
+
+    # does not meet definition: symptomatic after positive test result
+    create(:laboratory, patient: patient, result: 'positive', report: 15.days.ago)
+    create(:assessment, patient: patient, symptomatic: true, created_at: 8.days.ago)
+    assert_equal 0, Patient.isolation_requiring_review.count
+    Assessment.destroy_all
+    Laboratory.destroy_all
+
+    # does not meet definition: symptomatic after positive test result even though symptomatic more than 10 days ago
+    create(:laboratory, patient: patient, result: 'positive', report: 13.days.ago)
+    create(:assessment, patient: patient, symptomatic: true, created_at: 12.days.ago)
+    assert_equal 0, Patient.isolation_requiring_review.count
+    Assessment.destroy_all
+    Laboratory.destroy_all
+
+    # does not meet definition: symptomatic after positive test result even though symptomatic more than 10 days ago
+    create(:laboratory, patient: patient, result: 'positive', report: 12.days.ago)
+    create(:assessment, patient: patient, symptomatic: true, created_at: 6.days.ago)
+    create(:assessment, patient: patient, symptomatic: false, created_at: 5.days.ago)
+    create(:laboratory, patient: patient, result: 'negative', report: 3.days.ago)
+    assert_equal 0, Patient.isolation_requiring_review.count
+    Assessment.destroy_all
+    Laboratory.destroy_all
+
+    # does not meet definition: symptomatic after positive test result even though symptomatic more than 10 days ago
+    create(:laboratory, patient: patient, result: 'positive', report: 15.days.ago)
+    create(:assessment, patient: patient, symptomatic: true, created_at: 14.days.ago)
+    create(:assessment, patient: patient, symptomatic: false, created_at: 13.days.ago)
+    create(:laboratory, patient: patient, result: 'negative', report: 12.days.ago)
+    assert_equal 0, Patient.isolation_requiring_review.count
+    Assessment.destroy_all
+    Laboratory.destroy_all
+  end
+
+  test 'address timezone offset' do
     jur = Jurisdiction.create
     user = User.create!(
       email: 'foobar@example.com',

--- a/test/models/reported_condition_test.rb
+++ b/test/models/reported_condition_test.rb
@@ -35,36 +35,30 @@ class ReportedConditionTest < ActiveSupport::TestCase
                       threshold_condition_hash: Faker::Alphanumeric.alphanumeric(number: 64)).threshold_condition)
   end
 
-  test 'fever medication' do
-    assert_difference('ReportedCondition.fever_medication.size', 1) do
+  test 'reported condition fever or fever medication' do
+    assert_difference('ReportedCondition.fever_or_fever_medication.size', 1) do
+      fever_symptom = create(:fever_symptom)
+      create(:reported_condition, symptoms: [fever_symptom])
+    end
+
+    assert_difference('ReportedCondition.fever_or_fever_medication.size', 1) do
       fever_medication_symptom = create(:fever_medication_symptom)
       create(:reported_condition, symptoms: [fever_medication_symptom])
     end
 
-    assert_no_difference('ReportedCondition.fever_medication.size') do
-      fever_medication_symptom = create(:fever_medication_symptom, bool_value: false)
-      create(:reported_condition, symptoms: [fever_medication_symptom])
-    end
-
-    assert_no_difference('ReportedCondition.fever_medication.size') do
+    assert_difference('ReportedCondition.fever_or_fever_medication.size', 1) do
       fever_symptom = create(:fever_symptom)
-      create(:reported_condition, symptoms: [fever_symptom])
-    end
-  end
-
-  test 'reported condition fever' do
-    assert_difference('ReportedCondition.fever.size', 1) do
-      fever_symptom = create(:fever_symptom)
-      create(:reported_condition, symptoms: [fever_symptom])
+      fever_medication_symptom = create(:fever_medication_symptom)
+      create(:reported_condition, symptoms: [fever_symptom, fever_medication_symptom])
     end
 
-    assert_no_difference('ReportedCondition.fever.size') do
+    assert_no_difference('ReportedCondition.fever_or_fever_medication.size') do
       fever_symptom = create(:fever_symptom, bool_value: false)
       create(:reported_condition, symptoms: [fever_symptom])
     end
 
-    assert_no_difference('ReportedCondition.fever.size') do
-      fever_medication_symptom = create(:fever_medication_symptom)
+    assert_no_difference('ReportedCondition.fever_or_fever_medication.size') do
+      fever_medication_symptom = create(:fever_medication_symptom, bool_value: false)
       create(:reported_condition, symptoms: [fever_medication_symptom])
     end
   end

--- a/test/models/symptom_test.rb
+++ b/test/models/symptom_test.rb
@@ -37,25 +37,18 @@ class SymptomTest < ActiveSupport::TestCase
     end
   end
 
-  test 'symptom fever' do
-    assert_difference('Symptom.fever.size', 1) do
+  test 'symptom fever or fever medication' do
+    assert_difference('Symptom.fever_or_fever_medication.size', 1) do
       create(:bool_symptom, bool_value: true, name: 'fever')
     end
 
-    assert_no_difference('Symptom.fever.size') do
-      create(:bool_symptom, bool_value: false, name: 'fever')
-      create(:bool_symptom, bool_value: true, name: 'not fever')
-    end
-  end
-
-  test 'fever medication' do
-    assert_difference('Symptom.fever_medication.size', 1) do
+    assert_difference('Symptom.fever_or_fever_medication.size', 1) do
       create(:bool_symptom, bool_value: true, name: 'used-a-fever-reducer')
     end
 
-    assert_no_difference('Symptom.fever_medication.size') do
-      create(:bool_symptom, bool_value: false, name: 'used-a-fever-reducer')
-      create(:bool_symptom, bool_value: true, name: 'fever-reducer')
+    assert_no_difference('Symptom.fever_or_fever_medication.size') do
+      create(:bool_symptom, bool_value: false, name: 'fever')
+      create(:bool_symptom, bool_value: true, name: 'not fever')
     end
   end
 


### PR DESCRIPTION
Changes:
- [x] update demo.rake to generate more patients in the different isolation requiring review scopes
- [x] rewrite/optimize the following patient status scopes
  - [x] isolation_requiring_review
  - [x] isolation_reporting
  - [x] isolation_non_reporting