### PR TITLE
SARAALERT-743: Logic updates to send_assessment and CloseSubjectsJob

### DIFF
--- a/app/jobs/close_subjects_job.rb
+++ b/app/jobs/close_subjects_job.rb
@@ -23,8 +23,8 @@ class CloseSubjectsJob < ApplicationJob
 
     # Close subjects who are past the monitoring period (and are actually closable from above logic)
     eligible.find_each do |subject|
-      if (!subject.last_date_of_exposure.nil? && subject.last_date_of_exposure <= (ADMIN_OPTIONS['monitoring_period_days']).days.ago) ||
-         (subject.last_date_of_exposure.nil? && subject.created_at <= (ADMIN_OPTIONS['monitoring_period_days']).days.ago)
+      if (!subject.last_date_of_exposure.nil? && subject.last_date_of_exposure <= (ADMIN_OPTIONS['monitoring_period_days']).days.ago.beginning_of_day) ||
+         (subject.last_date_of_exposure.nil? && subject.created_at <= (ADMIN_OPTIONS['monitoring_period_days']).days.ago.beginning_of_day)
         begin
           subject[:monitoring] = false
           subject.closed_at = DateTime.now

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -484,7 +484,7 @@ class Patient < ApplicationRecord
 
     # Do not allow messages to go to household members
     return unless responder_id == id
-    
+
     # This  check is necessary as we do not close out folks on the non-reporting line list in exposure (therefore monitoring will still be true for them),
     # and we want to guarantee they they are not receiving messages past their monitoring period.
     # Return if:
@@ -502,8 +502,6 @@ class Patient < ApplicationRecord
                   continuous_exposure ||
                   dependents.where(monitoring: true).exists? ||
                   dependents.where(continuous_exposure: true).exists?
-
-
 
     # If force is set, the preferred contact time will be ignored
     unless force
@@ -542,7 +540,6 @@ class Patient < ApplicationRecord
     elsif preferred_contact_method&.downcase == 'e-mailed web link' && ADMIN_OPTIONS['enable_email'] && responder.id == id && email.present?
       PatientMailer.assessment_email(self).deliver_later
     end
-
   end
 
   # Return the calculated age based on the date of birth

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -498,7 +498,7 @@ class Patient < ApplicationRecord
                   dependents_exclude_self.where('monitoring = ? OR continuous_exposure = ?', true, true).exists?
 
     # Return if closed, UNLESS there are still group members who need to be reported on
