### PR TITLE
Break exports up into batches of 10k patients

### DIFF
--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -5,6 +5,10 @@ class ExportJob < ApplicationJob
   queue_as :default
   include ImportExport
 
+  # Limits number of records to be considered for a single exported file to handle maximum file size limit.
+  # Adds additional files as needed if records exceeds batch size.
+  RECORD_BATCH_SIZE = 10_000
+
   def perform(user_id, export_type)
     user = User.find_by(id: user_id)
     return if user.nil?
@@ -17,86 +21,70 @@ class ExportJob < ApplicationJob
     case export_type
     when 'csv_exposure'
       patients = user.viewable_patients.where(isolation: false).where(purged: false)
-      filename = "Sara-Alert-Linelist-Exposure-#{DateTime.now}.csv"
-      patients.find_in_batches(batch_size: 10_000).with_index do |group, index|
+      filename = 'Sara-Alert-Linelist-Exposure'
+      file_extension = 'csv'
+      patients.in_batches(of: RECORD_BATCH_SIZE).each_with_index do |group, index|
         data = csv_line_list(group)
-        lookups << { lookup: save_download(user_id, data, "#{filename}-#{index}.csv", export_type), filename: "#{filename}-#{index}.csv" }
+        lookups << get_file(user_id, data, filename, file_extension, export_type, index + 1)
       end
     when 'csv_isolation'
       patients = user.viewable_patients.where(isolation: true).where(purged: false)
-      filename = "Sara-Alert-Linelist-Isolation-#{DateTime.now}.csv"
-      patients.find_in_batches(batch_size: 10_000).with_index do |group, index|
+      filename = 'Sara-Alert-Linelist-Isolation'
+      file_extension = 'csv'
+      patients.in_batches(of: RECORD_BATCH_SIZE).each_with_index do |group, index|
         data = csv_line_list(group)
-        lookups << { lookup: save_download(user_id, data, "#{filename}-#{index}.csv", export_type), filename: "#{filename}-#{index}.csv" }
+        lookups << get_file(user_id, data, filename, file_extension, export_type, index + 1)
       end
     when 'sara_format_exposure'
       patients = user.viewable_patients.where(isolation: false).where(purged: false)
-      filename = "Sara-Alert-Format-Exposure-#{DateTime.now}.xlsx"
-      patients.find_in_batches(batch_size: 10_000).with_index do |group, index|
+      filename = 'Sara-Alert-Format-Exposure'
+      file_extension = 'xlsx'
+      patients.in_batches(of: RECORD_BATCH_SIZE).each_with_index do |group, index|
         data = sara_alert_format(group)
-        lookups << { lookup: save_download(user_id, data, "#{filename}-#{index}.xlsx", export_type), filename: "#{filename}-#{index}.csv" }
+        lookups << get_file(user_id, data, filename, file_extension, export_type, index + 1)
       end
     when 'sara_format_isolation'
       patients = user.viewable_patients.where(isolation: true).where(purged: false)
-      filename = "Sara-Alert-Format-Isolation-#{DateTime.now}.xlsx"
-      patients.find_in_batches(batch_size: 10_000).with_index do |group, index|
+      filename = 'Sara-Alert-Format-Isolation'
+      file_extension = 'xlsx'
+      patients.in_batches(of: RECORD_BATCH_SIZE).each_with_index do |group, index|
         data = sara_alert_format(group)
-        lookups << { lookup: save_download(user_id, data, "#{filename}-#{index}.xlsx", export_type), filename: "#{filename}-#{index}.csv" }
+        lookups << get_file(user_id, data, filename, file_extension, export_type, index + 1)
       end
     when 'full_history_all'
       patients = user.viewable_patients.where(purged: false)
