### PR TITLE
Tweaks to improve assessment send job performance

### DIFF
--- a/app/jobs/send_assessments_job.rb
+++ b/app/jobs/send_assessments_job.rb
@@ -5,7 +5,15 @@ class SendAssessmentsJob < ApplicationJob
   queue_as :default
 
   def perform(*_args)
-    Patient.reminder_eligible_exposure.find_each(batch_size: 50_000, &:send_assessment)
-    Patient.reminder_eligible_isolation.find_each(batch_size: 50_000, &:send_assessment)
+    ids = []
+    Patient.reminder_eligible_exposure.find_each(batch_size: 50_000) do |patient|
+      ids << patient.send_assessment
+    end
+    Patient.reminder_eligible_isolation.find_each(batch_size: 50_000) do |patient|
+      ids << patient.send_assessment
+    end
+    # Update last_assessment_reminder_sent for all patients that were just sent a daily
+    # report notification (by rejecting nils, we remove patients who were sent nothing).
+    Patient.where(id: ids.reject(&:nil?)).update_all(last_assessment_reminder_sent: DateTime.now)
   end
 end

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -44,7 +44,6 @@ class PatientMailer < ApplicationMailer
   rescue Twilio::REST::RestError => e
     Rails.logger.warn e.error_message
     add_fail_history_sms(patient)
-    patient.update(last_assessment_reminder_sent: DateTime.now)
   end
 
   def enrollment_sms_text_based(patient)
@@ -65,7 +64,6 @@ class PatientMailer < ApplicationMailer
   rescue Twilio::REST::RestError => e
     Rails.logger.warn e.error_message
     add_fail_history_sms(patient)
-    patient.update(last_assessment_reminder_sent: DateTime.now)
   end
 
   # Right now the wording of this message is the same as for enrollment
@@ -96,12 +94,10 @@ class PatientMailer < ApplicationMailer
       )
       add_success_history(p)
       # Always update the last contact time so the system does not try and send emails again.
-      patient.update(last_assessment_reminder_sent: DateTime.now)
     end
   rescue Twilio::REST::RestError => e
     Rails.logger.warn e.error_message
     add_fail_history_sms(patient)
-    patient.update(last_assessment_reminder_sent: DateTime.now)
   end
 
   def assessment_sms_reminder(patient)
@@ -120,11 +116,9 @@ class PatientMailer < ApplicationMailer
     )
     add_success_history(patient)
     # Always update the last contact time so the system does not try and send emails again.
-    patient.update(last_assessment_reminder_sent: DateTime.now)
   rescue Twilio::REST::RestError => e
     Rails.logger.warn e.error_message
     add_fail_history_sms(patient)
-    patient.update(last_assessment_reminder_sent: DateTime.now)
   end
 
   def assessment_sms(patient)
@@ -163,12 +157,9 @@ class PatientMailer < ApplicationMailer
       parameters: params
     )
     add_success_history(patient)
-    # Always update the last contact time so the system does not try and send emails again.
-    patient.update(last_assessment_reminder_sent: DateTime.now)
   rescue Twilio::REST::RestError => e
     Rails.logger.warn e.error_message
     add_fail_history_sms(patient)
-    patient.update(last_assessment_reminder_sent: DateTime.now)
   end
 
   def assessment_voice(patient)
@@ -210,11 +201,9 @@ class PatientMailer < ApplicationMailer
     )
     add_success_history(patient)
     # Always update the last contact time so the system does not try and send emails again.
-    patient.update(last_assessment_reminder_sent: DateTime.now)
   rescue Twilio::REST::RestError => e
     Rails.logger.warn e.error_message
     History.report_reminder(patient: patient, comment: "Sara Alert failed to call monitoree at #{patient.primary_telephone}.")
-    patient.update(last_assessment_reminder_sent: DateTime.now)
   end
 
   def assessment_email(patient)
@@ -229,8 +218,6 @@ class PatientMailer < ApplicationMailer
       format.html { render layout: 'main_mailer' }
     end
     add_success_history(patient)
-    # Always update the last contact time so the system does not try and send emails again.
-    patient.update(last_assessment_reminder_sent: DateTime.now)
   end
 
   def closed_email(patient)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -510,6 +510,8 @@ class Patient < ApplicationRecord
     elsif preferred_contact_method&.downcase == 'e-mailed web link' && ADMIN_OPTIONS['enable_email'] && responder.id == id && email.present?
       PatientMailer.assessment_email(self).deliver_later
     end
+
+    id # Return ID if we reached this point, to mark as sent later in the send job
   end
 
   def calc_current_age

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -471,8 +471,8 @@ class Patient < ApplicationRecord
 
     # Return if closed, UNLESS there are still group members who need to be reported on
     return unless monitoring ||
-                  dependents.where(monitoring: true).count.positive? ||
                   continuous_exposure ||
+                  dependents.where(monitoring: true).count.positive? ||
                   dependents.where(continuous_exposure: true).count.positive?
 
     # If force is set, the preferred contact time will be ignored


### PR DESCRIPTION
Description*
Various tweaks to improve job performance and simplify database interactions

Changes include:
- Set last_assessment_reminder_sent in bulk instead of individually

Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`patient.rb`
- Return id if reached the end of the send assessment method (nil otherwise)
`patient_mailer.rb`
- Removed extra updates for last assessment sent
`send_assessment_job.rb`
- Collect ids of patients who were sent notifications, then do a bulk update

