### PR TITLE
Improve export performance via bulk queries

### DIFF
--- a/app/helpers/import_export_helper.rb
+++ b/app/helpers/import_export_helper.rb
@@ -208,19 +208,11 @@ module ImportExportHelper # rubocop:todo Metrics/ModuleLength
     package = CSV.generate(headers: true) do |csv|
       csv << LINELIST_HEADERS
       patient_statuses = get_patient_statuses(patients)
-      latest_assessments = get_latest_assessments(patients)
-      latest_transfers = get_latest_transfers(patients)
-      patients.find_each(batch_size: 500) do |patient|
-        patient_details = patient.linelist_export
-        patient_details[:name] = patient_details[:name][:name]
-        patient_details[:latest_report] = latest_assessments[patient.id]&.rfc2822 || ''
-        if latest_transfers[patient.id]
-          patient_details[:transferred] = latest_transfers[patient.id][:transferred]
-          patient_details[:transferred_from] = latest_transfers[patient.id][:transferred_from]
-          patient_details[:transferred_to] = latest_transfers[patient.id][:transferred_to]
+      patients.find_in_batches(batch_size: 500) do |patients_group|
+        linelists = get_linelists(patients_group, patient_statuses)
+        patients_group.each do |patient|
+          csv << linelists[patient.id].values
         end
-        patient_details[:status] = patient_statuses[patient.id] || ''
-        csv << patient_details.values
       end
     end
     Base64.encode64(package)
@@ -231,10 +223,11 @@ module ImportExportHelper # rubocop:todo Metrics/ModuleLength
       p.workbook.add_worksheet(name: 'Monitorees') do |sheet|
         sheet.add_row COMPREHENSIVE_HEADERS
         patient_statuses = get_patient_statuses(patients)
-        patients.find_each(batch_size: 500) do |patient|
-          patient_details = patient.comprehensive_details
-          patient_details[:status] = patient_statuses[patient.id] || ''
-          sheet.add_row patient_details.values, { types: Array.new(COMPREHENSIVE_HEADERS.length, :string) }
+        patients.find_in_batches(batch_size: 500) do |patients_group|
+          comprehensive_details = get_comprehensive_details(patients_group, patient_statuses)
+          patients_group.each do |patient|
+            sheet.add_row comprehensive_details[patient.id].values, { types: Array.new(COMPREHENSIVE_HEADERS.length, :string) }
+          end
         end
       end
       return Base64.encode64(p.to_stream.read)
@@ -247,10 +240,11 @@ module ImportExportHelper # rubocop:todo Metrics/ModuleLength
         headers = MONITOREES_LIST_HEADERS
         sheet.add_row headers
         patient_statuses = get_patient_statuses(patients)
-        patients.find_each(batch_size: 500) do |patient|
-          patient_details = patient.comprehensive_details
-          patient_details[:status] = patient_statuses[patient.id] || ''
-          sheet.add_row [patient.id] + patient_details.values, { types: Array.new(headers.length, :string) }
+        patients.find_in_batches(batch_size: 500) do |patients_group|
+          comprehensive_details = get_comprehensive_details(patients_group, patient_statuses)
+          patients_group.each do |patient|
+            sheet.add_row [patient.id] + comprehensive_details[patient.id].values, { types: Array.new(MONITOREES_LIST_HEADERS.length, :string) }
+          end
         end
       end
       p.workbook.add_worksheet(name: 'Assessments') do |sheet|
@@ -293,6 +287,50 @@ module ImportExportHelper # rubocop:todo Metrics/ModuleLength
     end
   end
 
