### PR TITLE
SARAALERT-716: Configure Twilio Messaging Services and Update Patient Mailer

### DIFF
--- a/.env-prod-enrollment-example
+++ b/.env-prod-enrollment-example
@@ -30,6 +30,7 @@ TWILIO_API_ACCOUNT=<Account number for Twilio Account>
 TWILIO_API_KEY=<API key for Twilio Account>
 TWILIO_SENDING_NUMBER=<Phone number registered to Twilio Account for SMS/Voice>
 TWILIO_STUDIO_FLOW=<Twilio Studio Flow ID for handling SMS/Voice Assessments>
+TWILIO_MESSAGING_SERVICE_SID=<SID of assigned messaging service>
 AUTHY_API_KEY=<API key for Authy project>
 
 SHOW_DEMO_WARNING=true

--- a/.env-prod-enrollment-example
+++ b/.env-prod-enrollment-example
@@ -26,10 +26,10 @@ SECRET_KEY_BASE=<result of running `rake secret`>
 
 SARA_ALERT_REPORT_MODE=false
 
-TWILLIO_API_ACCOUNT=<Account number for Twilio Account>
-TWILLIO_API_KEY=<API key for Twilio Account>
-TWILLIO_SENDING_NUMBER=<Phone number registered to Twilio Account for SMS/Voice>
-TWILLIO_STUDIO_FLOW=<Twilio Studio Flow ID for handling SMS/Voice Assessments>
+TWILIO_API_ACCOUNT=<Account number for Twilio Account>
+TWILIO_API_KEY=<API key for Twilio Account>
+TWILIO_SENDING_NUMBER=<Phone number registered to Twilio Account for SMS/Voice>
+TWILIO_STUDIO_FLOW=<Twilio Studio Flow ID for handling SMS/Voice Assessments>
 AUTHY_API_KEY=<API key for Authy project>
 
 SHOW_DEMO_WARNING=true

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'sass-rails', '>= 6'
 gem 'webpacker', '~> 4.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.7'
-# Twillio gem for sending SMS and robo calls
+# Twilio gem for sending SMS and robo calls
 gem 'twilio-ruby'
 # Sidekiq for queueing
 gem 'sidekiq'

--- a/README.md
+++ b/README.md
@@ -174,10 +174,10 @@ The `SECRET_KEY_BASE` and `MYSQL_PASSWORD` variables should be changed at the ve
 
 **Twilio/Authy Environment Variables**
 The following environment variables need to be set on the enrollment instances, which are the instances that will be dispatching the SMS/Voice assessments via Twilio and performing Two-Factor Authentication using Authy. These environment variables can be set in a `config/local_env.yml` file, or via a method provided by the deployment environment.
-* `TWILLIO_API_ACCOUNT: <Account number for Twilio Account>`
-* `TWILLIO_API_KEY: <API key for Twilio Account>`
-* `TWILLIO_SENDING_NUMBER: <Phone number registered to Twilio Account for SMS/Voice>`
-* `TWILLIO_STUDIO_FLOW: <Twilio Studio Flow ID for handling SMS/Voice Assessments>`
+* `TWILIO_API_ACCOUNT: <Account number for Twilio Account>`
+* `TWILIO_API_KEY: <API key for Twilio Account>`
+* `TWILIO_SENDING_NUMBER: <Phone number registered to Twilio Account for SMS/Voice>`
+* `TWILIO_STUDIO_FLOW: <Twilio Studio Flow ID for handling SMS/Voice Assessments>`
 * `AUTHY_API_KEY: <API key for Authy project>`
 
 **Container Dependencies**

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The following environment variables need to be set on the enrollment instances, 
 * `TWILIO_SENDING_NUMBER: <Phone number registered to Twilio Account for SMS/Voice>`
 * `TWILIO_STUDIO_FLOW: <Twilio Studio Flow ID for handling SMS/Voice Assessments>`
 * `AUTHY_API_KEY: <API key for Authy project>`