-      patients.find_in_batches(batch_size: 10_000).with_index do |group, index|
-        lookups << { lookup: save_download(user_id,
-                                          excel_export_monitorees(group),
-                                          "Sara-Alert-Full-Export-Monitorees-#{DateTime.now}-#{index}.xlsx",
-                                          export_type),
-                    filename: "Sara-Alert-Full-Export-Monitorees-#{DateTime.now}-#{index}.xlsx" }
-        lookups << { lookup: save_download(user_id,
-                                          excel_export_assessments(group),
-                                          "Sara-Alert-Full-Export-Assessments-#{DateTime.now}-#{index}.xlsx",
-                                          export_type),
-                    filename: "Sara-Alert-Full-Export-Assessments-#{DateTime.now}-#{index}.xlsx" }
-        lookups << { lookup: save_download(user_id,
-                                          excel_export_lab_results(group),
-                                          "Sara-Alert-Full-Export-Lab-Results-#{DateTime.now}-#{index}.xlsx",
-                                          export_type),
-                    filename: "Sara-Alert-Full-Export-Lab-Results-#{DateTime.now}-#{index}.xlsx" }
-        lookups << { lookup: save_download(user_id,
-                                          excel_export_histories(group),
-                                          "Sara-Alert-Full-Export-Histories-#{DateTime.now}-#{index}.xlsx",
-                                          export_type),
-                    filename: "Sara-Alert-Full-Export-Histories-#{DateTime.now}-#{index}.xlsx" }
+      file_extension = 'xlsx'
+      patients.in_batches(of: RECORD_BATCH_SIZE).each_with_index do |group, index|
+        file_index = index + 1
+        lookups << get_file(user_id, excel_export_monitorees(group), 'Sara-Alert-Full-Export-Monitorees', file_extension, export_type, file_index)
+        lookups << get_file(user_id, excel_export_assessments(group), 'Sara-Alert-Full-Export-Assessments', file_extension, export_type, file_index)
+        lookups << get_file(user_id, excel_export_lab_results(group), 'Sara-Alert-Full-Export-Lab-Results', file_extension, export_type, file_index)
+        lookups << get_file(user_id, excel_export_histories(group), 'Sara-Alert-Full-Export-Histories', file_extension, export_type, file_index)
       end
     when 'full_history_purgeable'
       patients = user.viewable_patients.purge_eligible
-      patients.find_in_batches(batch_size: 10_000).with_index do |group, index|
-        lookups << { lookup: save_download(user_id,
-                                          excel_export_monitorees(group),
-                                          "Sara-Alert-Purge-Eligible-Export-Monitorees-#{DateTime.now}-#{index}.xlsx",
-                                          export_type),
-                    filename: "Sara-Alert-Purge-Eligible-Export-Monitorees-#{DateTime.now}-#{index}.xlsx" }
-        lookups << { lookup: save_download(user_id,
-                                          excel_export_assessments(group),
-                                          "Sara-Alert-Purge-Eligible-Export-Assessments-#{DateTime.now}-#{index}.xlsx",
-                                          export_type),
-                    filename: "Sara-Alert-Purge-Eligible-Export-Assessments-#{DateTime.now}-#{index}.xlsx" }
-        lookups << { lookup: save_download(user_id,
-                                          excel_export_lab_results(group),
-                                          "Sara-Alert-Purge-Eligible-Export-Lab-Results-#{DateTime.now}-#{index}.xlsx",
-                                          export_type),
-                    filename: "Sara-Alert-Purge-Eligible-Export-Lab-Results-#{DateTime.now}-#{index}.xlsx" }
-        lookups << { lookup: save_download(user_id,
-                                          excel_export_histories(group),
-                                          "Sara-Alert-Purge-Eligible-Export-Histories-#{DateTime.now}-#{index}.xlsx",
-                                          export_type),
-                    filename: "Sara-Alert-Purge-Eligible-Export-Histories-#{DateTime.now}-#{index}.xlsx" }
+      patients.in_batches(of: RECORD_BATCH_SIZE).each_with_index do |group, index|
+        file_index = index + 1
+        lookups << get_file(user_id, excel_export_monitorees(group), 'Sara-Alert-Purge-Eligible-Export-Monitorees', file_extension, export_type, file_index)
+        lookups << get_file(user_id, excel_export_assessments(group), 'Sara-Alert-Purge-Eligible-Export-Assessments', file_extension, export_type, file_index)
+        lookups << get_file(user_id, excel_export_lab_results(group), 'Sara-Alert-Purge-Eligible-Export-Lab-Results', file_extension, export_type, file_index)
+        lookups << get_file(user_id, excel_export_histories(group), 'Sara-Alert-Purge-Eligible-Export-Histories', file_extension, export_type, file_index)
       end
     end
     return if lookups.empty?
 
+    puts "lookups: #{lookups}"
     # Send an email to user
     UserMailer.download_email(user, export_type, lookups).deliver_later
   end
+
+  # Gets a single download with the provided filename information and containing the provided data.
+  # rubocop:disable Metrics/ParameterLists
+  def get_file(user_id, data, filename, file_extension, export_type, file_index)
+    full_filename = "#{filename}-#{DateTime.now}-#{file_index}.#{file_extension}"
+    { lookup: save_download(user_id, data, full_filename, export_type), filename: full_filename }
+  end
+  # rubocop:enable Metrics/ParameterLists
 
   # Save a download file and return the lookup
   def save_download(user_id, data, filename, export_type)

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -21,70 +21,96 @@ class ExportJob < ApplicationJob
     case export_type
     when 'csv_exposure'
       patients = user.viewable_patients.where(isolation: false).where(purged: false)
-      filename = 'Sara-Alert-Linelist-Exposure'
+      base_filename = 'Sara-Alert-Linelist-Exposure'
       file_extension = 'csv'
       patients.in_batches(of: RECORD_BATCH_SIZE).each_with_index do |group, index|
         data = csv_line_list(group)
