### PR TITLE
Adds analytics stylesheet

### DIFF
--- a/app/javascript/packs/stylesheets/application.scss
+++ b/app/javascript/packs/stylesheets/application.scss
@@ -8,3 +8,4 @@
 @import 'recharts';
 @import 'datatables';
 @import 'toastify';
+@import 'analytics';


### PR DESCRIPTION
The analytics styling-code was removed from `application.scss` and put into its own file: `analytics.scss`. This file, however, was never included with the rest of the project, causing the County Level Maps to look wonky
![image](https://user-images.githubusercontent.com/17532163/87930718-8d9b8800-ca56-11ea-922a-79b82d09241b.png)
