### PR TITLE
Add monitoree maps to analytics

### DIFF
--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -36,9 +36,7 @@ class CacheAnalyticsJob < ApplicationJob
         patients = Jurisdiction.find(analytic.jurisdiction_id).all_patients
         MonitoreeCount.import! self.class.all_monitoree_counts(analytic.id, patients)
         MonitoreeSnapshot.import! self.class.all_monitoree_snapshots(analytic.id, patients, analytic.jurisdiction_id)
-        if root_jurs.include?(analytic.jurisdiction_id)
-          MonitoreeMap.import! self.class.all_monitoree_maps(analytic.id, patients)
-        end
+        MonitoreeMap.import! self.class.all_monitoree_maps(analytic.id, patients) if root_jurs.include?(analytic.jurisdiction_id)
       end
     end
   end
@@ -172,8 +170,8 @@ class CacheAnalyticsJob < ApplicationJob
               .group(age_groups, :exposure_risk_assessment)
               .order(Arel.sql(age_groups), :exposure_risk_assessment)
               .size
-              .map do |fields, total|
-                monitoree_count(analytic_id, active_monitoring, 'Age Group', fields[0], fields[1], total)
+              .map do |(age_group, risk), total|
+                monitoree_count(analytic_id, active_monitoring, 'Age Group', age_group, risk, total)
               end
   end
 
@@ -183,8 +181,8 @@ class CacheAnalyticsJob < ApplicationJob
               .group(:sex, :exposure_risk_assessment)
               .order(:sex, :exposure_risk_assessment)
               .size
-              .map do |fields, total|
-                monitoree_count(analytic_id, active_monitoring, 'Sex', fields[0].nil? ? 'Missing' : fields[0], fields[1], total)
+              .map do |(sex, risk), total|
+                monitoree_count(analytic_id, active_monitoring, 'Sex', sex.nil? ? 'Missing' : sex, risk, total)
               end
   end
 
@@ -198,8 +196,8 @@ class CacheAnalyticsJob < ApplicationJob
                 .group(risk_factor, :exposure_risk_assessment)
                 .order(:exposure_risk_assessment)
                 .size
-                .map do |fields, total|
-                  counts.append(monitoree_count(analytic_id, active_monitoring, 'Risk Factor', label, fields[1], total))
+                .map do |(_, risk), total|
+                  counts.append(monitoree_count(analytic_id, active_monitoring, 'Risk Factor', label, risk, total))
                 end
     end
     # Total
@@ -230,8 +228,8 @@ class CacheAnalyticsJob < ApplicationJob
               .group(:potential_exposure_country, :exposure_risk_assessment)
               .order(:potential_exposure_country, :exposure_risk_assessment)
               .size
-              .map do |fields, total|
-                counts.append(monitoree_count(analytic_id, active_monitoring, 'Exposure Country', fields[0], fields[1], total))
+              .map do |(country, risk), total|
+                counts.append(monitoree_count(analytic_id, active_monitoring, 'Exposure Country', country, risk, total))
               end
     # Total
     monitorees.monitoring_active(active_monitoring)
@@ -251,8 +249,8 @@ class CacheAnalyticsJob < ApplicationJob
               .group(:last_date_of_exposure, :exposure_risk_assessment)
               .order(:last_date_of_exposure, :exposure_risk_assessment)
               .size
-              .map do |fields, total|
-                monitoree_count(analytic_id, active_monitoring, 'Last Exposure Date', fields[0], fields[1], total)
+              .map do |(date, risk), total|
+                monitoree_count(analytic_id, active_monitoring, 'Last Exposure Date', date, risk, total)
               end
   end
 
@@ -266,8 +264,8 @@ class CacheAnalyticsJob < ApplicationJob
               .group(exposure_weeks, :exposure_risk_assessment)
               .order(Arel.sql(exposure_weeks), :exposure_risk_assessment)
               .size
-              .map do |fields, total|
-                monitoree_count(analytic_id, active_monitoring, 'Last Exposure Week', fields[0], fields[1], total)
+              .map do |(week, risk), total|
+                monitoree_count(analytic_id, active_monitoring, 'Last Exposure Week', week, risk, total)
               end
   end
 
@@ -281,8 +279,8 @@ class CacheAnalyticsJob < ApplicationJob
               .group(exposure_months, :exposure_risk_assessment)
               .order(Arel.sql(exposure_months), :exposure_risk_assessment)
               .size
-              .map do |fields, total|
-                monitoree_count(analytic_id, active_monitoring, 'Last Exposure Month', fields[0], fields[1], total)
+              .map do |(month, risk), total|
+                monitoree_count(analytic_id, active_monitoring, 'Last Exposure Month', month, risk, total)
               end
   end
 
@@ -344,7 +342,7 @@ class CacheAnalyticsJob < ApplicationJob
   end
 
   # Monitoree map
