### PR TITLE
Update Rubocop to v0.89

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -83,3 +83,31 @@ Lint/DuplicateElsifCondition:
   Enabled: true
 Style/ArrayCoercion:
   Enabled: true
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+Lint/DuplicateRescueException:
+  Enabled: true
+Lint/EmptyConditionalBody:
+  Enabled: true
+Lint/FloatComparison:
+  Enabled: true
+Lint/MissingSuper:
+  Enabled: true
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+Lint/SelfAssignment:
+  Enabled: true
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+Lint/UnreachableLoop:
+  Enabled: true
+Style/StringConcatenation:
+  Enabled: false
+Style/SingleArgumentDig:
+  Enabled: true
+Style/OptionalBooleanParameter:
+  Enabled: true
+Style/GlobalStdStream:
+  Enabled: true
+Style/ExplicitBlockArgument:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,3 +71,15 @@ Style/RedundantRegexpEscape:
   Enabled: true
 Style/SlicingWithRange:
   Enabled: true
+Style/HashLikeCase:
+  Enabled: true
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+Style/CaseLikeIf:
+  Enabled: true
+Style/HashAsLastArrayItem:
+  Enabled: true
+Lint/DuplicateElsifCondition:
+  Enabled: true
+Style/ArrayCoercion:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -111,3 +111,5 @@ Style/GlobalStdStream:
   Enabled: true
 Style/ExplicitBlockArgument:
   Enabled: true
+Style/SoleNestedConditional:
+  Enabled: true

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -16,13 +16,13 @@ class AssessmentsController < ApplicationController
     @assessment = Assessment.new
 
     # If monitoree, limit number of reports per time period
-    if current_user.nil?
-      if AssessmentReceipt.where(submission_token: @patient_submission_token)
-                          .where('created_at >= ?', ADMIN_OPTIONS['reporting_limit'].minutes.ago).exists?
-        redirect_to(already_reported_report_url) && return if ADMIN_OPTIONS['report_mode']
+    if current_user.nil? && AssessmentReceipt.where(submission_token: @patient_submission_token)
+                                             .where('created_at >= ?', ADMIN_OPTIONS['reporting_limit'].minutes.ago)
+                                             .exists?
 
-        redirect_to(already_reported_url) && return
-      end
+      redirect_to(already_reported_report_url) && return if ADMIN_OPTIONS['report_mode']
+
+      redirect_to(already_reported_url) && return
     end
 
     # Figure out the jurisdiction to know which symptoms to render
@@ -133,8 +133,8 @@ class AssessmentsController < ApplicationController
     typed_reported_symptoms.each do |symptom|
       new_val = symptom.bool_value
       old_val = assessment.reported_condition&.symptoms&.find_by(name: symptom.name)&.bool_value
-      unless new_val.nil? || old_val.nil?
-        delta << symptom.name + '=' + (new_val ? 'Yes' : 'No') if new_val != old_val
+      if (!new_val.nil? || !old_val.nil?) && new_val != old_val
+        delta << symptom.name + '=' + (new_val ? 'Yes' : 'No')
       end
     end
 

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -133,7 +133,7 @@ class AssessmentsController < ApplicationController
     typed_reported_symptoms.each do |symptom|
       new_val = symptom.bool_value
       old_val = assessment.reported_condition&.symptoms&.find_by(name: symptom.name)&.bool_value
-      if (!new_val.nil? || !old_val.nil?) && new_val != old_val
+      if new_val.present? && old_val.present? && new_val != old_val
         delta << symptom.name + '=' + (new_val ? 'Yes' : 'No')
       end
     end

--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -133,7 +133,8 @@ class ImportController < ApplicationController
   private
 
   def validate_headers(format, headers)
-    if format == :comprehensive_monitorees
+    case format
+    when :comprehensive_monitorees
       COMPREHENSIVE_HEADERS.each_with_index do |field, col_num|
         next if field == headers[col_num]
 
@@ -141,7 +142,7 @@ class ImportController < ApplicationController
                   'Please make sure to use the latest format specified by the Sara Alert Format guidance doc.'
         raise ValidationError.new(err_msg, 1)
       end
-    elsif format == :epix
+    when :epix
       EPI_X_HEADERS.each_with_index do |field, col_num|
         next if field == headers[col_num]
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -454,7 +454,7 @@ class PatientsController < ApplicationController
     patient = current_user.get_patient(params.permit(:id)[:id])
     redirect_to(root_url) && return if patient.nil?
 
-    patient.send_assessment(true)
+    patient.send_assessment(force: true)
 
     History.report_reminder(patient: patient, created_by: current_user)
   end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -127,9 +127,7 @@ class PatientsController < ApplicationController
     # Default responder to self if no responder condition met
     patient.responder = patient if patient.responder.nil?
 
-    if params.permit(:responder_id)[:responder_id]
-      patient.responder = patient.responder.responder if patient.responder.responder_id != patient.responder.id
-    end
+    patient.responder = patient.responder.responder if params.permit(:responder_id)[:responder_id] && (patient.responder.responder_id != patient.responder.id)
 
     # Set the creator as the current user
     patient.creator = current_user

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -183,7 +183,7 @@ class PublicHealthController < ApplicationController
     when 'symptom_onset'
       patients = patients.order('CASE WHEN symptom_onset IS NULL THEN 1 ELSE 0 END, symptom_onset ' + dir)
     when 'risk_level'
-      patients = patients.order_by_risk(dir == 'asc')
+      patients = patients.order_by_risk(asc: dir == 'asc')
     when 'monitoring_plan'
       patients = patients.order('CASE WHEN monitoring_plan IS NULL THEN 1 ELSE 0 END, monitoring_plan ' + dir)
     when 'public_health_action'

--- a/app/jobs/close_subjects_job.rb
+++ b/app/jobs/close_subjects_job.rb
@@ -29,9 +29,9 @@ class CloseSubjectsJob < ApplicationJob
           subject[:monitoring] = false
           subject.closed_at = DateTime.now
           subject[:monitoring_reason] = 'Completed Monitoring'
-          if subject.save! && subject.email.present?
-            PatientMailer.closed_email(subject).deliver_later if subject.self_reporter_or_proxy?
-          end
+
+          PatientMailer.closed_email(subject).deliver_later if subject.save! && subject.email.present? && subject.self_reporter_or_proxy?
+
           History.record_automatically_closed(patient: subject)
           closed << { id: subject.id }
         rescue StandardError => e

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -27,7 +27,8 @@ class ConsumeAssessmentsJob < ApplicationJob
         # Get list of dependents excluding the patient itself.
         dependents = patient.dependents_exclude_self
 
