### PR TITLE
Fix issue with dropdown modals being transparent

### DIFF
--- a/app/javascript/packs/stylesheets/bootstrap.scss
+++ b/app/javascript/packs/stylesheets/bootstrap.scss
@@ -25,6 +25,10 @@ body {
   z-index: 100 !important
 }
 
+.custom-control {
+  z-index: 0 !important;
+}
+
 .btn {
   border-radius: 0 !important;
 }


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-741](https://tracker.codev.mitre.org/browse/SARAALERT-741)

User can see other elements behind certain dropdown menus (datepicker, react select) even when they are open.  See screenshots in the JIRA ticket for additional examples.

<img width="768" alt="Screen Shot 2020-08-26 at 10 12 37 PM" src="https://user-images.githubusercontent.com/35042815/91864747-9929c380-ec3e-11ea-849c-2d1f96970391.png">

# (Bugfix) How to Replicate
On master, login as an admin and click `add user` or `edit` in one of the user rows.  Open up the jurisdiction or role dropdown menu and you will be able to see text that is not contained in that menu.  You can also recreate this with the primary language dropdown and some datepicker fields when enrolling a monitoree.

# (Bugfix) Solution
This actually ended up not being an issue with the dropdowns but rather the react `<Form.Check>` element we use.  React bootstrap adds a class (`.custom-control`) to the check element that sets the z-index at 1, causing it to be shown on top of any dropdown.  Because this is an issue with the `<Form.Check>` and causes errors with different dropdowns (react select dropdowns and the date picker, that I was able to find), I added a class to the `<Form.Check>` that overrides the z-index.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`UserModal.js`
`Exposure.js`
- two main files where the z-index on `<Form.Check>` was a problem

`layout.scss`
- updated css to override z-index

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [x] Firefox
* [x] Safari
* [x] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