+* `TWILIO_MESSAGING_SERVICE_SID=<SID of assigned messaging service>`
 
 **Container Dependencies**
 

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -27,9 +27,9 @@ class PatientMailer < ApplicationMailer
     url_contents = new_patient_assessment_jurisdiction_report_lang_url(patient.submission_token,
                                                                        lang&.to_s || 'en',
                                                                        patient.jurisdiction.unique_identifier[0, 32])
-    account_sid = ENV['TWILLIO_API_ACCOUNT']
-    auth_token = ENV['TWILLIO_API_KEY']
-    from = ENV['TWILLIO_SENDING_NUMBER']
+    account_sid = ENV['TWILIO_API_ACCOUNT']
+    auth_token = ENV['TWILIO_API_KEY']
+    from = ENV['TWILIO_SENDING_NUMBER']
     client = Twilio::REST::Client.new(account_sid, auth_token)
     client.messages.create(
       from: from,
@@ -53,9 +53,9 @@ class PatientMailer < ApplicationMailer
     lang = patient.select_language
     patient_name = "#{patient&.first_name&.first || ''}#{patient&.last_name&.first || ''}-#{patient&.calc_current_age || '0'}"
     contents = "#{I18n.t('assessments.sms.prompt.intro1', locale: lang)} #{patient_name} #{I18n.t('assessments.sms.prompt.intro2', locale: lang)}"
-    account_sid = ENV['TWILLIO_API_ACCOUNT']
-    auth_token = ENV['TWILLIO_API_KEY']
-    from = ENV['TWILLIO_SENDING_NUMBER']
+    account_sid = ENV['TWILIO_API_ACCOUNT']
+    auth_token = ENV['TWILIO_API_KEY']
+    from = ENV['TWILIO_SENDING_NUMBER']
     client = Twilio::REST::Client.new(account_sid, auth_token)
     client.messages.create(
       from: from,
@@ -80,9 +80,9 @@ class PatientMailer < ApplicationMailer
       url_contents = new_patient_assessment_jurisdiction_report_lang_url(p.submission_token,
                                                                          lang&.to_s || 'en',
                                                                          patient.jurisdiction.unique_identifier[0, 32])
-      account_sid = ENV['TWILLIO_API_ACCOUNT']
-      auth_token = ENV['TWILLIO_API_KEY']
-      from = ENV['TWILLIO_SENDING_NUMBER']
+      account_sid = ENV['TWILIO_API_ACCOUNT']
+      auth_token = ENV['TWILIO_API_KEY']
+      from = ENV['TWILIO_SENDING_NUMBER']
       client = Twilio::REST::Client.new(account_sid, auth_token)
       client.messages.create(
         from: from,
@@ -108,9 +108,9 @@ class PatientMailer < ApplicationMailer
 
     lang = patient.select_language
     contents = I18n.t('assessments.sms.prompt.reminder', locale: lang)
-    account_sid = ENV['TWILLIO_API_ACCOUNT']
-    auth_token = ENV['TWILLIO_API_KEY']
-    from = ENV['TWILLIO_SENDING_NUMBER']
+    account_sid = ENV['TWILIO_API_ACCOUNT']
+    auth_token = ENV['TWILIO_API_KEY']
+    from = ENV['TWILIO_SENDING_NUMBER']
     client = Twilio::REST::Client.new(account_sid, auth_token)
     client.messages.create(
       from: from,
@@ -146,9 +146,9 @@ class PatientMailer < ApplicationMailer
     # If the dependets are in a different jurisdiction they may end up with too many or too few symptoms in their response
     contents += I18n.t('assessments.sms.prompt.daily3', locale: lang) + patient.jurisdiction.hierarchical_condition_bool_symptoms_string(lang) + '.'
     contents += I18n.t('assessments.sms.prompt.daily4', locale: lang)
-    account_sid = ENV['TWILLIO_API_ACCOUNT']
-    auth_token = ENV['TWILLIO_API_KEY']
-    from = ENV['TWILLIO_SENDING_NUMBER']
+    account_sid = ENV['TWILIO_API_ACCOUNT']
+    auth_token = ENV['TWILIO_API_KEY']
+    from = ENV['TWILIO_SENDING_NUMBER']
     client = Twilio::REST::Client.new(account_sid, auth_token)
     threshold_hash = patient.jurisdiction.jurisdiction_path_threshold_hash
     # The medium parameter will either be SMS or VOICE
@@ -156,7 +156,7 @@ class PatientMailer < ApplicationMailer
                threshold_hash: threshold_hash, medium: 'SMS', language: lang.to_s.split('-').first.upcase,
                try_again: I18n.t('assessments.sms.prompt.try-again', locale: lang),
                thanks: I18n.t('assessments.sms.prompt.thanks', locale: lang) }
-    client.studio.v1.flows(ENV['TWILLIO_STUDIO_FLOW']).executions.create(
+    client.studio.v1.flows(ENV['TWILIO_STUDIO_FLOW']).executions.create(
       from: from,
       to: Phonelib.parse(patient.primary_telephone, 'US').full_e164,
       parameters: params
@@ -191,9 +191,9 @@ class PatientMailer < ApplicationMailer
     # If the dependets are in a different jurisdiction they may end up with too many or too few symptoms in their response
     contents += I18n.t('assessments.phone.daily3', locale: lang) + patient.jurisdiction.hierarchical_condition_bool_symptoms_string(lang) + '?'
     contents += I18n.t('assessments.phone.daily4', locale: lang)
-    account_sid = ENV['TWILLIO_API_ACCOUNT']
-    auth_token = ENV['TWILLIO_API_KEY']
-    from = ENV['TWILLIO_SENDING_NUMBER']
+    account_sid = ENV['TWILIO_API_ACCOUNT']
+    auth_token = ENV['TWILIO_API_KEY']
+    from = ENV['TWILIO_SENDING_NUMBER']
     client = Twilio::REST::Client.new(account_sid, auth_token)
     threshold_hash = patient.jurisdiction.jurisdiction_path_threshold_hash
     # The medium parameter will either be SMS or VOICE
@@ -202,7 +202,7 @@ class PatientMailer < ApplicationMailer
                intro: I18n.t('assessments.phone.intro', locale: lang),
                try_again: I18n.t('assessments.phone.try-again', locale: lang),
                thanks: I18n.t('assessments.phone.thanks', locale: lang) }
-    client.studio.v1.flows(ENV['TWILLIO_STUDIO_FLOW']).executions.create(
+    client.studio.v1.flows(ENV['TWILIO_STUDIO_FLOW']).executions.create(
       from: from,
       to: Phonelib.parse(patient.primary_telephone, 'US').full_e164,
       parameters: params

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -5,7 +5,8 @@ class PatientMailer < ApplicationMailer
   default from: 'notifications@saraalert.org'
 
   def enrollment_email(patient)
-    return if patient&.email.blank?
+    # Should not be sending enrollment email if no valid email or this patient is not a responder
+    return if patient&.email.blank? || patient.id != patient.responder_id
 
     # Gather patients and jurisdictions
     @patients = ([patient] + patient.dependents.where(monitoring: true)).uniq.collect do |p|
@@ -19,7 +20,8 @@ class PatientMailer < ApplicationMailer
   end
 
   def enrollment_sms_weblink(patient)
-    return if patient&.primary_telephone.blank?
+    # Should not be sending enrollment sms if no valid number or this patient is not a responder
+    return if patient&.primary_telephone.blank? || patient.id != patient.responder_id
 
     lang = patient.select_language
     patient_name = "#{patient&.first_name&.first || ''}#{patient&.last_name&.first || ''}-#{patient&.calc_current_age || '0'}"
@@ -48,7 +50,8 @@ class PatientMailer < ApplicationMailer
   end
 
   def enrollment_sms_text_based(patient)
-    return if patient&.primary_telephone.blank?
+    # Should not be sending enrollment sms if no valid number or this patient is not a responder
+    return if patient&.primary_telephone.blank? || patient.id != patient.responder_id
 
     lang = patient.select_language
     patient_name = "#{patient&.first_name&.first || ''}#{patient&.last_name&.first || ''}-#{patient&.calc_current_age || '0'}"

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -33,12 +33,12 @@ class PatientMailer < ApplicationMailer
     client = Twilio::REST::Client.new(account_sid, auth_token)
     client.messages.create(
       to: Phonelib.parse(patient.primary_telephone, 'US').full_e164,
-      body: intro_contents
+      body: intro_contents,
       messaging_service_sid: messaging_service_sid
     )
     client.messages.create(
       to: Phonelib.parse(patient.primary_telephone, 'US').full_e164,
-      body: url_contents
+      body: url_contents,
       messaging_service_sid: messaging_service_sid
     )
   rescue Twilio::REST::RestError => e
@@ -59,7 +59,7 @@ class PatientMailer < ApplicationMailer
     client = Twilio::REST::Client.new(account_sid, auth_token)
     client.messages.create(
       to: Phonelib.parse(patient.primary_telephone, 'US').full_e164,
-      body: contents
+      body: contents,
       messaging_service_sid: messaging_service_sid
     )
   rescue Twilio::REST::RestError => e
@@ -86,12 +86,12 @@ class PatientMailer < ApplicationMailer
       client = Twilio::REST::Client.new(account_sid, auth_token)
       client.messages.create(
         to: Phonelib.parse(num, 'US').full_e164,
-        body: intro_contents
+        body: intro_contents,
         messaging_service_sid: messaging_service_sid
       )
       client.messages.create(
         to: Phonelib.parse(num, 'US').full_e164,
-        body: url_contents
+        body: url_contents,
         messaging_service_sid: messaging_service_sid
       )
       add_success_history(p, patient)
@@ -114,7 +114,7 @@ class PatientMailer < ApplicationMailer
     client = Twilio::REST::Client.new(account_sid, auth_token)
     client.messages.create(
       to: Phonelib.parse(patient.primary_telephone, 'US').full_e164,
-      body: contents
+      body: contents,
       messaging_service_sid: messaging_service_sid
     )
     add_success_history(patient, patient)
@@ -158,7 +158,7 @@ class PatientMailer < ApplicationMailer
                thanks: I18n.t('assessments.sms.prompt.thanks', locale: lang) }
     client.studio.v1.flows(ENV['TWILIO_STUDIO_FLOW']).executions.create(
       to: Phonelib.parse(patient.primary_telephone, 'US').full_e164,
-      parameters: params
+      parameters: params,
       messaging_service_sid: messaging_service_sid
     )
     add_success_history(patient, patient)

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -29,17 +29,17 @@ class PatientMailer < ApplicationMailer
                                                                        patient.jurisdiction.unique_identifier[0, 32])
     account_sid = ENV['TWILIO_API_ACCOUNT']
     auth_token = ENV['TWILIO_API_KEY']
-    from = ENV['TWILIO_MESSAGING_SERVICE_SID']
+    messaging_service_sid = ENV['TWILIO_MESSAGING_SERVICE_SID']
     client = Twilio::REST::Client.new(account_sid, auth_token)
     client.messages.create(
-      from: from,
       to: Phonelib.parse(patient.primary_telephone, 'US').full_e164,
       body: intro_contents
+      messaging_service_sid: messaging_service_sid
     )
     client.messages.create(
-      from: from,
       to: Phonelib.parse(patient.primary_telephone, 'US').full_e164,
       body: url_contents
+      messaging_service_sid: messaging_service_sid
     )
   rescue Twilio::REST::RestError => e
     Rails.logger.warn e.error_message
@@ -55,12 +55,12 @@ class PatientMailer < ApplicationMailer
     contents = "#{I18n.t('assessments.sms.prompt.intro1', locale: lang)} #{patient_name} #{I18n.t('assessments.sms.prompt.intro2', locale: lang)}"
     account_sid = ENV['TWILIO_API_ACCOUNT']
     auth_token = ENV['TWILIO_API_KEY']
-    from = ENV['TWILIO_MESSAGING_SERVICE_SID']
+    messaging_service_sid = ENV['TWILIO_MESSAGING_SERVICE_SID']
     client = Twilio::REST::Client.new(account_sid, auth_token)
     client.messages.create(
-      from: from,
       to: Phonelib.parse(patient.primary_telephone, 'US').full_e164,
       body: contents
+      messaging_service_sid: messaging_service_sid
     )
   rescue Twilio::REST::RestError => e
     Rails.logger.warn e.error_message
@@ -82,17 +82,17 @@ class PatientMailer < ApplicationMailer
                                                                          patient.jurisdiction.unique_identifier[0, 32])
       account_sid = ENV['TWILIO_API_ACCOUNT']
       auth_token = ENV['TWILIO_API_KEY']
-      from = ENV['TWILIO_MESSAGING_SERVICE_SID']
+      messaging_service_sid = ENV['TWILIO_MESSAGING_SERVICE_SID']
       client = Twilio::REST::Client.new(account_sid, auth_token)
       client.messages.create(
-        from: from,
         to: Phonelib.parse(num, 'US').full_e164,
         body: intro_contents
+        messaging_service_sid: messaging_service_sid
       )
       client.messages.create(
-        from: from,
         to: Phonelib.parse(num, 'US').full_e164,
         body: url_contents
+        messaging_service_sid: messaging_service_sid
       )
       add_success_history(p, patient)
     end
@@ -110,12 +110,12 @@ class PatientMailer < ApplicationMailer
     contents = I18n.t('assessments.sms.prompt.reminder', locale: lang)
     account_sid = ENV['TWILIO_API_ACCOUNT']
     auth_token = ENV['TWILIO_API_KEY']
-    from = ENV['TWILIO_MESSAGING_SERVICE_SID']
+    messaging_service_sid = ENV['TWILIO_MESSAGING_SERVICE_SID']
     client = Twilio::REST::Client.new(account_sid, auth_token)
     client.messages.create(
-      from: from,
       to: Phonelib.parse(patient.primary_telephone, 'US').full_e164,
       body: contents
+      messaging_service_sid: messaging_service_sid
     )
     add_success_history(patient, patient)
     # Always update the last contact time so the system does not try and send emails again.
@@ -148,7 +148,7 @@ class PatientMailer < ApplicationMailer
     contents += I18n.t('assessments.sms.prompt.daily4', locale: lang)
     account_sid = ENV['TWILIO_API_ACCOUNT']
     auth_token = ENV['TWILIO_API_KEY']
-    from = ENV['TWILIO_MESSAGING_SERVICE_SID']
+    messaging_service_sid = ENV['TWILIO_MESSAGING_SERVICE_SID']
     client = Twilio::REST::Client.new(account_sid, auth_token)
     threshold_hash = patient.jurisdiction.jurisdiction_path_threshold_hash
     # The medium parameter will either be SMS or VOICE
@@ -157,9 +157,9 @@ class PatientMailer < ApplicationMailer
                try_again: I18n.t('assessments.sms.prompt.try-again', locale: lang),
                thanks: I18n.t('assessments.sms.prompt.thanks', locale: lang) }
     client.studio.v1.flows(ENV['TWILIO_STUDIO_FLOW']).executions.create(
-      from: from,
       to: Phonelib.parse(patient.primary_telephone, 'US').full_e164,
       parameters: params
+      messaging_service_sid: messaging_service_sid
     )
     add_success_history(patient, patient)
     # Always update the last contact time so the system does not try and send emails again.

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -29,7 +29,7 @@ class PatientMailer < ApplicationMailer
                                                                        patient.jurisdiction.unique_identifier[0, 32])
     account_sid = ENV['TWILIO_API_ACCOUNT']
     auth_token = ENV['TWILIO_API_KEY']
-    from = ENV['TWILIO_SENDING_NUMBER']
+    from = ENV['TWILIO_MESSAGING_SERVICE_SID']
     client = Twilio::REST::Client.new(account_sid, auth_token)
     client.messages.create(
       from: from,
@@ -55,7 +55,7 @@ class PatientMailer < ApplicationMailer
     contents = "#{I18n.t('assessments.sms.prompt.intro1', locale: lang)} #{patient_name} #{I18n.t('assessments.sms.prompt.intro2', locale: lang)}"
     account_sid = ENV['TWILIO_API_ACCOUNT']
     auth_token = ENV['TWILIO_API_KEY']
-    from = ENV['TWILIO_SENDING_NUMBER']
+    from = ENV['TWILIO_MESSAGING_SERVICE_SID']
     client = Twilio::REST::Client.new(account_sid, auth_token)
     client.messages.create(
       from: from,
@@ -82,7 +82,7 @@ class PatientMailer < ApplicationMailer
                                                                          patient.jurisdiction.unique_identifier[0, 32])
       account_sid = ENV['TWILIO_API_ACCOUNT']
       auth_token = ENV['TWILIO_API_KEY']
-      from = ENV['TWILIO_SENDING_NUMBER']
+      from = ENV['TWILIO_MESSAGING_SERVICE_SID']
       client = Twilio::REST::Client.new(account_sid, auth_token)
       client.messages.create(
         from: from,
@@ -110,7 +110,7 @@ class PatientMailer < ApplicationMailer
     contents = I18n.t('assessments.sms.prompt.reminder', locale: lang)
     account_sid = ENV['TWILIO_API_ACCOUNT']
     auth_token = ENV['TWILIO_API_KEY']
-    from = ENV['TWILIO_SENDING_NUMBER']
+    from = ENV['TWILIO_MESSAGING_SERVICE_SID']
     client = Twilio::REST::Client.new(account_sid, auth_token)
     client.messages.create(
       from: from,
@@ -148,7 +148,7 @@ class PatientMailer < ApplicationMailer
     contents += I18n.t('assessments.sms.prompt.daily4', locale: lang)
     account_sid = ENV['TWILIO_API_ACCOUNT']
     auth_token = ENV['TWILIO_API_KEY']
-    from = ENV['TWILIO_SENDING_NUMBER']
+    from = ENV['TWILIO_MESSAGING_SERVICE_SID']
     client = Twilio::REST::Client.new(account_sid, auth_token)
     threshold_hash = patient.jurisdiction.jurisdiction_path_threshold_hash
     # The medium parameter will either be SMS or VOICE

--- a/test/mailers/patient_mailer_test.rb
+++ b/test/mailers/patient_mailer_test.rb
@@ -87,14 +87,6 @@ class PatientMailerTest < ActionMailer::TestCase
     end
   end
 
-  %i[enrollment_sms_text_based enrollment_sms_weblink].each do |mthd|
-    test "#{mthd} no phone provided" do
-      @patient.update(primary_telephone: nil)
-      email = PatientMailer.send(mthd, @patient)
-      assert_nil email.deliver_now
-    end
-  end
-
   %i[enrollment_sms_text_based enrollment_sms_weblink assessment_sms_weblink assessment_sms_reminder].each do |mthd|
     test "#{mthd} twilio rest error" do
       def twilio_error

--- a/test/mailers/patient_mailer_test.rb
+++ b/test/mailers/patient_mailer_test.rb
@@ -87,6 +87,14 @@ class PatientMailerTest < ActionMailer::TestCase
     end
   end
 
+  %i[enrollment_sms_text_based enrollment_sms_weblink].each do |mthd|
+    test "#{mthd} no messaging service SID provided" do
+      @patient.update(primary_telephone: nil)
+      email = PatientMailer.send(mthd, @patient)
+      assert_nil email.deliver_now
+    end
+  end
+
   %i[enrollment_sms_text_based enrollment_sms_weblink assessment_sms_weblink assessment_sms_reminder].each do |mthd|
     test "#{mthd} twilio rest error" do
       def twilio_error

--- a/test/mailers/patient_mailer_test.rb
+++ b/test/mailers/patient_mailer_test.rb
@@ -20,17 +20,17 @@ class PatientMailerTest < ActionMailer::TestCase
                     submission_token: patient_submission_token,
                     primary_telephone: '(555) 555-0111',
                     preferred_contact_method: 'Phone')
-    ENV['TWILLIO_SENDING_NUMBER'] = 'test'
-    ENV['TWILLIO_API_ACCOUNT'] = 'test'
-    ENV['TWILLIO_API_KEY'] = 'test'
-    ENV['TWILLIO_STUDIO_FLOW'] = 'test'
+    ENV['TWILIO_SENDING_NUMBER'] = 'test'
+    ENV['TWILIO_API_ACCOUNT'] = 'test'
+    ENV['TWILIO_API_KEY'] = 'test'
+    ENV['TWILIO_STUDIO_FLOW'] = 'test'
   end
 
   def teardown
-    ENV['TWILLIO_SENDING_NUMBER'] = nil
-    ENV['TWILLIO_API_ACCOUNT'] = nil
-    ENV['TWILLIO_API_KEY'] = nil
-    ENV['TWILLIO_STUDIO_FLOW'] = nil
+    ENV['TWILIO_SENDING_NUMBER'] = nil
+    ENV['TWILIO_API_ACCOUNT'] = nil
+    ENV['TWILIO_API_KEY'] = nil
+    ENV['TWILIO_STUDIO_FLOW'] = nil
   end
 
   test 'enrollment email contents' do

--- a/test/mailers/patient_mailer_test.rb
+++ b/test/mailers/patient_mailer_test.rb
@@ -24,6 +24,7 @@ class PatientMailerTest < ActionMailer::TestCase
     ENV['TWILIO_API_ACCOUNT'] = 'test'
     ENV['TWILIO_API_KEY'] = 'test'
     ENV['TWILIO_STUDIO_FLOW'] = 'test'
+    ENV['TWILIO_MESSAGING_SERVICE_SID'] = 'test_messaging_sid'
   end
 
   def teardown
@@ -31,6 +32,7 @@ class PatientMailerTest < ActionMailer::TestCase
     ENV['TWILIO_API_ACCOUNT'] = nil
     ENV['TWILIO_API_KEY'] = nil
     ENV['TWILIO_STUDIO_FLOW'] = nil
+    ENV['TWILIO_MESSAGING_SERVICE_SID'] = nil
   end
 
   test 'enrollment email contents' do
@@ -126,14 +128,14 @@ class PatientMailerTest < ActionMailer::TestCase
       true
     end)
     expect_any_instance_of(::Twilio::REST::Api::V2010::AccountContext::MessageList).to(receive(:create).with(
-                                                                                         from: 'test',
                                                                                          to: '+15555550111',
-                                                                                         body: first_contents
+                                                                                         body: first_contents,
+                                                                                         messaging_service_sid: 'test_messaging_sid'
                                                                                        ))
     expect_any_instance_of(::Twilio::REST::Api::V2010::AccountContext::MessageList).to(receive(:create).with(
-                                                                                         from: 'test',
                                                                                          to: '+15555550111',
-                                                                                         body: second_contents
+                                                                                         body: second_contents,
+                                                                                         messaging_service_sid: 'test_messaging_sid'
                                                                                        ))
 
     PatientMailer.enrollment_sms_weblink(@patient).deliver_now
@@ -146,9 +148,9 @@ class PatientMailerTest < ActionMailer::TestCase
       true
     end)
     expect_any_instance_of(::Twilio::REST::Api::V2010::AccountContext::MessageList).to(receive(:create).with(
-                                                                                         from: 'test',
                                                                                          to: '+15555550111',
-                                                                                         body: contents
+                                                                                         body: contents,
+                                                                                         messaging_service_sid: 'test_messaging_sid'
                                                                                        ))
 
     PatientMailer.enrollment_sms_text_based(@patient).deliver_now
@@ -162,14 +164,14 @@ class PatientMailerTest < ActionMailer::TestCase
       true
     end)
     expect_any_instance_of(::Twilio::REST::Api::V2010::AccountContext::MessageList).to(receive(:create).with(
-                                                                                         from: 'test',
                                                                                          to: '+15555550111',
-                                                                                         body: first_contents
+                                                                                         body: first_contents,
+                                                                                         messaging_service_sid: 'test_messaging_sid'
                                                                                        ))
     expect_any_instance_of(::Twilio::REST::Api::V2010::AccountContext::MessageList).to(receive(:create).with(
-                                                                                         from: 'test',
                                                                                          to: '+15555550111',
-                                                                                         body: second_contents
+                                                                                         body: second_contents,
+                                                                                         messaging_service_sid: 'test_messaging_sid'
                                                                                        ))
 
     PatientMailer.assessment_sms_weblink(@patient).deliver_now
