### PR TITLE
Log Additional System Actions in History

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -126,8 +126,6 @@ class AssessmentsController < ApplicationController
     # Attempt to save and continue; else if failed redirect to index
     return unless assessment.save
 
-    patient.refresh_symptom_onset(assessment.id)
-
     comment = 'User updated an existing report (ID: ' + assessment.id.to_s + ').'
     comment += ' Symptom updates: ' + delta.join(', ') + '.' unless delta.empty?
     History.report_updated(patient: patient, created_by: current_user.email, comment: comment)

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -90,13 +90,8 @@ class AssessmentsController < ApplicationController
         # Save a receipt
         assessment_receipt = AssessmentReceipt.new(submission_token: params.permit(:patient_submission_token)[:patient_submission_token])
         assessment_receipt.save
-        history = History.new
-        history.created_by = current_user.email
-        comment = 'User created a new report. ID: ' + @assessment.id.to_s
-        history.comment = comment
-        history.patient = patient
-        history.history_type = 'Report Created'
-        history.save
+
+        History.report_created(patient: patient, created_by: current_user.email, comment: "User created a new report. ID: #{@assessment.id}")
       end
 
       redirect_to(patient_assessments_url)
@@ -131,14 +126,11 @@ class AssessmentsController < ApplicationController
     # Attempt to save and continue; else if failed redirect to index
     return unless assessment.save
 
-    history = History.new
-    history.created_by = current_user.email
+    patient.refresh_symptom_onset(assessment.id)
+
     comment = 'User updated an existing report (ID: ' + assessment.id.to_s + ').'
     comment += ' Symptom updates: ' + delta.join(', ') + '.' unless delta.empty?
-    history.comment = comment
-    history.patient = patient
-    history.history_type = 'Report Updated'
-    history.save
+    History.report_updated(patient: patient, created_by: current_user.email, comment: comment)
     redirect_to(patient_assessments_url) && return
   end
 

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -57,6 +57,6 @@ class ExportController < ApplicationController
     return if patients.empty?
 
     History.monitoree_data_downloaded(patient: patients.first, created_by: current_user.email)
-    send_data build_excel_export_for_patients(patients)
+    send_data excel_export(patients)
   end
 end

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -56,13 +56,7 @@ class ExportController < ApplicationController
     patients = current_user.viewable_patients.where(id: params[:patient_id])
     return if patients.empty?
 
-    history = History.new
-    history.created_by = current_user.email
-    comment = 'User downloaded monitoree\'s data in Excel Export.'
-    history.comment = comment
-    history.patient = patients.first
-    history.history_type = 'Monitoree Data Downloaded'
-    history.save
-    send_data excel_export(patients)
+    History.monitoree_data_downloaded(patient: patients.first, created_by: current_user.email)
+    send_data build_excel_export_for_patients(patients)
   end
 end

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -111,12 +111,7 @@ class Fhir::R4::ApiController < ActionController::API
       resource.send_enrollment_notification
 
       # Create a history for the enrollment
-      history = History.new
-      history.created_by = current_resource_owner.email
-      history.comment = 'User enrolled monitoree via API.'
-      history.patient = resource
-      history.history_type = 'Enrollment'
-      history.save
+      History.enrollment(patient: resource, created_by: current_resource_owner.email, comment: 'User enrolled monitoree via API.')
     end
     status_created(resource.as_fhir) && return
   rescue StandardError

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -7,11 +7,10 @@ class HistoriesController < ApplicationController
   # Create a new history route; this is used to create comments on subjects.
   def create
     redirect_to root_url unless current_user.can_create_subject_history?
-    history = History.new(comment: params.permit(:comment)[:comment])
-    history.created_by = current_user.email
-    history.patient_id = params.permit(:patient_id)[:patient_id]
-    history.history_type = params.permit(:type)[:type] || 'Comment'
-    history.save
+    History.create!(patient_id: params.permit(:patient_id)[:patient_id],
+                    created_by: current_user.email,
+                    comment: params.permit(:comment)[:comment],
+                    history_type: params.permit(:type)[:type] || 'Comment')
     redirect_back fallback_location: root_path
   end
 end

--- a/app/controllers/laboratories_controller.rb
+++ b/app/controllers/laboratories_controller.rb
@@ -13,11 +13,9 @@ class LaboratoriesController < ApplicationController
                          result: params.permit(:result)[:result])
     lab.patient_id = params.permit(:patient_id)[:patient_id]
     lab.save
-    history = History.new(comment: 'User added a new lab result (ID: ' + lab.id.to_s + ').')
-    history.created_by = current_user.email
-    history.patient_id = params.permit(:patient_id)[:patient_id]
-    history.history_type = 'Lab Result'
-    history.save
+    History.lab_result(patient: params.permit(:patient_id)[:patient_id],
+                       created_by: current_user.email,
+                       comment: "User added a new lab result (ID: #{lab.id}).")
   end
 
   # Update an existing lab result
