### PR TITLE
SARAALERT-724: Update reminder_eligible scope, Patient mailers, and toggle continuous_exposure off when closed.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Please list important files (meaning substantial or integral to the PR) along wi
 `example_file.js`
 - Example change (ex: refactored import function)
 
-# Testing*
+# Testing
 This fix was tested on the following browsers (submitter must check all those that apply):
 * [ ] Chrome
 * [ ] Firefox

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -321,7 +321,7 @@ class PatientsController < ApplicationController
       end
     end
 
-    # Do we need to propagate to household where continuous_monitoring is true?
+    # Do we need to propagate to household where continuous_exposure is true?
     if params.permit(:apply_to_group_cm_only)[:apply_to_group_cm_only]
       # Scope lookup
       ([patient] + (current_user.get_patient(patient.responder_id)&.dependents&.where(continuous_exposure: true) || [])).uniq.each do |member|
@@ -350,6 +350,7 @@ class PatientsController < ApplicationController
                          status_fields & diff_state # Set intersection between what the front end is saying changed, and status fields
                        end
     if params_to_update.include?(:monitoring) && params.require(:patient).permit(:monitoring)[:monitoring] != patient.monitoring && patient.monitoring
+      patient.continuous_exposure = false
       patient.closed_at = DateTime.now
     end
     if params_to_update.include?(:isolation) && !params.require(:patient).permit(:isolation)[:isolation]

--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -120,7 +120,7 @@ const TOOLTIP_TEXT = {
     <div>
       Calculated by the system based on Last Date of Exposure
       <div>
-        <i>Only relevent for Exposure Workflow</i>
+        <i>Only relevant for Exposure Workflow</i>
       </div>
     </div>
   ),

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -8,6 +8,7 @@ class PatientMailer < ApplicationMailer
     return if patient&.email.blank?
 
     # Gather patients and jurisdictions
+    # patient.dependents includes the patient themselves if patient.id = patient.responder_id (which should be the case)
     @patients = patient.dependents.where(monitoring: true).uniq.collect do |p|
       { patient: p, jurisdiction_unique_id: Jurisdiction.find_by_id(p.jurisdiction_id).unique_identifier }
     end
@@ -73,6 +74,7 @@ class PatientMailer < ApplicationMailer
     add_fail_history_blank_field(patient, 'primary phone number') && return if patient&.primary_telephone.blank?
 
     num = patient.primary_telephone
+    # patient.dependents includes the patient themselves if patient.id = patient.responder_id (which should be the case)
     patient.dependents.where(monitoring: true).uniq.each do |p|
       lang = p.select_language
       patient_name = "#{p&.first_name&.first || ''}#{p&.last_name&.first || ''}-#{p&.calc_current_age || '0'}"
@@ -130,6 +132,7 @@ class PatientMailer < ApplicationMailer
     add_fail_history_blank_field(patient, 'primary phone number') && return if patient&.primary_telephone.blank?
 
     lang = patient.select_language
+    # patient.dependents includes the patient themselves if patient.id = patient.responder_id (which should be the case)
     patient_names = patient.dependents.where(monitoring: true).uniq.collect do |p|
       "#{p&.first_name&.first || ''}#{p&.last_name&.first || ''}-#{p&.calc_current_age || '0'}"
     end
@@ -175,6 +178,7 @@ class PatientMailer < ApplicationMailer
 
     lang = patient.select_language
     lang = :en if %i[so].include?(lang) # Some languages are not supported via voice
+    # patient.dependents includes the patient themselves if patient.id = patient.responder_id (which should be the case)
     patient_names = patient.dependents.where(monitoring: true).uniq.collect do |p|
       "#{p&.first_name&.first || ''}, #{p&.last_name&.first || ''}, #{I18n.t('assessments.phone.age', locale: lang)} #{p&.calc_current_age || '0'},"
     end
@@ -221,6 +225,7 @@ class PatientMailer < ApplicationMailer
 
     @lang = patient.select_language
     # Gather patients and jurisdictions
+    # patient.dependents includes the patient themselves if patient.id = patient.responder_id (which should be the case)
     @patients = patient.dependents.where(monitoring: true).uniq.collect do |p|
       { patient: p, jurisdiction_unique_id: Jurisdiction.find_by_id(p.jurisdiction_id).unique_identifier }
     end

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -9,7 +9,7 @@ class PatientMailer < ApplicationMailer
 
     # Gather patients and jurisdictions
     # patient.dependents includes the patient themselves if patient.id = patient.responder_id (which should be the case)
