### PR TITLE
Automatically update public health action when case status is changed

### DIFF
--- a/app/javascript/components/subject/CaseStatus.js
+++ b/app/javascript/components/subject/CaseStatus.js
@@ -73,7 +73,11 @@ class CaseStatus extends React.Component {
 
   submit() {
     let diffState = Object.keys(this.state).filter(k => _.get(this.state, k) !== _.get(this.origState, k));
-    diffState.push('public_health_action'); // force last public health action to update
+
+    // force last public health action to update
+    if (this.state.case_status === 'Suspect' || this.state.case_status === 'Unknown' || this.state.case_status == 'Not a Case') {
+      diffState.push('public_health_action');
+    }
 
     this.setState({ loading: true }, () => {
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;

--- a/app/javascript/components/subject/CaseStatus.js
+++ b/app/javascript/components/subject/CaseStatus.js
@@ -32,7 +32,7 @@ class CaseStatus extends React.Component {
     event.persist();
 
     const value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
-    const confirmedOrProbable = value === 'Confirmed' || value === 'Probable' ? true : false;
+    const confirmedOrProbable = value === 'Confirmed' || value === 'Probable';
     const hideModal = this.state.isolation && confirmedOrProbable;
 
     this.setState({ [event.target.id]: value, showCaseStatusModal: !hideModal, confirmedOrProbable: confirmedOrProbable }, () => {

--- a/app/javascript/components/subject/CaseStatus.js
+++ b/app/javascript/components/subject/CaseStatus.js
@@ -35,7 +35,7 @@ class CaseStatus extends React.Component {
     const confirmedOrProbable = value === 'Confirmed' || value === 'Probable';
     const hideModal = this.state.isolation && confirmedOrProbable;
 
-    this.setState({ [event.target.id]: value, showCaseStatusModal: !hideModal, confirmedOrProbable: confirmedOrProbable }, () => {
+    this.setState({ [event.target.id]: value, showCaseStatusModal: !hideModal, confirmedOrProbable }, () => {
       // specific case where case status is just changed with no modal
       if (hideModal) {
         this.setState({ message: 'case status to "' + this.state.case_status + '".' });

--- a/app/javascript/components/subject/CaseStatus.js
+++ b/app/javascript/components/subject/CaseStatus.js
@@ -73,6 +73,8 @@ class CaseStatus extends React.Component {
 
   submit() {
     let diffState = Object.keys(this.state).filter(k => _.get(this.state, k) !== _.get(this.origState, k));
+    diffState.push('public_health_action'); // force last public health action to update
+
     this.setState({ loading: true }, () => {
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
       axios


### PR DESCRIPTION
# Description*
Jira Ticket: SARAALERT-573
https://jira.mitre.org/browse/SARAALERT-573

In the PUI line list, if the "Case Status" is changed to “suspect”, “unknown”, and “not a case”, the record stays in the PUI workflow until the User manually sets “Public Health Action” to None. The action that actually triggers the record to move is not “Case status”, but is “Latest Public Health Action”. The intention is that setting “suspect”, “unknown”, and “not a case” for Case Status will automatically change “Latest Public Health Action” to none (and thus move the record off PUI to appropriate Exposure line list).

# (Bugfix) How to Replicate
- Select a monitoree from the PUI line list
- Change their cast status to 'Suspect', 'Unknown' or 'Not a Case' 
- Latest public health action does not update to 'None' (remains whatever it was previously)

# (Bugfix) Solution
Post to the `/status` contained the right value, however the diffState array did not contain `public_health_action`, so that field was never updated.  I added that field to the diffState array and now latest public health action updates in the correct circumstances.

# Important Changes*
`CaseStatus.js` line 76

# Testing*
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [x] Firefox
* [x] Safari
* [x] IE11

# Submitter Checklist*
- [x] I have tested all of my changes locally. 
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if any).
- [x] My changes generate no new warnings/errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

# Reviewer Checklist*
## Reviewer 1
Reviewer: @DPC15038 

Checklist:
 - [x] I have carried out all tests described in the PR and verified functionality. 
 - [x] I have reviewed every file in the diff to verify that changes are reasonable, and that any updated/added code is maintainable and reusable and follows good practices.

## Reviewer 2
Reviewer: @kylietmo 

Checklist:
 - [x] I have carried out all tests described in the PR and verified functionality. 
 - [x] I have reviewed every file in the diff to verify that changes are reasonable, and that any updated/added code is maintainable and reusable and follows good practices.

