### PR TITLE
Omit USA jurisdiction from jurisdictionPaths

### DIFF
--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -19,7 +19,7 @@
       has_group_members: @group_members.exists?,
       in_a_group: @all_group_members.count > 1,
       patient: @patient,
-      jurisdictionPaths: Hash[Jurisdiction.all.pluck(:id, :path).map {|id, path| [id, path]}],
+      jurisdictionPaths: Hash[Jurisdiction.all.where.not(name: "USA").pluck(:id, :path).map {|id, path| [id, path]}],
       assignedUsers: @patient.jurisdiction.assigned_users,
       isolation: @patient.isolation
       }) %>


### PR DESCRIPTION
# Description
https://tracker.codev.mitre.org/browse/SARAALERT-598

Write out a concise summary of this pull request and what it addresses.
"USA" should not show up in the Jurisdiction transfer list in the patient view page


# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.

Open up a patient, search  for "USA", in the jurisdiction list, it should not be there.