+  def get_comprehensive_details(patients, patient_statuses)
+    comprehensive_details = get_incomplete_comprehensive_details(patients)
+    patients_jurisdiction_paths = get_jurisdiction_paths(patients)
+    patients_labs = get_latest_labs(patients)
+    patients.each do |patient|
+      comprehensive_details[patient.id][:jurisdiction_path] = patients_jurisdiction_paths[patient.id]
+      comprehensive_details[patient.id][:status] = patient_statuses[patient.id]
+      next unless patients_labs.key?(patient.id)
+      next unless patients_labs[patient.id].key?(:first)
+
+      comprehensive_details[patient.id][:lab_1_type] = patients_labs[patient.id][:first][:lab_type]
+      comprehensive_details[patient.id][:lab_1_specimen_collection] = patients_labs[patient.id][:first][:specimen_collection]&.strftime('%F')
+      comprehensive_details[patient.id][:lab_1_report] = patients_labs[patient.id][:first][:report]&.strftime('%F')
+      comprehensive_details[patient.id][:lab_1_result] = patients_labs[patient.id][:first][:result]
+      next unless patients_labs[patient.id].key?(:second)
+
+      comprehensive_details[patient.id][:lab_2_type] = patients_labs[patient.id][:second][:lab_type]
+      comprehensive_details[patient.id][:lab_2_specimen_collection] = patients_labs[patient.id][:second][:specimen_collection]&.strftime('%F')
+      comprehensive_details[patient.id][:lab_2_report] = patients_labs[patient.id][:second][:report]&.strftime('%F')
+      comprehensive_details[patient.id][:lab_2_result] = patients_labs[patient.id][:second][:result]
+    end
+    comprehensive_details
+  end
+
+  def get_linelists(patients, patient_statuses)
+    linelists = get_incomplete_linelists(patients)
+    patients_jurisdiction_names = get_jurisdiction_names(patients)
+    patients_assessments = get_latest_assessments(patients)
+    patients_end_of_monitorings = get_end_of_monitorings(patients)
+    patients_transfers = get_latest_transfers(patients)
+    patients.each do |patient|
+      linelists[patient.id][:jurisdiction] = patients_jurisdiction_names[patient.id]
+      linelists[patient.id][:status] = patient_statuses[patient.id]
+      linelists[patient.id][:latest_report] = patients_assessments[patient.id]&.rfc2822
+      linelists[patient.id][:end_of_monitoring] = patients_end_of_monitorings[patient.id]
+      next unless patients_transfers[patient.id]
+
+      linelists[patient.id][:transferred] = patients_transfers[patient.id][:transferred]
+      linelists[patient.id][:transferred_from] = patients_transfers[patient.id][:transferred_from]
+      linelists[patient.id][:transferred_to] = patients_transfers[patient.id][:transferred_to]
+    end
+    linelists
+  end
+
   def get_patient_statuses(patients)
     statuses = {
       closed: patients.monitoring_closed.pluck(:id),
@@ -317,9 +355,7 @@ module ImportExportHelper # rubocop:todo Metrics/ModuleLength
   end
 
   def get_latest_assessments(patients)
-    latest_assessments = Assessment.where(patient_id: patients.pluck(:id)).group(:patient_id).maximum(:created_at)
-    assessments = Assessment.where(patient_id: latest_assessments.keys, created_at: latest_assessments.values)
-    Hash[assessments.pluck(:patient_id, :created_at).map { |patient_id, created_at| [patient_id, created_at] }]
+    Assessment.where(patient_id: patients.pluck(:id)).group(:patient_id).maximum(:created_at)
   end
 
   def get_latest_transfers(patients)
@@ -336,5 +372,187 @@ module ImportExportHelper # rubocop:todo Metrics/ModuleLength
                     }]
                   end
         ]
