### PR TITLE
SARAALERT-376:  Show duplicate match criteria for duplicate detection on import and enroll UI message

### DIFF
--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -83,11 +83,11 @@ class ImportController < ApplicationController
           validate_required_primary_contact(patient, row_ind)
 
           # Checking for duplicates under current user's viewable patients is acceptable because custom jurisdictions must fall under hierarchy
-          patient[:appears_to_be_duplicate] = current_user.viewable_patients.matches(patient[:first_name],
-                                                                                     patient[:last_name],
-                                                                                     patient[:sex],
-                                                                                     patient[:date_of_birth],
-                                                                                     patient[:user_defined_id_statelocal]).exists?
+          patient[:duplicate_data] = current_user.viewable_patients.duplicate_data(patient[:first_name],
+                                                                                   patient[:last_name],
+                                                                                   patient[:sex],
+                                                                                   patient[:date_of_birth],
+                                                                                   patient[:user_defined_id_statelocal])
 
           if format == :comprehensive_monitorees
             lab_results = []

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -88,12 +88,13 @@ class PatientsController < ApplicationController
 
     # Check for potential duplicate
     unless params[:bypass_duplicate]
-      duplicate = current_user.viewable_patients.matches(params[:patient].permit(*allowed_params)[:first_name],
-                                                         params[:patient].permit(*allowed_params)[:last_name],
-                                                         params[:patient].permit(*allowed_params)[:sex],
-                                                         params[:patient].permit(*allowed_params)[:date_of_birth],
-                                                         params[:patient].permit(*allowed_params)[:user_defined_id_statelocal]).exists?
-      render(json: { duplicate: true }) && return if duplicate
+      duplicate_data = current_user.viewable_patients.duplicate_data(params[:patient].permit(*allowed_params)[:first_name],
+                                                                     params[:patient].permit(*allowed_params)[:last_name],
+                                                                     params[:patient].permit(*allowed_params)[:sex],
+                                                                     params[:patient].permit(*allowed_params)[:date_of_birth],
+                                                                     params[:patient].permit(*allowed_params)[:user_defined_id_statelocal])
+
+      render(json: duplicate_data) && return if duplicate_data[:is_duplicate]
     end
 
     # Add patient details that were collected from the form

