### PR TITLE
Fix monitoree counts by country of exposure not being displayed

### DIFF
--- a/app/javascript/components/dashboard/widgets/RiskFactors.js
+++ b/app/javascript/components/dashboard/widgets/RiskFactors.js
@@ -31,7 +31,8 @@ class RiskFactors extends React.Component {
     if (!this.ERRORS) {
       this.riskData = this.obtainValueFromMonitoreeCounts(RISK_FACTORS, 'Risk Factor', this.state.viewTotal);
       this.coiData = this.obtainValueFromMonitoreeCounts(COUNTRIES_OF_INTEREST, 'Exposure Country', this.state.viewTotal);
-      this.NO_COUNTRY_DATA = this.coiData.some(x => x.name === null);
+      this.coiData = this.coiData.filter(data => data.name && data.name != null);
+      this.NO_COUNTRY_DATA = this.coiData.length === 0;
       this.fullCountryData = JSON.parse(JSON.stringify(this.coiData));
       // obtainValueFromMonitoreeCounts returns the data in a format that recharts can read
       // but is not the easiest to parse. The gross lodash functions here just sum the total count of each category

--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -19,8 +19,8 @@ class CacheAnalyticsJob < ApplicationJob
       # Map data will be on the top-level jurisdiction only
       root_nodes = Jurisdiction.where(ancestry: nil)
       root_nodes.each do |root_jurisdiction|
-        symp_by_state = root_jurisdiction.all_patients.pluck(:monitored_address_state).each_with_object(Hash.new(0)) { |state, counts| counts[state] += 1 }
-        monitored_by_state = root_jurisdiction.all_patients.symptomatic.uniq.pluck(:monitored_address_state).each_with_object(Hash.new(0)) do |state, counts|
+        symp_by_state = root_jurisdiction.all_patients.pluck(:address_state).each_with_object(Hash.new(0)) { |state, counts| counts[state] += 1 }
+        monitored_by_state = root_jurisdiction.all_patients.symptomatic.uniq.pluck(:address_state).each_with_object(Hash.new(0)) do |state, counts|
           counts[state] += 1
         end
         root_node_path = root_jurisdiction[:path]

--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -214,6 +214,7 @@ class CacheAnalyticsJob < ApplicationJob
     counts = []
     # Individual countries
     exposure_countries = monitorees.monitoring_active(active_monitoring)
+                                   .where.not(potential_exposure_country: nil)
                                    .group(:potential_exposure_country)
                                    .order(count_potential_exposure_country: :desc)
                                    .order(:potential_exposure_country)

--- a/test/jobs/analytics_job_test.rb
+++ b/test/jobs/analytics_job_test.rb
@@ -17,7 +17,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     assert_equal(112, MonitoreeCount.where(category_type: 'Age Group').size)
     assert_equal(96, MonitoreeCount.where(category_type: 'Sex').size)
     assert_equal(53, MonitoreeCount.where(category_type: 'Risk Factor').size)
-    assert_equal(80, MonitoreeCount.where(category_type: 'Exposure Country').size)
+    assert_equal(29, MonitoreeCount.where(category_type: 'Exposure Country').size)
     assert_not_equal(0, MonitoreeCount.where(category_type: 'Last Exposure Date').size)
     assert_not_equal(0, MonitoreeCount.where(category_type: 'Last Exposure Week').size)
     assert_not_equal(0, MonitoreeCount.where(category_type: 'Last Exposure Month').size)


### PR DESCRIPTION
Monitoree counts by country of exposure is currently not being displayed saying "no country data available" when there is data available.
- [x] correct the front end logic
- [x] modify cache analytics job to not produce monitoree counts where potential exposure country is not provided