### PR TITLE
Disable logging when running tests unless env set

### DIFF
--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -42,8 +42,12 @@ class ExportJob < ApplicationJob
     existing_download = user.downloads.find_by(export_type: export_type)
     existing_download&.destroy!
     download = Download.new(user_id: user_id, contents: data, filename: filename, lookup: SecureRandom.uuid, export_type: export_type)
-    ActiveRecord::Base.logger.silence do
+    if ActiveRecord::Base.logger.nil?
       download.save!
+    else
+      ActiveRecord::Base.logger.silence do
+        download.save!
+      end
     end
 
     # Send an email to user

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -42,6 +42,7 @@ class ExportJob < ApplicationJob
     existing_download = user.downloads.find_by(export_type: export_type)
     existing_download&.destroy!
     download = Download.new(user_id: user_id, contents: data, filename: filename, lookup: SecureRandom.uuid, export_type: export_type)
+
     if ActiveRecord::Base.logger.formatter.nil?
       download.save!
     else

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -42,7 +42,7 @@ class ExportJob < ApplicationJob
     existing_download = user.downloads.find_by(export_type: export_type)
     existing_download&.destroy!
     download = Download.new(user_id: user_id, contents: data, filename: filename, lookup: SecureRandom.uuid, export_type: export_type)
-    if ActiveRecord::Base.logger.nil?
+    if ActiveRecord::Base.logger.formatter.nil?
       download.save!
     else
       ActiveRecord::Base.logger.silence do

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,11 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  unless ENV['RAILS_ENABLE_TEST_LOG']
+    config.logger = Logger.new(nil)
+    config.log_level = :fatal
+  end
+
   config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,7 +6,7 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  unless ENV['RAILS_ENABLE_TEST_LOG']
+  if ENV['APP_IN_CI']
     config.logger = Logger.new(nil)
     config.log_level = :fatal
   end


### PR DESCRIPTION
Here are some numbers for non-system tests.
```
# No logging
bundle exec rake test  10.39s user 1.88s system 85% cpu 14.313 total
bundle exec rake test  10.97s user 1.66s system 87% cpu 14.494 total
bundle exec rake test  10.42s user 1.72s system 87% cpu 13.915 total

# Logging
bundle exec rake test  12.67s user 1.92s system 87% cpu 16.616 total
bundle exec rake test  11.39s user 1.89s system 87% cpu 15.146 total
bundle exec rake test  11.90s user 2.00s system 87% cpu 15.883 total
```

I'll let the system test run on this branch and see if that speaks for itself...