-        if message['response_status'] == 'no_answer_voice'
+        case message['response_status']
+        when 'no_answer_voice'
           # If nobody answered, nil out the last_reminder_sent field so the system will try calling again
           patient.update(last_assessment_reminder_sent: nil)
           History.contact_attempt(patient: patient, comment: "Sara Alert called this monitoree's primary telephone \
@@ -38,7 +39,7 @@ class ConsumeAssessmentsJob < ApplicationJob
           end
 
           next
-        elsif message['response_status'] == 'no_answer_sms'
+        when 'no_answer_sms'
           # No need to wipe out last_assessment_reminder_sent so that another sms will be sent because the sms studio flow is kept open for 18hrs
           History.contact_attempt(patient: patient, comment: "Sara Alert texted this monitoree's primary telephone \
                                                              number #{patient.primary_telephone} during their preferred \
@@ -49,7 +50,7 @@ class ConsumeAssessmentsJob < ApplicationJob
           end
 
           next
-        elsif message['response_status'] == 'error_voice'
+        when 'error_voice'
           # If there was an error in completeing the call, nil out the last_reminder_sent field so the system will try calling again
           patient.update(last_assessment_reminder_sent: nil)
           History.contact_attempt(patient: patient, comment: "Sara Alert was unable to complete a call to this \
@@ -60,7 +61,7 @@ class ConsumeAssessmentsJob < ApplicationJob
           end
 
           next
-        elsif message['response_status'] == 'error_sms'
+        when 'error_sms'
           # If there was an error sending an SMS, nil out the last_reminder_sent field so the system will try calling again
           patient.update(last_assessment_reminder_sent: nil)
           History.contact_attempt(patient: patient, comment: "Sara Alert was unable to send an SMS to this monitoree's \

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -20,9 +20,8 @@ class ConsumeAssessmentsJob < ApplicationJob
         next if patient.nil?
 
         # Prevent duplicate patient assessment spam
-        unless patient.latest_assessment.nil? # Only check for latest assessment if there is one
-          next if patient.latest_assessment.created_at > ADMIN_OPTIONS['reporting_limit'].minutes.ago
-        end
+        # Only check for latest assessment if there is one
+        next if !patient.latest_assessment.nil? && (patient.latest_assessment.created_at > ADMIN_OPTIONS['reporting_limit'].minutes.ago)
 
         # Get list of dependents excluding the patient itself.
         dependents = patient.dependents_exclude_self

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -48,14 +48,15 @@ class Assessment < ApplicationRecord
     threshold_operator = threshold_symptom&.threshold_operator&.downcase
     threshold_operator ||= 'less than'
 
-    if reported_symptom.type == 'FloatSymptom' || reported_symptom.type == 'IntegerSymptom'
+    case reported_symptom.type
+    when 'FloatSymptom', 'IntegerSymptom'
       return true if threshold_operator == 'less than' && reported_symptom.value < threshold_symptom.value
       return true if threshold_operator == 'less than or equal' && reported_symptom.value <= threshold_symptom.value
       return true if threshold_operator == 'greater than' && reported_symptom.value > threshold_symptom.value
       return true if threshold_operator == 'greater than or equal' && reported_symptom.value >= threshold_symptom.value
       return true if threshold_operator == 'equal' && reported_symptom.value == threshold_symptom.value
       return true if threshold_operator == 'not equal' && reported_symptom.value != threshold_symptom.value
-    elsif reported_symptom.type == 'BoolSymptom'
+    when 'BoolSymptom'
       return reported_symptom.value != threshold_symptom.value if threshold_operator == 'not equal'
       # Bool symptom threshold_operator will fall back to equal
       return true if reported_symptom.value == threshold_symptom.value
@@ -104,15 +105,16 @@ class Assessment < ApplicationRecord
       subject: FHIR::Reference.new(reference: "Patient/#{patient_id}"),
       status: 'completed',
       item: reported_condition.symptoms.enum_for(:each_with_index).collect do |s, index|
-        if s.type == 'IntegerSymptom'
+        case s.type
+        when 'IntegerSymptom'
           FHIR::QuestionnaireResponse::Item.new(text: s.name,
                                                 answer: FHIR::QuestionnaireResponse::Item::Answer.new(valueInteger: s.int_value),
                                                 linkId: index.to_s)
-        elsif s.type == 'FloatSymptom'
+        when 'FloatSymptom'
           FHIR::QuestionnaireResponse::Item.new(text: s.name,
                                                 answer: FHIR::QuestionnaireResponse::Item::Answer.new(valueDecimal: s.float_value),
                                                 linkId: index.to_s)
-        elsif s.type == 'BoolSymptom'
+        when 'BoolSymptom'
           FHIR::QuestionnaireResponse::Item.new(text: s.name,
                                                 answer: FHIR::QuestionnaireResponse::Item::Answer.new(valueBoolean: s.bool_value),
                                                 linkId: index.to_s)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -369,7 +369,7 @@ class Patient < ApplicationRecord
   }
 
   # Order individuals based on their public health assigned risk assessment
-  def self.order_by_risk(asc = true)
+  def self.order_by_risk(asc: true)
     order_by = ["WHEN exposure_risk_assessment='High' THEN 0",
                 "WHEN exposure_risk_assessment='Medium' THEN 1",
                 "WHEN exposure_risk_assessment='Low' THEN 2",
@@ -481,7 +481,7 @@ class Patient < ApplicationRecord
   end
 
   # Send a daily assessment to this monitoree
-  def send_assessment(force = false)
+  def send_assessment(force: false)
     return if ['Unknown', 'Opt-out', '', nil].include?(preferred_contact_method)
 
     unless last_assessment_reminder_sent.nil?

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -484,9 +484,7 @@ class Patient < ApplicationRecord
   def send_assessment(force: false)
     return if ['Unknown', 'Opt-out', '', nil].include?(preferred_contact_method)
 
-    unless last_assessment_reminder_sent.nil?
-      return if last_assessment_reminder_sent > 12.hours.ago
-    end
+    return if !last_assessment_reminder_sent.nil? && last_assessment_reminder_sent > 12.hours.ago
 
     # Do not allow messages to go to household members
     return unless responder_id == id
@@ -602,12 +600,10 @@ class Patient < ApplicationRecord
     end
 
     # Exposure workflow specific conditions
-    unless isolation
-      # Monitoring period has elapsed
-      if (!last_date_of_exposure.nil? && last_date_of_exposure < reporting_period) && !continuous_exposure
-        eligible = false
-        messages << { message: "Monitoree\'s monitoring period has elapsed and continuous exposure is not enabled", datetime: nil }
-      end
+    # Monitoring period has elapsed
+    if !isolation && (!last_date_of_exposure.nil? && last_date_of_exposure < reporting_period) && !continuous_exposure
+      eligible = false
+      messages << { message: "Monitoree\'s monitoring period has elapsed and continuous exposure is not enabled", datetime: nil }
     end
 
     # Has already been contacted today

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -511,11 +511,12 @@ class Patient < ApplicationRecord
       morning = (8..12)
       afternoon = (12..16)
       evening = (16..19)
-      if preferred_contact_time == 'Morning'
+      case preferred_contact_time
+      when 'Morning'
         return unless morning.include? hour
-      elsif preferred_contact_time == 'Afternoon'
+      when 'Afternoon'
         return unless afternoon.include? hour
-      elsif preferred_contact_time == 'Evening'
+      when 'Evening'
         return unless evening.include? hour
       end
     end
@@ -625,11 +626,12 @@ class Patient < ApplicationRecord
 
     # Rough estimate of next contact time
     if eligible
-      messages << if preferred_contact_time == 'Morning'
+      messages << case preferred_contact_time
+                  when 'Morning'
                     { message: '8:00 AM local time (Morning)', datetime: nil }
-                  elsif preferred_contact_time == 'Afternoon'
+                  when 'Afternoon'
                     { message: '12:00 PM local time (Afternoon)', datetime: nil }
-                  elsif preferred_contact_time == 'Evening'
+                  when 'Evening'
                     { message: '4:00 PM local time (Evening)', datetime: nil }
                   else
                     { message: 'Today', datetime: nil }

--- a/app/models/symptom.rb
+++ b/app/models/symptom.rb
@@ -26,9 +26,10 @@ class Symptom < ApplicationRecord
 
   def bool_based_prompt(lang = :en)
     I18n.backend.send(:init_translations) unless I18n.backend.initialized?
-    if type == 'BoolSymptom'
+    case type
+    when 'BoolSymptom'
       I18n.t("assessments.symptoms.#{name}.name", locale: lang)
-    elsif type == 'IntegerSymptom' || type == 'FloatSymptom'
+    when 'IntegerSymptom', 'FloatSymptom'
       [
         I18n.t("assessments.symptoms.#{name}.name", locale: lang),
         I18n.t("assessments.threshold-op.#{threshold_operator.parameterize}", locale: lang), value
@@ -43,11 +44,12 @@ class Symptom < ApplicationRecord
   end
 
   def value
-    if type == 'BoolSymptom'
+    case type
+    when 'BoolSymptom'
       bool_value
-    elsif type == 'IntegerSymptom'
+    when 'IntegerSymptom'
       int_value
-    elsif type == 'FloatSymptom'
+    when 'FloatSymptom'
       float_value
     end
   end

--- a/test/system/lib/system_test_utils.rb
+++ b/test/system/lib/system_test_utils.rb
@@ -30,7 +30,7 @@ class SystemTestUtils < ApplicationSystemTestCase
     click_on 'Logout'
   end
 
-  def return_to_dashboard(workflow, is_epi = true)
+  def return_to_dashboard(workflow, is_epi: true)
     if !is_epi
       click_on 'Return To Dashboard'
     elsif !workflow.nil?
@@ -48,12 +48,12 @@ class SystemTestUtils < ApplicationSystemTestCase
     find("##{tab}_tab").click
   end
 
-  def go_to_next_page(wait = true)
+  def go_to_next_page(wait: true)
     wait_for_enrollment_page_transition if wait
     click_on 'Next'
   end
 
-  def go_to_prev_page(wait = true)
+  def go_to_prev_page(wait: true)
     wait_for_enrollment_page_transition if wait
     click_on 'Previous'
   end

--- a/test/system/roles/admin/admin_test_helper.rb
+++ b/test/system/roles/admin/admin_test_helper.rb
@@ -15,21 +15,21 @@ class AdminTestHelper < ApplicationSystemTestCase
     jurisdiction_id = @@system_test_utils.login(user_label)
     User.where(jurisdiction_id: Jurisdiction.find(jurisdiction_id).subtree_ids).each do |user|
       @@admin_dashboard.search_for_user(user.email)
-      @@admin_dashboard_verifier.verify_user(user, true)
+      @@admin_dashboard_verifier.verify_user(user, should_exist: true)
     end
     User.where.not(jurisdiction_id: Jurisdiction.find(jurisdiction_id).subtree_ids).each do |user|
       @@admin_dashboard.search_for_user(user.email)
-      @@admin_dashboard_verifier.verify_user(user, false)
+      @@admin_dashboard_verifier.verify_user(user, should_exist: false)
     end
     @@system_test_utils.logout
   end
 
-  def add_user(user_data, submit = true)
+  def add_user(user_data, submit: true)
     @@system_test_utils.login(user_data[:label])
     Capybara.using_wait_time(4) do
-      @@admin_dashboard.add_user(user_data, submit)
+      @@admin_dashboard.add_user(user_data, submit: submit)
       @@admin_dashboard.search_for_user(user_data[:email])
-      @@admin_dashboard_verifier.verify_add_user(user_data, submit)
+      @@admin_dashboard_verifier.verify_add_user(user_data, submit: submit)
     end
     @@system_test_utils.logout
   end

--- a/test/system/roles/admin/dashboard/dashboard.rb
+++ b/test/system/roles/admin/dashboard/dashboard.rb
@@ -9,7 +9,7 @@ class AdminDashboard < ApplicationSystemTestCase
   @@admin_dashboard_verifier = AdminDashboardVerifier.new(nil)
   @@system_test_utils = SystemTestUtils.new(nil)
 
-  def add_user(user_data, submit = true)
+  def add_user(user_data, submit: true)
     # Remove fade animation from Bootstrap modal
     # NOTE: This can apparently affect Capybara's fill_in functionality and more
     page.execute_script("$('user-modal').css('transition','none')")

--- a/test/system/roles/admin/dashboard/dashboard_verifier.rb
+++ b/test/system/roles/admin/dashboard/dashboard_verifier.rb
@@ -7,7 +7,7 @@ require_relative '../../../lib/system_test_utils'
 class AdminDashboardVerifier < ApplicationSystemTestCase
   @@system_test_utils = SystemTestUtils.new(nil)
 
-  def verify_user(user, should_exist = true)
+  def verify_user(user, should_exist: true)
     Capybara.using_wait_time(4) do
       if should_exist
         assert page.has_content?(user.email), @@system_test_utils.get_err_msg('User info', 'email', user.email)
@@ -20,7 +20,7 @@ class AdminDashboardVerifier < ApplicationSystemTestCase
     end
   end
 
-  def verify_add_user(user_data, submit = true)
+  def verify_add_user(user_data, submit: true)
     if submit
       assert page.has_content?(user_data[:email]), @@system_test_utils.get_err_msg('New user info', 'email', user_data[:email])
       assert page.has_content?(user_data[:jurisdiction]), @@system_test_utils.get_err_msg('New user info', 'jurisdiction', user_data[:jurisdiction])

--- a/test/system/roles/enroller/dashboard/dashboard_verifier.rb
+++ b/test/system/roles/enroller/dashboard/dashboard_verifier.rb
@@ -39,31 +39,34 @@ class EnrollerDashboardVerifier < ApplicationSystemTestCase
     end
   end
 
-  def verify_monitoree_info_on_dashboard(monitoree, is_epi = false, go_back = true)
+  def verify_monitoree_info_on_dashboard(monitoree, is_epi: false, go_back: true)
     displayed_name = search_for_monitoree(monitoree, is_epi)
     click_on displayed_name
-    @@enroller_patient_page_verifier.verify_monitoree_info(monitoree, is_epi)
-    @@system_test_utils.return_to_dashboard('exposure', is_epi) if go_back
+    @@enroller_patient_page_verifier.verify_monitoree_info(monitoree, is_epi: is_epi)
+    @@system_test_utils.return_to_dashboard('exposure', is_epi: is_epi) if go_back
   end
 
-  def verify_group_member_on_dashboard(existing_monitoree, new_monitoree, is_epi = false)
+  def verify_group_member_on_dashboard(existing_monitoree, new_monitoree, is_epi: false)
     displayed_name = search_for_monitoree(new_monitoree, is_epi)
     click_on displayed_name
-    @@enroller_patient_page_verifier.verify_group_member_info(existing_monitoree, new_monitoree, is_epi)
+    @@enroller_patient_page_verifier.verify_group_member_info(existing_monitoree, new_monitoree, is_epi: is_epi)
     click_on 'Click here to view that monitoree'
-    @@enroller_patient_page_verifier.verify_monitoree_info(existing_monitoree, is_epi)
-    @@system_test_utils.return_to_dashboard('exposure', is_epi)
+    @@enroller_patient_page_verifier.verify_monitoree_info(existing_monitoree, is_epi: is_epi)
+    @@system_test_utils.return_to_dashboard('exposure', is_epi: is_epi)
   end
 
-  def verify_monitoree_info_not_on_dashboard(monitoree, is_epi = false)
+  def verify_monitoree_info_not_on_dashboard(monitoree, is_epi: false)
     displayed_birthday = monitoree['identification']['date_of_birth']
-    search_and_verify_nonexistence("#{monitoree['identification']['first_name']} #{monitoree['identification']['last_name']} #{displayed_birthday}", is_epi)
+    search_and_verify_nonexistence("#{monitoree['identification']['first_name']} #{monitoree['identification']['last_name']} #{displayed_birthday}",
+                                   is_epi)
   end
 
   def search_for_monitoree(monitoree, is_epi)
     displayed_name = @@system_test_utils.get_displayed_name(monitoree)
-    search_and_verify_existence(monitoree['identification']['first_name'], displayed_name, monitoree['identification']['date_of_birth'], is_epi)
-    search_and_verify_existence(monitoree['identification']['last_name'], displayed_name, monitoree['identification']['date_of_birth'], is_epi)
+    search_and_verify_existence(monitoree['identification']['first_name'], displayed_name, monitoree['identification']['date_of_birth'],
+                                is_epi)
+    search_and_verify_existence(monitoree['identification']['last_name'], displayed_name, monitoree['identification']['date_of_birth'],
+                                is_epi)
     displayed_name
   end
 

--- a/test/system/roles/enroller/enroller_dashboard_test.rb
+++ b/test/system/roles/enroller/enroller_dashboard_test.rb
@@ -22,6 +22,30 @@ class EnrollerTest < ApplicationSystemTestCase
     @@enroller_test_helper.view_enrollment_analytics('state1_enroller')
   end
 
+  test 'enroll monitoree with all fields' do
+    @@enroller_test_helper.enroll_monitoree('state1_epi_enroller', 'monitoree_2', is_epi: true)
+  end
+
+  test 'enroll monitoree with only required fields' do
+    @@enroller_test_helper.enroll_monitoree('locals1c2_enroller', 'monitoree_3')
+  end
+
+  test 'enroll monitoree with jurisdiction within hierarchy' do
+    @@enroller_test_helper.enroll_monitoree('state1_enroller', 'monitoree_5')
+  end
+
+  test 'epi enroll monitoree with any jurisdiction' do
+    @@enroller_test_helper.enroll_monitoree('state1_epi_enroller', 'monitoree_1', is_epi: true)
+  end
+
+  test 'add group member' do
+    @@enroller_test_helper.enroll_group_member('state2_enroller', 'monitoree_6', 'monitoree_7')
+  end
+
+  test 'add group member with foreign address and international additional planned travel' do
+    @@enroller_test_helper.enroll_group_member('locals2c3_enroller', 'monitoree_4', 'monitoree_9')
+  end
+
   test 'copy home address to monitored address' do
     @@enroller_test_helper.enroll_monitoree_with_same_monitored_address('state2_enroller', 'monitoree_10')
   end

--- a/test/system/roles/enroller/enroller_enrollment_test.rb
+++ b/test/system/roles/enroller/enroller_enrollment_test.rb
@@ -10,7 +10,7 @@ class EnrollerTest < ApplicationSystemTestCase
   @@enroller_test_helper = EnrollerTestHelper.new(nil)
 
   test 'enroll monitoree with all fields' do
-    @@enroller_test_helper.enroll_monitoree('state1_epi_enroller', 'monitoree_2', true)
+    @@enroller_test_helper.enroll_monitoree('state1_epi_enroller', 'monitoree_2', is_epi: true)
   end
 
   test 'enroll monitoree with only required fields' do
@@ -18,11 +18,11 @@ class EnrollerTest < ApplicationSystemTestCase
   end
 
   test 'enroll monitoree with jurisdiction within hierarchy' do
-    @@enroller_test_helper.enroll_monitoree('state1_enroller', 'monitoree_5', false)
+    @@enroller_test_helper.enroll_monitoree('state1_enroller', 'monitoree_5')
   end
 
   test 'epi enroll monitoree with any jurisdiction' do
-    @@enroller_test_helper.enroll_monitoree('state1_epi_enroller', 'monitoree_1', true)
+    @@enroller_test_helper.enroll_monitoree('state1_epi_enroller', 'monitoree_1', is_epi: true)
   end
 
   test 'add group member' do

--- a/test/system/roles/enroller/enroller_test_helper.rb
+++ b/test/system/roles/enroller/enroller_test_helper.rb
@@ -25,37 +25,37 @@ class EnrollerTestHelper < ApplicationSystemTestCase
     @@system_test_utils.logout
   end
 
-  def enroll_monitoree(user_label, monitoree_label, is_epi = false)
+  def enroll_monitoree(user_label, monitoree_label, is_epi: false)
     monitoree = MONITOREES[monitoree_label]
     @@system_test_utils.login(user_label)
     click_on 'Enroll New Monitoree'
     @@enrollment_form.populate_monitoree_info(monitoree)
-    @@enroller_patient_page_verifier.verify_monitoree_info(monitoree, false)
+    @@enroller_patient_page_verifier.verify_monitoree_info(monitoree, is_epi: false)
     click_on 'Finish'
     @@system_test_utils.wait_for_enrollment_submission
-    @@enroller_patient_page_verifier.verify_monitoree_info(monitoree, is_epi)
+    @@enroller_patient_page_verifier.verify_monitoree_info(monitoree, is_epi: is_epi)
     visit '/'
-    @@enroller_dashboard_verifier.verify_monitoree_info_on_dashboard(monitoree, is_epi)
+    @@enroller_dashboard_verifier.verify_monitoree_info_on_dashboard(monitoree, is_epi: is_epi)
     @@system_test_utils.logout
   end
 
-  def enroll_group_member(user_label, existing_monitoree_label, new_monitoree_label, is_epi = false)
+  def enroll_group_member(user_label, existing_monitoree_label, new_monitoree_label, is_epi: false)
     existing_monitoree = MONITOREES[existing_monitoree_label]
     new_monitoree = MONITOREES[new_monitoree_label]
     @@system_test_utils.login(user_label)
     click_link 'Enroll New Monitoree'
     @@enrollment_form.populate_monitoree_info(existing_monitoree)
-    @@enroller_patient_page_verifier.verify_monitoree_info(existing_monitoree, false)
+    @@enroller_patient_page_verifier.verify_monitoree_info(existing_monitoree)
     click_on 'Finish and Add a Household Member'
     click_on 'Continue'
     @@system_test_utils.wait_for_enrollment_submission
     @@enrollment_form.populate_monitoree_info(new_monitoree)
-    @@enroller_patient_page_verifier.verify_group_member_info(existing_monitoree, new_monitoree, false)
+    @@enroller_patient_page_verifier.verify_group_member_info(existing_monitoree, new_monitoree)
     click_on 'Finish'
     @@system_test_utils.wait_for_enrollment_submission
-    @@enroller_patient_page_verifier.verify_group_member_info(existing_monitoree, new_monitoree, is_epi)
+    @@enroller_patient_page_verifier.verify_group_member_info(existing_monitoree, new_monitoree, is_epi: is_epi)
     visit '/'
-    @@enroller_dashboard_verifier.verify_group_member_on_dashboard(existing_monitoree, new_monitoree, is_epi)
+    @@enroller_dashboard_verifier.verify_group_member_on_dashboard(existing_monitoree, new_monitoree, is_epi: is_epi)
     @@system_test_utils.logout
   end
 
@@ -64,7 +64,7 @@ class EnrollerTestHelper < ApplicationSystemTestCase
     @@system_test_utils.login(user_label)
     click_link 'Enroll New Monitoree'
     @@enrollment_form.populate_enrollment_step(:identification, monitoree['identification'])
-    @@enrollment_form.populate_enrollment_step(:address, monitoree['address'], false)
+    @@enrollment_form.populate_enrollment_step(:address, monitoree['address'], continue: false)
     click_on 'Copy from Home Address'
     @@enrollment_form_verifier.verify_home_address_copied(monitoree)
     @@system_test_utils.logout
@@ -90,7 +90,7 @@ class EnrollerTestHelper < ApplicationSystemTestCase
     @@system_test_utils.logout
   end
 
-  def enroll_monitoree_and_cancel(user_label, monitoree_label, is_epi = false)
+  def enroll_monitoree_and_cancel(user_label, monitoree_label, is_epi: false)
     monitoree = MONITOREES[monitoree_label]
     @@system_test_utils.login(user_label)
     click_link 'Enroll New Monitoree'
@@ -103,7 +103,7 @@ class EnrollerTestHelper < ApplicationSystemTestCase
     click_on 'Cancel'
     @@system_test_utils.wait_for_pop_up_alert
     page.driver.browser.switch_to.alert.accept
-    @@enroller_dashboard_verifier.verify_monitoree_info_not_on_dashboard(monitoree, is_epi)
+    @@enroller_dashboard_verifier.verify_monitoree_info_not_on_dashboard(monitoree, is_epi: is_epi)
     @@system_test_utils.logout
   end
 

--- a/test/system/roles/enroller/enrollment/form.rb
+++ b/test/system/roles/enroller/enrollment/form.rb
@@ -26,7 +26,7 @@ class EnrollmentForm < ApplicationSystemTestCase
     end
   end
 
-  def populate_enrollment_step(step, data, continue = true)
+  def populate_enrollment_step(step, data, continue: true)
     jurisdiction_change = false
     if data
       @@enrollment_form_steps.steps[step].each do |field|

--- a/test/system/roles/enroller/enrollment/form_validator.rb
+++ b/test/system/roles/enroller/enrollment/form_validator.rb
@@ -25,7 +25,7 @@ class EnrollmentFormValidator < ApplicationSystemTestCase
     verify_text_displayed('Please enter a Last Name')
     verify_text_displayed('Please enter a date of birth')
     fill_in 'date_of_birth', with: '01/05/3099'
-    @@system_test_utils.go_to_next_page(false)
+    @@system_test_utils.go_to_next_page(wait: false)
     verify_text_displayed('Date can not be in the future')
     verify_text_not_displayed('Please enter a date of birth')
     @@enrollment_form.populate_enrollment_step(:identification, identification)

--- a/test/system/roles/enroller/patient_page/patient_page_verifier.rb
+++ b/test/system/roles/enroller/patient_page/patient_page_verifier.rb
@@ -10,14 +10,14 @@ class EnrollerPatientPageVerifier < ApplicationSystemTestCase
   @@enrollment_form_steps = EnrollmentFormSteps.new(nil)
   @@system_test_utils = SystemTestUtils.new(nil)
 
-  def verify_monitoree_info(monitoree, is_epi = false)
+  def verify_monitoree_info(monitoree, is_epi: false)
     find('#patient-info-header').click if is_epi
     @@enrollment_form_steps.steps.each do |enrollment_step, enrollment_fields|
       verify_enrollment_step(monitoree[enrollment_step.to_s], enrollment_fields)
     end
   end
 
-  def verify_group_member_info(existing_monitoree, new_monitoree, is_epi = false)
+  def verify_group_member_info(existing_monitoree, new_monitoree, is_epi: false)
     find('#patient-info-header').click if is_epi
     verify_enrollment_step(new_monitoree['identification'], @@enrollment_form_steps.steps[:identification])
     verify_enrollment_step(existing_monitoree['address'], @@enrollment_form_steps.steps[:address])

--- a/test/system/roles/public_health/dashboard/dashboard.rb
+++ b/test/system/roles/public_health/dashboard/dashboard.rb
@@ -74,23 +74,24 @@ class PublicHealthDashboard < ApplicationSystemTestCase
     find('a', text: "Epi-X (#{workflow})").click
     page.attach_file(file_fixture(file_name))
     click_on 'Upload'
-    if validity == :valid
+    case validity
+    when :valid
       @@public_health_import_verifier.verify_epi_x_import_page(jurisdiction_id, workflow, file_name)
       select_monitorees_to_import(rejects, accept_duplicates)
       @@public_health_import_verifier.verify_epi_x_import_data(jurisdiction_id, workflow, file_name, rejects, accept_duplicates)
-    elsif validity == :invalid_file
+    when :invalid_file
       assert_content('Please make sure that your import file is a .xlsx file.')
       find('.modal-header').find('.close').click
-    elsif validity == :invalid_format
+    when :invalid_format
       assert_content('Please make sure that .xlsx import file is formatted in accordance with the formatting guidance.')
       find('.modal-header').find('.close').click
-    elsif validity == :invalid_headers
+    when :invalid_headers
       assert_content('Please make sure to use the latest Epi-X format.')
       find('.modal-header').find('.close').click
-    elsif validity == :invalid_monitorees
+    when :invalid_monitorees
       assert_content('File must contain at least one monitoree to import')
       find('.modal-header').find('.close').click
-    elsif validity == :invalid_fields
+    when :invalid_fields
       @@public_health_import_verifier.verify_epi_x_field_validation(jurisdiction_id, workflow, file_name)
       find('.modal-header').find('.close').click
     end
@@ -102,23 +103,24 @@ class PublicHealthDashboard < ApplicationSystemTestCase
     find('a', text: "Sara Alert Format (#{workflow})").click
     page.attach_file(file_fixture(file_name))
     click_on 'Upload'
-    if validity == :valid
+    case validity
+    when :valid
       @@public_health_import_verifier.verify_sara_alert_format_import_page(jurisdiction_id, workflow, file_name)
       select_monitorees_to_import(rejects, accept_duplicates)
       @@public_health_import_verifier.verify_sara_alert_format_import_data(jurisdiction_id, workflow, file_name, rejects, accept_duplicates)
-    elsif validity == :invalid_file
+    when :invalid_file
       assert_content('Please make sure that your import file is a .xlsx file.')
       find('.modal-header').find('.close').click
-    elsif validity == :invalid_format
+    when :invalid_format
       assert_content('Please make sure that .xlsx import file is formatted in accordance with the formatting guidance.')
       find('.modal-header').find('.close').click
-    elsif validity == :invalid_headers
+    when :invalid_headers
       assert_content('Please make sure to use the latest format specified by the Sara Alert Format guidance doc.')
       find('.modal-header').find('.close').click
-    elsif validity == :invalid_monitorees
+    when :invalid_monitorees
       assert_content('File must contain at least one monitoree to import')
       find('.modal-header').find('.close').click
-    elsif validity == :invalid_fields
+    when :invalid_fields
       @@public_health_import_verifier.verify_sara_alert_format_field_validation(jurisdiction_id, workflow, file_name)
       find('.modal-header').find('.close').click
     end

--- a/test/system/roles/public_health/dashboard/dashboard_verifier.rb
+++ b/test/system/roles/public_health/dashboard/dashboard_verifier.rb
@@ -9,7 +9,7 @@ class PublicHealthDashboardVerifier < ApplicationSystemTestCase
   @@public_health_dashboard = PublicHealthDashboard.new(nil)
   @@system_test_utils = SystemTestUtils.new(nil)
 
-  def verify_patients_on_dashboard(jurisdiction_id, verify_scope = false)
+  def verify_patients_on_dashboard(jurisdiction_id, verify_scope: false)
     jurisdiction = Jurisdiction.find(jurisdiction_id)
     patients = jurisdiction.all_patients
     verify_workflow_count(:exposure, patients.where(isolation: false).count)

--- a/test/system/roles/public_health/patient_page/actions.rb
+++ b/test/system/roles/public_health/patient_page/actions.rb
@@ -58,7 +58,7 @@ class PublicHealthPatientPageActions < ApplicationSystemTestCase
     assert_equal latest_public_health_action, @@system_test_utils.get_patient_by_label(patient_label)[:public_health_action]
   end
 
-  def update_assigned_jurisdiction(user_label, patient_label, jurisdiction, reasoning, valid_jurisdiction = true, under_hierarchy = true)
+  def update_assigned_jurisdiction(user_label, patient_label, jurisdiction, reasoning, valid_jurisdiction: true, under_hierarchy: true)
     assert page.has_button?('Change Jurisdiction', disabled: true)
     fill_in 'jurisdictionId', with: jurisdiction
     if valid_jurisdiction
@@ -77,7 +77,7 @@ class PublicHealthPatientPageActions < ApplicationSystemTestCase
     end
   end
 
-  def update_assigned_user(user_label, patient_label, assigned_user, reasoning, valid_assigned_user = true, changed = true)
+  def update_assigned_user(user_label, patient_label, assigned_user, reasoning, valid_assigned_user: true, changed: true)
     assert page.has_button?('Change User', disabled: true)
     fill_in 'assignedUser', with: assigned_user
     if valid_assigned_user && changed

--- a/test/system/roles/public_health/patient_page/reports.rb
+++ b/test/system/roles/public_health/patient_page/reports.rb
@@ -21,7 +21,7 @@ class PublicHealthPatientPageReports < ApplicationSystemTestCase
     @@public_health_patient_page_history_verifier.verify_add_report(user_label)
   end
 
-  def edit_report(user_label, assessment_id, assessment, submit = true)
+  def edit_report(user_label, assessment_id, assessment, submit: true)
     search_for_report(assessment_id)
     find('button', class: 'a-dropdown').click
     click_on 'Edit'
@@ -38,7 +38,7 @@ class PublicHealthPatientPageReports < ApplicationSystemTestCase
     end
   end
 
-  def add_note_to_report(user_label, assessment_id, note, submit = true)
+  def add_note_to_report(user_label, assessment_id, note, submit: true)
     search_for_report(assessment_id)
     find('button', class: 'a-dropdown').click
     click_on 'Add Note'
@@ -51,7 +51,7 @@ class PublicHealthPatientPageReports < ApplicationSystemTestCase
     end
   end
 
-  def mark_all_as_reviewed(user_label, reasoning, submit = true)
+  def mark_all_as_reviewed(user_label, reasoning, submit: true)
     click_on 'Mark All As Reviewed'
     fill_in 'reasoning', with: reasoning
     if submit
@@ -63,7 +63,7 @@ class PublicHealthPatientPageReports < ApplicationSystemTestCase
     @@system_test_utils.wait_for_modal_animation
   end
 
-  def pause_notifications(user_label, submit = true)
+  def pause_notifications(user_label, submit: true)
     pause_notifications = find('#pause_notifications').text == 'Resume Notifications'
     find('#pause_notifications').click
     if submit

--- a/test/system/roles/public_health/public_health_bulk_edit_test.rb
+++ b/test/system/roles/public_health/public_health_bulk_edit_test.rb
@@ -13,39 +13,39 @@ class PublicHealthTest < ApplicationSystemTestCase
 
   test 'bulk edit case status from exposure to isolation' do
     @@public_health_test_helper.bulk_edit_update_case_status('state1_epi', %w[patient_1 patient_2], :exposure, 'all', 'Confirmed',
-                                                             'Continue Monitoring in Isolation Workflow', false)
+                                                             'Continue Monitoring in Isolation Workflow')
   end
 
   test 'bulk edit case status from exposure to closed' do
-    @@public_health_test_helper.bulk_edit_update_case_status('state1_epi', %w[patient_1 patient_2], :exposure, 'all', 'Confirmed', 'End Monitoring', false)
+    @@public_health_test_helper.bulk_edit_update_case_status('state1_epi', %w[patient_1 patient_2], :exposure, 'all', 'Confirmed', 'End Monitoring')
   end
 
   test 'bulk edit case status from isolation to exposure' do
-    @@public_health_test_helper.bulk_edit_update_case_status('state1_epi', %w[patient_45 patient_47], :isolation, 'all', 'Unknown', nil, false)
+    @@public_health_test_helper.bulk_edit_update_case_status('state1_epi', %w[patient_45 patient_47], :isolation, 'all', 'Unknown', nil)
   end
 
   test 'bulk edit case status from exposure to isolation with household' do
     @@public_health_test_helper.bulk_edit_update_case_status('state1_epi', %w[patient_52], :exposure, 'all', 'Confirmed',
-                                                             'Continue Monitoring in Isolation Workflow', true)
+                                                             'Continue Monitoring in Isolation Workflow', apply_to_group: true)
   end
 
   test 'bulk edit case status from isolation to exposure with household' do
-    @@public_health_test_helper.bulk_edit_update_case_status('state1_epi', %w[patient_54], :isolation, 'all', 'Unknown', nil, true)
+    @@public_health_test_helper.bulk_edit_update_case_status('state1_epi', %w[patient_54], :isolation, 'all', 'Unknown', nil, apply_to_group: true)
   end
 
   test 'bulk edit close records from exposure workflow' do
-    @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_1 patient_2], :exposure, 'all', '', '', false)
+    @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_1 patient_2], :exposure, 'all', '', '')
   end
 
   test 'bulk edit close records from isolation workflow' do
