### PR TITLE
adds some checks for empty objects in the front-end

### DIFF
--- a/app/javascript/components/dashboard/MonitorAnalytics.js
+++ b/app/javascript/components/dashboard/MonitorAnalytics.js
@@ -20,6 +20,7 @@ class MonitorAnalytics extends React.Component {
     this.state = {
       checked: false,
       viewTotal: false,
+      hasErrors: !this.props.stats,
     };
   }
 
@@ -52,70 +53,79 @@ class MonitorAnalytics extends React.Component {
   toggleBetweenActiveAndTotal = viewTotal => this.setState({ viewTotal });
 
   render() {
-    return (
-      <React.Fragment>
-        <Row className="mb-2 mx-0 px-0 pt-2">
-          <Col md="24" className="mx-2 px-0">
-            <Button variant="primary" className="btn-square" onClick={this.exportAsPNG}>
-              <i className="fas fa-download"></i>&nbsp;&nbsp;EXPORT ANALYSIS AS PNG
-            </Button>
-          </Col>
-        </Row>
-        <Row className="mb-2 mx-0 px-0 pt-4 pb-2">
-          <Col md="24" className="mx-2 px-0">
-            <p className="display-6">
-              <i className="fas fa-info-circle mr-1"></i> Analytics are generated using data from both exposure and isolation workflows. Last Updated At{' '}
-              {moment
-                .tz(this.props.stats.last_updated_at, 'UTC')
-                .tz(moment.tz.guess())
-                .format('YYYY-MM-DD HH:mm z')}
-              .
-            </p>
-          </Col>
-        </Row>
-        <Row className="mb-4 mx-2 px-0">
-          <Col md="14" className="ml-0 pl-0">
-            <RiskStratificationTable stats={this.props.stats} />
-          </Col>
-          <Col md="10" className="mr-0 pr-0">
-            <MonitoreeFlow stats={this.props.stats} />
-          </Col>
-        </Row>
-        <Row className="mb-4 mx-2 px-0 pt-4">
-          <Col md="24" className="mx-0 px-0">
-            <span className="display-5">Epidemiological Summary</span>
-            {/* <span className="float-right display-6">
-              View Overall
-              <Switch
-              className="ml-2"
-              onChange={this.toggleBetweenActiveAndTotal}
-              onColor="#82A0E4"
-              height={18}
-              width={40}
-              uncheckedIcon={false}
-              checked={this.state.viewTotal}
-              />
-            </span> */}
-          </Col>
-        </Row>
-        <Row className="mb-4 mx-2 px-0">
-          <Col md="12" className="ml-0 pl-0">
-            <Demographics stats={this.props.stats} viewTotal={this.state.viewTotal} />
-          </Col>
-          <Col md="12" className="mr-0 pr-0">
-            <RiskFactors stats={this.props.stats} viewTotal={this.state.viewTotal} />
-          </Col>
-        </Row>
-        <Row className="mb-1 mx-2 px-0">
-          <Col md="24" className="mx-0 px-0">
-            <MonitoreesByDateOfExposure stats={this.props.stats} />
-          </Col>
-        </Row>
-        <Row className="mb-5 pb-3 mx-2 px-0 pt-4">
-          <GeographicSummary stats={this.props.stats} />
-        </Row>
-      </React.Fragment>
-    );
+    if (this.state.hasErrors) {
+      return (
+        <div className="text-center mt-4" style={{ width: '100%' }}>
+          <h5>We are still crunching the latest numbers.</h5>
+          <h5>Please check back later...</h5>
+        </div>
+      );
+    } else {
+      return (
+        <React.Fragment>
+          <Row className="mb-2 mx-0 px-0 pt-2">
+            <Col md="24" className="mx-2 px-0">
+              <Button variant="primary" className="btn-square" onClick={this.exportAsPNG}>
+                <i className="fas fa-download"></i>&nbsp;&nbsp;EXPORT ANALYSIS AS PNG
+              </Button>
+            </Col>
+          </Row>
+          <Row className="mb-2 mx-0 px-0 pt-4 pb-2">
+            <Col md="24" className="mx-2 px-0">
+              <p className="display-6">
+                <i className="fas fa-info-circle mr-1"></i> Analytics are generated using data from both exposure and isolation workflows. Last Updated At{' '}
+                {moment
+                  .tz(this.props.stats.last_updated_at, 'UTC')
+                  .tz(moment.tz.guess())
+                  .format('YYYY-MM-DD HH:mm z')}
+                .
+              </p>
+            </Col>
+          </Row>
+          <Row className="mb-4 mx-2 px-0">
+            <Col md="14" className="ml-0 pl-0">
+              <RiskStratificationTable stats={this.props.stats} />
+            </Col>
+            <Col md="10" className="mr-0 pr-0">
+              <MonitoreeFlow stats={this.props.stats} />
+            </Col>
+          </Row>
+          <Row className="mb-4 mx-2 px-0 pt-4">
+            <Col md="24" className="mx-0 px-0">
+              <span className="display-5">Epidemiological Summary</span>
+              {/* <span className="float-right display-6">
+                View Overall
+                <Switch
+                className="ml-2"
+                onChange={this.toggleBetweenActiveAndTotal}
+                onColor="#82A0E4"
+                height={18}
+                width={40}
+                uncheckedIcon={false}
+                checked={this.state.viewTotal}
+                />
+              </span> */}
+            </Col>
+          </Row>
+          <Row className="mb-4 mx-2 px-0">
+            <Col md="12" className="ml-0 pl-0">
+              <Demographics stats={this.props.stats} viewTotal={this.state.viewTotal} />
+            </Col>
+            <Col md="12" className="mr-0 pr-0">
+              <RiskFactors stats={this.props.stats} viewTotal={this.state.viewTotal} />
+            </Col>
+          </Row>
+          <Row className="mb-1 mx-2 px-0">
+            <Col md="24" className="mx-0 px-0">
+              <MonitoreesByDateOfExposure stats={this.props.stats} />
+            </Col>
+          </Row>
+          <Row className="mb-5 pb-3 mx-2 px-0 pt-4">
+            <GeographicSummary stats={this.props.stats} />
+          </Row>
+        </React.Fragment>
+      );
+    }
   }
 }
 

