### PR TITLE
(WIP) Increasing Sidekiq Redis network timeout

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,13 +2,12 @@
 # According to sidekiq docs 25 retries will take 3 weeks to complete
 Sidekiq.options[:max_retries] = 5
 
-if Rails.env.production?
-  Sidekiq.configure_server do |config|
-    # Set the network timeout to be 5 seconds instead of the default 1 to help with
-    # cloud network latency and longer batch commands
-    config.redis = {url: ENV['REDIS_URL'], network_timeout: 5 }
-  end
-  Sidekiq.configure_client do |config|
-   config.redis = {url: ENV['REDIS_URL'], network_timeout: 5 }
-  end
+Sidekiq.configure_server do |config|
+  # Set the network timeout to be 5 seconds instead of the default 1 to help with
+  # cloud network latency and longer batch commands
+  config.redis = {url: ENV['REDIS_URL'], network_timeout: 5 }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = {url: ENV['REDIS_URL'], network_timeout: 5 }
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,14 @@
 # Jobs that fail during execution will only retry this many times, default is 25
-# Accordinig to sidekiq docs 25 retries will take 3 weeks to complete
+# According to sidekiq docs 25 retries will take 3 weeks to complete
 Sidekiq.options[:max_retries] = 5
+
+if Rails.env.production?
+  Sidekiq.configure_server do |config|
+    # Set the network timeout to be 5 seconds instead of the default 1 to help with
+    # cloud network latency and longer batch commands
+    config.redis = {url: ENV['REDIS_URL'], network_timeout: 5 }
+  end
+  Sidekiq.configure_client do |config|
+   config.redis = {url: ENV['REDIS_URL'], network_timeout: 5 }
+  end
+end


### PR DESCRIPTION
# Description
Increases the network timeout as described [here](https://github.com/mperham/sidekiq/wiki/Using-Redis#life-in-the-cloud) to help potentially address timeout issues with slower commands on production.

# Testing
Still want to read more about any repercussions here, and need to test - though not entirely sure there's much testing we can do other than checking everything works fine on test and demo. 
