### PR TITLE
Address UAT-14 feedback

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -324,6 +324,10 @@ class PatientsController < ApplicationController
     if params.permit(:apply_to_group_cm_only)[:apply_to_group_cm_only]
       ([patient] + current_user.get_patient(patient.responder_id).dependents.where(continuous_exposure: true)).uniq.each do |member|
         update_fields(member, params)
+        if params[:apply_to_group_cm_only_date].present?
+          lde_date = params.permit(:apply_to_group_cm_only_date)[:apply_to_group_cm_only_date]
+          member.update(last_date_of_exposure: lde_date)
+        end
         next unless params[:comment]
 
         update_history(member, params)

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -536,6 +536,7 @@ class PatientsController < ApplicationController
       assigned_user
       symptom_onset
       case_status
+      continuous_exposure
     ]
   end
 
@@ -612,6 +613,7 @@ class PatientsController < ApplicationController
       assigned_user
       symptom_onset
       case_status
+      continuous_exposure
     ]
   end
 

--- a/app/javascript/components/assessment/steps/SymptomsAssessment.js
+++ b/app/javascript/components/assessment/steps/SymptomsAssessment.js
@@ -25,7 +25,18 @@ class SymptomsAssessment extends React.Component {
 
   handleNoSymptomChange(event) {
     let value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
-    this.setState({ noSymptomsCheckbox: value });
+    this.setState({ noSymptomsCheckbox: value }, () => {
+      // Make sure pre-selected options are cleared
+      if (this.state.noSymptomsCheckbox) {
+        let current = { ...this.state.current };
+        for (const symptom in current?.symptoms) {
+          if (current?.symptoms[parseInt(symptom)]?.type == 'BoolSymptom') {
+            current.symptoms[parseInt(symptom)].value = false;
+          }
+        }
+        this.setState({ current: current });
+      }
+    });
   }
 
   updateBoolSymptomCount() {
@@ -50,7 +61,7 @@ class SymptomsAssessment extends React.Component {
         disabled={boolSymptomsSelected}
         label={
           <div>
-            <i>{this.props.translations[this.props.lang]['no-symptoms']}</i>
+            <i>{this.props.translations[this.props.lang]['symptoms']['no-symptoms']}</i>
           </div>
         }
         className="pb-2"

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -156,59 +156,58 @@ class Contact extends React.Component {
                     className="form-square"
                     value={this.state.current.patient.preferred_contact_method || ''}
                     onChange={this.handleChange}>
-                    <option></option>
+                    <option>Unknown</option>
                     <option>E-mailed Web Link</option>
                     <option>SMS Texted Weblink</option>
                     <option>Telephone call</option>
                     <option>SMS Text-message</option>
                     <option>Opt-out</option>
-                    <option>Unknown</option>
                   </Form.Control>
                   <Form.Control.Feedback className="d-block" type="invalid">
                     {this.state.errors['preferred_contact_method']}
                   </Form.Control.Feedback>
                 </Form.Group>
-                {this.state.current.patient.preferred_contact_method !== 'E-mailed Web Link' &&
-                  this.state.current.patient.preferred_contact_method !== 'Opt-out' &&
-                  this.state.current.patient.preferred_contact_method !== 'Unknown' && (
-                    <Form.Group as={Col} md="8" controlId="preferred_contact_time">
-                      <Form.Label className="nav-input-label">
-                        PREFERRED CONTACT TIME{schema?.fields?.preferred_contact_time?._exclusive?.required && ' *'}
-                        <InfoTooltip tooltipTextKey="preferredContactTime" location="right"></InfoTooltip>
-                      </Form.Label>
-                      <Form.Control
-                        isInvalid={this.state.errors['preferred_contact_time']}
-                        as="select"
-                        size="lg"
-                        className="form-square"
-                        value={this.state.current.patient.preferred_contact_time || ''}
-                        onChange={this.handleChange}>
-                        <option></option>
-                        <option>Morning</option>
-                        <option>Afternoon</option>
-                        <option>Evening</option>
-                      </Form.Control>
-                      <Form.Row className="pt-2">
-                        <Form.Group as={Col} md="auto">
-                          Morning:
-                          <br />
-                          Afternoon:
-                          <br />
-                          Evening:
-                        </Form.Group>
-                        <Form.Group as={Col} md="auto">
-                          <span className="font-weight-light">Between 8:00 and 12:00 in monitoree&apos;s timezone</span>
-                          <br />
-                          <span className="font-weight-light">Between 12:00 and 16:00 in monitoree&apos;s timezone</span>
-                          <br />
-                          <span className="font-weight-light">Between 16:00 and 20:00 in monitoree&apos;s timezone</span>
-                        </Form.Group>
-                      </Form.Row>
-                      <Form.Control.Feedback className="d-block" type="invalid">
-                        {this.state.errors['preferred_contact_time']}
-                      </Form.Control.Feedback>
-                    </Form.Group>
-                  )}
+                {(this.state.current.patient.preferred_contact_method === 'SMS Texted Weblink' ||
+                  this.state.current.patient.preferred_contact_method === 'Telephone call' ||
+                  this.state.current.patient.preferred_contact_method === 'SMS Text-message') && (
+                  <Form.Group as={Col} md="8" controlId="preferred_contact_time">
+                    <Form.Label className="nav-input-label">
+                      PREFERRED CONTACT TIME{schema?.fields?.preferred_contact_time?._exclusive?.required && ' *'}
+                      <InfoTooltip tooltipTextKey="preferredContactTime" location="right"></InfoTooltip>
+                    </Form.Label>
+                    <Form.Control
+                      isInvalid={this.state.errors['preferred_contact_time']}
+                      as="select"
+                      size="lg"
+                      className="form-square"
+                      value={this.state.current.patient.preferred_contact_time || ''}
+                      onChange={this.handleChange}>
+                      <option></option>
+                      <option>Morning</option>
+                      <option>Afternoon</option>
+                      <option>Evening</option>
+                    </Form.Control>
+                    <Form.Row className="pt-2">
+                      <Form.Group as={Col} md="auto">
+                        Morning:
+                        <br />
+                        Afternoon:
+                        <br />
+                        Evening:
+                      </Form.Group>
+                      <Form.Group as={Col} md="auto">
+                        <span className="font-weight-light">Between 8:00 and 12:00 in monitoree&apos;s timezone</span>
+                        <br />
+                        <span className="font-weight-light">Between 12:00 and 16:00 in monitoree&apos;s timezone</span>
+                        <br />
+                        <span className="font-weight-light">Between 16:00 and 20:00 in monitoree&apos;s timezone</span>
+                      </Form.Group>
+                    </Form.Row>
+                    <Form.Control.Feedback className="d-block" type="invalid">
+                      {this.state.errors['preferred_contact_time']}
+                    </Form.Control.Feedback>
+                  </Form.Group>
+                )}
               </Form.Row>
               <Form.Row className="pt-2">
                 <Form.Group as={Col} md="11" controlId="primary_telephone">

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -57,10 +57,7 @@ class Contact extends React.Component {
             .email('Please enter a valid email.')
             .max(200, 'Max length exceeded, please limit to 200 characters.'),
           confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
-          preferred_contact_method: yup
-            .string()
-            .required('Please indicate a preferred reporting method.')
-            .max(200, 'Max length exceeded, please limit to 200 characters.'),
+          preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
         });
       } else if (event?.currentTarget.value == 'E-mailed Web Link') {
         schema = yup.object().shape({
@@ -83,10 +80,7 @@ class Contact extends React.Component {
             .string()
             .required('Please confirm email.')
             .oneOf([yup.ref('email'), null], 'Confirm email must match.'),
-          preferred_contact_method: yup
-            .string()
-            .required('Please indicate a preferred reporting method.')
-            .max(200, 'Max length exceeded, please limit to 200 characters.'),
+          preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
         });
       } else {
         schema = yup.object().shape({
@@ -105,10 +99,7 @@ class Contact extends React.Component {
             .email('Please enter a valid email.')
             .max(200, 'Max length exceeded, please limit to 200 characters.'),
           confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
-          preferred_contact_method: yup
-            .string()
-            .required('Please indicate a preferred reporting method.')
-            .max(200, 'Max length exceeded, please limit to 200 characters.'),
+          preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
         });
       }
       this.setState({ errors: {} });
@@ -397,7 +388,6 @@ var schema = yup.object().shape({
     .nullable(),
   preferred_contact_method: yup
     .string()
-    .required('Please indicate a preferred reporting method.')
     .max(200, 'Max length exceeded, please limit to 200 characters.')
     .nullable(),
   preferred_contact_time: yup

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -230,6 +230,19 @@ class Exposure extends React.Component {
             </Form.Control.Feedback>
           </Form.Group>
         </Form.Row>
+        <Form.Row>
+          <Form.Group>
+            <Form.Check
+              size="lg"
+              label="CONTINUOUS EXPOSURE"
+              type="switch"
+              id="continuous_exposure"
+              className="ml-1"
+              checked={this.state.current.patient.continuous_exposure === true || false}
+              onChange={this.handleChange}
+            />
+          </Form.Group>
+        </Form.Row>
         <Form.Label className="nav-input-label pb-2">EXPOSURE RISK FACTORS (USE COMMAS TO SEPERATE MULTIPLE SPECIFIED VALUES)</Form.Label>
         <Form.Row>
           <Form.Group as={Col} md="auto" className="mb-0 my-auto pb-2">

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -6,6 +6,7 @@ import CaseStatus from './CaseStatus';
 import reportError from '../util/ReportError';
 import InfoTooltip from '../util/InfoTooltip';
 import _ from 'lodash';
+import moment from 'moment';
 
 class MonitoringStatus extends React.Component {
   constructor(props) {
@@ -38,6 +39,8 @@ class MonitoringStatus extends React.Component {
       isolation_status: props.patient.isolation ? 'Isolation' : 'Exposure',
       pause_notifications: props.patient.pause_notifications,
       loading: false,
+      apply_to_group_cm_only: false,
+      apply_to_group_cm_only_date: moment(new Date()).format('YYYY-MM-DD'),
     };
     this.origState = Object.assign({}, this.state);
     this.handleChange = this.handleChange.bind(this);
@@ -281,6 +284,8 @@ class MonitoringStatus extends React.Component {
           isolation: this.state.isolation,
           pause_notifications: this.state.pause_notifications,
           diffState: diffState,
+          apply_to_group_cm_only: this.state.apply_to_group_cm_only,
+          apply_to_group_cm_only_date: this.state.apply_to_group_cm_only_date,
         })
         .then(() => {
           location.reload(true);
@@ -314,6 +319,29 @@ class MonitoringStatus extends React.Component {
                   </option>
                 ))}
               </Form.Control>
+            </Form.Group>
+          )}
+          {this.props.isolation && this.state.monitoring_status_options && this.props.in_a_group && (
+            <Form.Group>
+              <Form.Check
+                type="switch"
+                id="apply_to_group_cm_only"
+                label="If this monitoree's household has any active members in the exposure workflow that have continuous exposure on, update their last date of exposure"
+                onChange={this.handleChange}
+                checked={this.state.apply_to_group_cm_only === true || false}
+              />
+            </Form.Group>
+          )}
+          {this.props.isolation && this.state.monitoring_status_options && this.props.in_a_group && this.state.apply_to_group_cm_only && (
+            <Form.Group>
+              <Form.Control
+                size="lg"
+                id="apply_to_group_cm_only_date"
+                type="date"
+                className="form-square"
+                value={this.state.apply_to_group_cm_only_date || ''}
+                onChange={this.handleChange}
+              />
             </Form.Group>
           )}
           <Form.Group>
@@ -536,6 +564,8 @@ MonitoringStatus.propTypes = {
   jurisdictionPaths: PropTypes.object,
   assignedUsers: PropTypes.array,
   has_group_members: PropTypes.bool,
+  in_a_group: PropTypes.bool,
+  isolation: PropTypes.bool,
 };
 
 export default MonitoringStatus;

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -735,7 +735,7 @@ class Patient < ApplicationRecord # rubocop:todo Metrics/ClassLength
       state_local_id: user_defined_id_statelocal || '',
       sex: sex || '',
       dob: date_of_birth&.strftime('%F') || '',
-      end_of_monitoring: end_of_monitoring || '',
+      end_of_monitoring: (continuous_exposure ? 'Continuous Exposure' : end_of_monitoring) || '',
       risk_level: exposure_risk_assessment || '',
       monitoring_plan: monitoring_plan || '',
       latest_report: latest_assessment&.created_at&.rfc2822 || '',

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -70,7 +70,7 @@ class Patient < ApplicationRecord # rubocop:todo Metrics/ClassLength
       .where('patients.id = patients.responder_id')
       .where(purged: false)
       .where.not(id: Patient.unscoped.exposure_under_investigation)
-      .where('last_date_of_exposure >= ?', ADMIN_OPTIONS['monitoring_period_days'].days.ago)
+      .where('last_date_of_exposure >= ? OR continuous_exposure = ?', ADMIN_OPTIONS['monitoring_period_days'].days.ago, true)
       .left_outer_joins(:assessments)
       .where_assoc_not_exists(:assessments, ['created_at >= ?', Time.now.getlocal('-04:00').beginning_of_day])
       .or(
@@ -79,7 +79,7 @@ class Patient < ApplicationRecord # rubocop:todo Metrics/ClassLength
           .where('patients.id = patients.responder_id')
           .where(purged: false)
           .where.not(id: Patient.unscoped.exposure_under_investigation)
-          .where('last_date_of_exposure >= ?', ADMIN_OPTIONS['monitoring_period_days'].days.ago)
+          .where('last_date_of_exposure >= ? OR continuous_exposure = ?', ADMIN_OPTIONS['monitoring_period_days'].days.ago, true)
           .left_outer_joins(:assessments)
           .where(assessments: { patient_id: nil })
       )
@@ -549,7 +549,6 @@ class Patient < ApplicationRecord # rubocop:todo Metrics/ClassLength
     return if !symptom_onset.nil? && !assessment.nil? && symptom_onset < assessment.created_at
 
     update(symptom_onset: assessment&.created_at&.to_date) unless assessment.nil?
-    save
   end
 
   # Send initial enrollment notification via patient's preferred contact method

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -17,9 +17,11 @@
       current_user: current_user,
       authenticity_token: form_authenticity_token,
       has_group_members: @group_members.exists?,
+      in_a_group: @all_group_members.count > 1,
       patient: @patient,
       jurisdictionPaths: Hash[Jurisdiction.all.pluck(:id, :path).map {|id, path| [id, path]}],
-      assignedUsers: @patient.jurisdiction.assigned_users
+      assignedUsers: @patient.jurisdiction.assigned_users,
+      isolation: @patient.isolation
       }) %>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,7 @@ en:
       pulse-ox:
         name: 'Pulse Ox'
         notes: 'What was your lowest oxygen level in the past 24 hours?'
-    no-symptoms: 'I am not experiencing any symptoms'
+      no-symptoms: 'I am not experiencing any symptoms'
     threshold-op:
       less-than: 'Less Than'
       less-than-or-equal: 'Less Than Or Equal to'

--- a/config/locales/es-PR.yml
+++ b/config/locales/es-PR.yml
@@ -34,6 +34,7 @@ es-PR:
       pulse-ox:
         name: 'oxímetro de pulso'
         notes: 'Ingrese la lectura más baja del oxímetro de pulso en las últimas 24 horas'
+      no-symptoms: 'No tengo ningún síntoma.'
     threshold-op:
       less-than: 'Menos que'
       less-than-or-equal: 'Menor o igual a'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -34,7 +34,7 @@ es:
       pulse-ox:
         name: 'oxímetro de pulso'
         notes: 'Ingrese la lectura más baja del oxímetro de pulso en las últimas 24 horas'
-    no-symptoms: 'No tengo ningún síntoma.'
+      no-symptoms: 'No tengo ningún síntoma.'
     threshold-op:
       less-than: 'Menos que'
       less-than-or-equal: 'Menor o igual a'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -34,7 +34,7 @@ fr:
       pulse-ox:
         name: 'd’oxymétrie de pouls'
         notes: 'Saisissez votre mesure d’oxymétrie de pouls la plus faible au cours des dernières 24 heures'
-      no-symptoms: 'aucun symptôme'
+      no-symptoms: 'Aucun symptôme'
     threshold-op:
       less-than: 'moins que'
       less-than-or-equal: 'inférieur ou égal à'

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -368,7 +368,7 @@ class PatientTest < ActiveSupport::TestCase
     Assessment.destroy_all
   end
 
-  test 'exposure send report' do
+  test 'exposure send report without continuous exposure' do
     # patient was created more than 24 hours ago
     Patient.destroy_all
     patient = create(:patient, monitoring: true, purged: false, isolation: false, created_at: 4.days.ago, last_date_of_exposure: 5.days.ago)
@@ -379,10 +379,29 @@ class PatientTest < ActiveSupport::TestCase
     assert_not Patient.reminder_eligible_exposure.find_by(id: patient.id).nil?
   end
 
-  test 'exposure dont send report' do
+  test 'exposure dont send report without continuous exposure' do
     # patient was created more than 24 hours ago
     Patient.destroy_all
     patient = create(:patient, monitoring: true, purged: false, isolation: false, created_at: 2.days.ago, last_date_of_exposure: 20.days.ago)
+
+    assert Patient.reminder_eligible_exposure.find_by(id: patient.id).nil?
+  end
+
+  test 'exposure send report with continuous exposure' do
+    # patient was created more than 24 hours ago
+    Patient.destroy_all
+    patient = create(:patient, monitoring: true, purged: false, isolation: false, created_at: 4.days.ago, continuous_exposure: true)
+
+    # patient has symptomatic assessment more than 1 day ago but less than 7 days ago
+    create(:assessment, patient: patient, symptomatic: false, created_at: 2.days.ago)
+
+    assert_not Patient.reminder_eligible_exposure.find_by(id: patient.id).nil?
+  end
+
+  test 'exposure dont send report with continuous exposure' do
+    # patient was created more than 24 hours ago
+    Patient.destroy_all
+    patient = create(:patient, monitoring: true, purged: false, isolation: false, created_at: 2.days.ago, continuous_exposure: false)
 
     assert Patient.reminder_eligible_exposure.find_by(id: patient.id).nil?
   end

--- a/test/system/roles/enroller/enrollment/form_validator.rb
+++ b/test/system/roles/enroller/enrollment/form_validator.rb
@@ -62,8 +62,6 @@ class EnrollmentFormValidator < ApplicationSystemTestCase
   end
 
   def verify_input_validation_for_contact_info(contact_info)
-    @@system_test_utils.go_to_next_page
-    verify_text_displayed('Please indicate a preferred reporting method')
     select 'Telephone call', from: 'preferred_contact_method'
     click_on 'Next'
     verify_text_not_displayed('Please provide an email')


### PR DESCRIPTION
- Unknown is now the default contact method on enrollment
- Change LDE now resets continuous exposure status
- When no-symptoms is selected, make sure to blank out any other existing boolean options
- On close case in isolation, prompt for updating LDE for household contacts in exposure WF
- Added continuous exposure toggle to enrollment wizard (Exposure step)
- Line lists show "Continuous Exposure" for End of Monitoring column if continuous exposure is enabled