@@ -200,9 +202,9 @@ class PatientMailerTest < ActionMailer::TestCase
       true
     end)
     expect_any_instance_of(::Twilio::REST::Api::V2010::AccountContext::MessageList).to(receive(:create).with(
-                                                                                         from: 'test',
                                                                                          to: '+15555550111',
-                                                                                         body: contents
+                                                                                         body: contents,
+                                                                                         messaging_service_sid: 'test_messaging_sid'
                                                                                        ))
 
     PatientMailer.assessment_sms_reminder(@patient).deliver_now
@@ -294,9 +296,9 @@ class PatientMailerTest < ActionMailer::TestCase
       true
     end)
     expect_any_instance_of(::Twilio::REST::Studio::V1::FlowContext::ExecutionList).to(receive(:create)).with({
-                                                                                                               from: 'test',
                                                                                                                to: '+15555550111',
-                                                                                                               parameters: params
+                                                                                                               parameters: params,
+                                                                                                               messaging_service_sid: 'test_messaging_sid'
                                                                                                              })
     PatientMailer.assessment_sms(@patient).deliver_now
   end


### PR DESCRIPTION
**Keeping as a draft to prevent merging until after we tag 1.11.**

# Description
Jira Ticket: [SARAALERT-716](https://tracker.codev.mitre.org/browse/SARAALERT-716)

This PR makes the necessary code changes to work with a messaging service for sending out SMS messages.
It also fixes our Twilio env variables to spell Twilio correctly. This means the env variables in `.env-prod-enrollment` on the demo runner need to be updated for testing, and then the ENV variables on staging and production will need to change when this is deployed.

You can read the instructions for switching to sending messages with a Messaging Service here (you can switch the language to Ruby to see an example): https://www.twilio.com/docs/sms/services#send-a-message-with-a-messaging-service

There is messaging service set up for demo here: https://www.twilio.com/console/sms/services/MG5f733cdc3e21e7e1ca3b239554efabb6/properties

# Important Changes
`app/mailers/patient_mailer.rb`
- Updated methods that send SMS to not include a `from` number but instead include a `messaging_service_sid`
- Updated with new ENV var spelling
- Updated enrollment methods to only send enrollment messages to reporters (HoH and patients not in a household). 

`test/mailers/patient_mailer_test.rb`
- Updated tests for SMS to no longer depend on from sending number.

`.env-prod-enrollment-example` and `README.md`
- Updated to include new Twilio ENV variable and fix typos.

# Testing
This needs to be tested on demo where we actually have Twilio configured. 
I updated the patient mailer tests, which I would like @Bialogs to take a look at specifically.