### PR TITLE
Case status modal changes for isolation workflow

### DIFF
--- a/app/javascript/components/subject/CaseStatus.js
+++ b/app/javascript/components/subject/CaseStatus.js
@@ -32,31 +32,31 @@ class CaseStatus extends React.Component {
     let hideModal = this.state.isolation && (value === 'Confirmed' || value === 'Probable');
 
     this.setState({ [event.target.id]: value, showCaseStatusModal: !hideModal }, () => {
-      // update case status without showing modal (rare)
+      // specific case where case status is just changed with no modal
       if (hideModal) {
+        this.setState({ message: 'case status to "' + this.state.case_status + '".' });
         this.submit();
+      }
 
-        // instances where case status modal is shown
-      } else {
-        if (event.target.id === 'confirmed') {
-          if (event.target.value === 'End Monitoring') {
-            this.setState({
-              monitoring: false,
-              monitoring_reason: 'Meets Case Definition',
-              message: 'case status to "' + this.state.case_status + '", and chose to "' + event.target.value + '".',
-            });
-          }
-          if (event.target.value === 'Continue Monitoring in Isolation Workflow') {
-            this.setState({
-              monitoring: true,
-              isolation: true,
-              monitoring_reason: 'Meets Case Definition',
-              message: 'case status to "' + this.state.case_status + '", and chose to "' + event.target.value + '".',
-            });
-          }
-        } else if (event.target.value === 'Suspect' || event.target.value === 'Unknown' || event.target.value === 'Not a Case' || event.target.value === '') {
-          this.setState({ monitoring: true, isolation: false, message: 'case status to "' + this.state.case_status + '".' });
+      // all other cases
+      if (event.target.id === 'confirmed') {
+        if (event.target.value === 'End Monitoring') {
+          this.setState({
+            monitoring: false,
+            monitoring_reason: 'Meets Case Definition',
+            message: 'case status to "' + this.state.case_status + '", and chose to "' + event.target.value + '".',
+          });
         }
+        if (event.target.value === 'Continue Monitoring in Isolation Workflow') {
+          this.setState({
+            monitoring: true,
+            isolation: true,
+            monitoring_reason: 'Meets Case Definition',
+            message: 'case status to "' + this.state.case_status + '", and chose to "' + event.target.value + '".',
+          });
+        }
+      } else if (event.target.value === 'Suspect' || event.target.value === 'Unknown' || event.target.value === 'Not a Case' || event.target.value === '') {
+        this.setState({ monitoring: true, isolation: false, message: 'case status to "' + this.state.case_status + '".' });
       }
     });
   }


### PR DESCRIPTION
This PR is for [JIRA 375](https://jira.mitre.org/browse/SARAALERT-375).  Spoke with @hackrm and the following changes were made to the isolation workflow only:
- Changing from 'Confirmed' or 'Probable' to 'Suspect', 'Unknown' or 'Not a Case' now has the following language: `This case will be moved to the exposure workflow and will be placed in the symptomatic, non-reporting, or asymptomatic line list as appropriate to continue exposure monitoring.`
- Any case status changing to 'Confirmed' or 'Probable' does not show the case status modal, rather just update the case status and reload the page.  One question is if we still want to reload the page. In my opinion I think it helps the user know their change was accepted, which is why I left it in

The code is a hair janky but gets it done the way it is intended.  Definitely confirm that no other functionality broke with these changes