### PR TITLE
add special case to adjust the index if browser is safari

### DIFF
--- a/app/javascript/components/layout/Breadcrumb.js
+++ b/app/javascript/components/layout/Breadcrumb.js
@@ -8,6 +8,11 @@ class Breadcrumb extends React.Component {
   }
 
   goBack(index) {
+    // check for if the browser is safari and bump up the index due to a safari off by one history.go bug
+    // remove once this bug is fixed in safari
+    var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+    if (isSafari) index++;
+
     window.history.go(0 - index);
   }
 


### PR DESCRIPTION
takes care of [JIRA 409](https://jira.mitre.org/browse/SARAALERT-409)

I added a special case to check if the browser is safari to account for the history.go bug.  we'll have to remove this once that bug is fixed in safari