-    @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_45 patient_47], :isolation, 'all', 'Completed Monitoring', 'reasoning', false)
+    @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_45 patient_47], :isolation, 'all', 'Completed Monitoring', 'reasoning')
   end
 
   test 'bulk edit close records from exposure workflow with household' do
-    @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_52], :exposure, 'all', 'Duplicate', '', true)
+    @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_52], :exposure, 'all', 'Duplicate', '', apply_to_group: true)
   end
 
   test 'bulk edit close records from isolation workflow with household' do
-    @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_54], :isolation, 'all', '', 'details', true)
+    @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_54], :isolation, 'all', '', 'details', apply_to_group: true)
   end
 end

--- a/test/system/roles/public_health/public_health_dashboard_test.rb
+++ b/test/system/roles/public_health/public_health_dashboard_test.rb
@@ -12,23 +12,23 @@ class PublicHealthTest < ApplicationSystemTestCase
   @@system_test_utils = SystemTestUtils.new(nil)
 
   test 'verify patient information on dashboard' do
-    @@public_health_test_helper.verify_patients_on_dashboard('locals1c2_epi', false)
+    @@public_health_test_helper.verify_patients_on_dashboard('locals1c2_epi', verify_scope: false)
   end
 
   test 'verify jurisdiction scope filtering logic on dashboard for state epi' do
