### PR TITLE
Change scope used within purge job to not purge a head of household u…

### DIFF
--- a/app/jobs/purge_job.rb
+++ b/app/jobs/purge_job.rb
@@ -13,7 +13,7 @@ class PurgeJob < ApplicationJob
 
     # Loop through and purge
     eligible.find_each do |monitoree|
-      next if monitoree.dependents_exclude_self.where(monitoring: true).count.positive?
+      next if monitoree.active_dependents.count.positive?
 
       # Whitelist attributes to keep
       attributes = Patient.new.attributes.keys


### PR DESCRIPTION
…nless both monitoring or continuous exposure is true

# Description
Jira Ticket: None

Will not purge head of household if their dependent is in continuous exposure.

# Important Changes
Uses `active_dependents` scope in `purge_job.rb`

