### PR TITLE
Slim down the HTML used in the assessment job emails

### DIFF
--- a/app/views/user_mailer/assessment_job_email.html.erb
+++ b/app/views/user_mailer/assessment_job_email.html.erb
@@ -3,38 +3,22 @@
 <br />
 Total eligible for notifications at runtime: <%= @eligible %>
 <br />
-Sent during this job run: <%= @sent.count %>
+Sent during this job run: <b><%= @sent.count %></b>
 <br />
-Not sent during this job run (due to exception): <%= @not_sent.count %>
-<br />
+Not sent during this job run (due to exceptions): <b><%= @not_sent.count %></b>
 <br />
 <h2>Sent</h2>
-<table style="border: 1px solid black; border-collapse: collapse;">
-  <tr>
-    <th style="border: 1px solid black; border-collapse: collapse;">ID</th>
-    <th style="border: 1px solid black; border-collapse: collapse;">Method</th>
-  </tr>
-  <% @sent.each do |s| %>
-    <tr>
-      <td style="border: 1px solid black; border-collapse: collapse;"><%= s[:id] %></td>
-      <td style="border: 1px solid black; border-collapse: collapse;"><%= s[:method] %></td>
-    <tr>
-  <% end %>
-</table>
 <br />
+ID, method, reason
+<br />
+<% @sent.each do |s| %>
+  <%= s[:id] %>, <%= s[:method] %><br />
+<% end %>
 <br />
 <h2>Not Sent</h2>
-<table style="border: 1px solid black; border-collapse: collapse;">
-  <tr>
-    <th style="border: 1px solid black; border-collapse: collapse;">ID</th>
-    <th style="border: 1px solid black; border-collapse: collapse;">Method</th>
-    <th style="border: 1px solid black; border-collapse: collapse;">Reason</th>
-  </tr>
-  <% @not_sent.each do |s| %>
-    <tr>
-      <td style="border: 1px solid black; border-collapse: collapse;"><%= s[:id] %></td>
-      <td style="border: 1px solid black; border-collapse: collapse;"><%= s[:method] %></td>
-      <td style="border: 1px solid black; border-collapse: collapse;"><%= s[:reason] %></td>
-    <tr>
-  <% end %>
-</table>
+<br />
+ID, method, reason
+<br />
+<% @not_sent.each do |ns| %>
+  <%= ns[:id] %>, <%= ns[:method] %>, <%= ns[:reason] %><br />
+<% end %>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,9 +5,9 @@ Sidekiq.options[:max_retries] = 5
 Sidekiq.configure_server do |config|
   # Set the network timeout to be 5 seconds instead of the default 1 to help with
   # cloud network latency and longer batch commands
-  config.redis = {url: ENV['REDIS_URL'], network_timeout: 5 }
+  config.redis = { url: ENV['REDIS_URL'], network_timeout: 5 }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = {url: ENV['REDIS_URL'], network_timeout: 5 }
+  config.redis = { url: ENV['REDIS_URL'], network_timeout: 5 }
 end


### PR DESCRIPTION
# Description
Make the emails for assessment job results have far less HTML (to shrink total size). Values are now comma separated, to make it easy to put into a spreadsheet.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/views/user_mailer/assessment_job_email.html.erb `
- Removed a lot of HTML tags, made results comma separated per row

Will deploy to demo after merge.