-    @@public_health_test_helper.verify_patients_on_dashboard('state1_epi_enroller', true)
+    @@public_health_test_helper.verify_patients_on_dashboard('state1_epi_enroller', verify_scope: true)
   end
 
   test 'verify jurisdiction scope filtering logic on dashboard for local epi' do
-    @@public_health_test_helper.verify_patients_on_dashboard('locals1c1_epi', true)
+    @@public_health_test_helper.verify_patients_on_dashboard('locals1c1_epi', verify_scope: true)
   end
 
   test 'verify assigned user filtering logic on dashboard for state epi' do
-    @@public_health_test_helper.verify_patients_on_dashboard('state2_epi', false)
+    @@public_health_test_helper.verify_patients_on_dashboard('state2_epi', verify_scope: false)
   end
 
   test 'verify assigned user filtering logic on dashboard for local epi' do
-    @@public_health_test_helper.verify_patients_on_dashboard('locals2c3_epi', false)
-    @@public_health_test_helper.verify_patients_on_dashboard('locals2c4_epi', false)
+    @@public_health_test_helper.verify_patients_on_dashboard('locals2c3_epi', verify_scope: false)
+    @@public_health_test_helper.verify_patients_on_dashboard('locals2c4_epi', verify_scope: false)
   end
 end