-        lookups << get_file(user_id, data, filename, file_extension, export_type, index + 1)
+        lookups << get_file(user_id, data, build_filename(base_filename, index + 1, file_extension), export_type)
       end
     when 'csv_isolation'
       patients = user.viewable_patients.where(isolation: true).where(purged: false)
-      filename = 'Sara-Alert-Linelist-Isolation'
+      base_filename = 'Sara-Alert-Linelist-Isolation'
       file_extension = 'csv'
       patients.in_batches(of: RECORD_BATCH_SIZE).each_with_index do |group, index|
         data = csv_line_list(group)
-        lookups << get_file(user_id, data, filename, file_extension, export_type, index + 1)
+        lookups << get_file(user_id, data, build_filename(base_filename, index + 1, file_extension), export_type)
       end
     when 'sara_format_exposure'
       patients = user.viewable_patients.where(isolation: false).where(purged: false)
-      filename = 'Sara-Alert-Format-Exposure'
+      base_filename = 'Sara-Alert-Format-Exposure'
       file_extension = 'xlsx'
       patients.in_batches(of: RECORD_BATCH_SIZE).each_with_index do |group, index|
         data = sara_alert_format(group)
-        lookups << get_file(user_id, data, filename, file_extension, export_type, index + 1)
+        lookups << get_file(user_id, data, build_filename(base_filename, index + 1, file_extension), export_type)
       end
     when 'sara_format_isolation'
       patients = user.viewable_patients.where(isolation: true).where(purged: false)
-      filename = 'Sara-Alert-Format-Isolation'
+      base_filename = 'Sara-Alert-Format-Isolation'
       file_extension = 'xlsx'
       patients.in_batches(of: RECORD_BATCH_SIZE).each_with_index do |group, index|
         data = sara_alert_format(group)
-        lookups << get_file(user_id, data, filename, file_extension, export_type, index + 1)
+        lookups << get_file(user_id, data, build_filename(base_filename, index + 1, file_extension), export_type)
       end
     when 'full_history_all'
       patients = user.viewable_patients.where(purged: false)
       file_extension = 'xlsx'
       patients.in_batches(of: RECORD_BATCH_SIZE).each_with_index do |group, index|
         file_index = index + 1
-        lookups << get_file(user_id, excel_export_monitorees(group), 'Sara-Alert-Full-Export-Monitorees', file_extension, export_type, file_index)
-        lookups << get_file(user_id, excel_export_assessments(group), 'Sara-Alert-Full-Export-Assessments', file_extension, export_type, file_index)
-        lookups << get_file(user_id, excel_export_lab_results(group), 'Sara-Alert-Full-Export-Lab-Results', file_extension, export_type, file_index)
-        lookups << get_file(user_id, excel_export_histories(group), 'Sara-Alert-Full-Export-Histories', file_extension, export_type, file_index)
+        lookups << get_file(user_id,
+                            excel_export_monitorees(group),
+                            build_filename('Sara-Alert-Full-Export-Monitorees', file_index, file_extension),
+                            export_type)
+        lookups << get_file(user_id,
+                            excel_export_assessments(group),
+                            build_filename('Sara-Alert-Full-Export-Assessments', file_index, file_extension),
+                            export_type)
+        lookups << get_file(user_id,
+                            excel_export_lab_results(group),
+                            build_filename('Sara-Alert-Full-Export-Lab-Results', file_index, file_extension),
+                            export_type)
+        lookups << get_file(user_id,
+                            excel_export_histories(group),
+                            build_filename('Sara-Alert-Full-Export-Histories', file_index, file_extension),
+                            export_type)
       end
     when 'full_history_purgeable'
       patients = user.viewable_patients.purge_eligible
       patients.in_batches(of: RECORD_BATCH_SIZE).each_with_index do |group, index|
         file_index = index + 1
-        lookups << get_file(user_id, excel_export_monitorees(group), 'Sara-Alert-Purge-Eligible-Export-Monitorees', file_extension, export_type, file_index)
-        lookups << get_file(user_id, excel_export_assessments(group), 'Sara-Alert-Purge-Eligible-Export-Assessments', file_extension, export_type, file_index)
-        lookups << get_file(user_id, excel_export_lab_results(group), 'Sara-Alert-Purge-Eligible-Export-Lab-Results', file_extension, export_type, file_index)
-        lookups << get_file(user_id, excel_export_histories(group), 'Sara-Alert-Purge-Eligible-Export-Histories', file_extension, export_type, file_index)
+        lookups << get_file(user_id,
+                            excel_export_monitorees(group),
+                            build_filename('Sara-Alert-Purge-Eligible-Export-Monitorees', file_index, file_extension),
+                            export_type)
+        lookups << get_file(user_id,
+                            excel_export_assessments(group),
+                            build_filename('Sara-Alert-Purge-Eligible-Export-Assessments', file_index, file_extension),
+                            export_type)
+        lookups << get_file(user_id,
+                            excel_export_lab_results(group),
+                            build_filename('Sara-Alert-Purge-Eligible-Export-Lab-Results', file_index, file_extension),
+                            export_type)
+        lookups << get_file(user_id,
+                            excel_export_histories(group),
+                            build_filename('Sara-Alert-Purge-Eligible-Export-Histories', file_index, file_extension),
+                            export_type)
       end
     end
     return if lookups.empty?
 