-  def self.monitoree_map(analytic_id, level, workflow, state, county, total)
+  def self.monitoree_map(analytic_id, level, workflow, state, county, total) # rubocop:todo Metrics/ParameterLists
     MonitoreeMap.new(
       analytic_id: analytic_id,
       level: level,

--- a/app/models/monitoree_map.rb
+++ b/app/models/monitoree_map.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# MonitoreeMap: a county of monitorees currently being monitored by workflow, state, and county used for analytics
+class MonitoreeMap < ApplicationRecord
+  belongs_to :analytic
+end

--- a/db/migrate/20200619192502_create_monitoree_maps.rb
+++ b/db/migrate/20200619192502_create_monitoree_maps.rb
@@ -1,0 +1,15 @@
+class CreateMonitoreeMaps < ActiveRecord::Migration[6.0]
+  def change
+    create_table :monitoree_maps do |t|
+      t.references :analytic, index: true
+
+      t.string :level
+      t.string :workflow
+      t.string :state
+      t.string :county
+      t.integer :total
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_17_191458) do
+ActiveRecord::Schema.define(version: 2020_06_19_192502) do
 
   create_table "analytics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "jurisdiction_id"
@@ -109,6 +109,18 @@ ActiveRecord::Schema.define(version: 2020_06_17_191458) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["analytic_id"], name: "index_monitoree_counts_on_analytic_id"
+  end
+
+  create_table "monitoree_maps", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "analytic_id"
+    t.string "level"
+    t.string "workflow"
+    t.string "state"
+    t.string "county"
+    t.integer "total"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["analytic_id"], name: "index_monitoree_maps_on_analytic_id"
   end
 
   create_table "monitoree_snapshots", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -90,9 +90,13 @@ namespace :demo do
 
     print 'Creating public health enroller users...'
 
-    phe1 = User.new(email: 'state1_epi_enroller@example.com', password: '1234567ab!', jurisdiction: jurisdictions[:state1], force_password_change: false, authy_enabled: false, authy_enforced: false, api_enabled: true)
+    phe1 = User.new(email: 'epi_enroller_all@example.com', password: '1234567ab!', jurisdiction: jurisdictions[:usa], force_password_change: false, authy_enabled: false, authy_enforced: false, api_enabled: true)
     phe1.add_role :public_health_enroller
     phe1.save
+
+    phe2 = User.new(email: 'state1_epi_enroller@example.com', password: '1234567ab!', jurisdiction: jurisdictions[:state1], force_password_change: false, authy_enabled: false, authy_enforced: false, api_enabled: true)
+    phe2.add_role :public_health_enroller
+    phe2.save
 
     puts ' done!'
 
@@ -113,6 +117,14 @@ namespace :demo do
     analyst1 = User.new(email: 'analyst_all@example.com', password: '1234567ab!', jurisdiction: jurisdictions[:usa], force_password_change: false, authy_enabled: false, authy_enforced: false)
     analyst1.add_role :analyst
     analyst1.save
+
+    analyst2 = User.new(email: 'state1_analyst@example.com', password: '1234567ab!', jurisdiction: jurisdictions[:state1], force_password_change: false, authy_enabled: false, authy_enforced: false)
+    analyst2.add_role :analyst
+    analyst2.save
+
+    analyst3 = User.new(email: 'localS1C1_analyst@example.com', password: '1234567ab!', jurisdiction: jurisdictions[:county1], force_password_change: false, authy_enabled: false, authy_enforced: false)
+    analyst3.add_role :analyst
+    analyst3.save
 
     puts ' done!'
 
@@ -208,46 +220,49 @@ namespace :demo do
 
           # Address
           if rand < 0.8
-            patient[:address_line_1] = Faker::Address.street_address
-            patient[:address_city] = Faker::Address.city
-            patient[:address_state] = rand < 0.7 ? Faker::Address.state : territory_names[rand(territory_names.count)]
+            patient[:address_line_1] = Faker::Address.street_address if rand < 0.95
+            patient[:address_city] = Faker::Address.city if rand < 0.95
+            patient[:address_state] = rand < 0.7 ? Faker::Address.state : territory_names[rand(territory_names.count)] if rand < 0.95
             patient[:address_line_2] = Faker::Address.secondary_address if rand < 0.4
-            patient[:address_zip] = Faker::Address.zip_code
+            patient[:address_zip] = Faker::Address.zip_code if rand < 0.95
+            patient[:address_county] = Faker::Address.community if rand < 0.7
             if rand < 0.7
               patient[:monitored_address_line_1] = patient[:address_line_1]
               patient[:monitored_address_city] = patient[:address_city]
               patient[:monitored_address_state] = patient[:address_state]
               patient[:monitored_address_line_2] = patient[:address_line_2]
               patient[:monitored_address_zip] = patient[:address_zip]
+              patient[:monitored_address_county] = patient[:address_county]
             else
-              patient[:monitored_address_line_1] = Faker::Address.street_address
-              patient[:monitored_address_city] = Faker::Address.city
-              patient[:monitored_address_state] = rand < 0.7 ? Faker::Address.state : territory_names[rand(territory_names.count)]
+              patient[:monitored_address_line_1] = Faker::Address.street_address if rand < 0.95
+              patient[:monitored_address_city] = Faker::Address.city if rand < 0.95
+              patient[:monitored_address_state] = rand < 0.7 ? Faker::Address.state : territory_names[rand(territory_names.count)] if rand < 0.95
               patient[:monitored_address_line_2] = Faker::Address.secondary_address if rand < 0.4
-              patient[:monitored_address_zip] = Faker::Address.zip_code
+              patient[:monitored_address_zip] = Faker::Address.zip_code if rand < 0.95
+              patient[:monitored_address_county] = Faker::Address.community if rand < 0.7
             end
           else