-    @patients = patient.dependents.where(monitoring: true).uniq.collect do |p|
+    @patients = patient.dependents.where('monitoring = ? OR continuous_exposure = ?', true, true).uniq.collect do |p|
       { patient: p, jurisdiction_unique_id: Jurisdiction.find_by_id(p.jurisdiction_id).unique_identifier }
     end
     @lang = patient.select_language
@@ -75,7 +75,7 @@ class PatientMailer < ApplicationMailer
 
     num = patient.primary_telephone
     # patient.dependents includes the patient themselves if patient.id = patient.responder_id (which should be the case)
-    patient.dependents.where(monitoring: true).uniq.each do |p|
+    patient.dependents.where('monitoring = ? OR continuous_exposure = ?', true, true).uniq.each do |p|
       lang = p.select_language
       patient_name = "#{p&.first_name&.first || ''}#{p&.last_name&.first || ''}-#{p&.calc_current_age || '0'}"
       intro_contents = "#{I18n.t('assessments.sms.weblink.intro1', locale: lang)} #{patient_name} #{I18n.t('assessments.sms.weblink.intro2', locale: lang)}"
@@ -133,13 +133,13 @@ class PatientMailer < ApplicationMailer
 
     lang = patient.select_language
     # patient.dependents includes the patient themselves if patient.id = patient.responder_id (which should be the case)
-    patient_names = patient.dependents.where(monitoring: true).uniq.collect do |p|
+    patient_names = patient.dependents.where('monitoring = ? OR continuous_exposure = ?', true, true).uniq.collect do |p|
       "#{p&.first_name&.first || ''}#{p&.last_name&.first || ''}-#{p&.calc_current_age || '0'}"
     end
     contents = I18n.t('assessments.sms.prompt.daily1', locale: lang) + patient_names.join(', ') + '.'
 
     # Prepare text asking about anyone in the group
-    contents += if patient.dependents.where(monitoring: true).uniq.count > 1
+    contents += if patient.dependents.where('monitoring = ? OR continuous_exposure = ?', true, true).uniq.count > 1
                   I18n.t('assessments.sms.prompt.daily2-p', locale: lang)
                 else
                   I18n.t('assessments.sms.prompt.daily2-s', locale: lang)
@@ -179,13 +179,13 @@ class PatientMailer < ApplicationMailer
     lang = patient.select_language
     lang = :en if %i[so].include?(lang) # Some languages are not supported via voice
     # patient.dependents includes the patient themselves if patient.id = patient.responder_id (which should be the case)
-    patient_names = patient.dependents.where(monitoring: true).uniq.collect do |p|
+    patient_names = patient.dependents.where('monitoring = ? OR continuous_exposure = ?', true, true).uniq.collect do |p|
       "#{p&.first_name&.first || ''}, #{p&.last_name&.first || ''}, #{I18n.t('assessments.phone.age', locale: lang)} #{p&.calc_current_age || '0'},"
     end
     contents = I18n.t('assessments.phone.daily1', locale: lang) + patient_names.join(', ')
 
     # Prepare text asking about anyone in the group
-    contents += if patient.dependents.where(monitoring: true).uniq.count > 1
+    contents += if patient.dependents.where('monitoring = ? OR continuous_exposure = ?', true, true).uniq.count > 1
                   I18n.t('assessments.phone.daily2-p', locale: lang)
                 else
                   I18n.t('assessments.phone.daily2-s', locale: lang)
@@ -226,7 +226,7 @@ class PatientMailer < ApplicationMailer
     @lang = patient.select_language
     # Gather patients and jurisdictions
     # patient.dependents includes the patient themselves if patient.id = patient.responder_id (which should be the case)
-    @patients = patient.dependents.where(monitoring: true).uniq.collect do |p|
+    @patients = patient.dependents.where('monitoring = ? OR continuous_exposure = ?', true, true).uniq.collect do |p|
       { patient: p, jurisdiction_unique_id: Jurisdiction.find_by_id(p.jurisdiction_id).unique_identifier }
     end
     mail(to: patient.email&.strip, subject: I18n.t('assessments.email.reminder.subject', locale: @lang || :en)) do |format|

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -8,7 +8,7 @@ class PatientMailer < ApplicationMailer
     return if patient&.email.blank?
 
     # Gather patients and jurisdictions