-    puts "lookups: #{lookups}"
     # Send an email to user
     UserMailer.download_email(user, export_type, lookups).deliver_later
   end
 
+  # Builds a file name using the base name, index, date, and extension.
+  # Ex: "Sara-Alert-Linelist-Isolation-2020-09-01T14:15:05-04:00-1"
+  def build_filename(base_name, file_index, file_extension)
+    "#{base_name}-#{DateTime.now}-#{file_index}.#{file_extension}"
+  end
+
   # Gets a single download with the provided filename information and containing the provided data.
-  # rubocop:disable Metrics/ParameterLists
-  def get_file(user_id, data, filename, file_extension, export_type, file_index)
-    full_filename = "#{filename}-#{DateTime.now}-#{file_index}.#{file_extension}"
+  def get_file(user_id, data, full_filename, export_type)
     { lookup: save_download(user_id, data, full_filename, export_type), filename: full_filename }
   end
-  # rubocop:enable Metrics/ParameterLists
 
   # Save a download file and return the lookup
   def save_download(user_id, data, filename, export_type)

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -98,7 +98,7 @@ class ExportJob < ApplicationJob
     return if lookups.empty?
 
     # Sort lookups by filename so that they are grouped together accordingly after batching
-    lookups = lookups.sort_by{|lookup| lookup[:filename]}
+    lookups = lookups.sort_by { |lookup| lookup[:filename] }
 
     # Send an email to user
     UserMailer.download_email(user, export_type, lookups, RECORD_BATCH_SIZE).deliver_later

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -97,8 +97,11 @@ class ExportJob < ApplicationJob
     end
     return if lookups.empty?
 
+    # Sort lookups by filename so that they are grouped together accordingly after batching
+    lookups = lookups.sort_by{|lookup| lookup[:filename]}
+
     # Send an email to user
-    UserMailer.download_email(user, export_type, lookups).deliver_later
+    UserMailer.download_email(user, export_type, lookups, RECORD_BATCH_SIZE).deliver_later
   end
 
   # Builds a file name using the base name, index, date, and extension.

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -34,10 +34,11 @@ class UserMailer < ApplicationMailer
     mail(to: ADMIN_OPTIONS['job_run_email'], subject: "Sara Alert Cache Analytics Job Results (#{ActionMailer::Base.default_url_options[:host]})")
   end
 
-  def download_email(user, export_type, lookups)
+  def download_email(user, export_type, lookups, batch_size)
     @user = user
     @export_type = export_type
     @lookups = lookups
+    @batch_size = batch_size
     mail(to: user.email.strip, subject: 'Your Sara Alert system export is ready') do |format|
       format.html { render layout: 'main_mailer' }
     end

--- a/app/views/user_mailer/download_email.html.erb
+++ b/app/views/user_mailer/download_email.html.erb
@@ -17,8 +17,14 @@
       <b>Default</b>
     <% end %>
     &quot; is now ready.
+    <p>
+    Please note that this export is one-time use only and is only valid for 24 hours. The system will delete an export once you've downloaded a file or a 24 hour period has elapsed.
+    These downloads will be invalid if you attempt another export of this type before retrieving the file(s). Exports will not work if forwarded to another user. You must be logged into Sara Alert to access exports.
+    <br />
+    If your export exceeded <%=@batch_size%> records, you will see separate files below with each containing data for no more than <%=@batch_size%> monitorees. 
+    Each file (e.g., monitorees, assessments, etc) belonging to the same batch will have the same number at the end of the filename.
+    </p>
   </p>
-  <p>Please note that this export is one-time use only and is only valid for 24 hours. The system will delete an export once you've downloaded a file or a 24 hour period has elapsed. These downloads will be invalid if you attempt another export of this type before retrieving the file(s). Exports will not work if forwarded to another user. You must be logged into Sara Alert to access exports.</p>
   <% @lookups.each do |lookup| %>
     <%= render partial: 'main_mailer/responsive_button', locals: {link: export_download_url(lookup: lookup[:lookup]) , text: "Click here to download #{lookup[:filename]}"} %>
     <br />


### PR DESCRIPTION
## Description

Limits number of records considered for a single export file to handle max file size limit, in response to errors seen on production. Doesn't exclude data, just breaks it up into separate files if record limit is reached.