### PR TITLE
User can no longer select contact method requiring a phone number and…

### DIFF
--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -70,7 +70,10 @@ class Contact extends React.Component {
           .nullable()
           .when('preferred_contact_method', pcm => {
             if (pcm && ['Telephone call', 'SMS Text-message', 'SMS Texted Weblink'].includes(pcm)) {
-              return yup.string().required('Please provide a primary telephone number, or change Preferred Contact Method.');
+              return yup
+                .string()
+                .phone()
+                .required('Please provide a primary telephone number, or change Preferred Contact Method.');
             }
           }),
         secondary_telephone: yup

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -64,34 +64,6 @@ class Contact extends React.Component {
           confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
           preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
         });
-      } else if (event?.currentTarget.id == 'primary_telephone') {
-        schema = yup.object().shape({
-          primary_telephone: yup
-            .string()
-            .phone()
-            .max(200, 'Max length exceeded, please limit to 200 characters.')
-            .nullable()
-            .when('preferred_contact_method', pcm => {
-              if (pcm && ['Telephone call', 'SMS Text-message', 'SMS Texted Weblink'].includes(pcm)) {
-                return yup
-                  .string()
-                  .phone()
-                  .required('Please provide a primary telephone number, or change Preferred Contact Method.');
-              }
-            }),
-          secondary_telephone: yup
-            .string()
-            .phone()
-            .max(200, 'Max length exceeded, please limit to 200 characters.'),
-          primary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-          secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-          email: yup
-            .string()
-            .email('Please enter a valid email.')
-            .max(200, 'Max length exceeded, please limit to 200 characters.'),
-          confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
-          preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-        });
       } else if (event?.currentTarget.value == 'E-mailed Web Link') {
         schema = yup.object().shape({
           primary_telephone: yup
@@ -135,6 +107,34 @@ class Contact extends React.Component {
           preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
         });
       }
+    } else if (event?.currentTarget.id == 'primary_telephone') {
+      schema = yup.object().shape({
+        primary_telephone: yup
+          .string()
+          .phone()
+          .max(200, 'Max length exceeded, please limit to 200 characters.')
+          .nullable()
+          .when('preferred_contact_method', pcm => {
+            if (pcm && ['Telephone call', 'SMS Text-message', 'SMS Texted Weblink'].includes(pcm)) {
+              return yup
+                .string()
+                .phone()
+                .required('Please provide a primary telephone number, or change Preferred Contact Method.');
+            }
+          }),
+        secondary_telephone: yup
+          .string()
+          .phone()
+          .max(200, 'Max length exceeded, please limit to 200 characters.'),
+        primary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+        secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+        email: yup
+          .string()
+          .email('Please enter a valid email.')
+          .max(200, 'Max length exceeded, please limit to 200 characters.'),
+        confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
+        preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+      });
     }
     this.setState({ errors: {} });
   }

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -366,7 +366,12 @@ var schema = yup.object().shape({
     .string()
     .phone()
     .max(200, 'Max length exceeded, please limit to 200 characters.')
-    .nullable(),
+    .nullable()
+    .when('preferred_contact_method', pcm => {
+      if (pcm && ['Telephone call', 'SMS Text-message', 'SMS Texted Weblink'].includes(pcm)) {
+        return yup.string().required('Please provide a primary telephone number, or change Preferred Contact Method.');
+      }
+    }),
   secondary_telephone: yup
     .string()
     .phone()

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -40,11 +40,7 @@ class Contact extends React.Component {
 
   updatePrimaryContactMethodValidations(event) {
     if (event?.currentTarget.id == 'preferred_contact_method') {
-      if (
-        event?.currentTarget.value == 'Telephone call' ||
-        event?.currentTarget.value == 'SMS Text-message' ||
-        event?.currentTarget.value == 'SMS Texted Weblink'
-      ) {
+      if (['Telephone call', 'SMS Text-message', 'SMS Texted Weblink'].includes(event?.currentTarget.value)) {
         schema = yup.object().shape({
           primary_telephone: yup
             .string()
@@ -64,51 +60,76 @@ class Contact extends React.Component {
           confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
           preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
         });
-      } else if (event?.currentTarget.value == 'E-mailed Web Link') {
-        schema = yup.object().shape({
-          primary_telephone: yup
-            .string()
-            .phone()
-            .max(200, 'Max length exceeded, please limit to 200 characters.'),
-          secondary_telephone: yup
-            .string()
-            .phone()
-            .max(200, 'Max length exceeded, please limit to 200 characters.'),
-          primary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-          secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-          email: yup
-            .string()
-            .email('Please enter a valid email.')
-            .required('Please provide an email')
-            .max(200, 'Max length exceeded, please limit to 200 characters.'),
-          confirm_email: yup
-            .string()
-            .required('Please confirm email.')
-            .oneOf([yup.ref('email'), null], 'Confirm email must match.'),
-          preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-        });
-      } else {
-        schema = yup.object().shape({
-          primary_telephone: yup
-            .string()
-            .phone()
-            .max(200, 'Max length exceeded, please limit to 200 characters.'),
-          secondary_telephone: yup
-            .string()
-            .phone()
-            .max(200, 'Max length exceeded, please limit to 200 characters.'),
-          primary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-          secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-          email: yup
-            .string()
-            .email('Please enter a valid email.')
-            .max(200, 'Max length exceeded, please limit to 200 characters.'),
-          confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
-          preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-        });
       }
-      this.setState({ errors: {} });
+    } else if (event?.currentTarget.id == 'primary_telephone') {
+      schema = yup.object().shape({
+        primary_telephone: yup
+          .string()
+          .phone()
+          .max(200, 'Max length exceeded, please limit to 200 characters.')
+          .nullable()
+          .when('preferred_contact_method', pcm => {
+            if (pcm && ['Telephone call', 'SMS Text-message', 'SMS Texted Weblink'].includes(pcm)) {
+              return yup.string().required('Please provide a primary telephone number, or change Preferred Contact Method.');
+            }
+          }),
+        secondary_telephone: yup
+          .string()
+          .phone()
+          .max(200, 'Max length exceeded, please limit to 200 characters.'),
+        primary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+        secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+        email: yup
+          .string()
+          .email('Please enter a valid email.')
+          .max(200, 'Max length exceeded, please limit to 200 characters.'),
+        confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
+        preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+      });
+    } else if (event?.currentTarget.value == 'E-mailed Web Link') {
+      schema = yup.object().shape({
+        primary_telephone: yup
+          .string()
+          .phone()
+          .max(200, 'Max length exceeded, please limit to 200 characters.'),
+        secondary_telephone: yup
+          .string()
+          .phone()
+          .max(200, 'Max length exceeded, please limit to 200 characters.'),
+        primary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+        secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+        email: yup
+          .string()
+          .email('Please enter a valid email.')
+          .required('Please provide an email')
+          .max(200, 'Max length exceeded, please limit to 200 characters.'),
+        confirm_email: yup
+          .string()
+          .required('Please confirm email.')
+          .oneOf([yup.ref('email'), null], 'Confirm email must match.'),
+        preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+      });
+    } else {
+      schema = yup.object().shape({
+        primary_telephone: yup
+          .string()
+          .phone()
+          .max(200, 'Max length exceeded, please limit to 200 characters.'),
+        secondary_telephone: yup
+          .string()
+          .phone()
+          .max(200, 'Max length exceeded, please limit to 200 characters.'),
+        primary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+        secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+        email: yup
+          .string()
+          .email('Please enter a valid email.')
+          .max(200, 'Max length exceeded, please limit to 200 characters.'),
+        confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
+        preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+      });
     }
+    this.setState({ errors: {} });
   }
 
   validate(callback) {
@@ -366,12 +387,7 @@ var schema = yup.object().shape({
     .string()
     .phone()
     .max(200, 'Max length exceeded, please limit to 200 characters.')
-    .nullable()
-    .when('preferred_contact_method', pcm => {
-      if (pcm && ['Telephone call', 'SMS Text-message', 'SMS Texted Weblink'].includes(pcm)) {
-        return yup.string().required('Please provide a primary telephone number, or change Preferred Contact Method.');
-      }
-    }),
+    .nullable(),
   secondary_telephone: yup
     .string()
     .phone()

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -40,7 +40,11 @@ class Contact extends React.Component {
 
   updatePrimaryContactMethodValidations(event) {
     if (event?.currentTarget.id == 'preferred_contact_method') {
-      if (['Telephone call', 'SMS Text-message', 'SMS Texted Weblink'].includes(event?.currentTarget.value)) {
+      if (
+        event?.currentTarget.value === 'Telephone call' ||
+        event?.currentTarget.value === 'SMS Text-message' ||
+        event?.currentTarget.value === 'SMS Texted Weblink'
+      ) {
         schema = yup.object().shape({
           primary_telephone: yup
             .string()
@@ -60,77 +64,77 @@ class Contact extends React.Component {
           confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
           preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
         });
+      } else if (event?.currentTarget.id == 'primary_telephone') {
+        schema = yup.object().shape({
+          primary_telephone: yup
+            .string()
+            .phone()
+            .max(200, 'Max length exceeded, please limit to 200 characters.')
+            .nullable()
+            .when('preferred_contact_method', pcm => {
+              if (pcm && ['Telephone call', 'SMS Text-message', 'SMS Texted Weblink'].includes(pcm)) {
+                return yup
+                  .string()
+                  .phone()
+                  .required('Please provide a primary telephone number, or change Preferred Contact Method.');
+              }
+            }),
+          secondary_telephone: yup
+            .string()
+            .phone()
+            .max(200, 'Max length exceeded, please limit to 200 characters.'),
+          primary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+          secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+          email: yup
+            .string()
+            .email('Please enter a valid email.')
+            .max(200, 'Max length exceeded, please limit to 200 characters.'),
+          confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
+          preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+        });
+      } else if (event?.currentTarget.value == 'E-mailed Web Link') {
+        schema = yup.object().shape({
+          primary_telephone: yup
+            .string()
+            .phone()
+            .max(200, 'Max length exceeded, please limit to 200 characters.'),
+          secondary_telephone: yup
+            .string()
+            .phone()
+            .max(200, 'Max length exceeded, please limit to 200 characters.'),
+          primary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+          secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+          email: yup
+            .string()
+            .email('Please enter a valid email.')
+            .required('Please provide an email')
+            .max(200, 'Max length exceeded, please limit to 200 characters.'),
+          confirm_email: yup
+            .string()
+            .required('Please confirm email.')
+            .oneOf([yup.ref('email'), null], 'Confirm email must match.'),
+          preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+        });
+      } else {
+        schema = yup.object().shape({
+          primary_telephone: yup
+            .string()
+            .phone()
+            .max(200, 'Max length exceeded, please limit to 200 characters.'),
+          secondary_telephone: yup
+            .string()
+            .phone()
+            .max(200, 'Max length exceeded, please limit to 200 characters.'),
+          primary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+          secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+          email: yup
+            .string()
+            .email('Please enter a valid email.')
+            .max(200, 'Max length exceeded, please limit to 200 characters.'),
+          confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
+          preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
+        });
       }
-    } else if (event?.currentTarget.id == 'primary_telephone') {
-      schema = yup.object().shape({
-        primary_telephone: yup
-          .string()
-          .phone()
-          .max(200, 'Max length exceeded, please limit to 200 characters.')
-          .nullable()
-          .when('preferred_contact_method', pcm => {
-            if (pcm && ['Telephone call', 'SMS Text-message', 'SMS Texted Weblink'].includes(pcm)) {
-              return yup
-                .string()
-                .phone()
-                .required('Please provide a primary telephone number, or change Preferred Contact Method.');
-            }
-          }),
-        secondary_telephone: yup
-          .string()
-          .phone()
-          .max(200, 'Max length exceeded, please limit to 200 characters.'),
-        primary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-        secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-        email: yup
-          .string()
-          .email('Please enter a valid email.')
-          .max(200, 'Max length exceeded, please limit to 200 characters.'),
-        confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
-        preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-      });
-    } else if (event?.currentTarget.value == 'E-mailed Web Link') {
-      schema = yup.object().shape({
-        primary_telephone: yup
-          .string()
-          .phone()
-          .max(200, 'Max length exceeded, please limit to 200 characters.'),
-        secondary_telephone: yup
-          .string()
-          .phone()
-          .max(200, 'Max length exceeded, please limit to 200 characters.'),
-        primary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-        secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-        email: yup
-          .string()
-          .email('Please enter a valid email.')
-          .required('Please provide an email')
-          .max(200, 'Max length exceeded, please limit to 200 characters.'),
-        confirm_email: yup
-          .string()
-          .required('Please confirm email.')
-          .oneOf([yup.ref('email'), null], 'Confirm email must match.'),
-        preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-      });
-    } else {
-      schema = yup.object().shape({
-        primary_telephone: yup
-          .string()
-          .phone()
-          .max(200, 'Max length exceeded, please limit to 200 characters.'),
-        secondary_telephone: yup
-          .string()
-          .phone()
-          .max(200, 'Max length exceeded, please limit to 200 characters.'),
-        primary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-        secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-        email: yup
-          .string()
-          .email('Please enter a valid email.')
-          .max(200, 'Max length exceeded, please limit to 200 characters.'),
-        confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
-        preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
-      });
     }
     this.setState({ errors: {} });
   }


### PR DESCRIPTION
… then null out that phone number

# Description
Jira Ticket: SARAALERT-720

There existed a bug where the user could select a Contact Method requiring a phone number (text/call...etc), and then null out that phone number. This PR adds a form validation test to confirm that, if the Contact Method is set to something requiring a phone number, the user cannot continue without the existence of the primary phone number field. 

# (Feature) Demo/Screenshots
![image](https://user-images.githubusercontent.com/17532163/91807409-3d3d4b80-ebfa-11ea-88f9-a7445d22752e.png)


# (Bugfix) How to Replicate
Edit the Contact Information of a Monitoree, and then null out their primary phone number. You will (incorrectly) be able to move on to the next page

# (Bugfix) Solution
Adds a new `yup` test to ensure the user cannot continue without a phone number (when required)

# Important Changes
`app/javascript/components/enrollment/steps/Contact.js`
- Added new `yup` validation test