### PR TITLE
add additional check for preferred contact method when emailing web link

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -580,7 +580,7 @@ class Patient < ApplicationRecord # rubocop:todo Metrics/ClassLength
       PatientMailer.assessment_sms_weblink(self).deliver_later if ADMIN_OPTIONS['enable_sms'] && !Rails.env.test?
     elsif preferred_contact_method&.downcase == 'telephone call' && responder.id == id
       PatientMailer.assessment_voice(self).deliver_later if ADMIN_OPTIONS['enable_voice'] && !Rails.env.test?
-    elsif ADMIN_OPTIONS['enable_email'] && responder.id == id && !email.blank?
+    elsif preferred_contact_method&.downcase == 'e-mailed web link' && ADMIN_OPTIONS['enable_email'] && responder.id == id && !email.blank?
       PatientMailer.assessment_email(self).deliver_later
     end
   end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -580,7 +580,7 @@ class Patient < ApplicationRecord # rubocop:todo Metrics/ClassLength
       PatientMailer.assessment_sms_weblink(self).deliver_later if ADMIN_OPTIONS['enable_sms'] && !Rails.env.test?
     elsif preferred_contact_method&.downcase == 'telephone call' && responder.id == id
       PatientMailer.assessment_voice(self).deliver_later if ADMIN_OPTIONS['enable_voice'] && !Rails.env.test?
-    elsif preferred_contact_method&.downcase == 'e-mailed web link' && ADMIN_OPTIONS['enable_email'] && responder.id == id && !email.blank?
+    elsif preferred_contact_method&.downcase == 'e-mailed web link' && ADMIN_OPTIONS['enable_email'] && responder.id == id && email.present?
       PatientMailer.assessment_email(self).deliver_later
     end
   end


### PR DESCRIPTION
For [JIRA 459](https://jira.mitre.org/browse/SARAALERT-459)

Added a check to confirm that preferred contact method is email before sending - before if the preferred contact method was not set, it would sneak into this else.

See JIRA for recreate steps.  Can test using `Patient.find_by(id: <ID>).send_assessment` and changing the line in the conditional to `deliver_now`.