-            patient[:foreign_address_line_1] = Faker::Address.street_address
-            patient[:foreign_address_city] = Faker::Nation.capital_city
-            patient[:foreign_address_country] = Faker::Address.country
+            patient[:foreign_address_line_1] = Faker::Address.street_address if rand < 0.95
+            patient[:foreign_address_city] = Faker::Nation.capital_city if rand < 0.95
+            patient[:foreign_address_country] = Faker::Address.country if rand < 0.95
             patient[:foreign_address_line_2] = Faker::Address.secondary_address if rand < 0.4
-            patient[:foreign_address_zip] = Faker::Address.zip_code
+            patient[:foreign_address_zip] = Faker::Address.zip_code if rand < 0.95
             patient[:foreign_address_line_3] = Faker::Address.secondary_address if patient[:foreign_address_line2] && rand < 0.3
-            patient[:foreign_address_state] = rand < 0.7 ? Faker::Address.state : territory_names[rand(territory_names.count)]
+            patient[:foreign_address_state] = rand < 0.7 ? Faker::Address.state : territory_names[rand(territory_names.count)] if rand < 0.95
             if rand < 0.6
               patient[:foreign_monitored_address_line_1] = patient[:foreign_address_line_1]
               patient[:foreign_monitored_address_city] = patient[:foreign_address_city]
               patient[:foreign_monitored_address_state] = patient[:foreign_address_state]
               patient[:foreign_monitored_address_line_2] = patient[:foreign_address_line_2]
               patient[:foreign_monitored_address_zip] = patient[:foreign_address_zip]
-              patient[:foreign_monitored_address_county] = Faker::Nation.capital_city if rand < 0.5
+              patient[:foreign_monitored_address_county] = Faker::Nation.capital_city if rand < 0.6
             else
-              patient[:foreign_monitored_address_line_1] = Faker::Address.street_address
-              patient[:foreign_monitored_address_city] = Faker::Address.city
-              patient[:foreign_monitored_address_state] = rand < 0.7 ? Faker::Address.state : territory_names[rand(territory_names.count)]
+              patient[:foreign_monitored_address_line_1] = Faker::Address.street_address if rand < 0.95
+              patient[:foreign_monitored_address_city] = Faker::Nation.capital_city if rand < 0.95
+              patient[:foreign_monitored_address_state] = rand < 0.7 ? Faker::Address.state : territory_names[rand(territory_names.count)] if rand < 0.95
               patient[:foreign_monitored_address_line_2] = Faker::Address.secondary_address if rand < 0.4
-              patient[:foreign_monitored_address_zip] = Faker::Address.zip_code
-              patient[:foreign_monitored_address_county] = Faker::Nation.capital_city if rand < 0.5
+              patient[:foreign_monitored_address_zip] = Faker::Address.zip_code if rand < 0.95
+              patient[:foreign_monitored_address_county] = Faker::Address.community if rand < 0.7
             end
           end
 

--- a/test/fixtures/patients.yml
+++ b/test/fixtures/patients.yml
@@ -18,11 +18,12 @@ patient_1:
   primary_language: "English"
   address_line_1: "76640 Barney Street"
   address_city: "South Lenport"
-  address_state: "New Jersey"
+  address_state: "New York"
   address_zip: "41987-5448"
+  address_county: "Monroe"
   monitored_address_line_1: "77289 Noma Row"
   monitored_address_city: "Grahamshire"
-  monitored_address_state: "VT"
+  monitored_address_state: "California"
   monitored_address_zip: "03824"
   primary_telephone: "(555) 555-0111"
   primary_telephone_type: "Smartphone"
@@ -70,11 +71,12 @@ patient_2:
   primary_language: "English"
   address_line_1: "358 Stefany Village"
   address_city: "Spinkaville"
-  address_state: "Pennsylvania"
+  address_state: "California"
+  address_county: "Monroe"
   address_zip: "19521"
   monitored_address_line_1: "358 Stefany Village"
   monitored_address_city: "Spinkaville"
-  monitored_address_state: "NH"
+  monitored_address_state: "New Hampshire"
   monitored_address_zip: "19521"
   primary_telephone: "(555) 555-0141"
   primary_telephone_type: "Plain Cell"
@@ -132,7 +134,7 @@ patient_4:
   sex: "Female"
   address_line_1: "91227 Rueben Skyway"
   address_city: "Port Kaycee"
-  address_state: "Connecticut"
+  address_state: "New York"
   address_zip: "15212"
   primary_telephone: "(555) 555-0146"
   primary_telephone_type: "Plain Cell"
@@ -156,6 +158,7 @@ patient_5:
   address_line_1: "74671 Beahan Stravenue"
   address_city: "South Wilmertown"
   address_state: "New York"
+  address_county: "Warren"
   address_zip: "08291"
   primary_telephone: "(555) 555-0148"
   primary_telephone_type: "Plain Cell"
@@ -179,8 +182,9 @@ patient_6:
   sex: "Male"
   address_line_1: "3212 Granville Corners"
   address_city: "Emoryburgh"
-  address_state: "Wisconsin"
+  address_state: "California"
   address_zip: "39204"
+  address_county: "Monroe"
   primary_telephone: "(555) 555-0152"
   primary_telephone_type: "Plain Cell"
   preferred_contact_method: "Telephone call"
@@ -204,7 +208,8 @@ patient_7:
   sex: "Unknown"
   address_line_1: "55068 Elliott Garden"
   address_city: "Mohammedville"
-  address_state: "North Dakota"
+  address_state: "New York"
+  address_county: "Pike"
   address_zip: "16810-0047"
   primary_telephone: "(555) 555-0164"
   primary_telephone_type: "Plain Cell"
