### PR TITLE
Add extra check for return to dashboard for enrollers

### DIFF
--- a/app/javascript/components/layout/Breadcrumb.js
+++ b/app/javascript/components/layout/Breadcrumb.js
@@ -58,9 +58,14 @@ class Breadcrumb extends React.Component {
                         href="#"
                         onClick={() => {
                           if (this.renderWorkflowName(crumb['value']).includes('Isolation')) {
+                            // Public Health "Return to Isolation Dashboard"
                             location.assign((window.BASE_PATH ? window.BASE_PATH : '') + '/public_health/isolation');
                           } else if (this.renderWorkflowName(crumb['value']).includes('Exposure')) {
+                            // Public Health "Return to Exposure Dashboard"
                             location.assign((window.BASE_PATH ? window.BASE_PATH : '') + '/public_health');
+                          } else if (this.renderWorkflowName(crumb['value']).includes('Dashboard')) {
+                            // Enroller "Return to Dashboard"
+                            location.assign((window.BASE_PATH ? window.BASE_PATH : '') + '/patients');
                           } else {
                             this.goBack(this.props.crumbs.length - (index + 1));
                           }


### PR DESCRIPTION
# Bug Description
When logged in as an enroller. After clicking Finish and then Return to Dashboard, the user is returned to the start of the data entry dialog, not the dashboard.

# How To Replicate:
1. Log in as enroller
2. Edit monitoree and click finish
3. Click Return to Dashboard

# Solution
Added extra check in breadcrumb component for enrollers

# Testing

This fix was tested on the following browsers:
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] IE11


