### PR TITLE
Added watermark for demo instances

### DIFF
--- a/app/javascript/packs/stylesheets/bootstrap.scss
+++ b/app/javascript/packs/stylesheets/bootstrap.scss
@@ -13,7 +13,8 @@ body {
 }
 
 .demo-bg {
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='100px' width='100px'><text transform='translate(20, 100) rotate(-45)' fill='rgb(220,220,220)' font-size='30'>DEMO</text></svg>");
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20version%3D%271.1%27%20height%3D%27100px%27%20width%3D%27100px%27%3E%3Ctext%20transform%3D%27translate(20%2C%20100)%20rotate(-45)%27%20fill%3D%27rgb(220%2C220%2C220)%27%20font-size%3D%2730%27%3EDEMO%3C%2Ftext%3E%3C%2Fsvg%3E");
+  background-size: 100px 100px;
 }
 
 .btn.btn-square {

--- a/app/javascript/packs/stylesheets/bootstrap.scss
+++ b/app/javascript/packs/stylesheets/bootstrap.scss
@@ -12,6 +12,10 @@ body {
   background-color: #f5f5f5 !important;
 }
 
+.demo-bg {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='100px' width='100px'><text transform='translate(20, 100) rotate(-45)' fill='rgb(220,220,220)' font-size='30'>DEMO</text></svg>");
+}
+
 .btn.btn-square {
   border-radius: 0;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
   <%= render 'layouts/html_head' %>
-  <body id="sara-alert-body">
+  <body id="sara-alert-body" class="<%= ENV['SHOW_DEMO_WARNING'].present? ? 'demo-bg' : '' %>">
     <%= render 'layouts/header' %>
     <div class="container-fluid">
       <%= yield %>


### PR DESCRIPTION
# Description

Adds a watermark to explicitly indicate (beyond the yellow warning banner) that a demo instance is a demo instance.

# (Feature) Demo/Screenshots
<img width="1480" alt="Screen Shot 2020-08-24 at 4 51 11 PM" src="https://user-images.githubusercontent.com/14923551/91095424-58242480-e62a-11ea-9152-223ba7c4473a.png">

# Important Changes

`app/views/layouts/application.html.erb`
- Inject background css class if in demo mode

`app/javascript/packs/stylesheets/bootstrap.scss`
- Added SVG based background for demo mode

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [x] Firefox
* [x] Safari
* [x] IE11
