### PR TITLE
Add extension to filename for full_history_purgable export.

### DIFF
--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -75,6 +75,7 @@ class ExportJob < ApplicationJob
       end
     when 'full_history_purgeable'
       patients = user.viewable_patients.purge_eligible
+      file_extension = 'xlsx'
       patients.in_batches(of: RECORD_BATCH_SIZE).each_with_index do |group, index|
         file_index = index + 1
         lookups << get_file(user_id,


### PR DESCRIPTION
# Description
Adds back missing extension. As of right now, for this particular export folks have to manually add the extension back.

# Important Changes
`app/jobs/export_job.rb`
- Adds missing variable.

# Testing
Can test locally by manually running job for `full_history_purgeable` export.
