### PR TITLE
Fix assessment symptoms not showing up in export bug

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -585,25 +585,6 @@ class Patient < ApplicationRecord # rubocop:todo Metrics/ClassLength
     end
   end
 
-  # All of the monitorees assessments
-  def assessmenmts_summary_array(assessment_headers, symptoms_headers)
-    # A header will be included in this
-    assessments_summary = []
-    assessments.each do |assessment|
-      entry = []
-      assessment_headers.each do |header|
-        # Whether or not the assessment has that particular attribute, the row still needs a value
-        entry.push(assessment[header] || '')
-      end
-      symptoms_headers.each do |header|
-        # Whether or not the assessment has that particular symptom, the row still needs a value
-        entry.push(assessment.get_reported_symptom_value(header) || '')
-      end
-      assessments_summary.push(entry)
-    end
-    assessments_summary
-  end
-
   def calc_current_age
     dob = date_of_birth || Date.today
     today = Date.today

--- a/app/models/symptom.rb
+++ b/app/models/symptom.rb
@@ -38,4 +38,14 @@ class Symptom < ApplicationRecord
                            type: type
                          })
   end
+
+  def value
+    if type == 'BoolSymptom'
+      bool_value
+    elsif type == 'IntegerSymptom'
+      int_value
+    elsif type == 'FloatSymptom'
+      float_value
+    end
+  end
 end

--- a/test/system/roles/public_health/public_health_test.rb
+++ b/test/system/roles/public_health/public_health_test.rb
@@ -120,7 +120,7 @@ class PublicHealthTest < ApplicationSystemTestCase
 
   test 'export excel all monitorees' do
     @@public_health_test_helper.export_excel_all_monitorees('locals1c1_epi', :exposure, :cancel)
-    @@public_health_test_helper.export_excel_all_monitorees('locals1c2_epi', :isolation, :export)
+    @@public_health_test_helper.export_excel_all_monitorees('state1_epi', :isolation, :export)
   end
 
   test 'export excel single monitoree' do


### PR DESCRIPTION
### Changes

-[x] refactor assessments export code and fix bug

### Performance testing

Patients: 41,720 (22,240 exposure / 19,489 isolation)
Assessments: 104,814
Laboratories: 29,840
Histories: 249,102

All monitorees excel: 5:19.778
Line list csv (exposure): 8.939
Line list csv (isolation): 18.856
Sara alert format (exposure): 28.195
Sara alert format (isolation): 36.259