+  end
+
+  def get_end_of_monitorings(patients)
+    end_of_monitorings = {}
+    patients.each do |patient|
+      start = patient[:last_date_of_exposure].present? ? patient[:last_date_of_exposure] : patient[:created_at]
+      end_of_monitorings[patient.id] = (start + ADMIN_OPTIONS['monitoring_period_days'].days)&.to_s
+    end
+    end_of_monitorings
+  end
+
+  def get_latest_labs(patients)
+    latest_labs = Hash[patients.pluck(:id).map { |id| [id, {}] }]
+    Laboratory.where(patient_id: patients.pluck(:id)).order(report: :desc).each do |lab|
+      if !latest_labs[lab.patient_id].key?(:first)
+        latest_labs[lab.patient_id][:first] = {
+          lab_type: lab[:lab_type],
+          specimen_collection: lab[:specimen_collection],
+          report: lab[:report],
+          result: lab[:result]
+        }
+      elsif !latest_labs[lab.patient_id].key?(:second)
+        latest_labs[lab.patient_id][:second] = {
+          lab_type: lab[:lab_type],
+          specimen_collection: lab[:specimen_collection],
+          report: lab[:report],
+          result: lab[:result]
+        }
+      end
+    end
+    latest_labs
+  end
+
+  def get_jurisdiction_paths(patients)
+    jurisdiction_paths = Hash[Jurisdiction.find(patients.pluck(:jurisdiction_id).uniq).pluck(:id, :path).map { |id, path| [id, path] }]
+    patients_jurisdiction_paths = {}
+    patients.each do |patient|
+      patients_jurisdiction_paths[patient.id] = jurisdiction_paths[patient.jurisdiction_id]
+    end
+    patients_jurisdiction_paths
+  end
+
+  def get_jurisdiction_names(patients)
+    jurisdiction_names = Hash[Jurisdiction.find(patients.pluck(:jurisdiction_id).uniq).pluck(:id, :name).map { |id, name| [id, name] }]
+    patients_jurisdiction_names = {}
+    patients.each do |patient|
+      patients_jurisdiction_names[patient.id] = jurisdiction_names[patient.jurisdiction_id]
+    end
+    patients_jurisdiction_names
+  end
+
+  def get_incomplete_linelists(patients)
+    linelists = {}
+    patients.each do |patient|
+      linelists[patient.id] = {
+        name: "#{patient[:last_name]}#{patient[:first_name].blank? ? '' : ', ' + patient[:first_name]}",
+        jurisdiction: '',
+        assigned_user: patient[:assigned_user] || '',
+        state_local_id: patient[:user_defined_id_statelocal] || '',
+        sex: patient[:sex] || '',
+        dob: patient[:date_of_birth]&.strftime('%F') || '',
+        end_of_monitoring: '',
+        risk_level: patient[:exposure_risk_assessment] || '',
+        monitoring_plan: patient[:monitoring_plan] || '',
+        latest_report: '',
+        transferred: '',
+        reason_for_closure: patient[:monitoring_reason] || '',
+        public_health_action: patient[:public_health_action] || '',
+        status: '',
+        closed_at: patient[:closed_at]&.rfc2822 || '',
+        transferred_from: '',
+        transferred_to: '',
+        expected_purge_date: patient[:updated_at].nil? ? '' : ((patient[:updated_at] + ADMIN_OPTIONS['purgeable_after'].minutes)&.rfc2822 || '')
+      }
+    end
+    linelists
+  end
+
+  def get_incomplete_comprehensive_details(patients) # rubocop:todo Metrics/MethodLength
+    comprehensive_details = {}
+    patients.each do |patient|
+      comprehensive_details[patient.id] = {
+        first_name: patient[:first_name] || '',
+        middle_name: patient[:middle_name] || '',
+        last_name: patient[:last_name] || '',
+        date_of_birth: patient[:date_of_birth]&.strftime('%F') || '',
+        sex: patient[:sex] || '',
+        white: patient[:white] || false,
+        black_or_african_american: patient[:black_or_african_american] || false,
+        american_indian_or_alaska_native: patient[:american_indian_or_alaska_native] || false,
+        asian: patient[:asian] || false,
+        native_hawaiian_or_other_pacific_islander: patient[:native_hawaiian_or_other_pacific_islander] || false,
+        ethnicity: patient[:ethnicity] || '',
+        primary_language: patient[:primary_language] || '',
+        secondary_language: patient[:secondary_language] || '',
+        interpretation_required: patient[:interpretation_required] || false,
+        nationality: patient[:nationality] || '',
+        user_defined_id_statelocal: patient[:user_defined_id_statelocal] || '',
+        user_defined_id_cdc: patient[:user_defined_id_cdc] || '',
+        user_defined_id_nndss: patient[:user_defined_id_nndss] || '',
+        address_line_1: patient[:address_line_1] || '',
+        address_city: patient[:address_city] || '',
+        address_state: patient[:address_state] || '',
+        address_line_2: patient[:address_line_2] || '',
+        address_zip: patient[:address_zip] || '',
+        address_county: patient[:address_county] || '',
+        foreign_address_line_1: patient[:foreign_address_line_1] || '',
+        foreign_address_city: patient[:foreign_address_city] || '',
+        foreign_address_country: patient[:foreign_address_country] || '',
+        foreign_address_line_2: patient[:foreign_address_line_2] || '',
+        foreign_address_zip: patient[:foreign_address_zip] || '',
+        foreign_address_line_3: patient[:foreign_address_line_3] || '',
+        foreign_address_state: patient[:foreign_address_state] || '',
+        monitored_address_line_1: patient[:monitored_address_line_1] || '',
+        monitored_address_city: patient[:monitored_address_city] || '',
+        monitored_address_state: patient[:monitored_address_state] || '',
+        monitored_address_line_2: patient[:monitored_address_line_2] || '',
+        monitored_address_zip: patient[:monitored_address_zip] || '',
+        monitored_address_county: patient[:monitored_address_county] || '',
+        foreign_monitored_address_line_1: patient[:foreign_monitored_address_line_1] || '',
+        foreign_monitored_address_city: patient[:foreign_monitored_address_city] || '',
+        foreign_monitored_address_state: patient[:foreign_monitored_address_state] || '',
+        foreign_monitored_address_line_2: patient[:foreign_monitored_address_line_2] || '',
+        foreign_monitored_address_zip: patient[:foreign_monitored_address_zip] || '',
+        foreign_monitored_address_county: patient[:foreign_monitored_address_county] || '',
+        preferred_contact_method: patient[:preferred_contact_method] || '',
+        primary_telephone: patient[:primary_telephone] || '',
+        primary_telephone_type: patient[:primary_telephone_type] || '',
+        secondary_telephone: patient[:secondary_telephone] || '',
+        secondary_telephone_type: patient[:secondary_telephone_type] || '',
+        preferred_contact_time: patient[:preferred_contact_time] || '',
+        email: patient[:email] || '',
+        port_of_origin: patient[:port_of_origin] || '',
+        date_of_departure: patient[:date_of_departure]&.strftime('%F') || '',
+        source_of_report: patient[:source_of_report] || '',
+        flight_or_vessel_number: patient[:flight_or_vessel_number] || '',
+        flight_or_vessel_carrier: patient[:flight_or_vessel_carrier] || '',
+        port_of_entry_into_usa: patient[:port_of_entry_into_usa] || '',
+        date_of_arrival: patient[:date_of_arrival]&.strftime('%F') || '',
+        travel_related_notes: patient[:travel_related_notes] || '',
+        additional_planned_travel_type: patient[:additional_planned_travel_type] || '',
+        additional_planned_travel_destination: patient[:additional_planned_travel_destination] || '',
+        additional_planned_travel_destination_state: patient[:additional_planned_travel_destination_state] || '',
+        additional_planned_travel_destination_country: patient[:additional_planned_travel_destination_country] || '',
+        additional_planned_travel_port_of_departure: patient[:additional_planned_travel_port_of_departure] || '',
+        additional_planned_travel_start_date: patient[:additional_planned_travel_start_date]&.strftime('%F') || '',
+        additional_planned_travel_end_date: patient[:additional_planned_travel_end_date]&.strftime('%F') || '',
+        additional_planned_travel_related_notes: patient[:additional_planned_travel_related_notes] || '',
+        last_date_of_exposure: patient[:last_date_of_exposure]&.strftime('%F') || '',
+        potential_exposure_location: patient[:potential_exposure_location] || '',
+        potential_exposure_country: patient[:potential_exposure_country] || '',
+        contact_of_known_case: patient[:contact_of_known_case] || '',
+        contact_of_known_case_id: patient[:contact_of_known_case_id] || '',
+        travel_to_affected_country_or_area: patient[:travel_to_affected_country_or_area] || false,
+        was_in_health_care_facility_with_known_cases: patient[:was_in_health_care_facility_with_known_cases] || false,
+        was_in_health_care_facility_with_known_cases_facility_name: patient[:was_in_health_care_facility_with_known_cases_facility_name] || '',
+        laboratory_personnel: patient[:laboratory_personnel] || false,
+        laboratory_personnel_facility_name: patient[:laboratory_personnel_facility_name] || '',
+        healthcare_personnel: patient[:healthcare_personnel] || false,
+        healthcare_personnel_facility_name: patient[:healthcare_personnel_facility_name] || '',
+        crew_on_passenger_or_cargo_flight: patient[:crew_on_passenger_or_cargo_flight] || false,
+        member_of_a_common_exposure_cohort: patient[:member_of_a_common_exposure_cohort] || false,
+        member_of_a_common_exposure_cohort_type: patient[:member_of_a_common_exposure_cohort_type] || '',
+        exposure_risk_assessment: patient[:exposure_risk_assessment] || '',
+        monitoring_plan: patient[:monitoring_plan] || '',
+        exposure_notes: patient[:exposure_notes] || '',
+        status: '',
+        symptom_onset: patient[:symptom_onset]&.strftime('%F') || '',
+        case_status: patient[:case_status] || '',
+        lab_1_type: '',
+        lab_1_specimen_collection: '',
+        lab_1_report: '',
+        lab_1_result: '',
+        lab_2_type: '',
+        lab_2_specimen_collection: '',
+        lab_2_report: '',
+        lab_2_result: '',
+        jurisdiction_path: '',
+        assigned_user: patient[:assigned_user] || ''
+      }
+    end
+    comprehensive_details
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -671,30 +671,6 @@ class Patient < ApplicationRecord # rubocop:todo Metrics/ClassLength
     }
   end
 