@@ -231,6 +236,7 @@ patient_8:
   address_city: "Port Kermithaven"
   address_state: "Delaware"
   address_zip: "62431-6865"
+  address_county: "Pike"
   primary_telephone: "(555) 555-0169"
   primary_telephone_type: "Plain Cell"
   preferred_contact_method: "Telephone call"
@@ -255,8 +261,9 @@ patient_9:
   sex: "Female"
   address_line_1: "65278 Ledner Island"
   address_city: "West Amosfurt"
-  address_state: "Hawaii"
+  address_state: "Delaware"
   address_zip: "62431-6865"
+  address_county: "Jackson"
   primary_telephone: "(555) 555-0189"
   primary_telephone_type: "Plain Cell"
   preferred_contact_method: "Telephone call"
@@ -280,8 +287,9 @@ patient_10:
   date_of_birth: "<%= 9.years.ago %>"
   address_line_1: "7135 Michaela Stravenue"
   address_city: "North Maciefort"
-  address_state: "Kansas"
+  address_state: "Massachusetts"
   address_zip: "62431-6865"
+  address_county: "Jackson"
   primary_telephone: "(555) 555-0173"
   primary_telephone_type: "Plain Cell"
   preferred_contact_method: "Telephone call"
@@ -307,6 +315,7 @@ patient_11:
   address_city: "South Arthur"
   address_state: "Massachusetts"
   address_zip: "62431-6865"
+  address_county: "Suffolk"
   primary_telephone: "(555) 555-0174"
   primary_telephone_type: "Plain Cell"
   preferred_contact_method: "Telephone call"
@@ -323,6 +332,8 @@ patient_12:
   last_name: "Smith"
   sex: "Male"
   date_of_birth: "<%= 100.years.ago %>"
+  address_state: "Massachusetts"
+  address_county: "Suffolk"
   exposure_risk_assessment: 'No Identified Risk'
   last_date_of_exposure: "<%= 35.days.ago %>"
   potential_exposure_country: "China"
@@ -344,6 +355,8 @@ patient_13:
   last_name: "Yoo"
   sex: "Male"
   date_of_birth: "<%= 69.years.ago %>"
+  address_state: "Massachusetts"
+  address_county: "Suffolk"
   exposure_risk_assessment: 'Medium'
   last_date_of_exposure: "<%= 179.days.ago %>"
   potential_exposure_country: "Korea"
@@ -366,6 +379,7 @@ patient_14:
   last_name: "Chung"
   sex: "Female"
   date_of_birth: "<%= 66.years.ago %>"
+  address_state: "Massachusetts"
   exposure_risk_assessment: 'Low'
   last_date_of_exposure: "<%= 318.days.ago %>"
   potential_exposure_country: "Brazil"
@@ -387,6 +401,8 @@ patient_15:
   last_name: "Snow"
   sex: "Unknown"
   date_of_birth: "<%= 50.years.ago %>"
+  address_state: "Massachusetts"
+  address_county: "Lake"
   exposure_risk_assessment: 'High'
   last_date_of_exposure: "<%= 134.days.ago %>"
   potential_exposure_country: "Iceland"
@@ -409,6 +425,8 @@ patient_16:
   last_name: "Curry"
   sex: "Male"
   date_of_birth: "<%= 45.years.ago %>"
+  address_state: "Massachusetts"
+  address_county: "Lake"
   exposure_risk_assessment: 'High'
   last_date_of_exposure: "<%= 26.days.ago %>"
   potential_exposure_country: "Faroe Islands"
@@ -430,6 +448,8 @@ patient_17:
   last_name: "Stark"
   sex: "Unknown"
   date_of_birth: "<%= 36.years.ago %>"
+  address_state: "Massachusetts"
+  address_county: "Lake"
   exposure_risk_assessment: 'No Identified Risk'
   last_date_of_exposure: "<%= 84.days.ago %>"
   potential_exposure_country: "Faroe Islands"
@@ -452,6 +472,8 @@ patient_18:
   last_name: "Greyjoy"
   sex: "Unknown"
   date_of_birth: "<%= 35.years.ago %>"
+  address_state: "Massachusetts"
+  address_county: "Lake"
   exposure_risk_assessment: 'Low'
   last_date_of_exposure: "<%= 322.days.ago %>"
   potential_exposure_country: "Malaysia"
@@ -473,6 +495,7 @@ patient_19:
   last_name: "Smith"
   sex: "Female"
   date_of_birth: "<%= 19.years.ago %>"
+  address_county: "Lake"
   exposure_risk_assessment: 'Medium'
   last_date_of_exposure: "<%= 34.days.ago %>"
   potential_exposure_country: "Malaysia"
@@ -510,18 +533,22 @@ patient_21:
   id: 21
   jurisdiction_id: 8
   monitoring: true
+  address_state: "American Samoa"
   exposure_risk_assessment: 'High'
   last_date_of_exposure: "<%= 1.week.ago %>"
 patient_22:
   id: 22
   jurisdiction_id: 8
   monitoring: true
+  address_state: "American Samoa"
   exposure_risk_assessment: 'High'
   last_date_of_exposure: "<%= 3.weeks.ago %>"
 patient_23:
   id: 23
   jurisdiction_id: 8
   monitoring: false
+  address_state: "American Samoa"
+  address_county: "Hancock"
   closed_at: "<%= 9.hours.ago %>"
   exposure_risk_assessment: 'Low'
   last_date_of_exposure: "<%= 3.weeks.ago %>"