@@ -29,10 +27,8 @@ class LaboratoriesController < ApplicationController
                report: params.permit(:report)[:report],
                result: params.permit(:result)[:result])
     lab.save
-    history = History.new(comment: 'User edited a lab result (ID: ' + lab.id.to_s + ').')
-    history.created_by = current_user.email
-    history.patient_id = params.permit(:patient_id)[:patient_id]
-    history.history_type = 'Lab Result Edit'
-    history.save
+    History.lab_result_edit(patient: params.permit(:patient_id)[:patient_id],
+                            created_by: current_user.email,
+                            comment: "User edited a lab result (ID: #{lab.id}).")
   end
 end

--- a/app/jobs/close_subjects_job.rb
+++ b/app/jobs/close_subjects_job.rb
@@ -19,20 +19,15 @@ class CloseSubjectsJob < ApplicationJob
 
     # Close subjects who are past the monitoring period (and are actually closable from above logic)
     closeable.find_each(batch_size: 5000) do |subject|
-      if !subject.last_date_of_exposure.nil? && subject.last_date_of_exposure < ADMIN_OPTIONS['monitoring_period_days'].days.ago
+      if (!subject.last_date_of_exposure.nil? && subject.last_date_of_exposure < ADMIN_OPTIONS['monitoring_period_days'].days.ago) ||
+         (subject.last_date_of_exposure.nil? && subject.created_at < ADMIN_OPTIONS['monitoring_period_days'].days.ago)
         subject[:monitoring] = false
         subject.closed_at = DateTime.now
         subject[:monitoring_reason] = 'Past monitoring period'
         if subject.save! && subject.email.present?
           PatientMailer.closed_email(subject).deliver_later if subject.self_reporter_or_proxy?
         end
-      elsif subject.last_date_of_exposure.nil? && subject.created_at < ADMIN_OPTIONS['monitoring_period_days'].days.ago
-        subject[:monitoring] = false
-        subject.closed_at = DateTime.now
-        subject[:monitoring_reason] = 'Past monitoring period'
-        if subject.save! && subject.email.present?
-          PatientMailer.closed_email(subject).deliver_later if subject.self_reporter_or_proxy?
-        end
+        History.record_automatically_closed(patient: subject)
       end
     end
   end

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -63,7 +63,7 @@ class ConsumeAssessmentsJob < ApplicationJob
                                                              primary telephone number #{patient.primary_telephone}.")
           unless patient.dependents.blank?
             create_contact_attempt_history_for_dependents(patient.dependents, "Sara Alert was unable to send an SMS to \
-                                                                              this moonitoree's head of household.")
+                                                                              this monitoree's head of household.")
           end
 
           next

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -116,7 +116,7 @@ class ConsumeAssessmentsJob < ApplicationJob
   private
 
   # Use the import method here to generate less SQL statements for a bulk insert of
-  # dependent histories instead of 1 staement per dependent.
+  # dependent histories instead of 1 statement per dependent.
   def create_contact_attempt_history_for_dependents(dependents, comment)
     histories = []
     dependents.each do |dependent|

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -232,7 +232,7 @@ class PatientMailer < ApplicationMailer
   end
 
   def assessment_email(patient)
-    if patient&.primary_telephone.blank?
+    if patient&.email.blank?
       History.report_reminder(patient: patient,
                               comment: "Sara Alert could not send a report reminder to this monitoree via \
                                        #{patient.preferred_contact_method}, because the monitoree email was blank.")

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -117,6 +117,8 @@ class History < ApplicationRecord
   private_class_method def self.create_history(patient, created_by, type, comment)
     return if patient.nil?
 
-    History.create!(created_by: created_by, comment: comment, patient: patient, history_type: type)
+    patient = patient.id if patient.respond_to?(:id)
+
+    History.create!(created_by: created_by, comment: comment, patient_id: patient, history_type: type)
   end
 end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -5,6 +5,24 @@ require 'action_view/helpers'
 
 # History: history model
 class History < ApplicationRecord
+  HISTORY_TYPES = {
+    report_created: 'Report Created',
+    report_updated: 'Report Updated',
+    comment: 'Comment',
+    enrollment: 'Enrollment',
+    monitoring_change: 'Monitoring Change',
+    monitoree_data_downloaded: 'Monitoree Data Downloaded',
+    reports_reviewed: 'Reports Reviewed',
+    report_reviewed: 'Report Reviewed',
+    report_reminder: 'Report Reminder',
+    report_note: 'Report Note',
+    lab_result: 'Lab Result',
+    lab_result_edit: 'Lab Result Edit',
+    contact_attempt: 'Contact Attempt',
+    welcome_message_sent: 'Welcome Message Sent',
+    record_automatically_closed: 'Record Automatically Closed'
+  }.freeze
+
   columns.each do |column|
     case column.type
     when :text
