### PR TITLE
After case transferred out, user taken back to correct dashboard

### DIFF
--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -293,11 +293,8 @@ class MonitoringStatus extends React.Component {
             // check if current_user has access to the changed jurisdiction
             // if so, reload the page, if not, redirect to exposure or isolation dashboard
             if (!this.state.jurisdiction_path.startsWith(currentUserJurisdictionString)) {
-              if (this.state.isolation) {
-                location.assign((window.BASE_PATH ? window.BASE_PATH : '') + '/public_health/isolation');
-              } else {
-                location.assign((window.BASE_PATH ? window.BASE_PATH : '') + '/public_health');
-              }
+              const pathEnd = this.state.isolation ? '/isolation' : '';
+              location.assign((window.BASE_PATH ? window.BASE_PATH : '') + '/public_health' + pathEnd);
             } else {
               location.reload(true);
             }

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -288,7 +288,22 @@ class MonitoringStatus extends React.Component {
           apply_to_group_cm_only_date: this.state.apply_to_group_cm_only_date,
         })
         .then(() => {
-          location.reload(true);
+          if (diffState.includes('jurisdiction_path')) {
+            const currentUserJurisdictionString = this.props.current_user.jurisdiction_path.join(', ');
+            // check if current_user has access to the changed jurisdiction
+            // if so, reload the page, if not, redirect to exposure or isolation dashboard
+            if (!this.state.jurisdiction_path.startsWith(currentUserJurisdictionString)) {
+              if (this.state.isolation) {
+                location.assign((window.BASE_PATH ? window.BASE_PATH : '') + '/public_health/isolation');
+              } else {
+                location.assign((window.BASE_PATH ? window.BASE_PATH : '') + '/public_health');
+              }
+            } else {
+              location.reload(true);
+            }
+          } else {
+            location.reload(true);
+          }
         })
         .catch(error => {
           reportError(error);
@@ -560,6 +575,7 @@ class MonitoringStatus extends React.Component {
 }
 
 MonitoringStatus.propTypes = {
+  current_user: PropTypes.object,
   patient: PropTypes.object,
   authenticity_token: PropTypes.string,
   jurisdictionPaths: PropTypes.object,


### PR DESCRIPTION
# Description*
Jira Ticket: [SARAALERT-533](https://jira.mitre.org/browse/SARAALERT-533)

Currently, when a user transfers a case in the Isolation dashboard out of their jurisdiction, Sara Alert loads the page after the transfer so the user is on the Exposure Dashboard view. I would expect the Isolation Dashboard view to load instead. Update Sara Alert so that after a case is transferred out of the jurisdiction, the user will be brought back to the Isolation dashboard instead of the exposure dashboard.

# (Bugfix) How to Replicate
Log in as `state1_epi_enroller`. Navigate to the isolation workflow and select a monitoree.  Change the jurisdiction to something in State 2 and click submit.  You are redirected to the exposure workflow.

# (Bugfix) Solution
Before, when `location.reload(true)` goes to reload the page fresh from the server, however the monitoree is now longer viewable by the user so the user is redirected to the default exposure workflow.  Unfortunately, location.reload doesn't support any kind of callback or error, so instead I added a check before reloading the page that checks if the new jurisdiction is viewable by the current user.  If it is, then the page is just reloaded.  If not, the user is either redirected to the exposure or isolation workflow depending on where the monitoree was before. 

# Important Changes*
`MonitoringStatus.js`

# Testing*
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [x] Firefox
* [x] Safari
* [x] IE11

# Submitter Checklist*
- [x] I have tested all of my changes locally. 
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if any).
- [x] My changes generate no new warnings/errors.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

# Reviewer Checklist*
## Reviewer 1
Reviewer: @DPC15038 

Checklist:
 - [x] I have carried out all tests described in the PR and verified functionality. 
 - [x] I have reviewed every file in the diff to verify that changes are reasonable, and that any updated/added code is maintainable and reusable and follows good practices.

## Reviewer 2
Reviewer: @kylietmo 

Checklist:
 - [x] I have carried out all tests described in the PR and verified functionality. 
 - [x] I have reviewed every file in the diff to verify that changes are reasonable, and that any updated/added code is maintainable and reusable and follows good practices.

