### PR TITLE
Align Heat Legend Vertical for Mainland USA Map

### DIFF
--- a/app/javascript/components/analytics/widgets/CountyLevelMaps.js
+++ b/app/javascript/components/analytics/widgets/CountyLevelMaps.js
@@ -230,11 +230,19 @@ class CountyLevelMaps extends React.Component {
     heatLegendReference.series = dataSeries;
     heatLegendReference.align = 'right';
     heatLegendReference.valign = 'bottom';
-    heatLegendReference.width = am4core.percent(25);
-    heatLegendReference.marginRight = am4core.percent(4);
-    heatLegendReference.background.fill = am4core.color('#3c5bdc');
+    heatLegendReference.marginRight = '7px';
+    heatLegendReference.background.fill = am4core.color('#fff');
     heatLegendReference.background.fillOpacity = 0.05;
-    heatLegendReference.padding(5, 5, 5, 5);
+    // For Insular Areas, we still want a Horizontal Legend, but for the 50-states we want a vertical legend
+    // so it doesnt sit over and obstruct Florida
+    if (this.props.jurisdictionToShow.category === 'territory') {
+      heatLegendReference.width = am4core.percent(25);
+      heatLegendReference.padding(5, 5, 5, 5);
+    } else {
+      heatLegendReference.width = '50px';
+      heatLegendReference.padding(10, 10, 10, 0);
+      heatLegendReference.orientation = 'vertical';
+    }
 
     let minRange = heatLegendReference.valueAxis.axisRanges.create();
     minRange.label.horizontalCenter = 'left';


### PR DESCRIPTION
# Summary
Previously, the heat legend obstructed the view of Florida 
![image](https://user-images.githubusercontent.com/17532163/87168575-b6748e00-c29c-11ea-80b0-8e6210699fb7.png)
This has been changed so that it is now vertical and no longer obstructs any states or counties.
![image](https://user-images.githubusercontent.com/17532163/87168617-c9875e00-c29c-11ea-90f4-1f324e1c774b.png)

The Insular Maps still show a Horizontal Heat Legend as it does not obstruct any insular areas.
# Important Changes
`CountyLevelMaps.js`