-    return unless (monitoring && ||
+    return unless monitoring ||
                   continuous_exposure ||
                   dependents.where(monitoring: true).exists? ||
                   dependents.where(continuous_exposure: true).exists?

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -492,7 +492,7 @@ class Patient < ApplicationRecord
     # - not in isolation (as patients on RRR linelist should receive notifications) AND
     # - NOT in continuous exposure AND
     # - is not a HoH with actively monitored dependents
-    return if last_date_of_exposure <= (ADMIN_OPTIONS['monitoring_period_days'] + 1).days.ago &&
+    return if last_date_of_exposure < (ADMIN_OPTIONS['monitoring_period_days'] + 1).days.ago &&
               !isolation &&
               !continuous_exposure &&
               !dependents_exclude_self.where('monitoring = ? OR continuous_exposure = ?', true, true).exists?

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -485,23 +485,17 @@ class Patient < ApplicationRecord
     # Do not allow messages to go to household members
     return unless responder_id == id
 
-    # This check is necessary as we do not close out folks on the non-reporting line list in exposure (therefore monitoring will still be true for them),
-    # and we want to guarantee they they are not receiving messages past their monitoring period. It is separated out for clarity.
-    # Return IF:
-    # - out of monitoring period AND
-    # - not in isolation (as patients on RRR linelist should receive notifications) AND
-    # - NOT in continuous exposure AND
-    # - is not a HoH with actively monitored dependents
-    return unless last_date_of_exposure >= ADMIN_OPTIONS['monitoring_period_days'].days.ago.beginning_of_day ||
+    # Return UNLESS:
+    # - being monitored AND within monitoring period OR
+    # - in isolation (as patients on RRR linelist should receive notifications) OR
+    # - in continuous exposure OR
+    # - is a HoH with actively monitored dependents
+    # NOTE: We do not close out folks on the non-reporting line list in exposure (therefore monitoring will still be true for them),
+    # so we also have to check that someone receiving messages is not past their monitoring period unless their in isolation, continuous exposure, or have active dependents.
+    return unless (monitoring && last_date_of_exposure >= ADMIN_OPTIONS['monitoring_period_days'].days.ago.beginning_of_day) ||
                   isolation ||
                   continuous_exposure ||
                   dependents_exclude_self.where('monitoring = ? OR continuous_exposure = ?', true, true).exists?
-
-    # Return if closed, UNLESS there are still group members who need to be reported on
-    return unless monitoring ||
-                  continuous_exposure ||
-                  dependents.where(monitoring: true).exists? ||
-                  dependents.where(continuous_exposure: true).exists?
 
     # If force is set, the preferred contact time will be ignored
     unless force

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -486,8 +486,8 @@ class Patient < ApplicationRecord
     return unless responder_id == id
 
     # Return UNLESS:
-    # - being monitored AND within monitoring period OR
-    # - in isolation and NOT closed (as patients on RRR linelist should receive notifications) OR
+    # - in exposure: NOT closed AND within monitoring period OR
+    # - in isolation: NOT closed (as patients on RRR linelist should receive notifications) OR
     # - in continuous exposure OR
     # - is a HoH with actively monitored dependents
     # NOTE: We do not close out folks on the non-reporting line list in exposure (therefore monitoring will still be true for them),
@@ -598,7 +598,7 @@ class Patient < ApplicationRecord
       # Monitoring period has elapsed
       if (!last_date_of_exposure.nil? && last_date_of_exposure < reporting_period) && !continuous_exposure
         eligible = false
-        messages << { message: "Monitoree\'s monitoring period has elapsed and continuous exposure is not enabled", datetime: end_of_monitoring }
+        messages << { message: "Monitoree\'s monitoring period has elapsed and continuous exposure is not enabled", datetime: nil }
       end
     end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -487,13 +487,13 @@ class Patient < ApplicationRecord
 
     # Return UNLESS:
     # - being monitored AND within monitoring period OR
-    # - in isolation (as patients on RRR linelist should receive notifications) OR
+    # - in isolation and NOT closed (as patients on RRR linelist should receive notifications) OR
     # - in continuous exposure OR
     # - is a HoH with actively monitored dependents
     # NOTE: We do not close out folks on the non-reporting line list in exposure (therefore monitoring will still be true for them),
     # so we also have to check that someone receiving messages is not past their monitoring period unless their in isolation, continuous exposure, or have active dependents.
     return unless (monitoring && last_date_of_exposure >= ADMIN_OPTIONS['monitoring_period_days'].days.ago.beginning_of_day) ||
-                  isolation ||
+                  (monitoring && isolation) ||
                   continuous_exposure ||
                   dependents_exclude_self.where('monitoring = ? OR continuous_exposure = ?', true, true).exists?
 


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-743

We removed logic recently specifically checking for LDE as it was causing the bug where HoHs that were out of the monitoring period but with active dependents were not getting messages. That same line was both causing that bug and preventing messages from being sent to folks past their monitoring period but not closed out in exposure (on the non-reporting line list). This PR adds a check back in that handles that case, but does not reintroduce the HoH bug. 

This is the PR that removed this logic and fixed the HoH bug: https://github.com/SaraAlert/SaraAlert/pull/334/files#diff-9c324f49a7c201a8392c7c309c6477f2L79

The key thing to note is that checking for `monitoring` actually isn't sufficient, because we do not set monitoring to false when folks are on the non-reporting line list in exposure. 

Another important note is that just comparing `last_date_of_exposure` (which does not have the level of precision to include time) to X.days.ago (which does have the precision of time) can cause issues (August 18th with no specified time assumes beginning of day, and is technically not equal to August 18th at 11pm), hence the addition of `.beginning_of_day`.

# Important Changes
`app/models/patient.rb`
- Updated send_assessment method to include this check. Needs to be done here rather than reminder_eligible scope right now as we need to check the dependents.

`app/jobs/close_subjects_job.rb`
- Adding `.beginning_of_day` to compared date for accuracy. 

# Testing
Some prime cases:
- [ ] A case in isolation out of the monitoring period SHOULD receive notifications
- [ ] A monitoree in exposure that has no active dependents, is not in continuous exposure, is not closed,  is out of their monitoring period AND on the non-reporting line list should NOT receive notifications
- [ ] A monitoree in isolation that has no active dependents, is not in continuous exposure, is closed, and  is out of their monitoring period SHOULD receive notifications
- [ ] Anyone with active dependents (dependents that are monitored or in continuous exposure) SHOULD receive notifications
- [ ] If it is the last day of the monitoree's monitoring period (ex: LDE is 9/2, last day is 9/16), then they SHOULD be sent an assessment, and also SHOULD beclosed out in the monitoring job

