### PR TITLE
1.12 Updates

### DIFF
--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -66,7 +66,7 @@ class Contact extends React.Component {
           primary_telephone: yup
             .string()
             .phone()
-            .required('Please provide a primary telephone number')
+            .required('Please provide a primary telephone number, or change Preferred Reporting Method.')
             .max(200, 'Max length exceeded, please limit to 200 characters.'),
           secondary_telephone: yup
             .string()
@@ -96,7 +96,7 @@ class Contact extends React.Component {
           email: yup
             .string()
             .email('Please enter a valid email.')
-            .required('Please provide an email')
+            .required('Please provide an email or change Preferred Reporting Method')
             .max(200, 'Max length exceeded, please limit to 200 characters.'),
           confirm_email: yup
             .string()
@@ -136,7 +136,7 @@ class Contact extends React.Component {
               return yup
                 .string()
                 .phone()
-                .required('Please provide a primary telephone number, or change Preferred Contact Method.');
+                .required('Please provide a primary telephone number, or change Preferred Reporting Method.');
             }
           }),
         secondary_telephone: yup

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -147,9 +147,6 @@ class Exposure extends React.Component {
             <DateInput
               id="symptom_onset"
               date={this.state.current.patient.symptom_onset}
-              minDate={moment()
-                .subtract(30, 'days')
-                .format('YYYY-MM-DD')}
               maxDate={moment()
                 .add(30, 'days')
                 .format('YYYY-MM-DD')}
@@ -213,9 +210,6 @@ class Exposure extends React.Component {
             <DateInput
               id="last_date_of_exposure"
               date={this.state.current.patient.last_date_of_exposure}
-              minDate={moment()
-                .subtract(30, 'days')
-                .format('YYYY-MM-DD')}
               maxDate={moment()
                 .add(30, 'days')
                 .format('YYYY-MM-DD')}

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -40,7 +40,7 @@ class PatientsTable extends React.Component {
           { field: 'state_local_id', label: 'State/Local ID', isSortable: true, tooltip: null },
           { field: 'dob', label: 'Date of Birth', isSortable: true, tooltip: null, filter: this.formatDate },
           { field: 'end_of_monitoring', label: 'End of Monitoring', isSortable: true, tooltip: null, filter: this.formatEndOfMonitoring },
-          { field: 'extended_isolation', label: 'Extended Isolation To', isSortable: true, tooltip: null, filter: this.formatDate },
+          { field: 'extended_isolation', label: 'Extended Isolation To', isSortable: true, tooltip: 'extendedIsolation', filter: this.formatDate },
           { field: 'symptom_onset', label: 'Symptom Onset', isSortable: true, tooltip: null, filter: this.formatDate },
           { field: 'risk_level', label: 'Risk Level', isSortable: true, tooltip: null },
           { field: 'monitoring_plan', label: 'Monitoring Plan', isSortable: true, tooltip: null },

--- a/app/javascript/components/subject/ExtendedIsolation.js
+++ b/app/javascript/components/subject/ExtendedIsolation.js
@@ -89,10 +89,12 @@ class ExtendedIsolation extends React.Component {
                     {moment(this.state.extended_isolation).isSameOrAfter(moment().format('MM/DD/YYYY')) ? (
                       <Form.Label className="mb-2">
                         {`Are you sure you want to extend this case’s isolation through ${moment(this.state.extended_isolation).format('MM/DD/YYYY')}?
-                        The case will not appear on the Records Requiring Review List until after ${moment(this.state.extended_isolation).format(
-                          'MM/DD/YYYY'
-                        )} AND a recovery definition is met.
-                        The case will move to the "Reporting" or "Non-Reporting" line list.`}
+                          After clicking “Submit”, the case will be moved to the "Reporting" or "Non-Reporting" line list. 
+                          This case cannot appear on the records Requiring Review Line List until after ${moment(this.state.extended_isolation).format(
+                            'MM/DD/YYYY'
+                          )}.
+                          If the record meets a recovery definition after ${moment(this.state.extended_isolation).format('MM/DD/YYYY')}, it will appear on the 
+                          Records Requiring Review Line List for review by public health to determine if it is safe to discontinue isolation.`}
                       </Form.Label>
                     ) : (
                       <Form.Label className="mb-2">

--- a/app/javascript/components/subject/ExtendedIsolation.js
+++ b/app/javascript/components/subject/ExtendedIsolation.js
@@ -88,8 +88,10 @@ class ExtendedIsolation extends React.Component {
                   <React.Fragment>
                     {moment(this.state.extended_isolation).isSameOrAfter(moment().format('MM/DD/YYYY')) ? (
                       <Form.Label className="mb-2">
-                        {`Are you sure you want to extend this case’s isolation through ${moment(this.state.extended_isolation).format('MM/DD/YYYY')}?
-                          After clicking “Submit”, the case will be moved to the "Reporting" or "Non-Reporting" line list. 
+                        {`Are you sure you want to extend this case’s isolation through ${moment(this.state.extended_isolation).format('MM/DD/YYYY')}?`}
+                        <br></br>
+                        <br></br>
+                        {`After clicking “Submit”, the case will be moved to the "Reporting" or "Non-Reporting" line list. 
                           This case cannot appear on the records Requiring Review Line List until after ${moment(this.state.extended_isolation).format(
                             'MM/DD/YYYY'
                           )}.

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -194,9 +194,6 @@ class LastDateExposure extends React.Component {
                 <DateInput
                   id="last_date_of_exposure"
                   date={this.state.last_date_of_exposure}
-                  minDate={moment()
-                    .subtract(30, 'days')
-                    .format('YYYY-MM-DD')}
                   maxDate={moment()
                     .add(30, 'days')
                     .format('YYYY-MM-DD')}

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -167,7 +167,7 @@ class LastDateExposure extends React.Component {
         {this.state.showExposureDateModal &&
           this.createModal(
             'Last Date of Exposure',
-            `Are you sure you want to modify the Last Date of Exposure to ${this.state.last_date_of_exposure}? The Last Date of Exposure will be updated and Continuous Exposure will be toggled off for any selected record`,
+            `Are you sure you want to modify the Last Date of Exposure to ${this.state.last_date_of_exposure}? The Last Date of Exposure will be updated and Continuous Exposure will be toggled off for the selected record`,
             this.closeExposureDateModal,
             () => this.submit(true)
           )}

--- a/app/javascript/components/subject/SymptomOnset.js
+++ b/app/javascript/components/subject/SymptomOnset.js
@@ -85,9 +85,6 @@ class SymptomOnset extends React.Component {
               <DateInput
                 id="symptom_onset"
                 date={this.state.symptom_onset}
-                minDate={moment()
-                  .subtract(30, 'days')
-                  .format('YYYY-MM-DD')}
                 maxDate={moment()
                   .add(30, 'days')
                   .format('YYYY-MM-DD')}

--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -177,16 +177,12 @@ const TOOLTIP_TEXT = {
       </div>
     </div>
   ),
-
   extendedIsolation: (
     <div>
-      Used to move records from &quot;Records Requiring Review&quot; to either the &quot;Reporting&quot; or &quot;Non-Reporting&quot; line list
-      <div>
-        <i>Only relevant for Isolation Workflow</i>
-      </div>
+      Used by the system to determine eligibility to appear on the <i>Records Requiring Review</i> line list. A case cannot appear on the{' '}
+      <i>Records Requiring Review</i> line list until after the user-specified date. This field may be blank.
     </div>
   ),
-
   // REQUIRES REVIEW RECOVERY LOGIC
   asymptomaticNonTestBased: (
     <div>At least 10 days have passed since the specimen collection date of a positive laboratory test and the monitoree has never reported symptoms.</div>

--- a/config/locales/es-PR.yml
+++ b/config/locales/es-PR.yml
@@ -35,13 +35,13 @@ es-PR:
         name: 'oxímetro de pulso'
         notes: 'Ingrese la lectura más baja del oxímetro de pulso en las últimas 24 horas'
       fatigue:
-        name: 'Fatigue'
+        name: 'Fatiga'
         notes: ''
       nausea-or-vomiting:
-        name: 'Nausea Or Vomiting'
+        name: 'Náuseas o vómitos'
         notes: ''
       diarrhea:
-        name: 'Diarrhea'
+        name: 'Diarrea'
         notes: ''
       nasal-congestion:
         name: 'Nasal Congestion'
@@ -57,16 +57,16 @@ es-PR:
         notes: 'I would like someone to call me to follow-up on other symptoms or additional needs'
       no-symptoms: 'No tengo ningún síntoma.'
       new-loss-of-smell:
-        name: 'New Loss of Smell'
+        name: 'Pérdida reciente el olfato'
         notes: ''
       new-loss-of-taste:
-        name: 'New Loss of Taste'
+        name: 'Pérdida reciente el gusto'
         notes: ''
       shortness-of-breath:
-        name: 'Shortness of Breath'
+        name: 'Falta de aire'
         notes: ''
       congestion-or-runny-nose:
-        name: 'Congestion or Runny Nose'
+        name: 'Congestión o nariz que moquea'
         notes: ''
     threshold-op:
       less-than: 'Menos que'

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -35,13 +35,13 @@ es:
         name: 'oxímetro de pulso'
         notes: 'Ingrese la lectura más baja del oxímetro de pulso en las últimas 24 horas'
       fatigue:
-        name: 'Fatigue'
+        name: 'Fatiga'
         notes: ''
       nausea-or-vomiting:
-        name: 'Nausea Or Vomiting'
+        name: 'Náuseas o vómitos'
         notes: ''
       diarrhea:
-        name: 'Diarrhea'
+        name: 'Diarrea'
         notes: ''
       nasal-congestion:
         name: 'Nasal Congestion'
@@ -57,16 +57,16 @@ es:
         notes: 'I would like someone to call me to follow-up on other symptoms or additional needs'
       no-symptoms: 'No tengo ningún síntoma.'
       new-loss-of-smell:
-        name: 'New Loss of Smell'
+        name: 'Pérdida reciente el olfato'
         notes: ''
       new-loss-of-taste:
-        name: 'New Loss of Taste'
+        name: 'Pérdida reciente el gusto'
         notes: ''
       shortness-of-breath:
-        name: 'Shortness of Breath'
+        name: 'Falta de aire'
         notes: ''
       congestion-or-runny-nose:
-        name: 'Congestion or Runny Nose'
+        name: 'Congestión o nariz que moquea'
         notes: ''
     threshold-op:
       less-than: 'Menos que'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -38,7 +38,7 @@ fr:
         name: 'Fatigue'
         notes: ''
       nausea-or-vomiting:
-        name: 'Nausea Or Vomiting'
+        name: 'Nausée ou vomissements'
         notes: ''
       diarrhea:
         name: 'Diarrhea'
@@ -57,16 +57,16 @@ fr:
         notes: 'I would like someone to call me to follow-up on other symptoms or additional needs'
       no-symptoms: 'Aucun symptôme'
       new-loss-of-smell:
-        name: 'New Loss of Smell'
+        name: 'Nouvelle perte de l’odorat'
         notes: ''
       new-loss-of-taste:
-        name: 'New Loss of Taste'
+        name: 'Nouvelle perte de goût'
         notes: ''
       shortness-of-breath:
-        name: 'Shortness of Breath'
+        name: 'Essoufflement'
         notes: ''
       congestion-or-runny-nose:
-        name: 'Congestion or Runny Nose'
+        name: 'Congestion nasale ou ecoulement nasal'
         notes: ''
     threshold-op:
       less-than: 'moins que'

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -35,13 +35,13 @@ so:
         name: 'Aksijiinta Dhiiggaaga'
         notes: 'Geli cabbirka aksijiinta dhiiggaaga ee ugu hooseeya ee la qaaday 24-kii saac ee la soo dhaafay'
       fatigue:
-        name: 'Fatigue'
+        name: 'Daal'
         notes: ''
       nausea-or-vomiting:
-        name: 'Nausea Or Vomiting'
+        name: 'Lalabbo ama matagid'
         notes: ''
       diarrhea:
-        name: 'Diarrhea'
+        name: 'Shuban'
         notes: ''
       nasal-congestion:
         name: 'Nasal Congestion'
@@ -57,16 +57,16 @@ so:
         notes: 'I would like someone to call me to follow-up on other symptoms or additional needs'
       no-symptoms: 'Astaamo ma laha'
       new-loss-of-smell:
-        name: 'New Loss of Smell'
+        name: 'ur cusub kaa lunta'
         notes: ''
       new-loss-of-taste:
-        name: 'New Loss of Taste'
+        name: 'Dhadhan kaa lunta'
         notes: ''
       shortness-of-breath:
-        name: 'Shortness of Breath'
+        name: 'Neef qabatin'
         notes: ''
       congestion-or-runny-nose:
-        name: 'Congestion or Runny Nose'
+        name: 'San xidhan ama duuf leh'
         notes: ''
     threshold-op:
       less-than: 'Ka yar'

--- a/config/sara/jurisdictions.yml
+++ b/config/sara/jurisdictions.yml
@@ -9,62 +9,100 @@
             # The expected threshold value for bool_values should always be true
             value: true
             type: 'BoolSymptom'
-            threshold_operator: 'Equal'
             required: true
+            threshold_operator: 'Equal'
             group: 1
         'Difficulty Breathing':
             value: true
             type: 'BoolSymptom'
-            threshold_operator: 'Equal'
             required: true
+            threshold_operator: 'Equal'
+            group: 1
+        'New Loss of Smell':
+            value: true
+            type: 'BoolSymptom'
+            required: true
+            threshold_operator: 'Equal'
+            group: 1
+        'New Loss of Taste':
+            value: true
+            type: 'BoolSymptom'
+            required: true
+            threshold_operator: 'Equal'
+            group: 1
+        'Shortness of Breath':
+            value: true
+            type: 'BoolSymptom'
+            required: true
+            threshold_operator: 'Equal'
             group: 1
         'Fever':
             value: true
             type: 'BoolSymptom'
-            threshold_operator: 'Equal'
+            notes: 'Feeling feverish or have a measured temperature at or above 100.4°F/38°C'
             required: true
+            threshold_operator: 'Equal'
             group: 2
         'Used A Fever Reducer':
             value: true
             type: 'BoolSymptom'
-            threshold_operator: 'Equal'
+            notes: 'In the past 24 hours, have you used any medicine that reduces fevers?'
             required: false
+            threshold_operator: 'Equal'
             group: 2
         'Chills':
             value: true
             type: 'BoolSymptom'
-            threshold_operator: 'Equal'
             required: true
+            threshold_operator: 'Equal'
             group: 2
         'Repeated Shaking with Chills':
             value: true
             type: 'BoolSymptom'
-            threshold_operator: 'Equal'
             required: true
+            threshold_operator: 'Equal'
             group: 2
         'Muscle Pain':
             value: true
             type: 'BoolSymptom'
-            threshold_operator: 'Equal'
             required: true
+            threshold_operator: 'Equal'
             group: 2
         'Headache':
             value: true
             type: 'BoolSymptom'
-            threshold_operator: 'Equal'
             required: true
+            threshold_operator: 'Equal'
             group: 2
         'Sore Throat':
             value: true
             type: 'BoolSymptom'
-            threshold_operator: 'Equal'
             required: true
+            threshold_operator: 'Equal'
             group: 2
-        'New Loss of Taste or Smell':
+        'Nausea or Vomiting':
             value: true
             type: 'BoolSymptom'
-            threshold_operator: 'Equal'
             required: true
+            threshold_operator: 'Equal'
+            group: 2
+        'Diarrhea':
+            value: true
+            type: 'BoolSymptom'
+            required: true
+            threshold_operator: 'Equal'
+            group: 2
+        'Fatigue':
+            value: true
+            type: 'BoolSymptom'
+            required: true
+            threshold_operator: 'Equal'
+            group: 2
+        'Congestion or Runny Nose':
+            value: true
+            type: 'BoolSymptom'
+            required: true
+            threshold_operator: 'Equal'
             group: 2
     # Jurisdictions follow a hierarchy, the hierarchy is defined by nesting jurisdictions
     # in the children: field

--- a/test/system/roles/enroller/enrollment/form_validator.rb
+++ b/test/system/roles/enroller/enrollment/form_validator.rb
@@ -61,28 +61,28 @@ class EnrollmentFormValidator < ApplicationSystemTestCase
   def verify_input_validation_for_contact_info(contact_info)
     select 'Telephone call', from: 'preferred_contact_method'
     click_on 'Next'
-    verify_text_not_displayed('Please provide an email')
+    verify_text_not_displayed('Please provide an email or change Preferred Reporting Method')
     verify_text_not_displayed('Please confirm email')
-    verify_text_displayed('Please provide a primary telephone number')
+    verify_text_displayed('Please provide a primary telephone number, or change Preferred Reporting Method.')
     select 'SMS Text-message', from: 'preferred_contact_method'
     click_on 'Next'
-    verify_text_not_displayed('Please provide an email')
+    verify_text_not_displayed('Please provide an email or change Preferred Reporting Method')
     verify_text_not_displayed('Please confirm email')
-    verify_text_displayed('Please provide a primary telephone number')
+    verify_text_displayed('Please provide a primary telephone number, or change Preferred Reporting Method.')
     select 'E-mailed Web Link', from: 'preferred_contact_method'
     click_on 'Next'
-    verify_text_displayed('Please provide an email')
+    verify_text_displayed('Please provide an email or change Preferred Reporting Method')
     verify_text_displayed('Please confirm email')
-    verify_text_not_displayed('Please provide a primary telephone number')
+    verify_text_not_displayed('Please provide a primary telephone number, or change Preferred Reporting Method.')
     fill_in 'email', with: 'email@eample.com'
     click_on 'Next'
-    verify_text_not_displayed('Please provide an email')
+    verify_text_not_displayed('Please provide an email or change Preferred Reporting Method')
     verify_text_displayed('Please confirm email')
-    verify_text_not_displayed('Please provide a primary telephone number')
+    verify_text_not_displayed('Please provide a primary telephone number, or change Preferred Reporting Method.')
     @@enrollment_form.populate_enrollment_step(:contact_info, contact_info)
-    verify_text_not_displayed('Please provide an email')
+    verify_text_not_displayed('Please provide an email or change Preferred Reporting Method')
     verify_text_not_displayed('Please confirm email')
-    verify_text_not_displayed('Please provide a primary telephone number')
+    verify_text_not_displayed('Please provide a primary telephone number, or change Preferred Reporting Method.')
   end
 
   def verify_input_validation_for_arrival_info(arrival_info)


### PR DESCRIPTION
# Description
Smaller updates before 1.12 release.
- Updated language in tooltips, modals,  validation based on product team feedback.
- Adding tooltip to extended isolation line list column.
- Removing min date for symptom onset and LDE only, maintaining for Extended Isolation per product team request.
- Adding locale translations.
- Updated default `jurisdictions.yml` to use new symptoms. 

NOTE: This is already deployed on demo for testing.