@@ -14,21 +32,7 @@ class History < ApplicationRecord
     end
   end
 
-  validates :history_type, inclusion: { in: ['Report Created',
-                                             'Report Updated',
-                                             'Comment',
-                                             'Enrollment',
-                                             'Monitoring Change',
-                                             'Monitoree Data Downloaded',
-                                             'Reports Reviewed',
-                                             'Report Reviewed',
-                                             'Report Reminder',
-                                             'Report Note',
-                                             'Lab Result',
-                                             'Lab Result Edit',
-                                             'Contact Attempt',
-                                             'Welcome Message Sent',
-                                             'Record Automatically Closed'] }
+  validates :history_type, inclusion: { in: HISTORY_TYPES.values }
 
   belongs_to :patient
 
@@ -47,55 +51,55 @@ class History < ApplicationRecord
   }
 
   def self.report_created(patient: nil, created_by: 'Sara Alert System', comment: 'User created a new report.')
-    create_history(patient, created_by, 'Report Created', comment)
+    create_history(patient, created_by, HISTORY_TYPES[:report_created], comment)
   end
 
   def self.report_updated(patient: nil, created_by: 'Sara Alert System', comment: 'User updated existing report.')
-    create_history(patient, created_by, 'Report Updated', comment)
+    create_history(patient, created_by, HISTORY_TYPES[:report_updated], comment)
   end
 
   def self.enrollment(patient: nil, created_by: 'Sara Alert System', comment: 'User enrolled monitoree.')
-    create_history(patient, created_by, 'Enrollment', comment)
+    create_history(patient, created_by, HISTORY_TYPES[:enrollment], comment)
   end
 
   def self.monitoring_change(patient: nil, created_by: 'Sara Alert System', comment: 'User updated monitoree.')
-    create_history(patient, created_by, 'Monitoring Change', comment)
+    create_history(patient, created_by, HISTORY_TYPES[:monitoring_change], comment)
   end
 
   def self.monitoree_data_downloaded(patient: nil, created_by: 'Sara Alert System', comment: 'User downloaded monitoree\'s data in Excel Export.')
-    create_history(patient, created_by, 'Monitoree Data Downloaded', comment)
+    create_history(patient, created_by, HISTORY_TYPES[:monitoree_data_downloaded], comment)
   end
 
   def self.reports_reviewed(patient: nil, created_by: 'Sara Alert System', comment: 'User reviewed all reports.')
-    create_history(patient, created_by, 'Reports Reviewed', comment)
+    create_history(patient, created_by, HISTORY_TYPES[:reports_reviewed], comment)
   end
 
   def self.report_reviewed(patient: nil, created_by: 'Sara Alert System', comment: 'User reviewed a report.')
-    create_history(patient, created_by, 'Report Reviewed', comment)
+    create_history(patient, created_by, HISTORY_TYPES[:report_reviewed], comment)
   end
 
   def self.report_reminder(patient: nil, created_by: 'Sara Alert System', comment: 'User sent a report reminder to the monitoree.')
-    create_history(patient, created_by, 'Report Reminder', comment) unless patient&.preferred_contact_method.nil?
+    create_history(patient, created_by, HISTORY_TYPES[:report_reminder], comment) unless patient&.preferred_contact_method.nil?
   end
 
   def self.lab_result(patient: nil, created_by: 'Sara Alert System', comment: 'User added a new lab result.')
-    create_history(patient, created_by, 'Lab Result', comment)
+    create_history(patient, created_by, HISTORY_TYPES[:lab_result], comment)
   end
 
   def self.lab_result_edit(patient: nil, created_by: 'Sara Alert System', comment: 'User edited a lab result.')
-    create_history(patient, created_by, 'Lab Result Edit', comment)
+    create_history(patient, created_by, HISTORY_TYPES[:lab_result_edit], comment)
   end
 
   def self.contact_attempt(patient: nil, created_by: 'Sara Alert System', comment: 'The system attempted to make contact with the monitoree.')
-    create_history(patient, created_by, 'Contact Attempt', comment)
+    create_history(patient, created_by, HISTORY_TYPES[:contact_attempt], comment)
   end
 
   def self.welcome_message_sent(patient: nil, created_by: 'Sara Alert System', comment: 'Initial Sara Alert welcome message was sent.')