-  # Linelist info without status, which gets populated in bulk during export
-  def linelist_export
-    {
-      name: { name: "#{last_name}#{first_name.blank? ? '' : ', ' + first_name}", id: id },
-      jurisdiction: jurisdiction&.name || '',
-      assigned_user: assigned_user || '',
-      state_local_id: user_defined_id_statelocal || '',
-      sex: sex || '',
-      dob: date_of_birth&.strftime('%F') || '',
-      end_of_monitoring: end_of_monitoring || '',
-      risk_level: exposure_risk_assessment || '',
-      monitoring_plan: monitoring_plan || '',
-      latest_report: '',
-      transferred: '',
-      reason_for_closure: monitoring_reason || '',
-      public_health_action: public_health_action || '',
-      status: '',
-      closed_at: closed_at&.rfc2822 || '',
-      transferred_from: '',
-      transferred_to: '',
-      expected_purge_date: updated_at.nil? ? '' : ((updated_at + ADMIN_OPTIONS['purgeable_after'].minutes)&.rfc2822 || '')
-    }
-  end
-
   # All information about this subject
   def comprehensive_details
     labs = Laboratory.where(patient_id: id).order(report: :desc)


### PR DESCRIPTION
Performance testing:

20,394 monitorees (14228 exp/6166 iso)

- LL exposure = 5.205 => 4.947
- LL isolation = 8.375 => 3.335
- SAF exposure = 31.362 => 17.056
- SAF isolation = 15.392 => 9.258
- Full export = 155.44 => 134.265
  - 14228 monitorees: 50.838 (280/s) => 25.292 (562/s)
  - 58998 assessments: 34.388 (1716/s)
  - 6388 labs: 3.605 (1772/s)
  - 119410 histories: 67.208 (1776/s)