--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -112,15 +112,27 @@ class Enrollment extends React.Component {
       data: data,
     })
       .then(response => {
-        if (response['data']['duplicate']) {
+        if (response.data && response.data.is_duplicate && response.data.duplicate_fields) {
+          const dupFields = response.data.duplicate_fields;
+          let confirmText = `This ${
+            this.state.enrollmentState.isolation ? 'case' : 'monitoree'
+          } appears to be a duplicate of an existing record in the system. `;
+          confirmText += 'There is a record with matching values in the following field(s): ';
+
+          let field;
+          for (let i = 0; i < response.data.duplicate_fields.length; i++) {
+            // parseInt() to satisfy eslint-security
+            field = response.data.duplicate_fields[parseInt(i)];
+            if (dupFields.length > 1) {
+              confirmText += i == dupFields.length - 1 ? `and ${field}. ` : `${field}, `;
+            } else {
+              confirmText += `${field}. `;
+            }
+          }
+          confirmText += ' Are you sure you want to enroll this monitoree?';
+
           // Duplicate, ask if want to continue with create
-          this.handleConfirmDuplicate(
-            data,
-            groupMember,
-            message,
-            reenableSubmit,
-            'This monitoree appears to be a duplicate of an existing record in the system. Are you sure you want to enroll this monitoree?'
-          );
+          this.handleConfirmDuplicate(data, groupMember, message, reenableSubmit, confirmText);
         } else {
           // Success, inform user and redirect to home
           toast.success(message, {

--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -114,9 +114,9 @@ class Enrollment extends React.Component {
       .then(response => {
         if (response.data && response.data.is_duplicate && response.data.duplicate_fields) {
           const dupFields = response.data.duplicate_fields;
-          let confirmText = `This ${
-            this.state.enrollmentState.isolation ? 'case' : 'monitoree'
-          } appears to be a duplicate of an existing record in the system. `;
+          const patientType = this.state.enrollmentState.isolation ? 'case' : 'monitoree';
+
+          let confirmText = `This ${patientType} appears to be a duplicate of an existing record in the system. `;
           confirmText += 'There is a record with matching values in the following field(s): ';
 
           let field;
@@ -129,7 +129,7 @@ class Enrollment extends React.Component {
               confirmText += `${field}. `;
             }
           }
-          confirmText += ' Are you sure you want to enroll this monitoree?';
+          confirmText += ` Are you sure you want to enroll this ${patientType}?`;
 
           // Duplicate, ask if want to continue with create
           this.handleConfirmDuplicate(data, groupMember, message, reenableSubmit, confirmText);

--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -112,27 +112,32 @@ class Enrollment extends React.Component {
       data: data,
     })
       .then(response => {
-        if (response.data && response.data.is_duplicate && response.data.duplicate_fields) {
-          const dupFields = response.data.duplicate_fields;
+        if (response.data && response.data.is_duplicate) {
+          const dupFieldData = response.data.duplicate_field_data;
           const patientType = this.state.enrollmentState.isolation ? 'case' : 'monitoree';
 
-          let confirmText = `This ${patientType} appears to be a duplicate of an existing record in the system. `;
-          confirmText += 'There is a record with matching values in the following field(s): ';
+          let text = `This ${patientType} already appears to exist in the system! `;
 
-          let field;
-          for (let i = 0; i < response.data.duplicate_fields.length; i++) {
-            // parseInt() to satisfy eslint-security
-            field = response.data.duplicate_fields[parseInt(i)];
-            if (dupFields.length > 1) {
-              confirmText += i == dupFields.length - 1 ? `and ${field}. ` : `${field}, `;
-            } else {
-              confirmText += `${field}. `;
+          if (dupFieldData) {
+            // Format matching fields and associated counts for text display
+            for (const fieldData of dupFieldData) {
+              text += `There ${fieldData.count > 1 ? `are ${fieldData.count} records` : 'is 1 record'}  with matching values in the following field(s): `;
+              let field;
+              for (let i = 0; i < fieldData.fields.length; i++) {
+                // parseInt() to satisfy eslint-security
+                field = fieldData.fields[parseInt(i)];
+                if (fieldData.fields.length > 1) {
+                  text += i == fieldData.fields.length - 1 ? `and ${field}. ` : `${field}, `;
+                } else {
+                  text += `${field}. `;
+                }
+              }
             }
           }
-          confirmText += ` Are you sure you want to enroll this ${patientType}?`;
+          text += ` Are you sure you want to enroll this ${patientType}?`;
 
           // Duplicate, ask if want to continue with create
-          this.handleConfirmDuplicate(data, groupMember, message, reenableSubmit, confirmText);
+          this.handleConfirmDuplicate(data, groupMember, message, reenableSubmit, text);
         } else {
           // Success, inform user and redirect to home
           toast.success(message, {

--- a/app/javascript/components/public_health/Import.js
+++ b/app/javascript/components/public_health/Import.js
@@ -127,6 +127,10 @@ class Import extends React.Component {
     });
   };
 
+  /**
+   * Gets rendered warning text for when duplicates are detected.
+   * @param {Object} dupFieldData - Data concerning the possible duplicates types and the specific fields in them.
+   */
   getDuplicateWarningText(dupFieldData) {
     let text = `Warning: This ${this.props.workflow === 'exposure' ? 'monitoree' : 'case'} already appears to exist in the system! `;
 
@@ -136,7 +140,6 @@ class Import extends React.Component {
       for (let i = 0; i < fieldData.fields.length; i++) {
         // parseInt() to satisfy eslint-security
         field = fieldData.fields[parseInt(i)];
-        console.log('field:', field);
         if (fieldData.fields.length > 1) {
           text += i == fieldData.fields.length - 1 ? `and ${field}. ` : `${field}, `;
         } else {

--- a/app/javascript/components/public_health/Import.js
+++ b/app/javascript/components/public_health/Import.js
@@ -127,23 +127,27 @@ class Import extends React.Component {
     });
   };
 
-  getDuplicateWarningText(dupFields) {
-    let warningText = `Warning: This ${this.props.workflow === 'exposure' ? 'monitoree' : 'case'} already appears to exist in the system! `;
-    warningText += 'There is a record with matching values in the following field(s): ';
+  getDuplicateWarningText(dupFieldData) {
+    let text = `Warning: This ${this.props.workflow === 'exposure' ? 'monitoree' : 'case'} already appears to exist in the system! `;
 
-    let field;
-    for (let i = 0; i < dupFields.length; i++) {
-      // parseInt() to satisfy eslint-security
-      field = dupFields[parseInt(i)];
-      if (dupFields.length > 1) {
-        warningText += i == dupFields.length - 1 ? `and ${field}. ` : `${field}, `;
-      } else {
-        warningText += `${field}. `;
+    for (const fieldData of dupFieldData) {
+      text += `There ${fieldData.count > 1 ? `are ${fieldData.count} records` : 'is 1 record'}  with matching values in the following field(s): `;
+      let field;
+      for (let i = 0; i < fieldData.fields.length; i++) {
+        // parseInt() to satisfy eslint-security
+        field = fieldData.fields[parseInt(i)];
+        console.log('field:', field);
+        if (fieldData.fields.length > 1) {
+          text += i == fieldData.fields.length - 1 ? `and ${field}. ` : `${field}, `;
+        } else {
+          text += `${field}. `;
+        }
       }
     }
+
     return (
       <Alert variant="danger">
-        <span>{warningText}</span>
+        <span>{text}</span>
       </Alert>
     );
   }
@@ -207,7 +211,7 @@ class Import extends React.Component {
                   bg="light"
                   border={this.state.accepted.includes(index) ? 'success' : this.state.rejected.includes(index) ? 'danger' : ''}>
                   <React.Fragment>
-                    {patient.duplicate_data.is_duplicate && this.getDuplicateWarningText(patient.duplicate_data.duplicate_fields)}
+                    {patient.duplicate_data.is_duplicate && this.getDuplicateWarningText(patient.duplicate_data.duplicate_field_data)}
                     {(patient.jurisdiction_path || patient.assigned_user) && (
                       <Alert variant="info">
                         Note:

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -364,16 +364,16 @@ class Patient < ApplicationRecord
   # - matching state/local id
   def self.duplicate_data(first_name, last_name, sex, date_of_birth, user_defined_id_statelocal)
     dup_info = where('first_name = ?', first_name)
-                  .where('last_name = ?', last_name)
-                  .where('sex = ?', sex)
-                  .where('date_of_birth = ?', date_of_birth)
+               .where('last_name = ?', last_name)
+               .where('sex = ?', sex)
+               .where('date_of_birth = ?', date_of_birth)
 
     dup_statelocal_id = where('user_defined_id_statelocal = ?', user_defined_id_statelocal&.to_s&.strip)
 
     # Get fields that have matching values
     duplicate_field_data = []
-    duplicate_field_data << {count: dup_info.count, fields: ['First Name', 'Last Name', 'Sex', 'Date of Birth']} if dup_info.present?
-    duplicate_field_data << {count: dup_statelocal_id.count, fields: ['State/Local ID']} if dup_statelocal_id.present?
+    duplicate_field_data << { count: dup_info.count, fields: ['First Name', 'Last Name', 'Sex', 'Date of Birth'] } if dup_info.present?
+    duplicate_field_data << { count: dup_statelocal_id.count, fields: ['State/Local ID'] } if dup_statelocal_id.present?
 
     { is_duplicate: duplicate_field_data.length.positive?, duplicate_field_data: duplicate_field_data }
   end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -363,19 +363,19 @@ class Patient < ApplicationRecord
   # OR
   # - matching state/local id
   def self.duplicate_data(first_name, last_name, sex, date_of_birth, user_defined_id_statelocal)
-    is_dup_info = where('first_name = ?', first_name)
+    dup_info = where('first_name = ?', first_name)
                   .where('last_name = ?', last_name)
                   .where('sex = ?', sex)
-                  .where('date_of_birth = ?', date_of_birth).present?
+                  .where('date_of_birth = ?', date_of_birth)
 
-    is_dup_statelocal_id = where('user_defined_id_statelocal = ?', user_defined_id_statelocal&.to_s&.strip).present?
+    dup_statelocal_id = where('user_defined_id_statelocal = ?', user_defined_id_statelocal&.to_s&.strip)
 
     # Get fields that have matching values
-    duplicate_fields = []
-    duplicate_fields.concat(['First Name', 'Last Name', 'Sex', 'Date of Birth']) if is_dup_info
-    duplicate_fields.concat(['State/Local ID']) if is_dup_statelocal_id
+    duplicate_field_data = []
+    duplicate_field_data << {count: dup_info.count, fields: ['First Name', 'Last Name', 'Sex', 'Date of Birth']} if dup_info.present?
+    duplicate_field_data << {count: dup_statelocal_id.count, fields: ['State/Local ID']} if dup_statelocal_id.present?
 
-    { is_duplicate: duplicate_fields.length.positive?, duplicate_fields: duplicate_fields }
+    { is_duplicate: duplicate_field_data.length.positive?, duplicate_field_data: duplicate_field_data }
   end
 
   # Get the patient who is responsible for responding on this phone number

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -510,6 +510,53 @@ class PatientTest < ActiveSupport::TestCase
     assert patient.address_timezone_offset == '+10:00'
   end
 
+  test 'duplicate_data finds duplicate that matches all criteria' do
+    patient_dup = Patient.first
+    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
+                                            patient_dup[:last_name],
+                                            patient_dup[:sex],
+                                            patient_dup[:date_of_birth],
+                                            patient_dup[:user_defined_id_statelocal])
+
+    assert duplicate_data[:is_duplicate]
+    assert_equal(duplicate_data[:duplicate_fields], ['First Name', 'Last Name', 'Sex', 'Date of Birth', 'State/Local ID'])
+  end
+
+  test 'duplicate_data finds duplicate that matches basic info fields' do
+    patient_dup = Patient.first
+    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
+                                            patient_dup[:last_name],
+                                            patient_dup[:sex],
+                                            patient_dup[:date_of_birth],
+                                            'test state/local ID')
+
+    assert duplicate_data[:is_duplicate]
+    assert_equal(duplicate_data[:duplicate_fields], ['First Name', 'Last Name', 'Sex', 'Date of Birth'])
+  end
+
+  test 'duplicate_data finds duplicate that matches state/local id' do
+    patient_dup = Patient.first
+    duplicate_data = Patient.duplicate_data('test first name',
+                                            'test last name',
+                                            'test sex',
+                                            Time.now,
+                                            patient_dup[:user_defined_id_statelocal])
+
+    assert duplicate_data[:is_duplicate]
+    assert_equal(duplicate_data[:duplicate_fields], ['State/Local ID'])
+  end
+
+  test 'duplicate_data correctly finds no duplicates' do
+    duplicate_data = Patient.duplicate_data('test first name',
+                                            'test last name',
+                                            'test sex',
+                                            Time.now,
+                                            'test state/local ID')
+
+    assert !duplicate_data[:is_duplicate]
+    assert_equal(duplicate_data[:duplicate_fields], [])
+  end
+
   def verify_patient_status(patient, status)
     patients = Patient.where(id: patient.id)
 

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -520,15 +520,15 @@ class PatientTest < ActiveSupport::TestCase
 
     assert duplicate_data[:is_duplicate]
     assert_equal(duplicate_data[:duplicate_field_data], [
-      { 
-        count: 1,
-        fields: ['First Name', 'Last Name', 'Sex', 'Date of Birth']
-      },
-      { 
-        count: 1,
-        fields: ['State/Local ID']
-      },
-    ])
+                   {
+                     count: 1,
+                     fields: ['First Name', 'Last Name', 'Sex', 'Date of Birth']
+                   },
+                   {
+                     count: 1,
+                     fields: ['State/Local ID']
+                   }
+                 ])
   end
 
   test 'duplicate_data finds duplicate that matches basic info fields' do
@@ -540,10 +540,10 @@ class PatientTest < ActiveSupport::TestCase
                                             'test state/local ID')
 
     assert duplicate_data[:is_duplicate]
-    assert_equal(duplicate_data[:duplicate_field_data], [{ 
-      count: 1,
-      fields: ['First Name', 'Last Name', 'Sex', 'Date of Birth']
-    }])
+    assert_equal(duplicate_data[:duplicate_field_data], [{
+                   count: 1,
+                   fields: ['First Name', 'Last Name', 'Sex', 'Date of Birth']
+                 }])
   end
 
   test 'duplicate_data finds duplicate that matches state/local id' do
@@ -555,10 +555,10 @@ class PatientTest < ActiveSupport::TestCase
                                             patient_dup[:user_defined_id_statelocal])
 
     assert duplicate_data[:is_duplicate]
-    assert_equal(duplicate_data[:duplicate_field_data], [{ 
-      count: 1,
-      fields: ['State/Local ID']
-    }])
+    assert_equal(duplicate_data[:duplicate_field_data], [{
+                   count: 1,
+                   fields: ['State/Local ID']
+                 }])
   end
 
   test 'duplicate_data correctly finds no duplicates' do

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -519,7 +519,16 @@ class PatientTest < ActiveSupport::TestCase
                                             patient_dup[:user_defined_id_statelocal])
 
     assert duplicate_data[:is_duplicate]
-    assert_equal(duplicate_data[:duplicate_fields], ['First Name', 'Last Name', 'Sex', 'Date of Birth', 'State/Local ID'])
+    assert_equal(duplicate_data[:duplicate_field_data], [
+      { 
+        count: 1,
+        fields: ['First Name', 'Last Name', 'Sex', 'Date of Birth']
+      },
+      { 
+        count: 1,
+        fields: ['State/Local ID']
+      },
+    ])
   end
 
   test 'duplicate_data finds duplicate that matches basic info fields' do
@@ -531,7 +540,10 @@ class PatientTest < ActiveSupport::TestCase
                                             'test state/local ID')
 
     assert duplicate_data[:is_duplicate]
-    assert_equal(duplicate_data[:duplicate_fields], ['First Name', 'Last Name', 'Sex', 'Date of Birth'])
+    assert_equal(duplicate_data[:duplicate_field_data], [{ 
+      count: 1,
+      fields: ['First Name', 'Last Name', 'Sex', 'Date of Birth']
+    }])
   end
 
   test 'duplicate_data finds duplicate that matches state/local id' do
@@ -543,7 +555,10 @@ class PatientTest < ActiveSupport::TestCase
                                             patient_dup[:user_defined_id_statelocal])
 
     assert duplicate_data[:is_duplicate]
-    assert_equal(duplicate_data[:duplicate_fields], ['State/Local ID'])
+    assert_equal(duplicate_data[:duplicate_field_data], [{ 
+      count: 1,
+      fields: ['State/Local ID']
+    }])
   end
 
   test 'duplicate_data correctly finds no duplicates' do
@@ -554,7 +569,7 @@ class PatientTest < ActiveSupport::TestCase
                                             'test state/local ID')
 
     assert !duplicate_data[:is_duplicate]
-    assert_equal(duplicate_data[:duplicate_fields], [])
+    assert_equal(duplicate_data[:duplicate_field_data], [])
   end
 
   def verify_patient_status(patient, status)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-376](https://tracker.codev.mitre.org/browse/SARAALERT-376)

This PR updates the class method on the Patient model for detecting duplicates records to return more information that the frontend can use to communicate what the match criteria for the duplicate was exactly. It will show the number of records that meet the duplicate criteria as follows:
- matching first name, last name, sex, AND DoB
OR
- matching state/local ID

# Screenshots
Import example:
<img width="1282" alt="Screen Shot 2020-08-16 at 4 04 25 PM" src="https://user-images.githubusercontent.com/11698457/90343254-bb83d600-dfdc-11ea-8ca5-30eeb414cb18.png">

Enrollment example:
<img width="829" alt="Screen Shot 2020-08-16 at 4 14 45 PM" src="https://user-images.githubusercontent.com/11698457/90343257-bb83d600-dfdc-11ea-96f5-15315a672d52.png">


# Important Changes
`app/models/patient.rb`
- Updating `matches` class method to be called `duplicate_data` and return more information.

`app/controllers/import_controller.rb` and `app/controllers/patients_controller.rb`
- Changed to call new updated in Patient model

`app/javascript/components/enrollment/Enrollment.js`
- Showing a more detailed message when duplicates are detected upon enrollment.

`app/javascript/components/public_health/Import.js`
- Showing a more detailed warning message when duplicates are detected upon import.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Tests for written for the new class method in the patient model here: `test/models/patient_test.rb`

The following are tests that require visual inspection:
- [ ] 1) Import a file with a record who has the same first name, last name, DoB, and sex as an existing record in the system. You should see an appropriate warning message.
- [ ] 2) Import a file with a record who has the same state/local ID as an existing record in the system. You should see an appropriate warning message.
- [ ] 3) Import a file with a record who has the same state/local ID, first name, last name, DoB, and sex as an existing record in the system. You should see an appropriate warning message.
- [ ] 4) Enroll a patient with a record who has the same first name, last name, DoB, and sex as an existing record in the system. You should see an appropriate warning message.
- [ ] 5) Enroll a patient with a record who has the same state/local ID as an existing record in the system. You should see an appropriate warning message.
- [ ] 6) Enroll a patient with a record who has the same state/local ID, first name, last name, DoB, and sex as an existing record in the system. You should see an appropriate warning message.
- [ ] 7) Enroll a patient IN ISOLATION with a record who has the same state/local ID, first name, last name, DoB, and sex as an existing record in the system. You should see an appropriate warning message that says "case" instead of "monitoree".
- [ ] 8) Enroll a patient IN EXPOSURE with a record who has the same state/local ID, first name, last name, DoB, and sex as an existing record in the system. You should see an appropriate warning message that says "monitoree" instead of "case".
- [ ] 9) Importing records and including duplicates should properly count duplicates in confirmation message and import properly

# Submitter Checklist
- [x] I have tested all of my changes locally. 
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if any).
- [x] My changes generate no new warnings/errors.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

# Reviewer Checklist
## Reviewer 1
Reviewer: @holmesie 
Checklist:
 - [ ] I have carried out all tests described in the PR and verified functionality. 
 - [ ] I have reviewed every file in the diff to verify that changes are reasonable, and that any updated/added code is maintainable and reusable and follows good practices.

## Reviewer 2
Reviewer: @DPC15038 

Checklist:
 - [x] I have carried out all tests described in the PR and verified functionality. 
 - [x] I have reviewed every file in the diff to verify that changes are reasonable, and that any updated/added code is maintainable and reusable and follows good practices.

