### PR TITLE
Multiple click button bug

### DIFF
--- a/app/javascript/components/assessment/steps/SymptomsAssessment.js
+++ b/app/javascript/components/assessment/steps/SymptomsAssessment.js
@@ -53,8 +53,9 @@ class SymptomsAssessment extends React.Component {
   }
 
   navigate() {
-    this.setState({ loading: true });
-    this.props.submit();
+    this.setState({ loading: true }, () => {
+      this.props.submit();
+    });
   }
 
   noSymptom() {

--- a/app/javascript/components/assessment/steps/SymptomsAssessment.js
+++ b/app/javascript/components/assessment/steps/SymptomsAssessment.js
@@ -5,7 +5,13 @@ import { Card, Button, Form } from 'react-bootstrap';
 class SymptomsAssessment extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { ...this.props, current: { ...this.props.currentState }, noSymptomsCheckbox: false, selectedBoolSymptomCount: 0 };
+    this.state = {
+      ...this.props,
+      current: { ...this.props.currentState },
+      loading: false,
+      noSymptomsCheckbox: false,
+      selectedBoolSymptomCount: 0,
+    };
     this.handleChange = this.handleChange.bind(this);
     this.handleNoSymptomChange = this.handleNoSymptomChange.bind(this);
     this.updateBoolSymptomCount = this.updateBoolSymptomCount.bind(this);
@@ -47,6 +53,7 @@ class SymptomsAssessment extends React.Component {
   }
 
   navigate() {
+    this.setState({ loading: true });
     this.props.submit();
   }
 
@@ -144,7 +151,12 @@ class SymptomsAssessment extends React.Component {
               </Form.Group>
             </Form.Row>
             <Form.Row className="pt-4">
-              <Button variant="primary" block size="lg" className="btn-block btn-square" onClick={this.navigate}>
+              <Button variant="primary" block size="lg" className="btn-block btn-square" disabled={this.state.loading} onClick={this.navigate}>
+                {this.state.loading && (
+                  <React.Fragment>
+                    <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
+                  </React.Fragment>
+                )}
                 {this.props.translations[this.props.lang]['web']['submit']}
               </Button>
             </Form.Row>

--- a/app/javascript/components/close_contact/CloseContact.js
+++ b/app/javascript/components/close_contact/CloseContact.js
@@ -11,6 +11,7 @@ class CloseContact extends React.Component {
     super(props);
     this.state = {
       showModal: false,
+      loading: false,
       first_name: this.props.close_contact.first_name || '',
       last_name: this.props.close_contact.last_name || '',
       primary_telephone: this.props.close_contact.primary_telephone || '',
@@ -46,24 +47,26 @@ class CloseContact extends React.Component {
   };
 
   submit() {
-    axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
-    axios
-      .post(window.BASE_PATH + '/close_contacts' + (this.props.close_contact.id ? '/' + this.props.close_contact.id : ''), {
-        patient_id: this.props.patient.id,
-        first_name: this.state.first_name || '',
-        last_name: this.state.last_name || '',
-        primary_telephone: this.state.primary_telephone || '',
-        email: this.state.email || '',
-        notes: this.state.notes || '',
-        enrolled_id: this.state.enrolled_id || null,
-        contact_attempts: this.state.contact_attempts || 0,
-      })
-      .then(() => {
-        location.reload(true);
-      })
-      .catch(error => {
-        reportError(error);
-      });
+    this.setState({ loading: true }, () => {
+      axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
+      axios
+        .post(window.BASE_PATH + '/close_contacts' + (this.props.close_contact.id ? '/' + this.props.close_contact.id : ''), {
+          patient_id: this.props.patient.id,
+          first_name: this.state.first_name || '',
+          last_name: this.state.last_name || '',
+          primary_telephone: this.state.primary_telephone || '',
+          email: this.state.email || '',
+          notes: this.state.notes || '',
+          enrolled_id: this.state.enrolled_id || null,
+          contact_attempts: this.state.contact_attempts || 0,
+        })
+        .then(() => {
+          location.reload(true);
+        })
+        .catch(error => {
+          reportError(error);
+        });
+    });
   }
 
   createModal(title, toggle, submit) {
@@ -119,7 +122,9 @@ class CloseContact extends React.Component {
           <Button
             variant="primary btn-square"
             onClick={submit}
-            disabled={!(this.state.first_name || this.state.last_name || this.state.email || this.state.primary_telephone || this.state.notes)}>
+            disabled={
+              !(this.state.first_name || this.state.last_name || this.state.email || this.state.primary_telephone || this.state.notes) || this.state.loading
+            }>
             {this.props.close_contact.id ? 'Update' : 'Create'}
           </Button>
         </Modal.Footer>

--- a/app/javascript/components/history/HistoryComponent.js
+++ b/app/javascript/components/history/HistoryComponent.js
@@ -3,26 +3,52 @@ import { PropTypes } from 'prop-types';
 import { Card, Row } from 'react-bootstrap';
 import Pagination from 'jw-react-pagination';
 import Select from 'react-select';
+import axios from 'axios';
 
 import History from './History';
 import InfoTooltip from '../util/InfoTooltip';
+import reportError from '../util/ReportError';
 
 class HistoryComponent extends React.Component {
   constructor(props) {
     super(props);
 
-    // bind the onChangePage method to this React component
-    this.onChangePage = this.onChangePage.bind(this);
-
     this.state = {
+      loading: false,
+      comment: '',
       selectedFilters: [],
       filteredHistories: this.props.histories,
       pageOfHistories: [],
     };
+
+    this.handleTextChange = this.handleTextChange.bind(this);
+    this.onChangePage = this.onChangePage.bind(this);
+    this.submit = this.submit.bind(this);
+  }
+
+  handleTextChange(event) {
+    this.setState({ comment: event.target.value });
   }
 
   onChangePage(pageOfHistories) {
     this.setState({ pageOfHistories });
+  }
+
+  submit() {
+    this.setState({ loading: true }, () => {
+      axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
+      axios
+        .post(window.BASE_PATH + '/histories', {
+          patient_id: this.props.patient_id,
+          comment: this.state.comment,
+        })
+        .then(() => {
+          location.reload(true);
+        })
+        .catch(error => {
+          reportError(error);
+        });
+    });
   }
 
   filterHistories = () => {
@@ -111,14 +137,22 @@ class HistoryComponent extends React.Component {
             <Card className="mb-4 mt-4 mx-3 card-square shadow-sm">
               <Card.Header>Add Comment</Card.Header>
               <Card.Body>
-                <form action="/histories" method="post">
-                  <input type="hidden" name="authenticity_token" value={this.props.authenticity_token} />
-                  <input name="patient_id" type="hidden" value={this.props.patient_id} />
-                  <textarea id="comment" name="comment" className="form-control" style={{ resize: 'none' }} rows="3" placeholder="enter comment here..." />
-                  <button type="submit" className="mt-3 btn btn-primary btn-square float-right">
-                    <i className="fas fa-comment-dots"></i> Add Comment
-                  </button>
-                </form>
+                <textarea
+                  id="comment"
+                  name="comment"
+                  className="form-control"
+                  style={{ resize: 'none' }}
+                  rows="3"
+                  placeholder="enter comment here..."
+                  value={this.state.comment}
+                  onChange={this.handleTextChange}
+                />
+                <button
+                  className="mt-3 btn btn-primary btn-square float-right"
+                  disabled={this.state.loading || this.state.comment === ''}
+                  onClick={this.submit}>
+                  <i className="fas fa-comment-dots"></i> Add Comment
+                </button>
               </Card.Body>
             </Card>
           </Card.Body>

--- a/app/javascript/components/laboratory/Laboratory.js
+++ b/app/javascript/components/laboratory/Laboratory.js
@@ -11,6 +11,7 @@ class Laboratory extends React.Component {
     super(props);
     this.state = {
       showModal: false,
+      loading: false,
       lab_type: this.props.lab.lab_type || '',
       specimen_collection: this.props.lab.specimen_collection,
       report: this.props.lab.report,
@@ -33,21 +34,23 @@ class Laboratory extends React.Component {
   }
 
   submit() {
-    axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
-    axios
-      .post(window.BASE_PATH + '/laboratories' + (this.props.lab.id ? '/' + this.props.lab.id : ''), {
-        patient_id: this.props.patient.id,
-        lab_type: this.state.lab_type,
-        specimen_collection: this.state.specimen_collection,
-        report: this.state.report,
-        result: this.state.result,
-      })
-      .then(() => {
-        location.reload(true);
-      })
-      .catch(error => {
-        reportError(error);
-      });
+    this.setState({ loading: true }, () => {
+      axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
+      axios
+        .post(window.BASE_PATH + '/laboratories' + (this.props.lab.id ? '/' + this.props.lab.id : ''), {
+          patient_id: this.props.patient.id,
+          lab_type: this.state.lab_type,
+          specimen_collection: this.state.specimen_collection,
+          report: this.state.report,
+          result: this.state.result,
+        })
+        .then(() => {
+          location.reload(true);
+        })
+        .catch(error => {
+          reportError(error);
+        });
+    });
   }
 
   createModal(title, toggle, submit) {
@@ -108,7 +111,7 @@ class Laboratory extends React.Component {
           <Button variant="secondary btn-square" onClick={toggle}>
             Cancel
           </Button>
-          <Button variant="primary btn-square" onClick={submit}>
+          <Button variant="primary btn-square" disabled={this.state.loading} onClick={submit}>
             Create
           </Button>
         </Modal.Footer>


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-756](https://tracker.codev.mitre.org/browse/SARAALERT-756)

Double clicking the "Submit"  or "Create" button many times very fast it will create duplicate objects.  This applies to the following buttons:

- `Add New Lab Result` in the lab results section
- `Add New Report` in the reports section
- `Add Comment` in history section
- `Add New Close Contact` in close contact section

I _think_ these are all the buttons that will result in creating multiple objects when clicked fast, but someone else should double check this.

# (Bugfix) How to Replicate
Pick one of the buttons above and click really fast when you submit.  You should see many new objects that are all the same appear.

# (Bugfix) Solution
Created a loading boolean that is kept in state and use that to disable/enable the submit button

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`CloseContact.js`
`HistoryComponent.js`- had to refactor here to have a submit function with the post instead of using forms
`Laboratory.js`
`SymptomsAssessment.js` - added loading spinner (this page is especially slow)

Similar changes are made in all these files but called out subtle differences above

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [x] Firefox
* [x] Safari
* [x] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
