### PR TITLE
Add no symptoms option to monitoree assessment

### DIFF
--- a/app/javascript/components/assessment/steps/SymptomsAssessment.js
+++ b/app/javascript/components/assessment/steps/SymptomsAssessment.js
@@ -50,8 +50,7 @@ class SymptomsAssessment extends React.Component {
         disabled={boolSymptomsSelected}
         label={
           <div>
-            {/* <b>{this.props.translations[this.props.lang]['symptoms'][symp.name]['name']}</b> */}
-            <i>I am not experiencing any symptoms</i>
+            <i>{this.props.translations[this.props.lang]['no-symptoms']}</i>
           </div>
         }
         className="pb-2"

--- a/app/javascript/components/assessment/steps/SymptomsAssessment.js
+++ b/app/javascript/components/assessment/steps/SymptomsAssessment.js
@@ -5,8 +5,10 @@ import { PropTypes } from 'prop-types';
 class SymptomsAssessment extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { ...this.props, current: { ...this.props.currentState } };
+    this.state = { ...this.props, current: { ...this.props.currentState }, noSymptomsCheckbox: false, selectedBoolSymptomCount: 0 };
     this.handleChange = this.handleChange.bind(this);
+    this.handleNoSymptomChange = this.handleNoSymptomChange.bind(this);
+    this.updateBoolSymptomCount = this.updateBoolSymptomCount.bind(this);
     this.navigate = this.navigate.bind(this);
   }
 
@@ -18,21 +20,57 @@ class SymptomsAssessment extends React.Component {
     this.setState({ current: { ...current } }, () => {
       this.props.setAssessmentState({ ...this.state.current });
     });
+    this.updateBoolSymptomCount();
+  }
+
+  handleNoSymptomChange(event) {
+    let value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
+    this.setState({ noSymptomsCheckbox: value });
+  }
+
+  updateBoolSymptomCount() {
+    let trueBoolSymptoms = this.state.current.symptoms.filter(s => {
+      return s.type === 'BoolSymptom' && s.value;
+    });
+    this.setState({ selectedBoolSymptomCount: trueBoolSymptoms.length });
   }
 
   navigate() {
     this.props.submit();
   }
 
+  noSymptom() {
+    let noSymptomsChecked = this.state.noSymptomsCheckbox;
+    let boolSymptomsSelected = this.state.selectedBoolSymptomCount > 0 ? true : false;
+
+    return (
+      <Form.Check
+        type="checkbox"
+        checked={noSymptomsChecked}
+        disabled={boolSymptomsSelected}
+        label={
+          <div>
+            {/* <b>{this.props.translations[this.props.lang]['symptoms'][symp.name]['name']}</b> */}
+            <i>I am not experiencing any symptoms</i>
+          </div>
+        }
+        className="pb-2"
+        onChange={this.handleNoSymptomChange}></Form.Check>
+    );
+  }
+
   boolSymptom = symp => {
     // null bool values will default to false
     symp.value = symp.value === true;
+    let noSymptomsChecked = this.state.noSymptomsCheckbox;
+
     return (
       <Form.Check
         type="checkbox"
         id={`${symp.name}${this.props.idPre ? '_idpre' + this.props.idPre : ''}`}
         key={`key_${symp.name}${this.props.idPre ? '_idpre' + this.props.idPre : ''}`}
         checked={symp.value === true || false}
+        disabled={noSymptomsChecked}
         label={
           <div>
             <b>{this.props.translations[this.props.lang]['symptoms'][symp.name]['name']}</b>{' '}
@@ -84,6 +122,7 @@ class SymptomsAssessment extends React.Component {
                     return x.type === 'BoolSymptom';
                   })
                   .map(symp => this.boolSymptom(symp))}
+                {this.noSymptom()}
                 {this.state.current.symptoms
                   .filter(x => {
                     return x.type === 'FloatSymptom';

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
       pulse-ox:
         name: 'Pulse Ox'
         notes: 'What was your lowest oxygen level in the past 24 hours?'
+    no-symptoms: 'I am not experiencing any symptoms'
     threshold-op:
       less-than: 'Less Than'
       less-than-or-equal: 'Less Than Or Equal to'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -34,6 +34,7 @@ es:
       pulse-ox:
         name: 'oxímetro de pulso'
         notes: 'Ingrese la lectura más baja del oxímetro de pulso en las últimas 24 horas'
+    no-symptoms: 'No tengo ningún síntoma.'
     threshold-op:
       less-than: 'Menos que'
       less-than-or-equal: 'Menor o igual a'


### PR DESCRIPTION
This PR covers [JIRA 429](https://jira.mitre.org/browse/SARAALERT-429)

The solution we went with involved adding a 'I am not experiencing any symptoms' checkbox beneath all the boolean symptoms.  This checkbox is disabled if any of the boolean symptoms are selected.  In addition, the boolean symptoms are all disabled if the no symptom checkbox is selected.  This should also work in spanish.