### PR TITLE
SARAALERT-691: Admins shouldn't email locked users, and don't need to email selected users.

### DIFF
--- a/app/javascript/components/admin/AdminTable.js
+++ b/app/javascript/components/admin/AdminTable.js
@@ -38,7 +38,6 @@ class AdminTable extends React.Component {
       entryOptions: [10, 15, 25, 50, 100],
       showEditUserModal: false,
       showAddUserModal: false,
-      showEmailModal: false,
       showEmailAllModal: false,
       actionsEnabled: false,
       cancelToken: axios.CancelToken.source(),
@@ -298,22 +297,11 @@ class AdminTable extends React.Component {
   };
 
   /**
-   * Called when the email action is selected.
-   * Updates the state appropriately to show the modal.
-   */
-  handleEmailClick = () => {
-    this.setState({
-      showEmailModal: true,
-    });
-  };
-
-  /**
    * Called when the email action modal cancel or X button is clicked.
    * Updates the state appropriately to hide the modal.
    */
   handleEmailModalClose = () => {
     this.setState({
-      showEmailModal: false,
       showEmailAllModal: false,
     });
   };
@@ -338,39 +326,6 @@ class AdminTable extends React.Component {
 
     const handleError = error => {
       toast.error('Failed to send emails.', {
-        autoClose: 2000,
-        position: toast.POSITION.TOP_CENTER,
-      });
-      console.log(error);
-    };
-
-    this.axiosAdminPostRequest(path, dataToSend, handleSuccess, handleError);
-  };
-
-  /**
-   * Closes email modal and send emails to selected users with POST request.
-   * @param {Object} data - Data submitted from the email modal.
-   */
-  handleEmailSave = data => {
-    this.handleEmailModalClose();
-
-    const path = 'email';
-    const ids = this.state.table.selectedRows.map(row => {
-      return this.state.table.rowData[parseInt(row)].id;
-    });
-    const dataToSend = {
-      ids: ids,
-      comment: data.comment,
-    };
-
-    const handleSuccess = () => {
-      toast.success('Successfully sent email(s).', {
-        position: toast.POSITION.TOP_CENTER,
-      });
-    };
-
-    const handleError = error => {
-      toast.error('Failed to send email(s).', {
         autoClose: 2000,
         position: toast.POSITION.TOP_CENTER,
       });
@@ -606,7 +561,7 @@ class AdminTable extends React.Component {
             {this.props.is_usa_admin && (
               <Button className="mx-1" size="md" variant="secondary" onClick={this.handleEmailAllClick}>
                 <i className="fas fa-envelope"></i>
-                &nbsp;Send Email to All
+                &nbsp;Email All Unlocked Users
               </Button>
             )}
             {this.state.csvData.length > 0 ? <CSVLink data={this.state.csvData} filename={'sara-accounts.csv'} ref={this.csvLink} /> : undefined}
@@ -642,12 +597,6 @@ class AdminTable extends React.Component {
                   <i className="fas fa-key"></i>
                   <span className="ml-2">Reset 2FA</span>
                 </Dropdown.Item>
-                {this.props.is_usa_admin && (
-                  <Dropdown.Item className="px-3" onClick={this.handleEmailClick}>
-                    <i className="fas fa-envelope"></i>
-                    <span className="ml-2">Send Email</span>
-                  </Dropdown.Item>
-                )}
               </DropdownButton>
             </InputGroup>
           </div>
@@ -681,13 +630,13 @@ class AdminTable extends React.Component {
             initialUserData={this.state.editRow === null ? {} : this.state.table.rowData[this.state.editRow]}
           />
         )}
-        {(this.state.showEmailModal || this.state.showEmailAllModal) && (
+        {this.state.showEmailAllModal && (
           <EmailModal
-            show={this.state.showEmailModal || this.state.showEmailAllModal}
-            title={this.state.showEmailModal ? 'Send Email to User(s)' : 'Send Email to All Users'}
+            show={this.state.showEmailAllModal}
+            title={'Send Email to All Unlocked Users'}
             onClose={this.handleEmailModalClose}
-            onSave={this.state.showEmailModal ? this.handleEmailSave : this.handleEmailAllSave}
-            userCount={this.state.showEmailModal ? this.state.table.selectedRows.length : this.state.table.totalRows}
+            onSave={this.handleEmailAllSave}
+            prompt={'Enter the message to send to all unlocked users:'}
           />
         )}
         <ToastContainer />

--- a/app/javascript/components/admin/EmailModal.js
+++ b/app/javascript/components/admin/EmailModal.js
@@ -21,7 +21,7 @@ class EmailModal extends React.Component {
           <Modal.Title>{this.props.title}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <p>Enter the message to send to {this.props.userCount} user(s):</p>
+          <p>{this.props.prompt}</p>
           <Form.Group>
             <Form.Control as="textarea" rows="10" id="comment" onChange={this.handleCommentChange} />
           </Form.Group>
@@ -44,7 +44,7 @@ EmailModal.propTypes = {
   title: PropTypes.string,
   onClose: PropTypes.func,
   onSave: PropTypes.func,
-  userCount: PropTypes.number,
+  prompt: PropTypes.string,
 };
 
 export default EmailModal;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,9 +43,7 @@ Rails.application.routes.draw do
   post 'admin/edit_user', to: 'admin#edit_user'
   post 'admin/reset_password', to: 'admin#reset_password'
   post 'admin/reset_2fa', to: 'admin#reset_2fa'
-  post 'admin/email', to: 'admin#email'
   post 'admin/email_all', to: 'admin#email_all'
-
 
   resources :histories, only: [:create]
 


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-691](https://tracker.codev.mitre.org/browse/SARAALERT-691)

This PR removes the functionality to send emails to selected users on the admin page as that wasn't necessary (as discussed with kelly). It also makes it so that emails that are sent to all users (functionality that is only available to us - USA admins), only sends to unlocked users. 

# Important Changes

`app/controllers/admin_controller.rb`
- Removed method for emailing a subset of user ids.
- Updated `email_all` method to only send to unlocked users.
- Updated check in `edit_user` method to use subtree_ids as we do everywhere else.

`app/javascript/components/admin/AdminTable.js`
- Removed methods for emailing selected users, and the email dropdown action.
- Updated button label and email modal title and text.

`app/javascript/components/admin/EmailModal.js`
- Removed user count prop and now taking in body text prop.

`config/routes.rb`
- Removed route for emailing select users.

`test/controllers/admin_controller_test.rb`
- Updated tests.

# Testing
Admin controller tests were updated accordingly.

To test that the email functionality works as intended, lock a user, then send an email to all unlocked users. You should see the right number of mailer jobs go out.

The following are tests that require visual inspection (remove if not applicable):
- [ ] 1) Should not see the "Email" action available when selecting users anymore
- [ ] 2) "Send Email to All" button should now say "Email All Unlocked Users", and modal text should say the same rather than a user count.
