### PR TITLE
Fixed logic for edge case in ConsumeAssessmentJob and broke logic out into new Patient method.

### DIFF
--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -85,7 +85,7 @@ class ConsumeAssessmentsJob < ApplicationJob
         else
           # If message['reported_symptoms_array'] is not populated then this assessment came in through
           # a generic channel ie: SMS where monitorees are asked YES/NO if they are experiencing symptoms
-          ([patient] + (patient&.dependents&.where(monitoring: true) || [])).uniq.each do |pat|
+          (patient.active_dependents || [])).uniq.each do |pat|
             typed_reported_symptoms = if message['experiencing_symptoms']
                                         # Remove values so that the values will appear as blank in a symptomatic report
                                         # this will indicate that the person needs to be reached out to to get the actual values

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -85,7 +85,7 @@ class ConsumeAssessmentsJob < ApplicationJob
         else
           # If message['reported_symptoms_array'] is not populated then this assessment came in through
           # a generic channel ie: SMS where monitorees are asked YES/NO if they are experiencing symptoms
-          (patient.active_dependents || [])).uniq.each do |pat|
+          patient.active_dependents.uniq.each do |pat|
             typed_reported_symptoms = if message['experiencing_symptoms']
                                         # Remove values so that the values will appear as blank in a symptomatic report
                                         # this will indicate that the person needs to be reached out to to get the actual values

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -9,7 +9,7 @@ class PatientMailer < ApplicationMailer
 
     # Gather patients and jurisdictions
     # patient.dependents includes the patient themselves if patient.id = patient.responder_id (which should be the case)
-    @patients = patient.dependents.where('monitoring = ? OR continuous_exposure = ?', true, true).uniq.collect do |p|
+    @patients = patient.active_dependents.uniq.collect do |p|
       { patient: p, jurisdiction_unique_id: Jurisdiction.find_by_id(p.jurisdiction_id).unique_identifier }
     end
     @lang = patient.select_language
@@ -75,7 +75,7 @@ class PatientMailer < ApplicationMailer
 
     num = patient.primary_telephone
     # patient.dependents includes the patient themselves if patient.id = patient.responder_id (which should be the case)
-    patient.dependents.where('monitoring = ? OR continuous_exposure = ?', true, true).uniq.each do |p|
+    patient.active_dependents.uniq.each do |p|
       lang = p.select_language
       patient_name = "#{p&.first_name&.first || ''}#{p&.last_name&.first || ''}-#{p&.calc_current_age || '0'}"
       intro_contents = "#{I18n.t('assessments.sms.weblink.intro1', locale: lang)} #{patient_name} #{I18n.t('assessments.sms.weblink.intro2', locale: lang)}"
@@ -133,13 +133,13 @@ class PatientMailer < ApplicationMailer
 
     lang = patient.select_language
     # patient.dependents includes the patient themselves if patient.id = patient.responder_id (which should be the case)
-    patient_names = patient.dependents.where('monitoring = ? OR continuous_exposure = ?', true, true).uniq.collect do |p|
+    patient_names = patient.active_dependents.uniq.collect do |p|
       "#{p&.first_name&.first || ''}#{p&.last_name&.first || ''}-#{p&.calc_current_age || '0'}"
     end
     contents = I18n.t('assessments.sms.prompt.daily1', locale: lang) + patient_names.join(', ') + '.'
 
     # Prepare text asking about anyone in the group
-    contents += if patient.dependents.where('monitoring = ? OR continuous_exposure = ?', true, true).uniq.count > 1
+    contents += if patient.active_dependents.uniq.count > 1
                   I18n.t('assessments.sms.prompt.daily2-p', locale: lang)
                 else
                   I18n.t('assessments.sms.prompt.daily2-s', locale: lang)
@@ -179,13 +179,13 @@ class PatientMailer < ApplicationMailer
     lang = patient.select_language
     lang = :en if %i[so].include?(lang) # Some languages are not supported via voice
     # patient.dependents includes the patient themselves if patient.id = patient.responder_id (which should be the case)
-    patient_names = patient.dependents.where('monitoring = ? OR continuous_exposure = ?', true, true).uniq.collect do |p|
+    patient_names = patient.active_dependents.uniq.collect do |p|
       "#{p&.first_name&.first || ''}, #{p&.last_name&.first || ''}, #{I18n.t('assessments.phone.age', locale: lang)} #{p&.calc_current_age || '0'},"
     end
     contents = I18n.t('assessments.phone.daily1', locale: lang) + patient_names.join(', ')
 
     # Prepare text asking about anyone in the group
-    contents += if patient.dependents.where('monitoring = ? OR continuous_exposure = ?', true, true).uniq.count > 1
+    contents += if patient.active_dependents.uniq.count > 1
                   I18n.t('assessments.phone.daily2-p', locale: lang)
                 else
                   I18n.t('assessments.phone.daily2-s', locale: lang)
@@ -226,7 +226,7 @@ class PatientMailer < ApplicationMailer
     @lang = patient.select_language
     # Gather patients and jurisdictions
     # patient.dependents includes the patient themselves if patient.id = patient.responder_id (which should be the case)
-    @patients = patient.dependents.where('monitoring = ? OR continuous_exposure = ?', true, true).uniq.collect do |p|
+    @patients = patient.active_dependents.uniq.collect do |p|
       { patient: p, jurisdiction_unique_id: Jurisdiction.find_by_id(p.jurisdiction_id).unique_identifier }
     end
     mail(to: patient.email&.strip, subject: I18n.t('assessments.email.reminder.subject', locale: @lang || :en)) do |format|

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -430,6 +430,11 @@ class Patient < ApplicationRecord
     jurisdiction&.path&.map(&:name)
   end
 
+  # Get all dependents (including self if id = responder_id) that are being monitored or in continuous exposure
+  def active_dependents
+    dependents.where('monitoring = ? OR continuous_exposure = ?', true, true)
+  end
+
   # Get this patient's dependents excluding itself
   def dependents_exclude_self
     dependents.where.not(id: id)


### PR DESCRIPTION
# Description
Jira Ticket: N/A

**This PR does the following:**
- Fixes bug in ConsumeAssessmentsJob where assessments wouldn't be made for a patient after they responded if they were closed but had continuous_monitoring toggled on. 
- Breaks out logic checking for what I've been calling "active dependents" into a Patient model method to avoid this in the future. Basically, this check is necessary in these places because there could be dependents (including the HoH) that are not being monitored that no longer are eligible for an assessment within a household. All of the other notification eligibility checks for the HoH will have been done prior. 

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/jobs/consume_assessments_job.rb` and `app/mailers/patient_mailer.rb`
- Now use the `active_dependents` method

`app/models/patient.rb`
- Added new method for this check.

# Testing
- Run the PatientMailer methods on Patients with dependents and different monitoring and continuous_exposure statuses and make sure they ask for assessments for the right patients. Specifically, if the HoH is not being monitored or in continuous_exposure, but has dependents that are, it should send an assessment asking for those dependents but not for the HoH themselves. 
- Run the consumeAssessmentsJob and make sure it creates assessments for the appropriate patients - test on similar cases to the above. This can be tested on demo too.