--- a/test/system/roles/public_health/public_health_import_export_test.rb
+++ b/test/system/roles/public_health/public_health_import_export_test.rb
@@ -11,6 +11,168 @@ class PublicHealthTest < ApplicationSystemTestCase
   @@public_health_test_helper = PublicHealthTestHelper.new(nil)
   @@system_test_utils = SystemTestUtils.new(nil)
 
+  ASSESSMENTS = @@system_test_utils.assessments
+
+  ## Dashboard
+
+  test 'verify patient information on dashboard' do
+    @@public_health_test_helper.verify_patients_on_dashboard('locals1c2_epi', verify_scope: false)
+  end
+
+  test 'verify jurisdiction scope filtering logic on dashboard for state epi' do
+    @@public_health_test_helper.verify_patients_on_dashboard('state1_epi_enroller', verify_scope: true)
+  end
+
+  test 'verify jurisdiction scope filtering logic on dashboard for local epi' do
+    @@public_health_test_helper.verify_patients_on_dashboard('locals1c1_epi', verify_scope: true)
+  end
+
+  test 'verify assigned user filtering logic on dashboard for state epi' do
+    @@public_health_test_helper.verify_patients_on_dashboard('state2_epi', verify_scope: false)
+  end
+
+  test 'verify assigned user filtering logic on dashboard for local epi' do
+    @@public_health_test_helper.verify_patients_on_dashboard('locals2c3_epi', verify_scope: false)
+    @@public_health_test_helper.verify_patients_on_dashboard('locals2c4_epi', verify_scope: false)
+  end
+
+  test 'verify patient details and reports' do
+    @@public_health_test_helper.view_patients_details_and_reports('state1_epi')
+    @@public_health_test_helper.view_patients_details_and_reports('state2_epi')
+  end
+
+  test 'bulk edit case status from exposure to isolation' do
+    @@public_health_test_helper.bulk_edit_update_case_status('state1_epi', %w[patient_1 patient_2], :exposure, 'all', 'Confirmed',
+                                                             'Continue Monitoring in Isolation Workflow', apply_to_group: false)
+  end
+
+  test 'bulk edit case status from exposure to closed' do
+    @@public_health_test_helper.bulk_edit_update_case_status('state1_epi', %w[patient_1 patient_2], :exposure, 'all', 'Confirmed',
+                                                             'End Monitoring', apply_to_group: false)
+  end
+
+  test 'bulk edit case status from isolation to exposure' do
+    @@public_health_test_helper.bulk_edit_update_case_status('state1_epi', %w[patient_45 patient_47], :isolation, 'all', 'Unknown',
+                                                             nil, apply_to_group: false)
+  end
+
+  test 'bulk edit case status from exposure to isolation with household' do
+    @@public_health_test_helper.bulk_edit_update_case_status('state1_epi', %w[patient_52], :exposure, 'all', 'Confirmed',
+                                                             'Continue Monitoring in Isolation Workflow', apply_to_group: true)
+  end
+
+  test 'bulk edit case status from isolation to exposure with household' do
+    @@public_health_test_helper.bulk_edit_update_case_status('state1_epi', %w[patient_54], :isolation, 'all', 'Unknown', nil,
+                                                             apply_to_group: true)
+  end
+
+  test 'bulk edit close records from exposure workflow' do
+    @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_1 patient_2], :exposure, 'all', '', '',
+                                                        apply_to_group: false)
+  end
+
+  test 'bulk edit close records from isolation workflow' do
+    @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_45 patient_47], :isolation, 'all', 'Completed Monitoring',
+                                                        'reasoning', apply_to_group: false)
+  end
+
+  test 'bulk edit close records from exposure workflow with household' do
+    @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_52], :exposure, 'all', 'Duplicate', '', apply_to_group: true)
+  end
+
+  test 'bulk edit close records from isolation workflow with household' do
+    @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_54], :isolation, 'all', '', 'details', apply_to_group: true)
+  end
+
+  ## Patient page
+
+  test 'update monitoring status to not monitoring' do
+    @@public_health_test_helper.update_monitoring_status('state1_epi', 'patient_2', 'non_reporting', 'closed',
+                                                         'Not Monitoring', 'Completed Monitoring', 'details')
+  end
+
+  test 'update monitoring status to actively monitoring' do
+    @@public_health_test_helper.update_monitoring_status('state1_epi', 'patient_5', 'closed', 'all',
+                                                         'Actively Monitoring', nil, 'notes')
+  end
+
+  test 'update exposure risk assessment' do
+    @@public_health_test_helper.update_exposure_risk_assessment('locals1c1_epi', 'patient_4', 'asymptomatic', 'High', 'details')
+  end
+
+  test 'update monitoring plan' do
+    @@public_health_test_helper.update_monitoring_plan('locals1c2_epi', 'patient_6', 'pui', 'Daily active monitoring', 'details')
+  end
+
+  test 'update latest public health action' do
+    @@public_health_test_helper.update_latest_public_health_action('state1_epi_enroller', 'patient_7', 'pui',
+                                                                   'Recommended medical evaluation of symptoms', 'details')
+  end
+
+  test 'update assigned jurisdiction' do
+    @@public_health_test_helper.update_assigned_jurisdiction('state2_epi', 'patient_11', 'pui', 'USA, State 2, County 4', 'details',
+                                                             valid_jurisdiction: true, under_hierarchy: true)
+    @@public_health_test_helper.update_assigned_jurisdiction('state2_epi', 'patient_10', 'pui', 'USA, State 1', 'details',
+                                                             valid_jurisdiction: true, under_hierarchy: false)
+  end
+
+  test 'update assigned jurisdiction validation' do
+    @@public_health_test_helper.update_assigned_jurisdiction('state2_epi', 'patient_11', 'pui', 'Fake Jurisdiction', 'details',
+                                                             valid_jurisdiction: false, under_hierarchy: true)
+  end
+
+  test 'update assigned user' do
+    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_2', 'all', '9', 'reasoning', valid_assigned_user: true,
+                                                                                                         changed: true)
+    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_2', 'all', '', 'reasoning', valid_assigned_user: true,
+                                                                                                        changed: true)
+    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_4', 'all', '1444', 'reason', valid_assigned_user: true,
+                                                                                                         changed: true)
+  end
+
+  test 'update assigned user validation' do
+    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_2', 'all', '', 'reason', valid_assigned_user: false,
+                                                                                                     changed: false)
+    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_4', 'all', '1444', '', valid_assigned_user: false,
+                                                                                                   changed: false)
+    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_4', 'all', '0', 'reason', valid_assigned_user: false,
+                                                                                                      changed: true)
+    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_4', 'all', '10000', '', valid_assigned_user: false,
+                                                                                                    changed: true)
+    @@public_health_test_helper.update_assigned_user('state1_epi_enroller', 'patient_4', 'all', '-8', 'reason', valid_assigned_user: false,
+                                                                                                                changed: true)
+    @@public_health_test_helper.update_assigned_user('state1_epi_enroller', 'patient_2', 'all', '1.5', '', valid_assigned_user: false,
+                                                                                                           changed: true)
+    @@public_health_test_helper.update_assigned_user('state1_epi_enroller', 'patient_2', 'all', 'not valid', 'reason',
+                                                     valid_assigned_user: false, changed: true)
+  end
+
+  test 'add report' do
+    @@public_health_test_helper.add_report('locals1c1_epi', 'patient_4', 'asymptomatic', ASSESSMENTS['assessment_1'])
+  end
+
+  test 'edit report' do
+    @@public_health_test_helper.edit_report('locals2c4_epi', 'patient_10', 'pui', 1017, ASSESSMENTS['assessment_2'])
+  end
+
+  test 'add note to report' do
+    @@public_health_test_helper.add_note_to_report('state2_epi', 'patient_10', 'pui', 1016, 'note')
+  end
+
+  test 'mark all reports as reviewed' do
+    @@public_health_test_helper.mark_all_as_reviewed('state1_epi_enroller', 'patient_5', 'closed', 'comment')
+  end
+
+  test 'pause notifications' do
+    @@public_health_test_helper.pause_notifications('state1_epi', 'patient_2', 'non_reporting')
+    @@public_health_test_helper.pause_notifications('state1_epi', 'patient_2', 'non_reporting')
+  end
+
+  test 'add comment' do
+    @@public_health_test_helper.add_comment('locals2c3_epi', 'patient_11', 'pui', 'comment')
+  end
+
+  ## Export and import
   test 'export line list csv (exposure)' do
     @@public_health_test_helper.export_line_list_csv('locals2c3_epi', :exposure, :cancel)
     @@public_health_test_helper.export_line_list_csv('state1_epi', :exposure, :export)