@@ -529,6 +556,8 @@ patient_24:
   id: 24
   jurisdiction_id: 8
   monitoring: false
+  address_state: "American Samoa"
+  address_county: "Crawford"
   closed_at: "<%= 1.week.ago %>"
   exposure_risk_assessment: 'Medium'
   last_date_of_exposure: "<%= 11.weeks.ago %>"
@@ -536,12 +565,14 @@ patient_25:
   id: 25
   jurisdiction_id: 8
   monitoring: true
+  address_state: "Puerto Rico"
   exposure_risk_assessment: 'Medium'
   last_date_of_exposure: "<%= 19.weeks.ago %>"
 patient_26:
   id: 26
   jurisdiction_id: 8
   monitoring: false
+  address_state: "Puerto Rico"
   closed_at: "<%= 1.day.ago %>"
   exposure_risk_assessment: 'No Identified Risk'
   last_date_of_exposure: "<%= 21.weeks.ago %>"
@@ -549,40 +580,53 @@ patient_27:
   id: 27
   jurisdiction_id: 8
   monitoring: true
+  address_state: "Puerto Rico"
+  address_county: "Jackson"
   exposure_risk_assessment: 'Low'
   last_date_of_exposure: "<%= 25.weeks.ago %>"
 patient_28:
   id: 28
   jurisdiction_id: 8
   monitoring: true
+  address_state: "Puerto Rico"
+  address_county: "Jackson"
   exposure_risk_assessment: 'Low'
   last_date_of_exposure: "<%= 25.weeks.ago %>"
 patient_29:
   id: 29
   jurisdiction_id: 8
   monitoring: true
+  address_state: "Guam"
+  address_county: "Lawrence"
   last_date_of_exposure: "<%= 52.weeks.ago %>"
 patient_30:
   id: 30
   jurisdiction_id: 8
   monitoring: true
+  address_state: "Guam"
   last_date_of_exposure: "<%= 54.weeks.ago %>"
 patient_31:
   id: 31
   jurisdiction_id: 9
   monitoring: true
+  address_state: "Guam"
+  address_county: "Lawrence"
   exposure_risk_assessment: 'Low'
   last_date_of_exposure: '<%= 1.month.ago %>'
 patient_32:
   id: 32
   jurisdiction_id: 9
   monitoring: true
+  address_state: "Alaska"
+  address_county: "Lawrence"
   exposure_risk_assessment: 'High'
   last_date_of_exposure: '<%= 1.month.ago %>'
 patient_33:
   id: 33
   jurisdiction_id: 9
   monitoring: false
+  address_state: "Alaska"
+  address_county: "Pike"
   closed_at: "<%= 3.weeks.ago %>"
   exposure_risk_assessment: 'Medium'
   last_date_of_exposure: '<%= 2.months.ago %>'
@@ -590,30 +634,39 @@ patient_34:
   id: 34
   jurisdiction_id: 9
   monitoring: true
+  address_state: "Alaska"
+  address_county: "Polk"
   exposure_risk_assessment: 'Medium'
   last_date_of_exposure: '<%= 2.months.ago %>'
 patient_35:
   id: 35
   jurisdiction_id: 9
   monitoring: true
+  address_state: "Alaska"
+  address_county: "Polk"
   exposure_risk_assessment: 'Low'
   last_date_of_exposure: '<%= 5.months.ago %>'
 patient_36:
   id: 36
   jurisdiction_id: 9
   monitoring: true
+  address_state: "Indiana"
+  address_county: "Polk"
   exposure_risk_assessment: 'No Identified Risk'
   last_date_of_exposure: '<%= 5.months.ago %>'
 patient_37:
   id: 37
   jurisdiction_id: 9
   monitoring: true
+  address_state: "Indiana"
+  address_county: "Warren"
   exposure_risk_assessment: 'No Identified Risk'
   last_date_of_exposure: '<%= 11.months.ago %>'
 patient_38:
   id: 38
   jurisdiction_id: 9
   monitoring: false
+  address_state: "Indiana"
   closed_at: "<%= 5.days.ago %>"
   exposure_risk_assessment: 'Medium'
   last_date_of_exposure: '<%= 11.months.ago %>'
@@ -621,12 +674,16 @@ patient_39:
   id: 39
   jurisdiction_id: 9
   monitoring: true
+  address_state: "Indiana"
+  address_county: "Warren"
   exposure_risk_assessment: 'Low'
   last_date_of_exposure: '<%= 13.months.ago %>'
 patient_40:
   id: 40
   jurisdiction_id: 9
   monitoring: true
+  address_state: "Indiana"
+  address_county: "Washington"
   exposure_risk_assessment: 'High'
   last_date_of_exposure: '<%= 14.months.ago %>'
 patient_41:
@@ -643,7 +700,7 @@ patient_41:
   date_of_birth: "<%= 35.years.ago %>"
   address_line_1: "796 Lesch Heights"
   address_city: "Laurenceborough"
-  address_state: "Rhode Island"
+  address_state: "New York"
   address_zip: "55335"
   primary_telephone: "(555) 555-0175"
   primary_telephone_type: "Plain Cell"
@@ -665,7 +722,7 @@ patient_42:
   date_of_birth: "<%= 48.years.ago %>"
   address_line_1: "45727 Skiles Parkways"
   address_city: "Yundtborough"