--- a/app/javascript/components/dashboard/widgets/GeographicSummary.js
+++ b/app/javascript/components/dashboard/widgets/GeographicSummary.js
@@ -23,30 +23,36 @@ class GeographicSummary extends React.Component {
     this.analyticsData = this.parseAnalyticsStatistics();
     this.jurisdictionsPermittedToView = this.obtainJurisdictionsPermittedToView();
     this.obtainJurisdictionsNotInUse();
-    this.state = {
-      selectedDateIndex: INITIAL_SELECTED_DATE_INDEX,
-      showBackButton: false,
-      jurisdictionToShow: {
-        category: 'fullCountry',
-        name: 'USA',
-        eventValue: null,
-      },
-      mapObject: null,
-      showSpinner: false,
-      viewMapTable: false,
-      exposureMapData: this.analyticsData.exposure[Number(INITIAL_SELECTED_DATE_INDEX)].value,
-      isolationMapData: this.analyticsData.isolation[Number(INITIAL_SELECTED_DATE_INDEX)].value,
-    };
+    if (this.analyticsData.exposure[Number(INITIAL_SELECTED_DATE_INDEX)]) {
+      this.state = {
+        selectedDateIndex: INITIAL_SELECTED_DATE_INDEX,
+        showBackButton: false,
+        jurisdictionToShow: {
+          category: 'fullCountry',
+          name: 'USA',
+          eventValue: null,
+        },
+        mapObject: null,
+        showSpinner: false,
+        viewMapTable: false,
+        exposureMapData: this.analyticsData.exposure[Number(INITIAL_SELECTED_DATE_INDEX)].value,
+        isolationMapData: this.analyticsData.isolation[Number(INITIAL_SELECTED_DATE_INDEX)].value,
+      };
 
-    // A lot of times, the CountyLevelMaps functions will take time to render some new jurisdiction map.
-    // We want the Spinner to spin until they report back that they're done. Therefore, we set spinnerState to 2
-    // and subtract 1 every time they report back. When they each report back, 2 - 1 - 1 = 0 then we set `showSpinner` to false
-    // Because calls to setState are asynchronous, this value must be on the component itself
-    this.spinnerState = 0;
+      // A lot of times, the CountyLevelMaps functions will take time to render some new jurisdiction map.
+      // We want the Spinner to spin until they report back that they're done. Therefore, we set spinnerState to 2
+      // and subtract 1 every time they report back. When they each report back, 2 - 1 - 1 = 0 then we set `showSpinner` to false
+      // Because calls to setState are asynchronous, this value must be on the component itself
+      this.spinnerState = 0;
 
-    // this.analyticsData.exposure is the same as this.analyticsData.isolation (in terms of dates) so it doesnt matter which you use
-    this.dateSubset = this.analyticsData.exposure.map(x => x.date);
-    this.dateRange = this.analyticsData.exposure.map(x => moment(x.date).format('MM/DD'));
+      // this.analyticsData.exposure is the same as this.analyticsData.isolation (in terms of dates) so it doesnt matter which you use
+      this.dateSubset = this.analyticsData.exposure.map(x => x.date);
+      this.dateRange = this.analyticsData.exposure.map(x => moment(x.date).format('MM/DD'));
+    } else {
+      this.state = {
+        hasError: true,
+      };
+    }
   }
 
   parseAnalyticsStatistics = () => {
@@ -263,6 +269,13 @@ class GeographicSummary extends React.Component {
   };
 
   render() {
+    if (this.state.hasError) {
+      return (
+        <div className="text-center mt-4" style={{ width: '100%' }}>
+          <h5>No Geographic Analytics Data could be shown</h5>
+        </div>
+      );
+    }
     let backButton = this.state.showBackButton && (
       <Button variant="primary" size="md" className="ml-auto btn-square" onClick={() => this.backToFullCountryMap()}>
         <i className="fas fa-arrow-left mr-2"> </i>


### PR DESCRIPTION
If the analytics data was missing or not quite up to date, the front-end could crash. This PR now show error/warnings messages client-side to let the user know. This is unlikely to occur in production, but handles possible edge cases.