### PR TITLE
SARAALERT-590: Patient model method for getting dependents except self

### DIFF
--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -25,7 +25,7 @@ class ConsumeAssessmentsJob < ApplicationJob
         end
 
         # Get list of dependents excluding the patient itself.
-        dependents = patient.dependents.where.not(id: patient.id)
+        dependents = patient.dependents_exclude_self
 
         if message['response_status'] == 'no_answer_voice'
           # If nobody answered, nil out the last_reminder_sent field so the system will try calling again

--- a/app/jobs/purge_job.rb
+++ b/app/jobs/purge_job.rb
@@ -6,7 +6,7 @@ class PurgeJob < ApplicationJob
 
   def perform(*_args)
     Patient.purge_eligible.find_each(batch_size: 5000) do |monitoree|
-      next if monitoree.dependents.where.not(id: monitoree.id).where(monitoring: true).count.positive?
+      next if monitoree.dependents_exclude_self.where(monitoring: true).count.positive?
 
       # Whitelist attributes to keep
       attributes = Patient.new.attributes.keys

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -402,6 +402,11 @@ class Patient < ApplicationRecord
     jurisdiction&.path&.map(&:name)
   end
 
+  # Get this patient's dependents excluding itself
+  def dependents_exclude_self
+    dependents.where.not(id: id)
+  end
+
   # Single place for calculating the end of monitoring date for this subject.
   def end_of_monitoring
     return 'Continuous Exposure' if continuous_exposure


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-590

This is a really small ticket - just wrote a new method called `dependents_exclude_self` in the `Patient` model for ease of use since we make this query often.

# Testing
There should be no functionality changes as part of this PR. That being said, we can test that the following functionality still propagates to dependents correctly:
- Updating the monitoring status
- Any sort of edits that should propagate to dependents
- Updating the history of dependents when consuming an assessment

