### PR TITLE
(Hotfix) Updating query in Admin view to be faster

### DIFF
--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,2 +1,17 @@
-<%= react_component("admin/Admin", {data: User.all.where(jurisdiction_id: current_user.jurisdiction.subtree_ids).map{ |u| u.attributes.to_h.slice('id','email','api_enabled')
-.merge(jurisdiction_path: u.jurisdiction_path.join(', '), role: u.roles[0].name, locked: !u.locked_at.nil? ? 'Locked' : 'Unlocked', configured_2fa: !u.authy_id.nil? ? 'Yes' : 'No')}, role_types: Role.pluck(:name).uniq.reverse, authenticity_token: form_authenticity_token, jurisdiction_paths: Hash[Jurisdiction.where(id: current_user.jurisdiction.subtree_ids).map{|jur| [jur[:path], jur.id]}], is_usa_admin: current_user.can_send_admin_emails? }) %>
+<%= react_component("admin/Admin", {
+    data: User.all.where(jurisdiction_id: current_user.jurisdiction.subtree_ids)
+        .joins(:jurisdiction)
+        .select('users.id, users.email, users.api_enabled, users.locked_at, users.authy_id, jurisdictions.path')
+        .map {
+            |u| u.attributes.slice('id', 'email', 'api_enabled').merge(
+                jurisdiction_path: u.path, 
+                role: u.roles[0].name,
+                locked: !u.locked_at.nil? ? 'Locked' : 'Unlocked', 
+                configured_2fa: !u.authy_id.nil? ? 'Yes' : 'No'
+            )
+    },
+    role_types: Role.pluck(:name).uniq.reverse, 
+    authenticity_token: form_authenticity_token, 
+    jurisdiction_paths: Hash[Jurisdiction.where(id: current_user.jurisdiction.subtree_ids).map{|jur| [jur[:path], jur.id]}], 
+    is_usa_admin: current_user.can_send_admin_emails? })
+ %>


### PR DESCRIPTION
# Description
Jira Ticket: None

Right now USA Admins get 504s when trying to access the admin page because the query takes too long and exceeds the 15 second timeout. This PR updates the query for the Admin page data to be a lot faster. It's really a temporary fix until the Admin page refactor goes in. 

It does this by removing calls to the `jurisdiction_path` method in the User model and using a join instead to access the jurisdiction path. This reduces the number of queries overall pretty significantly. 

# Testing
For each version of the query, I ran it 10 times with 7117 users and took the average of the runtime. 

(When running the old version once it took 28 seconds pretty consistently, when running 10 times in a row and averaging it went to 40+ seconds, which I think is a result of my computer struggling more than anything.)

```
Old version: ~28-40 seconds 
New version: ~10-11 seconds
```

Our current number of users is ~5000 and production is much faster than my measly MacBook so hopefully we'll see a big improvement even with just this. 

@timwongj @holmesie If you see any other changes we can make to this query for a significant performance increase please let me know. 