-    @patients = ([patient] + patient.dependents.where(monitoring: true)).uniq.collect do |p|
+    @patients = patient.dependents.where(monitoring: true).uniq.collect do |p|
       { patient: p, jurisdiction_unique_id: Jurisdiction.find_by_id(p.jurisdiction_id).unique_identifier }
     end
     @lang = patient.select_language
@@ -73,7 +73,7 @@ class PatientMailer < ApplicationMailer
     add_fail_history_blank_field(patient, 'primary phone number') && return if patient&.primary_telephone.blank?
 
     num = patient.primary_telephone
-    ([patient] + patient.dependents.where(monitoring: true)).uniq.each do |p|
+    patient.dependents.where(monitoring: true).uniq.each do |p|
       lang = p.select_language
       patient_name = "#{p&.first_name&.first || ''}#{p&.last_name&.first || ''}-#{p&.calc_current_age || '0'}"
       intro_contents = "#{I18n.t('assessments.sms.weblink.intro1', locale: lang)} #{patient_name} #{I18n.t('assessments.sms.weblink.intro2', locale: lang)}"
@@ -130,13 +130,13 @@ class PatientMailer < ApplicationMailer
     add_fail_history_blank_field(patient, 'primary phone number') && return if patient&.primary_telephone.blank?
 
     lang = patient.select_language
-    patient_names = ([patient] + patient.dependents.where(monitoring: true)).uniq.collect do |p|
+    patient_names = patient.dependents.where(monitoring: true).uniq.collect do |p|
       "#{p&.first_name&.first || ''}#{p&.last_name&.first || ''}-#{p&.calc_current_age || '0'}"
     end
     contents = I18n.t('assessments.sms.prompt.daily1', locale: lang) + patient_names.join(', ') + '.'
 
     # Prepare text asking about anyone in the group
-    contents += if ([patient] + patient.dependents.where(monitoring: true)).uniq.count > 1
+    contents += if patient.dependents.where(monitoring: true).uniq.count > 1
                   I18n.t('assessments.sms.prompt.daily2-p', locale: lang)
                 else
                   I18n.t('assessments.sms.prompt.daily2-s', locale: lang)
@@ -175,13 +175,13 @@ class PatientMailer < ApplicationMailer
 
     lang = patient.select_language
     lang = :en if %i[so].include?(lang) # Some languages are not supported via voice
-    patient_names = ([patient] + patient.dependents.where(monitoring: true)).uniq.collect do |p|
+    patient_names = patient.dependents.where(monitoring: true).uniq.collect do |p|
       "#{p&.first_name&.first || ''}, #{p&.last_name&.first || ''}, #{I18n.t('assessments.phone.age', locale: lang)} #{p&.calc_current_age || '0'},"
     end
     contents = I18n.t('assessments.phone.daily1', locale: lang) + patient_names.join(', ')
 
     # Prepare text asking about anyone in the group
-    contents += if ([patient] + patient.dependents.where(monitoring: true)).uniq.count > 1
+    contents += if patient.dependents.where(monitoring: true).uniq.count > 1
                   I18n.t('assessments.phone.daily2-p', locale: lang)
                 else
                   I18n.t('assessments.phone.daily2-s', locale: lang)
@@ -221,7 +221,7 @@ class PatientMailer < ApplicationMailer
 
     @lang = patient.select_language
     # Gather patients and jurisdictions
-    @patients = ([patient] + patient.dependents.where(monitoring: true)).uniq.collect do |p|
+    @patients = patient.dependents.where(monitoring: true).uniq.collect do |p|
       { patient: p, jurisdiction_unique_id: Jurisdiction.find_by_id(p.jurisdiction_id).unique_identifier }
     end
     mail(to: patient.email&.strip, subject: I18n.t('assessments.email.reminder.subject', locale: @lang || :en)) do |format|

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -89,16 +89,16 @@ class Patient < ApplicationRecord
   #   - they haven't completed an assessment today OR they haven't completed an assessment at all
   #   - (TODO in this scope rather than send_assessment) actively monitored OR has dependents that are being actively monitored
   #