-    create_history(patient, created_by, 'Welcome Message Sent', comment)
+    create_history(patient, created_by, HISTORY_TYPES[:welcome_message_sent], comment)
   end
 
   def self.record_automatically_closed(patient: nil, created_by: 'Sara Alert System', comment: 'Monitoree has completed monitoring.')
-    create_history(patient, created_by, 'Record Automatically Closed', comment)
+    create_history(patient, created_by, HISTORY_TYPES[:record_automatically_closed], comment)
   end
 
   # Information about this history

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -26,7 +26,9 @@ class History < ApplicationRecord
                                              'Report Note',
                                              'Lab Result',
                                              'Lab Result Edit',
-                                             'Contact Attempt'] }
+                                             'Contact Attempt',
+                                             'Welcome Message Sent',
+                                             'Record Automatically Closed'] }
 
   belongs_to :patient
 
@@ -44,6 +46,58 @@ class History < ApplicationRecord
     end
   }
 
+  def self.report_created(patient: nil, created_by: 'Sara Alert System', comment: 'User created a new report.')
+    create_history(patient, created_by, 'Report Created', comment)
+  end
+
+  def self.report_updated(patient: nil, created_by: 'Sara Alert System', comment: 'User updated existing report.')
+    create_history(patient, created_by, 'Report Updated', comment)
+  end
+
+  def self.enrollment(patient: nil, created_by: 'Sara Alert System', comment: 'User enrolled monitoree.')
+    create_history(patient, created_by, 'Enrollment', comment)
+  end
+
+  def self.monitoring_change(patient: nil, created_by: 'Sara Alert System', comment: 'User updated monitoree.')
+    create_history(patient, created_by, 'Monitoring Change', comment)
+  end
+
+  def self.monitoree_data_downloaded(patient: nil, created_by: 'Sara Alert System', comment: 'User downloaded monitoree\'s data in Excel Export.')
+    create_history(patient, created_by, 'Monitoree Data Downloaded', comment)
+  end
+
+  def self.reports_reviewed(patient: nil, created_by: 'Sara Alert System', comment: 'User reviewed all reports.')
+    create_history(patient, created_by, 'Reports Reviewed', comment)
+  end
+
+  def self.report_reviewed(patient: nil, created_by: 'Sara Alert System', comment: 'User reviewed a report.')
+    create_history(patient, created_by, 'Report Reviewed', comment)
+  end
+
+  def self.report_reminder(patient: nil, created_by: 'Sara Alert System', comment: 'User sent a report reminder to the monitoree.')
+    create_history(patient, created_by, 'Report Reminder', comment) unless patient&.preferred_contact_method.nil?
+  end
+
+  def self.lab_result(patient: nil, created_by: 'Sara Alert System', comment: 'User added a new lab result.')
+    create_history(patient, created_by, 'Lab Result', comment)
+  end
+
+  def self.lab_result_edit(patient: nil, created_by: 'Sara Alert System', comment: 'User edited a lab result.')
+    create_history(patient, created_by, 'Lab Result Edit', comment)
+  end
+
+  def self.contact_attempt(patient: nil, created_by: 'Sara Alert System', comment: 'The system attempted to make contact with the monitoree.')
+    create_history(patient, created_by, 'Contact Attempt', comment)
+  end
+
+  def self.welcome_message_sent(patient: nil, created_by: 'Sara Alert System', comment: 'Initial Sara Alert welcome message was sent.')
+    create_history(patient, created_by, 'Welcome Message Sent', comment)
+  end
+
+  def self.record_automatically_closed(patient: nil, created_by: 'Sara Alert System', comment: 'Monitoree has completed monitoring.')
+    create_history(patient, created_by, 'Record Automatically Closed', comment)
+  end
+
   # Information about this history
   def details
     {
@@ -54,5 +108,11 @@ class History < ApplicationRecord
       history_created_at: created_at || '',
       history_updated_at: updated_at || ''
     }
+  end
+
+  private_class_method def self.create_history(patient, created_by, type, comment)
+    return if patient.nil?
+
+    History.create!(created_by: created_by, comment: comment, patient: patient, history_type: type)
   end
 end


### PR DESCRIPTION
Addresses SARAALERT-389

# Summary
Refactor the way histories are created to use methods on the History model. Add in history entries for dependents when their head of household is contacted, when the system automatically closes a monitoree, and when a welcome message is sent.

# Important Changes
`history.rb`
- Added several new class methods for creating a History.
- Added new types of history to support the feature request.

`consume_assessment_job.rb`
- Did not use the class methods for inserting dependent history for a small optimization.

`close_subjects_job.rb`
- Consolidated logic
- Create a History when the system closes out a monitoree.

`patient_mailer.rb`
- Create a new type of History when a welcome email is sent.