-  address_state: "Indiana"
+  address_state: "California"
   address_zip: "53922"
   primary_telephone: "(555) 555-0176"
   primary_telephone_type: "Plain Cell"
@@ -687,7 +744,7 @@ patient_43:
   date_of_birth: "<%= 79.years.ago %>"
   address_line_1: "656 Gracie Drives"
   address_city: "East Dewayneberg"
-  address_state: "West Virginia"
+  address_state: "New York"
   address_zip: "27382"
   primary_telephone: "(555) 555-0177"
   primary_telephone_type: "Plain Cell"
@@ -710,7 +767,7 @@ patient_44:
   date_of_birth: "<%= 61.years.ago %>"
   address_line_1: "5309 Nan Centers Suite 344"
   address_city: "Ailenemouth"
-  address_state: "Vermont"
+  address_state: "California"
   address_zip: "93872"
   primary_telephone: "(555) 555-0177"
   primary_telephone_type: "Plain Cell"
@@ -732,7 +789,7 @@ patient_45:
   date_of_birth: "<%= 2.years.ago %>"
   address_line_1: "544 Saul Green"
   address_city: "Port Walter"
-  address_state: "Oklahoma"
+  address_state: "California"
   address_zip: "61411-4761"
   primary_telephone: "(555) 555-0178"
   primary_telephone_type: "Plain Cell"
@@ -754,7 +811,7 @@ patient_46:
   date_of_birth: "<%= 18.years.ago %>"
   address_line_1: "630 Frederick Land Apt. 170"
   address_city: "Haydenburgh"
-  address_state: "Pennsylvania"
+  address_state: "California"
   address_zip: "82912-2919"
   primary_telephone: "(555) 555-0179"
   primary_telephone_type: "Plain Cell"
@@ -799,7 +856,7 @@ patient_48:
   date_of_birth: "<%= 31.years.ago %>"
   address_line_1: "7854 Funk Junctions"
   address_city: "South Douglasview"
-  address_state: "Texas"
+  address_state: "California"
   address_zip: "82922-2919"
   primary_telephone: "(555) 555-0182"
   primary_telephone_type: "Plain Cell"
@@ -821,7 +878,7 @@ patient_49:
   date_of_birth: "<%= 63.years.ago %>"
   address_line_1: "630 Frederick Land Apt. 170"
   address_city: "Port Clementeland"
-  address_state: "Nevada"
+  address_state: "California"
   address_zip: "99920"
   primary_telephone: "(555) 555-0188"
   primary_telephone_type: "Plain Cell"
@@ -845,7 +902,7 @@ patient_50:
   date_of_birth: "<%= 52.years.ago %>"
   address_line_1: "144 Jama Spurs"
   address_city: "West April"
-  address_state: "Wisconsin"
+  address_state: "California"
   address_zip: "22804"
   primary_telephone: "(555) 555-0189"
   primary_telephone_type: "Plain Cell"
@@ -869,7 +926,7 @@ patient_51:
   date_of_birth: "2005-08-18"
   address_line_1: "7197 Johnson Dale"
   address_city: "Irmaborough"
-  address_state: "South Dakota"
+  address_state: "California"
   address_zip: "86846-7192"
   primary_telephone: "(555) 555-0189"
   primary_telephone_type: "Plain Cell"

--- a/test/jobs/analytics_job_test.rb
+++ b/test/jobs/analytics_job_test.rb
@@ -11,7 +11,9 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     MonitoreeCount.delete_all
     MonitoreeSnapshot.delete_all
     CacheAnalyticsJob.perform_now()
+
     assert_equal(10, Analytic.all.size)
+
     assert_equal(55, MonitoreeCount.where(category_type: 'Overall Total').size)
     assert_equal(25, MonitoreeCount.where(category_type: 'Monitoring Status').size)
     assert_equal(112, MonitoreeCount.where(category_type: 'Age Group').size)
@@ -22,10 +24,17 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     assert_not_equal(0, MonitoreeCount.where(category_type: 'Last Exposure Week').size)
     assert_not_equal(0, MonitoreeCount.where(category_type: 'Last Exposure Month').size)
     assert_not_equal(0, MonitoreeCount.all.size)
+
     assert_equal(10, MonitoreeSnapshot.where(time_frame: 'Last 24 Hours').size)
     assert_equal(10, MonitoreeSnapshot.where(time_frame: 'Last 14 Days').size)
     assert_equal(10, MonitoreeSnapshot.where(time_frame: 'Total').size)
     assert_equal(30, MonitoreeSnapshot.all.size)
+
+    assert_equal(10, MonitoreeMap.where(level: 'State', workflow: 'Exposure').size)
+    assert_equal(3, MonitoreeMap.where(level: 'State', workflow: 'Isolation').size)
+    assert_equal(22, MonitoreeMap.where(level: 'County', workflow: 'Exposure').size)
+    assert_equal(3, MonitoreeMap.where(level: 'County', workflow: 'Isolation').size)
+    assert_equal(38, MonitoreeMap.all.size)
   end
   
   test 'calculate analytic local to jurisdiction' do
@@ -70,6 +79,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     verify_monitoree_count(active_counts, 3, true, 'Overall Total', 'Total', 'Medium', 4)
     verify_monitoree_count(active_counts, 4, true, 'Overall Total', 'Total', 'No Identified Risk', 4)
     assert_equal(5, active_counts.length)