@@ -66,11 +228,11 @@ class PublicHealthTest < ApplicationSystemTestCase
   end
 
   test 'import epi-x to exposure with duplicate patient and accept duplicates' do
-    @@public_health_test_helper.import_epi_x('state5_epi', :exposure, 'Epi-X-Format.xlsx', :valid, nil, true)
+    @@public_health_test_helper.import_epi_x('state5_epi', :exposure, 'Epi-X-Format.xlsx', :valid, nil, accept_duplicates: true)
   end
 
   test 'import epi-x to isolation with duplicate patient and reject duplicates' do
-    @@public_health_test_helper.import_epi_x('state5_epi', :isolation, 'Epi-X-Format.xlsx', :valid, nil, false)
+    @@public_health_test_helper.import_epi_x('state5_epi', :isolation, 'Epi-X-Format.xlsx', :valid, nil, accept_duplicates: false)
   end
 
   test 'import epi-x to isolation and validate file type' do
@@ -122,11 +284,11 @@ class PublicHealthTest < ApplicationSystemTestCase
   end
 
   test 'import sara alert format to isolation with duplicate patient and accept duplicates' do
-    @@public_health_test_helper.import_sara_alert_format('state5_epi', :isolation, 'Sara-Alert-Format.xlsx', :valid, nil, true)
+    @@public_health_test_helper.import_sara_alert_format('state5_epi', :isolation, 'Sara-Alert-Format.xlsx', :valid, nil, accept_duplicates: true)
   end
 
   test 'import sara alert format to exposure with duplicate patient and reject duplicates' do
-    @@public_health_test_helper.import_sara_alert_format('state5_epi', :exposure, 'Sara-Alert-Format.xlsx', :valid, nil, false)
+    @@public_health_test_helper.import_sara_alert_format('state5_epi', :exposure, 'Sara-Alert-Format.xlsx', :valid, nil, accept_duplicates: false)
   end
 
   test 'import sara alert format to exposure with custom jurisdictions' do

--- a/test/system/roles/public_health/public_health_patient_page_test.rb
+++ b/test/system/roles/public_health/public_health_patient_page_test.rb
@@ -42,12 +42,30 @@ class PublicHealthTest < ApplicationSystemTestCase
   end
 
   test 'update assigned jurisdiction' do