-  # NOTE: This method is currently being tested to be swapped in as the new reminder_eligible scope. 
+  # NOTE: This method is currently being tested to be swapped in as the new reminder_eligible scope.
   #       Once swapped in, the send_assessment method can be cut down to remove redundant logic.
   scope :optimal_reminder_eligible, lambda {
     where(purged: false)
-    .where(pause_notifications: false)
-    .where.not(preferred_contact_method: ['Unknown', 'Opt-out', '', nil])
-    .where('patients.id = patients.responder_id')
-    .where('patients.last_assessment_reminder_sent <= ? OR patients.last_assessment_reminder_sent IS NULL', 12.hours.ago)
-    .where('patients.latest_assessment_at < ? OR patients.latest_assessment_at IS NULL', Time.now.getlocal('-04:00').beginning_of_day)  
-    .distinct
+      .where(pause_notifications: false)
+      .where.not(preferred_contact_method: ['Unknown', 'Opt-out', '', nil])
+      .where('patients.id = patients.responder_id')
+      .where('last_assessment_reminder_sent <= ? OR last_assessment_reminder_sent IS NULL', 12.hours.ago)
+      .where('latest_assessment_at < ? OR latest_assessment_at IS NULL', Time.now.getlocal('-04:00').beginning_of_day)
+      .distinct
   }
 
   # All individuals currently being monitored

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -70,16 +70,38 @@ class Patient < ApplicationRecord
     where(purged: false)
       .where(pause_notifications: false)
       .where('patients.id = patients.responder_id')
-      .where('isolation = ? OR last_date_of_exposure >= ? OR continuous_exposure = ?', true, (ADMIN_OPTIONS['monitoring_period_days'] + 1).days.ago, true)
+      .where('isolation = ? OR continuous_exposure = ?', true, true)
       .where.not('latest_assessment_at >= ?', Time.now.getlocal('-04:00').beginning_of_day)
       .or(
         where(purged: false)
           .where(pause_notifications: false)
           .where('patients.id = patients.responder_id')
-          .where('isolation = ? OR last_date_of_exposure >= ? OR continuous_exposure = ?', true, (ADMIN_OPTIONS['monitoring_period_days'] + 1).days.ago, true)
+          .where('isolation = ? OR continuous_exposure = ?', true, true)
           .where(latest_assessment_at: nil)
       )
       .distinct
+  }
+
+  # Patients who are eligible for reminders:
+  #   - not purged AND
+  #   - notifications not paused AND
+  #   - valid preferred contact method AND
+  #   - HoH or not in a household AND
+  #   - we haven't sent them in an assessment within the past 12 hours AND
+  #   - they haven't completed an assessment today OR they haven't completed an assessment at all
+  #   - actively monitored OR has dependents that are being actively monitored
+  #
+  # NOTE: This method is currently being tested to be swapped in as the new reminder_eligible scope. 
+  #       Once swapped in, the send_assessment method can be cut down to remove redundant logic.
+  scope :optimal_reminder_eligible, lambda {
+    where(purged: false)
+    .where(pause_notifications: false)
+    .where.not(preferred_contact_method: ['Unknown', 'Opt-out', '', nil])
+    .where('patients.id = patients.responder_id')
+    .where('patients.last_assessment_reminder_sent <= ? OR patients.last_assessment_reminder_sent IS NULL', 12.hours.ago)
+    .where('patients.latest_assessment_at < ? OR patients.latest_assessment_at IS NULL', Time.now.getlocal('-04:00').beginning_of_day)  
+    .joins(:dependents).where(dependents_patients: { monitoring: true })
+    .distinct
   }
 
   # All individuals currently being monitored

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -85,7 +85,7 @@ class Patient < ApplicationRecord
   #   - notifications not paused AND
   #   - valid preferred contact method AND
   #   - HoH or not in a household AND
-  #   - we haven't sent them in an assessment within the past 12 hours AND
+  #   - we haven't sent them an assessment within the past 12 hours AND
   #   - they haven't completed an assessment today OR they haven't completed an assessment at all
   #   - (TODO in this scope rather than send_assessment) actively monitored OR has dependents that are being actively monitored
   #

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -70,13 +70,11 @@ class Patient < ApplicationRecord
     where(purged: false)
       .where(pause_notifications: false)
       .where('patients.id = patients.responder_id')
-      .where('isolation = ? OR continuous_exposure = ?', true, true)
       .where.not('latest_assessment_at >= ?', Time.now.getlocal('-04:00').beginning_of_day)
       .or(
         where(purged: false)
           .where(pause_notifications: false)
           .where('patients.id = patients.responder_id')
-          .where('isolation = ? OR continuous_exposure = ?', true, true)
           .where(latest_assessment_at: nil)
       )
       .distinct