+
     overall_counts = CacheAnalyticsJob.monitoree_counts_by_total(1, @@monitorees, false)
     verify_monitoree_count(overall_counts, 0, false, 'Overall Total', 'Total', 'Missing', 14)
     verify_monitoree_count(overall_counts, 1, false, 'Overall Total', 'Total', 'High', 3)
@@ -108,6 +118,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     verify_monitoree_count(active_counts, 16, true, 'Age Group', '70-79', 'Missing', 1)
     verify_monitoree_count(active_counts, 17, true, 'Age Group', '>=80', 'No Identified Risk', 1)
     assert_equal(18, active_counts.length)
+
     overall_counts = CacheAnalyticsJob.monitoree_counts_by_age_group(1, @@monitorees, false)
     verify_monitoree_count(overall_counts, 0, false, 'Age Group', '0-19', 'Missing', 3)
     verify_monitoree_count(overall_counts, 1, false, 'Age Group', '0-19', 'High', 1)
@@ -151,6 +162,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     verify_monitoree_count(active_counts, 14, true, 'Sex', 'Unknown', 'Medium', 1)
     verify_monitoree_count(active_counts, 15, true, 'Sex', 'Unknown', 'No Identified Risk', 1)
     assert_equal(16, active_counts.length)
+
     overall_counts = CacheAnalyticsJob.monitoree_counts_by_sex(1, @@monitorees, false)
     verify_monitoree_count(overall_counts, 0, false, 'Sex', 'Missing', 'Medium', 1)
     verify_monitoree_count(overall_counts, 1, false, 'Sex', 'Missing', 'No Identified Risk', 1)
@@ -195,6 +207,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     verify_monitoree_count(active_counts, 18, true, 'Risk Factor', 'Total', 'Medium', 2)
     verify_monitoree_count(active_counts, 19, true, 'Risk Factor', 'Total', 'No Identified Risk', 2)
     assert_equal(20, active_counts.length)
+
     overall_counts = CacheAnalyticsJob.monitoree_counts_by_risk_factor(1, @@monitorees, false)
     verify_monitoree_count(overall_counts, 0, false, 'Risk Factor', 'Close Contact with Known Case', 'High', 1)
     verify_monitoree_count(overall_counts, 1, false, 'Risk Factor', 'Close Contact with Known Case', 'Low', 1)
@@ -241,6 +254,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     verify_monitoree_count(active_counts, 10, true, 'Exposure Country', 'Total', 'Medium', 2)
     verify_monitoree_count(active_counts, 11, true, 'Exposure Country', 'Total', 'No Identified Risk', 2)
     assert_equal(12, active_counts.length)
+
     overall_counts = CacheAnalyticsJob.monitoree_counts_by_exposure_country(1, @@monitorees, false)
     verify_monitoree_count(overall_counts, 0, false, 'Exposure Country', 'Brazil', 'Low', 1)
     verify_monitoree_count(overall_counts, 1, false, 'Exposure Country', 'China', 'No Identified Risk', 1)
@@ -274,6 +288,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     verify_monitoree_count(active_counts, 10, true, 'Last Exposure Date', days_ago(3), 'Missing', 1)
     verify_monitoree_count(active_counts, 11, true, 'Last Exposure Date', days_ago(1), 'High', 1)
     assert_equal(12, active_counts.length)
+
     overall_counts = CacheAnalyticsJob.monitoree_counts_by_last_exposure_date(1, @@monitorees, false)
     verify_monitoree_count(overall_counts, 0, false, 'Last Exposure Date', days_ago(27), 'Missing', 1)
     verify_monitoree_count(overall_counts, 1, false, 'Last Exposure Date', days_ago(27), 'Medium', 1)
@@ -298,6 +313,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     verify_monitoree_count(active_counts, 3, true, 'Last Exposure Week', weeks_ago(3), 'High', 1)
     verify_monitoree_count(active_counts, 4, true, 'Last Exposure Week', weeks_ago(1), 'High', 1)
     assert_equal(5, active_counts.length)
+
     overall_counts = CacheAnalyticsJob.monitoree_counts_by_last_exposure_week(1, @@monitorees_by_exposure_week, false)
     verify_monitoree_count(overall_counts, 0, false, 'Last Exposure Week', weeks_ago(52), 'Missing', 1)
     verify_monitoree_count(overall_counts, 1, false, 'Last Exposure Week', weeks_ago(25), 'Low', 2)
@@ -320,6 +336,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     verify_monitoree_count(active_counts, 5, true, 'Last Exposure Month', months_ago(1), 'High', 1)
     verify_monitoree_count(active_counts, 6, true, 'Last Exposure Month', months_ago(1), 'Low', 1)
     assert_equal(7, active_counts.length)
+
     overall_counts = CacheAnalyticsJob.monitoree_counts_by_last_exposure_month(1, @@monitorees_by_exposure_month, false)
     verify_monitoree_count(overall_counts, 0, false, 'Last Exposure Month', months_ago(13), 'Low', 1)
     verify_monitoree_count(overall_counts, 1, false, 'Last Exposure Month', months_ago(11), 'Medium', 1)
@@ -336,18 +353,47 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     snapshots = CacheAnalyticsJob.all_monitoree_snapshots(1, @@monitorees, 1)
     verify_snapshot(snapshots, 0, 'Last 24 Hours', 5, 0, 2, 0)
     verify_snapshot(snapshots, 2, 'Total', 30, 0, 3, 0)