-    @@public_health_test_helper.update_assigned_jurisdiction('state2_epi', 'patient_11', 'pui', 'USA, State 2, County 4', 'details', valid_jurisdiction: true, under_hierarchy: true)
-    @@public_health_test_helper.update_assigned_jurisdiction('state2_epi', 'patient_10', 'pui', 'USA, State 1', 'details', valid_jurisdiction: true, under_hierarchy: false)
+    @@public_health_test_helper.update_assigned_jurisdiction('state2_epi',
+                                                             'patient_11',
+                                                             'pui',
+                                                             'USA, State 2, County 4',
+                                                             'details',
+                                                             valid_jurisdiction: true,
+                                                             under_hierarchy: true)
+    @@public_health_test_helper.update_assigned_jurisdiction('state2_epi',
+                                                             'patient_10',
+                                                             'pui',
+                                                             'USA, State 1',
+                                                             'details',
+                                                             valid_jurisdiction: true,
+                                                             under_hierarchy: false)
   end
 
   test 'update assigned jurisdiction validation' do
-    @@public_health_test_helper.update_assigned_jurisdiction('state2_epi', 'patient_11', 'pui', 'Fake Jurisdiction', 'details', valid_jurisdiction: false, under_hierarchy: true)
+    @@public_health_test_helper.update_assigned_jurisdiction('state2_epi',
+                                                             'patient_11',
+                                                             'pui',
+                                                             'Fake Jurisdiction',
+                                                             'details',
+                                                             valid_jurisdiction: false,
+                                                             under_hierarchy: true)
   end
 
   test 'update assigned user' do
@@ -63,7 +81,13 @@ class PublicHealthTest < ApplicationSystemTestCase
     @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_4', 'all', '10000', '', valid_assigned_user: false, changed: true)
     @@public_health_test_helper.update_assigned_user('state1_epi_enroller', 'patient_4', 'all', '-8', 'reason', valid_assigned_user: false, changed: true)
     @@public_health_test_helper.update_assigned_user('state1_epi_enroller', 'patient_2', 'all', '1.5', '', valid_assigned_user: false, changed: true)
-    @@public_health_test_helper.update_assigned_user('state1_epi_enroller', 'patient_2', 'all', 'not valid', 'reason', valid_assigned_user: false, changed: true)
+    @@public_health_test_helper.update_assigned_user('state1_epi_enroller',
+                                                     'patient_2',
+                                                     'all',
+                                                     'not valid',
+                                                     'reason',
+                                                     valid_assigned_user: false,
+                                                     changed: true)
   end
 
   test 'add report' do

--- a/test/system/roles/public_health/public_health_patient_page_test.rb
+++ b/test/system/roles/public_health/public_health_patient_page_test.rb
@@ -42,28 +42,28 @@ class PublicHealthTest < ApplicationSystemTestCase
   end
 
   test 'update assigned jurisdiction' do
-    @@public_health_test_helper.update_assigned_jurisdiction('state2_epi', 'patient_11', 'pui', 'USA, State 2, County 4', 'details', true, true)
-    @@public_health_test_helper.update_assigned_jurisdiction('state2_epi', 'patient_10', 'pui', 'USA, State 1', 'details', true, false)
+    @@public_health_test_helper.update_assigned_jurisdiction('state2_epi', 'patient_11', 'pui', 'USA, State 2, County 4', 'details', valid_jurisdiction: true, under_hierarchy: true)
+    @@public_health_test_helper.update_assigned_jurisdiction('state2_epi', 'patient_10', 'pui', 'USA, State 1', 'details', valid_jurisdiction: true, under_hierarchy: false)
   end
 
   test 'update assigned jurisdiction validation' do
-    @@public_health_test_helper.update_assigned_jurisdiction('state2_epi', 'patient_11', 'pui', 'Fake Jurisdiction', 'details', false, true)
+    @@public_health_test_helper.update_assigned_jurisdiction('state2_epi', 'patient_11', 'pui', 'Fake Jurisdiction', 'details', valid_jurisdiction: false, under_hierarchy: true)
   end
 
   test 'update assigned user' do
-    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_2', 'all', '9', 'reasoning', true, true)
-    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_2', 'all', '', 'reasoning', true, true)
-    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_4', 'all', '1444', 'reason', true, true)
+    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_2', 'all', '9', 'reasoning', valid_assigned_user: true, changed: true)
+    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_2', 'all', '', 'reasoning', valid_assigned_user: true, changed: true)
+    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_4', 'all', '1444', 'reason', valid_assigned_user: true, changed: true)
   end
 
   test 'update assigned user validation' do
-    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_2', 'all', '', 'reason', false, false)
-    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_4', 'all', '1444', '', false, false)
-    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_4', 'all', '0', 'reason', false, true)
-    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_4', 'all', '10000', '', false, true)
-    @@public_health_test_helper.update_assigned_user('state1_epi_enroller', 'patient_4', 'all', '-8', 'reason', false, true)
-    @@public_health_test_helper.update_assigned_user('state1_epi_enroller', 'patient_2', 'all', '1.5', '', false, true)
-    @@public_health_test_helper.update_assigned_user('state1_epi_enroller', 'patient_2', 'all', 'not valid', 'reason', false, true)
+    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_2', 'all', '', 'reason', valid_assigned_user: false, changed: false)
+    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_4', 'all', '1444', '', valid_assigned_user: false, changed: false)
+    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_4', 'all', '0', 'reason', valid_assigned_user: false, changed: true)
+    @@public_health_test_helper.update_assigned_user('state1_epi', 'patient_4', 'all', '10000', '', valid_assigned_user: false, changed: true)
+    @@public_health_test_helper.update_assigned_user('state1_epi_enroller', 'patient_4', 'all', '-8', 'reason', valid_assigned_user: false, changed: true)
+    @@public_health_test_helper.update_assigned_user('state1_epi_enroller', 'patient_2', 'all', '1.5', '', valid_assigned_user: false, changed: true)
+    @@public_health_test_helper.update_assigned_user('state1_epi_enroller', 'patient_2', 'all', 'not valid', 'reason', valid_assigned_user: false, changed: true)
   end
 
   test 'add report' do

--- a/test/system/roles/public_health/public_health_test_helper.rb
+++ b/test/system/roles/public_health/public_health_test_helper.rb
@@ -20,9 +20,9 @@ class PublicHealthTestHelper < ApplicationSystemTestCase
   @@system_test_utils = SystemTestUtils.new(nil)
 
   # rubocop:disable Metrics/ParameterLists
-  def verify_patients_on_dashboard(user_label, verify_scope = false)
+  def verify_patients_on_dashboard(user_label, verify_scope: false)
     jurisdiction_id = @@system_test_utils.login(user_label)
-    @@public_health_dashboard_verifier.verify_patients_on_dashboard(jurisdiction_id, verify_scope)
+    @@public_health_dashboard_verifier.verify_patients_on_dashboard(jurisdiction_id, verify_scope: verify_scope)
     @@system_test_utils.logout
   end
 
@@ -32,28 +32,30 @@ class PublicHealthTestHelper < ApplicationSystemTestCase
     @@system_test_utils.logout
   end
 
-  def bulk_edit_update_case_status(user_label, patient_labels, workflow, tab, case_status, next_step, apply_to_group = false)
+  def bulk_edit_update_case_status(user_label, patient_labels, workflow, tab, case_status, next_step, apply_to_group: false)
     @@system_test_utils.login(user_label)
     @@public_health_dashboard.select_monitorees_for_bulk_edit(workflow, tab, patient_labels)
-    @@public_health_dashboard.bulk_edit_update_case_status(workflow, case_status, next_step, apply_to_group)
+    @@public_health_dashboard.bulk_edit_update_case_status(workflow, case_status, next_step, apply_to_group: apply_to_group)
     assertions = {
       case_status: case_status,
       isolation: %w[Confirmed Probable].include?(case_status) && next_step == 'Continue Monitoring in Isolation Workflow',
       monitoring: next_step != 'End Monitoring'
     }
     patient_labels.each do |label|
-      @@public_health_dashboard_verifier.search_for_and_verify_patient_monitoring_actions(label, assertions, apply_to_group)
+      @@public_health_dashboard_verifier.search_for_and_verify_patient_monitoring_actions(label, assertions,
+                                                                                          apply_to_group: apply_to_group)
     end
     @@system_test_utils.logout
   end
 
-  def bulk_edit_close_records(user_label, patient_labels, workflow, tab, monitoring_reason, reasoning, apply_to_group = false)
+  def bulk_edit_close_records(user_label, patient_labels, workflow, tab, monitoring_reason, reasoning, apply_to_group: false)
     @@system_test_utils.login(user_label)
     @@public_health_dashboard.select_monitorees_for_bulk_edit(workflow, tab, patient_labels)
-    @@public_health_dashboard.bulk_edit_close_records(monitoring_reason, reasoning, apply_to_group)
+    @@public_health_dashboard.bulk_edit_close_records(monitoring_reason, reasoning, apply_to_group: apply_to_group)
     assertions = { monitoring: false, monitoring_reason: monitoring_reason }
     patient_labels.each do |label|
-      @@public_health_dashboard_verifier.search_for_and_verify_patient_monitoring_actions(label, assertions, apply_to_group)
+      @@public_health_dashboard_verifier.search_for_and_verify_patient_monitoring_actions(label, assertions,
+                                                                                          apply_to_group: apply_to_group)
     end
     @@system_test_utils.logout
   end
@@ -88,17 +90,19 @@ class PublicHealthTestHelper < ApplicationSystemTestCase
     @@system_test_utils.logout
   end
 