@@ -89,7 +87,7 @@ class Patient < ApplicationRecord
   #   - HoH or not in a household AND
   #   - we haven't sent them in an assessment within the past 12 hours AND
   #   - they haven't completed an assessment today OR they haven't completed an assessment at all
-  #   - actively monitored OR has dependents that are being actively monitored
+  #   - (TODO in this scope rather than send_assessment) actively monitored OR has dependents that are being actively monitored
   #
   # NOTE: This method is currently being tested to be swapped in as the new reminder_eligible scope. 
   #       Once swapped in, the send_assessment method can be cut down to remove redundant logic.
@@ -100,7 +98,6 @@ class Patient < ApplicationRecord
     .where('patients.id = patients.responder_id')
     .where('patients.last_assessment_reminder_sent <= ? OR patients.last_assessment_reminder_sent IS NULL', 12.hours.ago)
     .where('patients.latest_assessment_at < ? OR patients.latest_assessment_at IS NULL', Time.now.getlocal('-04:00').beginning_of_day)  
-    .joins(:dependents).where(dependents_patients: { monitoring: true })
     .distinct
   }
 

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -12,7 +12,7 @@ class PatientTest < ActiveSupport::TestCase
   #   - notifications not paused AND
   #   - valid preferred contact method AND
   #   - HoH or not in a household AND
-  #   - we haven't sent them in an assessment within the past 12 hours AND
+  #   - we haven't sent them an assessment within the past 12 hours AND
   #   - they haven't completed an assessment today OR they haven't completed an assessment at all
   #   - (TODO) actively monitored OR has dependents that are being actively monitored
   #

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -17,184 +17,188 @@ class PatientTest < ActiveSupport::TestCase
   #   - (TODO) actively monitored OR has dependents that are being actively monitored
   #
   test 'reminder eligible does not include purged records' do
-    patient = create(:patient, 
-                      purged: true, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: 'Telephone Call')
+    patient = create(:patient,
+                     purged: true,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: 'Telephone Call')
 
     assert_equal(0, Patient.optimal_reminder_eligible.where(id: patient.id).count)
 
-    patient = create(:patient, 
-                      purged: false,
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: 'Telephone Call')
-    
-    assert_equal(1, Patient.optimal_reminder_eligible.where(id: patient.id).count)
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: 'Telephone Call')
 
+    assert_equal(1, Patient.optimal_reminder_eligible.where(id: patient.id).count)
   end
 
   test 'reminder eligible does not include records with paused notifications' do
-    patient = create(:patient, 
-              purged: false, 
-              pause_notifications: true,
-              monitoring: true, 
-              preferred_contact_method: 'Telephone Call')
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: true,
+                     monitoring: true,
+                     preferred_contact_method: 'Telephone Call')
 
     assert_equal(0, Patient.optimal_reminder_eligible.where(id: patient.id).count)
 
-    patient = create(:patient, 
-                  purged: false, 
-                  pause_notifications: false,
-                  monitoring: true, 
-                  preferred_contact_method: 'Telephone Call')
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: 'Telephone Call')
 
     assert_equal(1, Patient.optimal_reminder_eligible.where(id: patient.id).count)
-
   end
 
   test 'reminder eligible does not include records with invalid, unknown, or opt-out contact methods' do
-    patient = create(:patient, 
-                      purged: false, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: '')
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: '')
 
     assert_equal(0, Patient.optimal_reminder_eligible.where(id: patient.id).count)
 
-    patient = create(:patient, 
-                      purged: false, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: nil)
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: nil)
 
-    assert_equal(0, Patient.optimal_reminder_eligible.where(id: patient.id).count)    
+    assert_equal(0, Patient.optimal_reminder_eligible.where(id: patient.id).count)
 
-    patient = create(:patient, 
-                      purged: false, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: 'Unknown')
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: 'Unknown')
 
-    assert_equal(0, Patient.optimal_reminder_eligible.where(id: patient.id).count)    
+    assert_equal(0, Patient.optimal_reminder_eligible.where(id: patient.id).count)
 
-    patient = create(:patient, 
-                      purged: false, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: 'Opt-out')
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: 'Opt-out')
 
-    assert_equal(0, Patient.optimal_reminder_eligible.where(id: patient.id).count)    
+    assert_equal(0, Patient.optimal_reminder_eligible.where(id: patient.id).count)
 