+
     snapshots = CacheAnalyticsJob.all_monitoree_snapshots(1, Patient.where(jurisdiction_id: 2), 2)
     verify_snapshot(snapshots, 0, 'Last 24 Hours', 2, 1, 1, 1)
     verify_snapshot(snapshots, 2, 'Total', 12, 2, 1, 2)
   end
 
-  def verify_monitoree_count(counts, index, active_monitoring, category_type, category, risk_level, count)
+  test 'monitoree maps' do
+    maps = CacheAnalyticsJob.all_monitoree_maps(1, @@monitorees)
+    verify_map(maps, 0, 'State', 'Exposure', nil, nil, 2)
+    verify_map(maps, 1, 'State', 'Exposure', 'California', nil, 4)
+    verify_map(maps, 2, 'State', 'Exposure', 'Delaware', nil, 2)
+    verify_map(maps, 3, 'State', 'Exposure', 'Massachusetts', nil, 7)
+    verify_map(maps, 4, 'State', 'Exposure', 'New York', nil, 4)
+    verify_map(maps, 5, 'State', 'Isolation', 'California', nil, 6)
+    verify_map(maps, 6, 'State', 'Isolation', 'Massachusetts', nil, 1)
+    verify_map(maps, 7, 'State', 'Isolation', 'New York', nil, 1)
+    verify_map(maps, 8, 'County', 'Exposure', nil, nil, 1)
+    verify_map(maps, 9, 'County', 'Exposure', nil, 'Lake', 1)
+    verify_map(maps, 10, 'County', 'Exposure', 'California', nil, 2)
+    verify_map(maps, 11, 'County', 'Exposure', 'California', 'Monroe', 2)
+    verify_map(maps, 12, 'County', 'Exposure', 'Delaware', 'Jackson', 1)
+    verify_map(maps, 13, 'County', 'Exposure', 'Delaware', 'Pike', 1)
+    verify_map(maps, 14, 'County', 'Exposure', 'Massachusetts', 'Jackson', 1)
+    verify_map(maps, 15, 'County', 'Exposure', 'Massachusetts', 'Lake', 3)
+    verify_map(maps, 16, 'County', 'Exposure', 'Massachusetts', 'Suffolk', 3)
+    verify_map(maps, 17, 'County', 'Exposure', 'New York', nil, 2)
+    verify_map(maps, 18, 'County', 'Exposure', 'New York', 'Monroe', 1)
+    verify_map(maps, 19, 'County', 'Exposure', 'New York', 'Pike', 1)
+    verify_map(maps, 20, 'County', 'Isolation', 'California', nil, 6)
+    verify_map(maps, 21, 'County', 'Isolation', 'Massachusetts', nil, 1)
+    verify_map(maps, 22, 'County', 'Isolation', 'New York', nil, 1)
+    assert_equal(23, maps.length)
+  end
+
+  def verify_monitoree_count(counts, index, active_monitoring, category_type, category, risk_level, total)
     assert_equal(1, counts[index].analytic_id, monitoree_count_err_msg(index, active_monitoring, category_type))
     assert_equal(active_monitoring, counts[index].active_monitoring, monitoree_count_err_msg(index, active_monitoring, category_type))
     assert_equal(category_type, counts[index].category_type, monitoree_count_err_msg(index, active_monitoring, category_type))
     assert_equal(category, counts[index].category, monitoree_count_err_msg(index, active_monitoring, category_type))
     assert_equal(risk_level, counts[index].risk_level, monitoree_count_err_msg(index, active_monitoring, category_type))
-    assert_equal(count, counts[index].total, monitoree_count_err_msg(index, active_monitoring, category_type))
+    assert_equal(total, counts[index].total, monitoree_count_err_msg(index, active_monitoring, category_type))
   end
 
   def verify_snapshot(snapshots, index, time_frame, new_enrollments, transferred_in, closed, transferred_out)
@@ -357,6 +403,23 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     assert_equal(transferred_in, snapshots[index].transferred_in, 'Incoming transfers')
     assert_equal(closed, snapshots[index].closed, 'Closed patients')
     assert_equal(transferred_out, snapshots[index].transferred_out, 'Outgoing transfers')
+  end
+
+  def verify_map(maps, index, level, workflow, state, county, total)
+    assert_equal(1, maps[index].analytic_id, 'Analytic ID')
+    assert_equal(level, maps[index].level, 'Level')
+    assert_equal(workflow, maps[index].workflow, 'Workflow')
+    if state.nil?
+      assert_nil(maps[index].state, 'State')
+    else
+      assert_equal(state, maps[index].state, 'State')
+    end
+    if county.nil?
+      assert_nil(maps[index].county, 'County')
+    else
+      assert_equal(county, maps[index].county, 'County')
+    end
+    assert_equal(total, maps[index].total, 'Total')
   end
 
   def get_absolute_date(relative_date)


### PR DESCRIPTION
Wanted to actually put this PR out early to hopefully get this into the next release so that by the time the front end stuff is released, there will some existing historical data for the timeline already.

- [x] create `monitoree_maps` schema
- [x] add address_county to `demo.rake` (currently using fake county names but once David merges his stuff, I'll update this to pull actual county names from the GeoJSON files)
- [x] populate analytics with `monitoree_maps`
- [x] tests

I decided to leave the value of states/counties in `monitoree_maps` as `null` for the categories where those fields are not present for patients that way we can be flexible with deciding/updating the wording of it in the front end whenever we want