-  def update_assigned_jurisdiction(user_label, patient_label, tab, jurisdiction, reasoning, valid_jurisdiction = true, under_hierarchy = true)
+  def update_assigned_jurisdiction(user_label, patient_label, tab, jurisdiction, reasoning, valid_jurisdiction: true, under_hierarchy: true)
     @@system_test_utils.login(user_label)
     @@public_health_dashboard.search_for_and_view_patient(tab, patient_label)
-    @@public_health_patient_page_actions.update_assigned_jurisdiction(user_label, patient_label, jurisdiction, reasoning, valid_jurisdiction, under_hierarchy)
+    @@public_health_patient_page_actions.update_assigned_jurisdiction(user_label, patient_label, jurisdiction, reasoning,
+                                                                      valid_jurisdiction: valid_jurisdiction, under_hierarchy: under_hierarchy)
     @@system_test_utils.logout
   end
 
-  def update_assigned_user(user_label, patient_label, tab, assigned_user, reasoning, valid_assigned_user = true, changed = true)
+  def update_assigned_user(user_label, patient_label, tab, assigned_user, reasoning, valid_assigned_user: true, changed: true)
     @@system_test_utils.login(user_label)
     @@public_health_dashboard.search_for_and_view_patient(tab, patient_label)
-    @@public_health_patient_page_actions.update_assigned_user(user_label, patient_label, assigned_user, reasoning, valid_assigned_user, changed)
+    @@public_health_patient_page_actions.update_assigned_user(user_label, patient_label, assigned_user, reasoning,
+                                                              valid_assigned_user: valid_assigned_user, changed: changed)
     @@system_test_utils.logout
   end
 
@@ -112,15 +116,15 @@ class PublicHealthTestHelper < ApplicationSystemTestCase
   def edit_report(user_label, patient_label, old_tab, assessment_id, assessment)
     @@system_test_utils.login(user_label)
     @@public_health_dashboard.search_for_and_view_patient(old_tab, patient_label)
-    @@public_health_patient_page_reports.edit_report(user_label, assessment_id, assessment, true)
+    @@public_health_patient_page_reports.edit_report(user_label, assessment_id, assessment, submit: true)
     @@system_test_utils.logout
   end
 
   def add_note_to_report(user_label, patient_label, tab, assessment_id, note)
     @@system_test_utils.login(user_label)
     @@public_health_dashboard.search_for_and_view_patient(tab, patient_label)
-    @@public_health_patient_page_reports.add_note_to_report(user_label, assessment_id, note, false)
-    @@public_health_patient_page_reports.add_note_to_report(user_label, assessment_id, note, true)
+    @@public_health_patient_page_reports.add_note_to_report(user_label, assessment_id, note, submit: false)
+    @@public_health_patient_page_reports.add_note_to_report(user_label, assessment_id, note, submit: true)
   end
 
   def mark_all_as_reviewed(user_label, patient_label, tab, reasoning)
@@ -133,8 +137,8 @@ class PublicHealthTestHelper < ApplicationSystemTestCase
   def pause_notifications(user_label, patient_label, tab)
     @@system_test_utils.login(user_label)
     @@public_health_dashboard.search_for_and_view_patient(tab, patient_label)
-    @@public_health_patient_page_reports.pause_notifications(user_label, true)
-    @@public_health_patient_page_reports.pause_notifications(user_label, false)
+    @@public_health_patient_page_reports.pause_notifications(user_label, submit: true)
+    @@public_health_patient_page_reports.pause_notifications(user_label, submit: false)
     @@system_test_utils.logout
   end
 
@@ -175,13 +179,13 @@ class PublicHealthTestHelper < ApplicationSystemTestCase
     @@system_test_utils.logout
   end
 
-  def import_epi_x(user_label, workflow, file_name, validity, rejects, accept_duplicates = false)
+  def import_epi_x(user_label, workflow, file_name, validity, rejects, accept_duplicates: false)
     jurisdiction_id = @@system_test_utils.login(user_label)
     @@public_health_dashboard.import_epi_x(jurisdiction_id, workflow, file_name, validity, rejects, accept_duplicates)
     @@system_test_utils.logout
   end
 
-  def import_sara_alert_format(user_label, workflow, file_name, validity, rejects, accept_duplicates = false)
+  def import_sara_alert_format(user_label, workflow, file_name, validity, rejects, accept_duplicates: false)
     jurisdiction_id = @@system_test_utils.login(user_label)
     @@public_health_dashboard.import_sara_alert_format(jurisdiction_id, workflow, file_name, validity, rejects, accept_duplicates)
     @@system_test_utils.logout

--- a/test/system/workflow/workflow_test.rb
+++ b/test/system/workflow/workflow_test.rb
@@ -40,7 +40,7 @@ class WorkflowTest < ApplicationSystemTestCase
     # enroll monitoree, should be asymptomatic
     epi_enroller_user_label = 'state1_epi_enroller'
     monitoree_label = 'monitoree_3'
-    @@enroller_test_helper.enroll_monitoree(epi_enroller_user_label, monitoree_label, true)
+    @@enroller_test_helper.enroll_monitoree(epi_enroller_user_label, monitoree_label, is_epi: true)
     @@system_test_utils.login(epi_enroller_user_label)
     @@public_health_dashboard.search_for_and_view_monitoree('asymptomatic', monitoree_label)
     @@public_health_patient_page_reports_verifier.verify_current_status('asymptomatic')
@@ -52,7 +52,7 @@ class WorkflowTest < ApplicationSystemTestCase
     @@public_health_dashboard.search_for_and_view_monitoree('symptomatic', monitoree_label)
 
     # mark all reports as reviewed, should be symptomatic again
-    @@public_health_patient_page_reports.mark_all_as_reviewed(epi_enroller_user_label, 'reason', true)
+    @@public_health_patient_page_reports.mark_all_as_reviewed(epi_enroller_user_label, 'reason', submit: true)
     @@system_test_utils.return_to_dashboard('exposure')
     @@public_health_dashboard.search_for_and_view_monitoree('asymptomatic', monitoree_label)
 
@@ -63,7 +63,8 @@ class WorkflowTest < ApplicationSystemTestCase
     @@public_health_dashboard.search_for_and_view_monitoree('pui', monitoree_label)
 
     # update assigned jurisdiction, should be transferred out of old jurisdiction and transferred into new one
-    @@public_health_patient_page_actions.update_assigned_jurisdiction(epi_enroller_user_label, monitoree_label, 'USA, State 2', 'reason', true, false)
+    @@public_health_patient_page_actions.update_assigned_jurisdiction(epi_enroller_user_label, monitoree_label, 'USA, State 2', 'reason',
+                                                                      valid_jurisdiction: true, under_hierarchy: false)
     @@public_health_dashboard_verifier.verify_monitoree_under_tab('transferred_out', monitoree_label)
     @@system_test_utils.logout
     @@system_test_utils.login('state2_epi')
@@ -98,7 +99,7 @@ class WorkflowTest < ApplicationSystemTestCase
     # edit parent jurisdiction but do not propagate to group member
     edited_monitoree_without_propogation_label = 'monitoree_13'
     @@system_test_utils.login(enroller_user_label)
-    @@enroller_dashboard_verifier.verify_monitoree_info_on_dashboard(MONITOREES[monitoree_label], false, false)
+    @@enroller_dashboard_verifier.verify_monitoree_info_on_dashboard(MONITOREES[monitoree_label], is_epi: false, go_back: false)
     @@enrollment_form.edit_monitoree_info(MONITOREES[edited_monitoree_without_propogation_label])
     click_on 'Finish'
     @@system_test_utils.wait_for_enrollment_submission
@@ -119,7 +120,7 @@ class WorkflowTest < ApplicationSystemTestCase
     # edit parent jurisdiction and propagate to group member
     edited_monitoree_with_propogation_label = 'monitoree_14'
     @@system_test_utils.login(enroller_user_label)
-    @@enroller_dashboard_verifier.verify_monitoree_info_on_dashboard(MONITOREES[monitoree_label], false, false)
+    @@enroller_dashboard_verifier.verify_monitoree_info_on_dashboard(MONITOREES[monitoree_label], is_epi: false, go_back: false)
     @@enrollment_form.edit_monitoree_info(MONITOREES[edited_monitoree_with_propogation_label])
     click_on 'Finish'
     @@system_test_utils.wait_for_enrollment_submission
@@ -145,7 +146,7 @@ class WorkflowTest < ApplicationSystemTestCase
     epi_enroller_user_label = 'state1_epi_enroller'
     monitoree_label = 'monitoree_3'
     group_member_label = 'monitoree_8'
-    @@enroller_test_helper.enroll_group_member(epi_enroller_user_label, monitoree_label, group_member_label, true)
+    @@enroller_test_helper.enroll_group_member(epi_enroller_user_label, monitoree_label, group_member_label, is_epi: true)
 
     # edit parent assigned user but do not propagate to group member
     @@system_test_utils.login(epi_enroller_user_label)


### PR DESCRIPTION
# Description

Update rubocop to v0.89 and enable the cops from v0.88 and v0.89

# Important Changes
I basically made the big decision to change certain `elsif` statements to case statements because we seemed to have more case statements fro the type of `elsif` statement it was replacing. Reference: https://docs.rubocop.org/rubocop/cops_style.html#stylecaselikeif

The main setting which drives most of the changes in system tests is the use of a default optional boolean parameter. The cop states that an optional boolean parameter should be a `kwarg` for readability. Example:

```ruby
# Sends mail to patient
def send_mail(patient, force = false); end
def send_mail(patient, force: true); end

Mail.send_mail(patient, true)
Mail.send_mail(patient, force: true) # more readable i think
```
