### PR TITLE
Adding PR Templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bugfix_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix_template.md
@@ -1,0 +1,27 @@
+Addresses SARAALERT-###
+
+# Bug Description
+Insert description of behavior caused by bug.
+
+# How To Replicate:
+1. Do something.
+2. Change something.
+3. Etc.
+
+# Solution
+Insert description of how this bug is fixed in this PR.
+
+# Important Changes
+`example_file.js`
+- Example change. 
+
+# Testing
+Verify that the original behavior as described above is no longer there after going through the replication steps again.
+
+This fix was tested on the following browsers:
+- [ ] Chrome
+- [ ] Firefox
+- [ ] Safari
+- [ ] IE11
+
+

--- a/.github/PULL_REQUEST_TEMPLATE/default_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default_template.md
@@ -1,0 +1,22 @@
+Addresses SARAALERT-###
+
+# Summary
+Write out a concise summary of this MR.
+
+# Important Changes
+`example_file.js`
+- Example change. 
+
+# Testing
+This fix was tested on the following browsers:
+* [ ] Chrome
+* [ ] Firefox
+* [ ] Safari
+* [ ] IE11
+
+The following are tests that require visual inspection:
+- [ ] 1) Example visual test.
+
+
+
+

--- a/.github/PULL_REQUEST_TEMPLATE/feature_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_template.md
@@ -1,0 +1,21 @@
+Addresses SARAALERT-###
+
+# Feature Description
+Write out a concise summary of this MR.
+
+# Demo
+Insert a demo video or photo(s) if relevant to this feature.
+
+# Important Changes
+`example_file.js`
+- Example change. 
+
+# Testing
+This fix was tested on the following browsers:
+* [ ] Chrome
+* [ ] Firefox
+* [ ] Safari
+* [ ] IE11
+
+The following are tests that require visual inspection:
+- [ ] 1) Example visual test.


### PR DESCRIPTION
# Summary
Adds a few options for PR templates to our repository. 
This helps with ensuring that the same important information is readily available for reviewers of PRs. 

# How to Use
Because I've included multiple templates rather than just one (since there are different kinds of PRs), GitHub doesn't automatically pre-populate the PR body. In order to do so, you will need to manually navigate to the URL of the specific Markdown file you want to pre-populate in the pull request form.

For example, one of our templates for the most generic PR use case is `default_template.md`. When I'm ready to create a new pull request, to pre-populate my pull request form with the content of the `default_template.md` file, I need to navigate to the appropriate URL by passing an additional template parameter:
```
https://github.com/SaraAlert/SaraAlert/compare/test-branch-name?expand=1&template=default_template.md
```
where `&template=default_template.md` is what I needed to manually add.

In order for this to work, these files must live in a folder named `PULL_REQUEST_TEMPLATE/`, which either must be at root or under the `.github` hidden folder, which is where I put them.

Github as allegedly said they are working on a UI for pre-selecting PR templates (like Gitlab already does), so we can look forward to that in the future. 