### PR TITLE
SARAALERT-581: Prevent multiple patient submissions.

### DIFF
--- a/app/javascript/components/enrollment/steps/Review.js
+++ b/app/javascript/components/enrollment/steps/Review.js
@@ -13,8 +13,10 @@ class Review extends React.Component {
   }
 
   submit(event, groupMember) {
-    this.setState({ submitDisabled: true });
-    this.props.submit(event, groupMember, this.reenableSubmit);
+    // Update state before submitting data so submit button disables when clicked to prevent multiple submissions.
+    this.setState({ submitDisabled: true }, () => {
+      this.props.submit(event, groupMember, this.reenableSubmit);
+    });
   }
 
   reenableSubmit() {


### PR DESCRIPTION
Addresses [SARAALERT-581](https://jira.mitre.org/browse/SARAALERT-581)

# Summary
Some users on IE were able to submit duplicates of a monitoree by clicking the submit button multiple times.

# Important Changes
app/javascript/components/enrollment/steps/Review.js
- Calling submit method in setState callback to guarantee button disable before patient submission.

# Testing
This fix was tested on the following browsers:
* [x] Chrome
* [x] Firefox
* [x] Safari
* [x] IE11

For some reason on IE11 and Safari I get a 500 when enrolling a monitoree on master and this branch, but I did confirm that I was unable to click the button more than once. Would love to know if reviewers can replicate the 500 locally for those two browsers.

You should never be able to click the "Finish" button or "Finish and Add Household Member" button when enrolling a new monitoree more than once. Please also verify it only ever adds a single record for enrolled monitoree when clicking the button.

NOTE: I was unable to replicate this. As a result, I'm not 100% sure this will address the issue but it's a needed change nonetheless. 




