### PR TITLE
Purge old analytics

### DIFF
--- a/app/jobs/purge_job.rb
+++ b/app/jobs/purge_job.rb
@@ -26,5 +26,9 @@ class PurgeJob < ApplicationJob
       monitoree.histories.destroy_all
     end
     Download.where('created_at < ?', 24.hours.ago).destroy_all
+    MonitoreeCount.where('created_at < ?', 1.month.ago).destroy_all
+    MonitoreeSnapshot.where('created_at < ?', 1.month.ago).destroy_all
+    MonitoreeMap.where('created_at < ?', 1.month.ago).destroy_all
+    Analytic.where('created_at < ?', 1.month.ago).destroy_all
   end
 end


### PR DESCRIPTION
Was debating between putting this in the purge job vs cache analytics job and decided to go with putting it in the purge job because:
  - putting it in the cache analytics job would slow it down a bit
  - this isn't necessarily something that needs to happen every hour

If putting it in the cache analytics job or somewhere else makes more sense, I would be more than happy to change that.

I also set the cutoff to 1 month for now, but happy to change that as well. Currently, our analytics controller only fetches past analytics up to 2 weeks old.