-    patient = create(:patient, 
-                      purged: false, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: 'Telephone Call')
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: 'Telephone Call')
 
     assert_equal(1, Patient.optimal_reminder_eligible.where(id: patient.id).count)
-
   end
 
   test 'reminder eligible does not include records that report through a HoH' do
-    responder = create(:patient, 
-                      purged: false, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: 'Telephone Call')
+    responder = create(:patient,
+                       purged: false,
+                       pause_notifications: false,
+                       monitoring: true,
+                       preferred_contact_method: 'Telephone Call')
 
-    patient = create(:patient, 
-                      purged: false, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: 'Telephone Call')
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: 'Telephone Call')
 
     patient.update!(responder_id: responder.id)
     assert_equal(0, Patient.optimal_reminder_eligible.where(id: patient.id).count)
 
-    patient = create(:patient, 
-                      purged: false, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: 'Telephone Call')
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: 'Telephone Call')
 
     assert_equal(1, Patient.optimal_reminder_eligible.where(id: patient.id).count)
   end
 
   test 'reminder eligible does not include records have received an assessment reminder in the last 12 hours' do
-    patient = create(:patient, 
-                      purged: false, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: 'Telephone Call',
-                      last_assessment_reminder_sent: 13.hours.ago)
-
-            
-    assert_equal(1, Patient.optimal_reminder_eligible.where(id: patient.id).count)
-
-    patient = create(:patient, 
-                      purged: false, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: 'Telephone Call',
-                      last_assessment_reminder_sent: nil)
+    # Assessment was sent more than 12 hours ago - should be eligible
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: 'Telephone Call',
+                     last_assessment_reminder_sent: 13.hours.ago)
 
     assert_equal(1, Patient.optimal_reminder_eligible.where(id: patient.id).count)
 
-    patient = create(:patient, 
-                      purged: false, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: 'Telephone Call',
-                      last_assessment_reminder_sent: 12.hours.ago)
+    # Assessment was not sent (nil) - should be eligible
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: 'Telephone Call',
+                     last_assessment_reminder_sent: nil)
 
     assert_equal(1, Patient.optimal_reminder_eligible.where(id: patient.id).count)
 
-    patient = create(:patient, 
-                      purged: false, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: 'Telephone Call',
-                      last_assessment_reminder_sent: Time.now)
+    # Assessment was sent exactly 12 hours ago - should be eligible
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: 'Telephone Call',
+                     last_assessment_reminder_sent: 12.hours.ago)
+
+    assert_equal(1, Patient.optimal_reminder_eligible.where(id: patient.id).count)
+
+    # Assessment was sent under 10 hours - should NOT be eligible
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: 'Telephone Call',
+                     last_assessment_reminder_sent: 10.hours.ago)
 
     assert_equal(0, Patient.optimal_reminder_eligible.where(id: patient.id).count)
   end
 
   test 'reminder eligible does not include records that have completed an assessment today' do
-    patient = create(:patient, 
-                      purged: false, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: 'Telephone Call',
-                      latest_assessment_at: 25.hours.ago)
+    # Assessment was completed more than a day ago - should be eligible
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: 'Telephone Call',
+                     latest_assessment_at: 25.hours.ago)
 
     assert_equal(1, Patient.optimal_reminder_eligible.where(id: patient.id).count)
 
-    patient = create(:patient, 
-                      purged: false, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: 'Telephone Call',
-                      last_assessment_reminder_sent: nil)
+    # Assessment was not completed (nil) - should be eligible
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: 'Telephone Call',
+                     latest_assessment_at: nil)
 
     assert_equal(1, Patient.optimal_reminder_eligible.where(id: patient.id).count)
 
-    patient = create(:patient, 
-                      purged: false, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: 'Telephone Call',
-                      last_assessment_reminder_sent: Time.now.getlocal('-04:00').beginning_of_day)
+    # Assessment was completed at the very beginning of the day - should NOT be eligible
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: 'Telephone Call',
+                     latest_assessment_at: Time.now.getlocal('-04:00').beginning_of_day)
 
-    assert_equal(1, Patient.optimal_reminder_eligible.where(id: patient.id).count)
+    assert_equal(0, Patient.optimal_reminder_eligible.where(id: patient.id).count)
 
