### PR TITLE
Fix update assigned user and monitoring reason bug

### DIFF
--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -26,13 +26,13 @@ class MonitoringStatus extends React.Component {
       monitoring_status: props.patient.monitoring ? 'Actively Monitoring' : 'Not Monitoring',
       monitoring_plan: props.patient.monitoring_plan ? props.patient.monitoring_plan : '',
       exposure_risk_assessment: props.patient.exposure_risk_assessment ? props.patient.exposure_risk_assessment : '',
-      jurisdictionPath: this.props.jurisdictionPaths[this.props.patient.jurisdiction_id],
-      originalJurisdictionId: this.props.patient.jurisdiction_id,
+      jurisdiction_path: this.props.jurisdictionPaths[this.props.patient.jurisdiction_id],
+      original_jurisdiction_id: this.props.patient.jurisdiction_id,
       validJurisdiction: true,
-      assignedUser: props.patient.assigned_user ? props.patient.assigned_user : '',
-      originalAssignedUser: props.patient.assigned_user ? props.patient.assigned_user : '',
-      monitoring_status_options: null,
-      monitoring_status_option: props.patient.monitoring_reason ? props.patient.monitoring_reason : '',
+      assigned_user: props.patient.assigned_user ? props.patient.assigned_user : '',
+      original_assigned_user: props.patient.assigned_user ? props.patient.assigned_user : '',
+      monitoring_reasons: null,
+      monitoring_reason: props.patient.monitoring_reason ? props.patient.monitoring_reason : '',
       public_health_action: props.patient.public_health_action ? props.patient.public_health_action : '',
       apply_to_group: false,
       isolation: props.patient.isolation,
@@ -50,7 +50,7 @@ class MonitoringStatus extends React.Component {
     this.toggleMonitoringPlanModal = this.toggleMonitoringPlanModal.bind(this);
     this.toggleExposureRiskAssessmentModal = this.toggleExposureRiskAssessmentModal.bind(this);
     this.toggleJurisdictionModal = this.toggleJurisdictionModal.bind(this);
-    this.toggleassignedUserModal = this.toggleassignedUserModal.bind(this);
+    this.toggleAssignedUserModal = this.toggleAssignedUserModal.bind(this);
     this.togglePublicHealthAction = this.togglePublicHealthAction.bind(this);
     this.toggleIsolation = this.toggleIsolation.bind(this);
     this.toggleNotifications = this.toggleNotifications.bind(this);
@@ -60,10 +60,10 @@ class MonitoringStatus extends React.Component {
     if (event?.target?.name && event.target.name === 'jurisdictionId') {
       // Jurisdiction is a weird case; the datalist and input work differently together
       this.setState({
-        message: 'jurisdiction from "' + this.props.jurisdictionPaths[this.state.originalJurisdictionId] + '" to "' + event.target.value + '".',
-        message_warning: this.state.assignedUser === '' ? '' : 'Please also consider removing or updating the assigned user if it is no longer applicable.',
-        jurisdictionPath: event?.target?.value ? event.target.value : '',
-        monitoring_status_options: null,
+        message: 'jurisdiction from "' + this.props.jurisdictionPaths[this.state.original_jurisdiction_id] + '" to "' + event.target.value + '".',
+        message_warning: this.state.assigned_user === '' ? '' : 'Please also consider removing or updating the assigned user if it is no longer applicable.',
+        jurisdiction_path: event?.target?.value ? event.target.value : '',
+        monitoring_reasons: null,
         validJurisdiction: Object.values(this.props.jurisdictionPaths).includes(event.target.value),
       });
     } else if (event?.target?.name && event.target.name === 'assignedUser') {
@@ -72,10 +72,10 @@ class MonitoringStatus extends React.Component {
         (event?.target?.value && !isNaN(event.target.value) && parseInt(event.target.value) > 0 && parseInt(event.target.value) <= 9999)
       ) {
         this.setState({
-          message: 'assigned user from "' + this.state.originalAssignedUser + '"to"' + event.target.value + '".',
+          message: 'assigned user from "' + this.state.original_assigned_user + '"to"' + event.target.value + '".',
           message_warning: '',
-          assignedUser: event?.target?.value ? parseInt(event.target.value) : '',
-          monitoring_status_options: null,
+          assigned_user: event?.target?.value ? parseInt(event.target.value) : '',
+          monitoring_reasons: null,
         });
       }
     } else if (event?.target?.id && event.target.id === 'exposure_risk_assessment') {
@@ -84,7 +84,7 @@ class MonitoringStatus extends React.Component {
         message: 'exposure risk assessment to "' + event.target.value + '".',
         message_warning: '',
         exposure_risk_assessment: event?.target?.value ? event.target.value : '',
-        monitoring_status_options: null,
+        monitoring_reasons: null,
       });
     } else if (event?.target?.id && event.target.id === 'monitoring_plan') {
       this.setState({
@@ -92,7 +92,7 @@ class MonitoringStatus extends React.Component {
         message: 'monitoring plan to "' + event.target.value + '".',
         message_warning: '',
         monitoring_plan: event?.target?.value ? event.target.value : '',
-        monitoring_status_options: null,
+        monitoring_reasons: null,
       });
     } else if (event?.target?.id && event.target.id === 'pause_notifications') {
       this.setState({
@@ -100,7 +100,7 @@ class MonitoringStatus extends React.Component {
         message: 'notification status to ' + (!this.state.pause_notifications ? 'paused.' : 'resumed.'),
         message_warning: '',
         pause_notifications: !this.state.pause_notifications,
-        monitoring_status_options: null,
+        monitoring_reasons: null,
       });
     } else if (event?.target?.id && event.target.id === 'public_health_action') {
       if (this.state.patient.isolation) {
@@ -110,7 +110,7 @@ class MonitoringStatus extends React.Component {
           message_warning:
             'The monitoree will be moved to the "Records Requiring Review" line list if they meet a recovery definition or will remain on the "Reporting" or "Non-Reporting" line list as appropriate until a recovery definition is met.',
           public_health_action: event?.target?.value ? event.target.value : '',
-          monitoring_status_options: null,
+          monitoring_reasons: null,
         });
       } else {
         this.setState({
@@ -121,7 +121,7 @@ class MonitoringStatus extends React.Component {
               ? 'The monitoree will be moved back into the primary status line lists.'
               : 'The monitoree will be moved into the PUI line list.',
           public_health_action: event?.target?.value ? event.target.value : '',
-          monitoring_status_options: null,
+          monitoring_reasons: null,
         });
       }
     } else if (event?.target?.id && event.target.id === 'isolation_status') {
@@ -134,7 +134,7 @@ class MonitoringStatus extends React.Component {
             : 'The monitoree will be moved into the Exposure workflow.',
         isolation: event.target.value === 'Isolation',
         isolation_status: event.target.value,
-        monitoring_status_options: null,
+        monitoring_reasons: null,
       });
     } else if (event?.target?.id && event.target.id === 'monitoring_status') {
       this.setState({
@@ -143,7 +143,7 @@ class MonitoringStatus extends React.Component {
         message_warning: event.target.value === 'Not Monitoring' ? 'This record will be moved to the closed line list.' : '',
         monitoring: event.target.value === 'Actively Monitoring' ? true : false,
         monitoring_status: event?.target?.value ? event.target.value : '',
-        monitoring_status_options:
+        monitoring_reasons:
           event.target.value === 'Not Monitoring'
             ? [
                 'Completed Monitoring',
@@ -173,7 +173,7 @@ class MonitoringStatus extends React.Component {
         this.toggleJurisdictionModal();
       } else if (event?.target?.name && event.target.name === 'assignedUser') {
         event.preventDefault();
-        this.toggleassignedUserModal();
+        this.toggleAssignedUserModal();
       }
     }
   }
@@ -221,20 +221,20 @@ class MonitoringStatus extends React.Component {
   toggleJurisdictionModal() {
     let current = this.state.showJurisdictionModal;
     this.setState({
-      message: 'jurisdiction from "' + this.props.jurisdictionPaths[this.state.originalJurisdictionId] + '" to "' + this.state.jurisdictionPath + '".',
+      message: 'jurisdiction from "' + this.props.jurisdictionPaths[this.state.original_jurisdiction_id] + '" to "' + this.state.jurisdiction_path + '".',
       showJurisdictionModal: !current,
-      jurisdictionPath: current ? this.props.jurisdictionPaths[this.state.originalJurisdictionId] : this.state.jurisdictionPath,
+      jurisdiction_path: current ? this.props.jurisdictionPaths[this.state.original_jurisdiction_id] : this.state.jurisdiction_path,
       apply_to_group: false,
       reasoning: '',
     });
   }
 
-  toggleassignedUserModal() {
+  toggleAssignedUserModal() {
     let current = this.state.showassignedUserModal;
     this.setState({
-      message: 'assigned user from "' + this.state.originalAssignedUser + '" to "' + this.state.assignedUser + '".',
+      message: 'assigned user from "' + this.state.original_assigned_user + '" to "' + this.state.assigned_user + '".',
       showassignedUserModal: !current,
-      assignedUser: current ? this.state.originalAssignedUser : this.state.assignedUser,
+      assigned_user: current ? this.state.original_assigned_user : this.state.assigned_user,
       apply_to_group: false,
       reasoning: '',
     });
@@ -275,11 +275,11 @@ class MonitoringStatus extends React.Component {
           message: this.state.message,
           reasoning:
             (this.state.showMonitoringStatusModal && this.state.monitoring_status === 'Not Monitoring'
-              ? this.state.monitoring_status_option + (this.state.reasoning ? ', ' : '')
+              ? this.state.monitoring_reason + (this.state.reasoning ? ', ' : '')
               : '') + this.state.reasoning,
-          monitoring_reason: this.state.monitoring_status === 'Not Monitoring' ? this.state.monitoring_status_option : null,
-          jurisdiction: Object.keys(this.props.jurisdictionPaths).find(id => this.props.jurisdictionPaths[parseInt(id)] === this.state.jurisdictionPath),
-          assigned_user: this.state.assignedUser,
+          monitoring_reason: this.state.monitoring_status === 'Not Monitoring' ? this.state.monitoring_reason : null,
+          jurisdiction: Object.keys(this.props.jurisdictionPaths).find(id => this.props.jurisdictionPaths[parseInt(id)] === this.state.jurisdiction_path),
+          assigned_user: this.state.assigned_user,
           apply_to_group: this.state.apply_to_group,
           isolation: this.state.isolation,
           pause_notifications: this.state.pause_notifications,
@@ -306,14 +306,14 @@ class MonitoringStatus extends React.Component {
           <p>
             You are about to change this monitoree&apos;s {this.state.message} {this.state.message_warning && <b>{this.state.message_warning}</b>}
           </p>
-          {this.state.monitoring_status_options && (
+          {this.state.monitoring_reasons && (
             <Form.Group>
               <Form.Label>Please select reason for status change:</Form.Label>
-              <Form.Control as="select" size="lg" className="form-square" id="monitoring_status_option" onChange={this.handleChange} defaultValue={-1}>
+              <Form.Control as="select" size="lg" className="form-square" id="monitoring_reason" onChange={this.handleChange} defaultValue={-1}>
                 <option value={-1} disabled>
                   --
                 </option>
-                {this.state.monitoring_status_options.map((option, index) => (
+                {this.state.monitoring_reasons.map((option, index) => (
                   <option key={`option-${index}`} value={option}>
                     {option}
                   </option>
@@ -321,7 +321,7 @@ class MonitoringStatus extends React.Component {
               </Form.Control>
             </Form.Group>
           )}
-          {this.props.isolation && this.state.monitoring_status_options && this.props.in_a_group && (
+          {this.props.isolation && this.state.monitoring_reasons && this.props.in_a_group && (
             <Form.Group>
               <Form.Check
                 type="switch"
@@ -332,7 +332,7 @@ class MonitoringStatus extends React.Component {
               />
             </Form.Group>
           )}
-          {this.props.isolation && this.state.monitoring_status_options && this.props.in_a_group && this.state.apply_to_group_cm_only && (
+          {this.props.isolation && this.state.monitoring_reasons && this.props.in_a_group && this.state.apply_to_group_cm_only && (
             <Form.Group>
               <Form.Label className="nav-input-label">LAST DATE OF EXPOSURE</Form.Label>
               <Form.Control
@@ -362,7 +362,7 @@ class MonitoringStatus extends React.Component {
           )}
         </Modal.Body>
         <Modal.Footer>
-          {this.state.monitoring_status_options && !this.state.monitoring_status_option ? (
+          {this.state.monitoring_reasons && !this.state.monitoring_reason ? (
             <Button variant="primary btn-square" disabled>
               Submit
             </Button>
@@ -484,7 +484,7 @@ class MonitoringStatus extends React.Component {
                       className="form-control-lg"
                       onChange={this.handleChange}
                       onKeyPress={this.handleKeyPress}
-                      value={this.state.assignedUser}
+                      value={this.state.assigned_user}
                     />
                     <datalist id="assignedUsers">
                       {this.props.assignedUsers.map(num => {
@@ -495,12 +495,12 @@ class MonitoringStatus extends React.Component {
                         );
                       })}
                     </datalist>
-                    {this.state.assignedUser === this.state.originalAssignedUser ? (
+                    {this.state.assigned_user === this.state.original_assigned_user ? (
                       <Button className="btn-lg btn-square text-nowrap ml-2" disabled>
                         <i className="fas fa-users"></i> Change User
                       </Button>
                     ) : (
-                      <Button className="btn-lg btn-square text-nowrap ml-2" onClick={this.toggleassignedUserModal}>
+                      <Button className="btn-lg btn-square text-nowrap ml-2" onClick={this.toggleAssignedUserModal}>
                         <i className="fas fa-users"></i> Change User
                       </Button>
                     )}
@@ -520,7 +520,7 @@ class MonitoringStatus extends React.Component {
                       className="form-control-lg"
                       onChange={this.handleChange}
                       onKeyPress={this.handleKeyPress}
-                      value={this.state.jurisdictionPath}
+                      value={this.state.jurisdiction_path}
                     />
                     <datalist id="jurisdictionPaths">
                       {Object.entries(this.props.jurisdictionPaths).map(([id, path]) => {
@@ -531,7 +531,7 @@ class MonitoringStatus extends React.Component {
                         );
                       })}
                     </datalist>
-                    {!this.state.validJurisdiction || this.state.jurisdictionPath === this.props.jurisdictionPaths[this.state.originalJurisdictionId] ? (
+                    {!this.state.validJurisdiction || this.state.jurisdiction_path === this.props.jurisdictionPaths[this.state.original_jurisdiction_id] ? (
                       <Button className="btn-lg btn-square text-nowrap ml-2" disabled>
                         <i className="fas fa-map-marked-alt"></i> Change Jurisdiction
                       </Button>
@@ -550,7 +550,7 @@ class MonitoringStatus extends React.Component {
         {this.state.showMonitoringPlanModal && this.createModal('Monitoring Plan', this.toggleMonitoringPlanModal, this.submit)}
         {this.state.showExposureRiskAssessmentModal && this.createModal('Exposure Risk Assessment', this.toggleExposureRiskAssessmentModal, this.submit)}
         {this.state.showJurisdictionModal && this.createModal('Jurisdiction', this.toggleJurisdictionModal, this.submit)}
-        {this.state.showassignedUserModal && this.createModal('Assigned User', this.toggleassignedUserModal, this.submit)}
+        {this.state.showassignedUserModal && this.createModal('Assigned User', this.toggleAssignedUserModal, this.submit)}
         {this.state.showPublicHealthActionModal && this.createModal('Public Health Action', this.togglePublicHealthAction, this.submit)}
         {this.state.showIsolationModal && this.createModal('Isolation', this.toggleIsolation, this.submit)}
         {this.state.showNotificationsModal && this.createModal('Notifications', this.toggleNotifications, this.submit)}

--- a/test/system/lib/system_test_utils.rb
+++ b/test/system/lib/system_test_utils.rb
@@ -84,6 +84,10 @@ class SystemTestUtils < ApplicationSystemTestCase
     "#{patient_label}_assessment_#{assessment_label}"
   end
 
+  def get_patient_by_label(patient_label)
+    Patient.where(id: PATIENTS[patient_label]['id']).first
+  end
+
   def get_patient_display_name(patient_label)
     "#{PATIENTS[patient_label]['last_name']}, #{PATIENTS[patient_label]['first_name']}"
   end

--- a/test/system/roles/public_health/patient_page/actions.rb
+++ b/test/system/roles/public_health/patient_page/actions.rb
@@ -9,18 +9,23 @@ class PublicHealthPatientPageActions < ApplicationSystemTestCase
   @@public_health_patient_page_history_verifier = PublicHealthPatientPageHistoryVerifier.new(nil)
   @@system_test_utils = SystemTestUtils.new(nil)
 
-  def update_monitoring_status(user_label, monitoring_status, status_change_reason, reasoning)
+  # rubocop:disable Metrics/ParameterLists
+  def update_monitoring_status(user_label, patient_label, monitoring_status, monitoring_reason, reasoning)
     return unless monitoring_status != find('#monitoring_status')['value']
 
     select monitoring_status, from: 'monitoring_status'
-    select status_change_reason, from: 'monitoring_status_option'
+    select monitoring_reason, from: 'monitoring_reason' if monitoring_reason && monitoring_status == 'Not Monitoring'
     fill_in 'reasoning', with: reasoning
     click_on 'Submit'
     @@system_test_utils.wait_for_modal_animation
-    @@public_health_patient_page_history_verifier.verify_monitoring_status(user_label, monitoring_status, status_change_reason, reasoning)
+    @@public_health_patient_page_history_verifier.verify_monitoring_status(user_label, monitoring_status, monitoring_reason, reasoning)
+    patient = @@system_test_utils.get_patient_by_label(patient_label)
+    assert_equal true, patient[:monitoring] if monitoring_status == 'Actively Monitoring'
+    assert [false, nil].include?(patient[:monitoring]) if monitoring_status == 'Not Monitoring'
+    assert_equal monitoring_reason, patient[:monitoring_reason] if monitoring_reason && monitoring_status == 'Not Monitoring'
   end
 
-  def update_exposure_risk_assessment(user_label, exposure_risk_assessment, reasoning)
+  def update_exposure_risk_assessment(user_label, patient_label, exposure_risk_assessment, reasoning)
     return unless exposure_risk_assessment != find('#exposure_risk_assessment')['value']
 
     select exposure_risk_assessment, from: 'exposure_risk_assessment'
@@ -28,9 +33,10 @@ class PublicHealthPatientPageActions < ApplicationSystemTestCase
     click_on 'Submit'
     @@system_test_utils.wait_for_modal_animation
     @@public_health_patient_page_history_verifier.verify_exposure_risk_assessment(user_label, exposure_risk_assessment, reasoning)
+    assert_equal exposure_risk_assessment, @@system_test_utils.get_patient_by_label(patient_label)[:exposure_risk_assessment]
   end
 
-  def update_monitoring_plan(user_label, monitoring_plan, reasoning)
+  def update_monitoring_plan(user_label, patient_label, monitoring_plan, reasoning)
     return unless monitoring_plan != find('#monitoring_plan')['value']
 
     select monitoring_plan, from: 'monitoring_plan'
@@ -38,9 +44,10 @@ class PublicHealthPatientPageActions < ApplicationSystemTestCase
     click_on 'Submit'
     @@system_test_utils.wait_for_modal_animation
     @@public_health_patient_page_history_verifier.verify_monitoring_plan(user_label, monitoring_plan, reasoning)
+    assert_equal monitoring_plan, @@system_test_utils.get_patient_by_label(patient_label)[:monitoring_plan]
   end
 
-  def update_latest_public_health_action(user_label, latest_public_health_action, reasoning)
+  def update_latest_public_health_action(user_label, patient_label, latest_public_health_action, reasoning)
     return unless latest_public_health_action != find('#public_health_action')['value']
 
     select latest_public_health_action, from: 'public_health_action'
@@ -48,9 +55,10 @@ class PublicHealthPatientPageActions < ApplicationSystemTestCase
     click_on 'Submit'
     @@system_test_utils.wait_for_modal_animation
     @@public_health_patient_page_history_verifier.verify_latest_public_health_action(user_label, latest_public_health_action, reasoning)
+    assert_equal latest_public_health_action, @@system_test_utils.get_patient_by_label(patient_label)[:public_health_action]
   end
 
-  def update_assigned_jurisdiction(user_label, jurisdiction, reasoning, valid_jurisdiction = true, under_hierarchy = true)
+  def update_assigned_jurisdiction(user_label, patient_label, jurisdiction, reasoning, valid_jurisdiction = true, under_hierarchy = true)
     assert page.has_button?('Change Jurisdiction', disabled: true)
     fill_in 'jurisdictionId', with: jurisdiction
     if valid_jurisdiction
@@ -62,13 +70,14 @@ class PublicHealthPatientPageActions < ApplicationSystemTestCase
       if under_hierarchy
         assert page.has_button?('Change Jurisdiction', disabled: true)
         @@public_health_patient_page_history_verifier.verify_assigned_jurisdiction(user_label, jurisdiction, reasoning)
+        assert_equal jurisdiction, @@system_test_utils.get_patient_by_label(patient_label).jurisdiction[:path].to_s
       end
     else
       assert page.has_button?('Change Jurisdiction', disabled: true)
     end
   end
 
-  def update_assigned_user(user_label, assigned_user, reasoning, valid_assigned_user = true, changed = true)
+  def update_assigned_user(user_label, patient_label, assigned_user, reasoning, valid_assigned_user = true, changed = true)
     assert page.has_button?('Change User', disabled: true)
     fill_in 'assignedUser', with: assigned_user
     if valid_assigned_user && changed
@@ -79,10 +88,12 @@ class PublicHealthPatientPageActions < ApplicationSystemTestCase
       @@system_test_utils.wait_for_modal_animation
       assert page.has_button?('Change User', disabled: true)
       @@public_health_patient_page_history_verifier.verify_assigned_user(user_label, assigned_user, reasoning)
+      assert_equal assigned_user, @@system_test_utils.get_patient_by_label(patient_label)[:assigned_user].to_s
     elsif valid_assigned_user && !changed
       assert page.has_button?('Change User', disabled: true)
     elsif !valid_assigned_user && changed
       assert_not_equal(assigned_user, page.find_field('assignedUser').value)
     end
   end
+  # rubocop:enable Metrics/ParameterLists
 end

--- a/test/system/roles/public_health/patient_page/history_verifier.rb
+++ b/test/system/roles/public_health/patient_page/history_verifier.rb
@@ -9,8 +9,8 @@ class PublicHealthPatientPageHistoryVerifier < ApplicationSystemTestCase
 
   USERS = @@system_test_utils.users
 
-  def verify_monitoring_status(user_label, monitoring_status, status_change_reason, reasoning)
-    verify_historical_event(user_label, 'Monitoring Change', ['User changed monitoring status', monitoring_status, status_change_reason, reasoning])
+  def verify_monitoring_status(user_label, monitoring_status, monitoring_reason, reasoning)
+    verify_historical_event(user_label, 'Monitoring Change', ['User changed monitoring status', monitoring_status, monitoring_reason, reasoning])
   end
 
   def verify_exposure_risk_assessment(user_label, exposure_risk_assessment, reasoning)
@@ -69,7 +69,7 @@ class PublicHealthPatientPageHistoryVerifier < ApplicationSystemTestCase
     assert page.has_content?(USERS[user_label]['email']), @@system_test_utils.get_err_msg("History #{event_type}", 'user email', USERS[user_label]['email'])
     assert page.has_content?(event_type), @@system_test_utils.get_err_msg("History #{event_type}", 'event type', event_type)
     contents.each do |content|
-      assert page.has_content?(content), @@system_test_utils.get_err_msg("History #{event_type}", 'content', content)
+      assert page.has_content?(content), @@system_test_utils.get_err_msg("History #{event_type}", 'content', content) unless content.nil?
     end
   end
 end

--- a/test/system/roles/public_health/public_health_test.rb
+++ b/test/system/roles/public_health/public_health_test.rb
@@ -34,6 +34,8 @@ class PublicHealthTest < ApplicationSystemTestCase
   test 'update monitoring status' do
     @@public_health_test_helper.update_monitoring_status('state1_epi', 'patient_2', 'non-reporting', 'closed',
                                                          'Not Monitoring', 'Completed Monitoring', 'details')
+    @@public_health_test_helper.update_monitoring_status('state1_epi', 'patient_5', 'closed', 'all',
+                                                         'Actively Monitoring', nil, 'notes')
   end
 
   test 'update exposure risk assessment' do

--- a/test/system/roles/public_health/public_health_test_helper.rb
+++ b/test/system/roles/public_health/public_health_test_helper.rb
@@ -32,10 +32,10 @@ class PublicHealthTestHelper < ApplicationSystemTestCase
   end
 
   # rubocop:disable Metrics/ParameterLists
-  def update_monitoring_status(user_label, patient_label, old_tab, new_tab, monitoring_status, status_change_reason, reasoning)
+  def update_monitoring_status(user_label, patient_label, old_tab, new_tab, monitoring_status, monitoring_reason, reasoning)
     @@system_test_utils.login(user_label)
     @@public_health_dashboard.search_for_and_view_patient(old_tab, patient_label)
-    @@public_health_patient_page_actions.update_monitoring_status(user_label, monitoring_status, status_change_reason, reasoning)
+    @@public_health_patient_page_actions.update_monitoring_status(user_label, patient_label, monitoring_status, monitoring_reason, reasoning)
     @@system_test_utils.return_to_dashboard(nil)
     @@public_health_dashboard.search_for_and_view_patient(new_tab, patient_label)
     @@system_test_utils.logout
@@ -44,35 +44,35 @@ class PublicHealthTestHelper < ApplicationSystemTestCase
   def update_exposure_risk_assessment(user_label, patient_label, tab, exposure_risk_assessment, reasoning)
     @@system_test_utils.login(user_label)
     @@public_health_dashboard.search_for_and_view_patient(tab, patient_label)
-    @@public_health_patient_page_actions.update_exposure_risk_assessment(user_label, exposure_risk_assessment, reasoning)
+    @@public_health_patient_page_actions.update_exposure_risk_assessment(user_label, patient_label, exposure_risk_assessment, reasoning)
     @@system_test_utils.logout
   end
 
   def update_monitoring_plan(user_label, patient_label, tab, monitoring_plan, reasoning)
     @@system_test_utils.login(user_label)
     @@public_health_dashboard.search_for_and_view_patient(tab, patient_label)
-    @@public_health_patient_page_actions.update_monitoring_plan(user_label, monitoring_plan, reasoning)
+    @@public_health_patient_page_actions.update_monitoring_plan(user_label, patient_label, monitoring_plan, reasoning)
     @@system_test_utils.logout
   end
 
   def update_latest_public_health_action(user_label, patient_label, tab, latest_public_health_action, reasoning)
     @@system_test_utils.login(user_label)
     @@public_health_dashboard.search_for_and_view_patient(tab, patient_label)
-    @@public_health_patient_page_actions.update_latest_public_health_action(user_label, latest_public_health_action, reasoning)
+    @@public_health_patient_page_actions.update_latest_public_health_action(user_label, patient_label, latest_public_health_action, reasoning)
     @@system_test_utils.logout
   end
 
   def update_assigned_jurisdiction(user_label, patient_label, tab, jurisdiction, reasoning, valid_jurisdiction = true, under_hierarchy = true)
     @@system_test_utils.login(user_label)
     @@public_health_dashboard.search_for_and_view_patient(tab, patient_label)
-    @@public_health_patient_page_actions.update_assigned_jurisdiction(user_label, jurisdiction, reasoning, valid_jurisdiction, under_hierarchy)
+    @@public_health_patient_page_actions.update_assigned_jurisdiction(user_label, patient_label, jurisdiction, reasoning, valid_jurisdiction, under_hierarchy)
     @@system_test_utils.logout
   end
 
   def update_assigned_user(user_label, patient_label, tab, assigned_user, reasoning, valid_assigned_user = true, changed = true)
     @@system_test_utils.login(user_label)
     @@public_health_dashboard.search_for_and_view_patient(tab, patient_label)
-    @@public_health_patient_page_actions.update_assigned_user(user_label, assigned_user, reasoning, valid_assigned_user, changed)
+    @@public_health_patient_page_actions.update_assigned_user(user_label, patient_label, assigned_user, reasoning, valid_assigned_user, changed)
     @@system_test_utils.logout
   end
 


### PR DESCRIPTION
# Bug Description
Updating assigned user and monitoring reason on patient page does not save to db

# How To Replicate:
1. Visit patient page as an epi
2. Update assigned user or monitoring status (with monitoring reason)

# Solution
Change javascript variables in diffState from using camel case to underscore to match patient fields

# Important Changes
`MonitoringStatus.js`
- Change javascript variables in diffState from using camel case to underscore to match patient fields

# Testing
Added some extra assertions in system tests to ensure that something like this would be caught in the future if it happens again
