### PR TITLE
Correct sorting issues for expected_purge_date and expected_purge_date

### DIFF
--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -176,7 +176,9 @@ class PublicHealthController < ApplicationController
     when 'dob'
       patients = patients.order('CASE WHEN date_of_birth IS NULL THEN 1 ELSE 0 END, date_of_birth ' + dir)
     when 'end_of_monitoring'
-      patients = patients.order('CASE WHEN continuous_exposure = 1 THEN now() WHEN last_date_of_exposure IS NULL THEN patients.created_at ELSE last_date_of_exposure END ' + dir)
+      patients = patients.order('CASE WHEN continuous_exposure = 1 THEN now()
+        WHEN last_date_of_exposure IS NULL
+        THEN patients.created_at ELSE last_date_of_exposure END ' + dir)
     when 'symptom_onset'
       patients = patients.order('CASE WHEN symptom_onset IS NULL THEN 1 ELSE 0 END, symptom_onset ' + dir)
     when 'risk_level'
@@ -186,7 +188,9 @@ class PublicHealthController < ApplicationController
     when 'public_health_action'
       patients = patients.order('CASE WHEN public_health_action IS NULL THEN 1 ELSE 0 END, public_health_action ' + dir)
     when 'expected_purge_date'
-      patients = patients.order('CASE WHEN continuous_exposure = 1 THEN now() WHEN last_date_of_exposure IS NULL THEN patients.created_at ELSE last_date_of_exposure END ' + dir)
+      patients = patients.order('CASE WHEN continuous_exposure = 1 THEN now()
+        WHEN last_date_of_exposure IS NULL
+        THEN patients.created_at ELSE last_date_of_exposure END ' + dir)
     when 'reason_for_closure'
       patients = patients.order('CASE WHEN monitoring_reason IS NULL THEN 1 ELSE 0 END, monitoring_reason ' + dir)
     when 'closed_at'

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -176,7 +176,7 @@ class PublicHealthController < ApplicationController
     when 'dob'
       patients = patients.order('CASE WHEN date_of_birth IS NULL THEN 1 ELSE 0 END, date_of_birth ' + dir)
     when 'end_of_monitoring'
-      patients = patients.order('CASE WHEN last_date_of_exposure IS NULL THEN 1 ELSE 0 END, last_date_of_exposure ' + dir)
+      patients = patients.order('CASE WHEN continuous_exposure = 1 THEN now() WHEN last_date_of_exposure IS NULL THEN patients.created_at ELSE last_date_of_exposure END ' + dir)
     when 'symptom_onset'
       patients = patients.order('CASE WHEN symptom_onset IS NULL THEN 1 ELSE 0 END, symptom_onset ' + dir)
     when 'risk_level'
@@ -186,7 +186,7 @@ class PublicHealthController < ApplicationController
     when 'public_health_action'
       patients = patients.order('CASE WHEN public_health_action IS NULL THEN 1 ELSE 0 END, public_health_action ' + dir)
     when 'expected_purge_date'
-      patients = patients.order('CASE WHEN last_date_of_exposure IS NULL THEN 1 ELSE 0 END, last_date_of_exposure ' + dir)
+      patients = patients.order('CASE WHEN continuous_exposure = 1 THEN now() WHEN last_date_of_exposure IS NULL THEN patients.created_at ELSE last_date_of_exposure END ' + dir)
     when 'reason_for_closure'
       patients = patients.order('CASE WHEN monitoring_reason IS NULL THEN 1 ELSE 0 END, monitoring_reason ' + dir)
     when 'closed_at'


### PR DESCRIPTION
We discovered the when importing or creating users through the API that fields based on last_date_of_exposure aren't sorting correctly. The following two modifications resolve this issue.

# Description
Jira Ticket: SARAALERT-###

We discovered the when importing or creating users through the API that fields based on last_date_of_exposure aren't sorting correctly. The following two modifications resolve this issue.

# (Feature) Demo/Screenshots
In SaraAlert v1.11.1 
![image](https://user-images.githubusercontent.com/6969342/92186238-2417e300-ee24-11ea-87f5-0c671ddfc1f5.png)


# (Bugfix) How to Replicate
Create a user without a last_date_of_exposure via the API or import function. The columns mentioned above will not sort correctly. Also any user-entered with continued exposure will sort based on their created_date or last_date_of_exposure, since they are continually exposed we place them above the latest exposures.

# (Bugfix) Solution
The PR implements the same logic as the end_of_monitoring field via SQL allowing for the table to be sorted reliably.

# Important Changes
This only modifies public_health_controller.rb
Adjusting the end_of_monitoring and expected_purge_date sorting.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ X] Chrome
* [ X] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.

Loading demo data and then using the API or the import tool to create a record without an last_date_of_exposure value.