-    patient = create(:patient, 
-                      purged: false, 
-                      pause_notifications: false,
-                      monitoring: true, 
-                      preferred_contact_method: 'Telephone Call',
-                      last_assessment_reminder_sent: Time.now)
+    # Assessment was completed now - should NOT be eligible
+    patient = create(:patient,
+                     purged: false,
+                     pause_notifications: false,
+                     monitoring: true,
+                     preferred_contact_method: 'Telephone Call',
+                     latest_assessment_at: Time.now)
 
     assert_equal(0, Patient.optimal_reminder_eligible.where(id: patient.id).count)
   end
@@ -656,14 +660,6 @@ class PatientTest < ActiveSupport::TestCase
     assert_not Patient.reminder_eligible.find_by(id: patient.id).nil?
   end
 
-  test 'exposure dont send report without continuous exposure' do
-    # patient was created more than 24 hours ago
-    Patient.destroy_all
-    patient = create(:patient, monitoring: true, purged: false, isolation: false, created_at: 2.days.ago, last_date_of_exposure: 20.days.ago)
-
-    assert Patient.reminder_eligible.find_by(id: patient.id).nil?
-  end
-
   test 'exposure send report with continuous exposure' do
     # patient was created more than 24 hours ago
     Patient.destroy_all
@@ -673,14 +669,6 @@ class PatientTest < ActiveSupport::TestCase
     create(:assessment, patient: patient, symptomatic: false, created_at: 2.days.ago)
 
     assert_not Patient.reminder_eligible.find_by(id: patient.id).nil?
-  end
-
-  test 'exposure dont send report with continuous exposure' do
-    # patient was created more than 24 hours ago
-    Patient.destroy_all
-    patient = create(:patient, monitoring: true, purged: false, isolation: false, created_at: 2.days.ago, continuous_exposure: false)
-
-    assert Patient.reminder_eligible.find_by(id: patient.id).nil?
   end
 
   test 'address timezone offset' do


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-724](https://tracker.codev.mitre.org/browse/SARAALERT-724)

**This PR addresses the following:**
- A bug where HoHs that are out of the monitoring period (current date is > LDE+14) will not receive notifications for active dependents. This is because of an extra check we were doing in the `reminder_eligible` scope that wasn't necessary given the [checks](https://github.com/SaraAlert/SaraAlert/blob/bcd8152b71d57520f66362854053370ef301413f/app/models/patient.rb#L456) done currently in `send_assessment`.

    For context: `monitoring` is true for a given patient in the following cases (assuming not purged and not manually closed):
     - within monitoring period (LDE + 14 days) (exposure workflow)
     - continuous_exposure is true (exposure workflow)
     - in isolation (isolation workflow)

- Addresses a bug in our Patient mailers where if the HoH was closed but had actively monitored dependents, the HoH was still being included in sent out assessments.
- Makes `continuous_exposure` false when a record is manually closed - this makes it so if `monitoring` is false, then we know `continuous_exposure` is false.
- Adds a new experimental `optimal_reminder_eligible` scope that may eventually replace the current reminder_eligible scope, along with tests for it. This scope brings in more checks from send_assessment (that could eventually be removed with this scope), and consolidates the logic more. Ideally, it would also be able to check if a given patient or any of their dependents are being monitored, but that isn't there yet. 

# Important Changes
`app/controllers/patients_controller.rb`
- Set `continuous_exposure` to be false when the patient is no longer being monitored.

app/mailers/patient_mailer.rb
- No longer appending `[patient]` to the list of patients as patient.dependents.where(monitoring: true) will capture the HoH if they are currently being monitored. 

`app/models/patient.rb`
- Removed a check from the reminder_eligible scope that is handled in send_assessment. This check is just checking if the patient is being monitored, which is checked in send_assessment in addition to whether or not any of their dependents are being monitored. 
- Added a new `optimal_reminder_eligible` scope **not being used yet** until we feel it's safe to do so (fully tested).

test/models/patient_test.rb
- Added tests for the `optimal_reminder_eligible` scope.
- Removed tests that weren't needed/correct. These tests were explicitly checking `continuous_exposure`, and that a patient shouldn't be included in the reminder_eligible scope if `continuous_exposure` is false or nil which is not the case if monitoring = true.

# Testing
Automated tests cover a lot, but will certainly need to test extensively on demo. Especially that the notifications are sent to the right people given the mailer and scope updates. Can test the `continuous_exposure` change by manually closing a record in continuous exposure and verifying that they are no longer in continuous exposure.
