### PR TITLE
SARAALERT-675: Log changes to LDE, symptom onset, continuous exposure, extended isolation in history

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -401,10 +401,18 @@ class PatientsController < ApplicationController
     # Log system onset change in history if initiated by system (user initiated changes are logged separately)
     return if content[:symptom_onset] == patient[:symptom_onset] || initiator != :system
 
-    comment = if content[:symptom_onset].nil?
-                'System cleared symptom onset date because patient was moved from isolation to exposure.'
+    comment = if !patient[:symptom_onset].nil? && !content[:symptom_onset].nil?
+                "System changed symptom onset date from #{patient[:symptom_onset].strftime('%m/%d/%Y')} to #{content[:symptom_onset].strftime('%m/%d/%Y')}
+                 because monitoree was moved from isolation to exposure workflow. This allows the system to show monitoree on appropriate line list based on
+                 daily reports."
+              elsif patient[:symptom_onset].nil? && !content[:symptom_onset].nil?
+                "System changed symptom onset date from blank to #{content[:symptom_onset].strftime('%m/%d/%Y')} because monitoree was moved from isolation to
+                 exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
+              elsif !patient[:symptom_onset].nil? && content[:symptom_onset].nil?
+                "System cleared symptom onset date from #{patient[:symptom_onset].strftime('%m/%d/%Y')} to blank because monitoree was moved from isolation to
+                 exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
               else
-                "System changed symptom onset date to #{content[:symptom_onset].strftime('%m/%d/%Y')} because patient was moved from isolation to exposure."
+                'System changed symptom onset date. This allows the system to show monitoree on appropriate line list based on daily reports.'
               end
     History.monitoring_change(patient: patient, created_by: 'Sara Alert System', comment: comment)
   end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -347,7 +347,16 @@ class PatientsController < ApplicationController
                        end
 
     # Update history before fields are changed
-    update_history(patient, params, household, propagation)
+    history = {
+      created_by: current_user.email,
+      patient: patient,
+      params: params,
+      household: household,
+      propagation: propagation,
+      reason: params[:reasoning]
+    }
+
+    History.monitoring_actions(history, diff_state)
 
     # If the monitoree record was closed, set continuous exposure to be false and set the closed at time.
     if params_to_update.include?(:monitoring) && params.require(:patient).permit(:monitoring)[:monitoring] != patient.monitoring && patient.monitoring
@@ -395,32 +404,6 @@ class PatientsController < ApplicationController
       end
     end
     patient.save
-  end
-
-  def update_history(patient, params, household, propagation)
-    diff_state = params[:diffState]&.map(&:to_sym)
-    return if diff_state.nil?
-
-    history = {
-      created_by: current_user.email,
-      patient: patient,
-      params: params,
-      household: household,
-      propagation: propagation,
-      reason: params[:reasoning]
-    }
-    History.monitoring_status(history) if diff_state.include?(:monitoring)
-    History.exposure_risk_assessment(history) if diff_state.include?(:exposure_risk_assessment)
-    History.monitoring_plan(history) if diff_state.include?(:monitoring_plan)
-    History.case_status(history) if diff_state.include?(:case_status)
-    History.public_health_action(history) if diff_state.include?(:public_health_action)
-    History.jurisdiction(history) if diff_state.include?(:jurisdiction_path)
-    History.assigned_user(history) if diff_state.include?(:assigned_user)
-    History.pause_notifications(history) if diff_state.include?(:pause_notifications)
-    History.symptom_onset(history) if diff_state.include?(:symptom_onset)
-    History.last_date_of_exposure(history) if diff_state.include?(:last_date_of_exposure)
-    History.continuous_exposure(history) if diff_state.include?(:continuous_exposure)
-    History.extended_isolation(history) if diff_state.include?(:extended_isolation)
   end
 
   def reset_symptom_onset(content, patient, initiator)

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -279,6 +279,7 @@ class PatientsController < ApplicationController
 
     # Nothing to do in this function if there isn't a list of patient ids.
     patient_ids = params.require(:ids)
+    non_dependent_patient_ids = patient_ids
 
     # If apply to group, find dependents ids and add to id array before user accessor for validation of access
     if ActiveModel::Type::Boolean.new.cast(params.require(:apply_to_group))
@@ -294,12 +295,12 @@ class PatientsController < ApplicationController
                        patients: responders }, status: 401
       end
 
-      patient_and_dependent_ids = patient_ids.union(dependent_ids)
+      patient_ids = patient_ids.union(dependent_ids)
     end
-    patients = current_user.get_patients(patient_and_dependent_ids)
+    patients = current_user.get_patients(patient_ids)
 
     patients.each do |patient|
-      update_fields(patient, params, patient_ids.include?(patient[:id]) ? :patient : :dependent, params[:apply_to_group] ? :group : :none)
+      update_fields(patient, params, non_dependent_patient_ids.include?(patient[:id]) ? :patient : :dependent, params[:apply_to_group] ? :group : :none)
     end
   end
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -407,7 +407,7 @@ class PatientsController < ApplicationController
   def reset_symptom_onset(content, patient, initiator)
     # Set user-defined symptom onset to be false and set the symptom onset date based on latest symptomatic report
     content[:user_defined_symptom_onset] = false
-    content[:symptom_onset] = patient.assessments.where(symptomatic: true).minimum(:created_at).to_date
+    content[:symptom_onset] = patient.assessments.where(symptomatic: true).minimum(:created_at)&.to_date
 
     # Log system onset change in history if initiated by system (user initiated changes are logged separately)
     return if content[:symptom_onset] == patient[:symptom_onset] || initiator != :system

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -488,13 +488,13 @@ class PatientsController < ApplicationController
   def patient_diff(patient_before, patient_after)
     diffs = []
     allowed_params.each do |attribute|
-      if patient_before[attribute] != patient_after[attribute]
-        diffs << {
-          attribute: attribute,
-          before: attribute == :jurisdiction_id ? Jurisdiction.find(patient_before[attribute])[:path] : patient_before[attribute],
-          after: attribute == :jurisdiction_id ? Jurisdiction.find(patient_after[attribute])[:path] : patient_after[attribute]
-        }
-      end
+      next if patient_before[attribute] == patient_after[attribute]
+
+      diffs << {
+        attribute: attribute,
+        before: attribute == :jurisdiction_id ? Jurisdiction.find(patient_before[attribute])[:path] : patient_before[attribute],
+        after: attribute == :jurisdiction_id ? Jurisdiction.find(patient_after[attribute])[:path] : patient_after[attribute]
+      }
     end
     diffs
   end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -395,6 +395,19 @@ class PatientsController < ApplicationController
   def update_history(patient, params, household, propagation)
     diff_state = params[:diffState]&.map(&:to_sym)
 
+    if diff_state.include?(:monitoring)
+      History.monitoring_status(patient: patient, created_by: current_user.email, household: household, propagation: propagation,
+                                old_value: patient[:monitoring], new_value: params[:monitoring], reason: params[:reasoning])
+    end
+
+    # exposure risk assessment
+    # monitoring plan
+    # case status
+    # workflow
+    # public health action
+    # jurisdiction
+    # assigned_user
+    # notification status
 
     if diff_state.include?(:symptom_onset)
       History.symptom_onset(patient: patient, created_by: current_user.email, household: household, propagation: propagation,

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -332,7 +332,8 @@ class PatientsController < ApplicationController
         if params[:apply_to_group_cm_only_date].present?
           lde_date = params.permit(:apply_to_group_cm_only_date)[:apply_to_group_cm_only_date]
           if member[:continuous_exposure]
-            History.monitoring_change(patient: member, created_by: 'Sara Alert System', comment: 'System turned off continuous exposure.')
+            History.monitoring_change(patient: member, created_by: 'Sara Alert System', comment: 'System turned off continuous exposure because monitoree is no
+            longer being exposed to a case.')
           end
           member.update(last_date_of_exposure: lde_date, continuous_exposure: false)
         end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -489,7 +489,11 @@ class PatientsController < ApplicationController
     diffs = []
     allowed_params.each do |attribute|
       if patient_before[attribute] != patient_after[attribute]
-        diffs << { attribute: attribute, before: patient_before[attribute], after: patient_after[attribute] }
+        diffs << {
+          attribute: attribute,
+          before: attribute == :jurisdiction_id ? Jurisdiction.find(patient_before[attribute])[:path] : patient_before[attribute],
+          after: attribute == :jurisdiction_id ? Jurisdiction.find(patient_after[attribute])[:path] : patient_after[attribute]
+        }
       end
     end
     diffs

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -418,8 +418,7 @@ class PatientsController < ApplicationController
   end
 
   def update_history(patient, params)
-    comment = ''
-    comment += params.permit(:message)[:message] unless params.permit(:message)[:message].blank?
+    comment = params.permit(:message)[:message] unless params.permit(:message)[:message].blank?
     comment += ' Reason: ' + params.permit(:reasoning)[:reasoning] unless params.permit(:reasoning)[:reasoning].blank?
     History.monitoring_change(patient: patient, created_by: current_user.email, comment: comment)
   end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -318,7 +318,7 @@ class PatientsController < ApplicationController
     if params.permit(:apply_to_group)[:apply_to_group]
       current_user.get_patient(patient.responder_id)&.dependents&.each do |member|
         update_fields(member, params)
-        next unless params[:comment]
+        next unless params[:comment] && member[:id] != patient[:id]
 
         update_history(member, params)
       end
@@ -337,7 +337,7 @@ class PatientsController < ApplicationController
           end
           member.update(last_date_of_exposure: lde_date, continuous_exposure: false)
         end
-        next unless params[:comment]
+        next unless params[:comment] && member[:id] != patient[:id]
 
         update_history(member, params)
       end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -377,7 +377,10 @@ class PatientsController < ApplicationController
       # Set extended isolation to nil.
       params_to_update << :extended_isolation
       params[:patient][:extended_isolation] = nil
-      History.monitoring_change(patient: patient, created_by: 'Sara Alert System', comment: 'System cleared extended isolation date because monitoree was moved from isolation to exposure workflow.')
+      unless patient[:extended_isolation].nil?
+        History.monitoring_change(patient: patient, created_by: 'Sara Alert System', comment: 'System cleared extended isolation date because monitoree was
+        moved from isolation to exposure workflow.')
+      end
     end
 
     # If the symptom onset was cleared by the user
@@ -409,22 +412,20 @@ class PatientsController < ApplicationController
     # Log system onset change in history if initiated by system (user initiated changes are logged separately)
     return if content[:symptom_onset] == patient[:symptom_onset] || initiator != :system
 
-    unless patient[:symptom_onset] == content[:symptom_onset]
-      comment = if !patient[:symptom_onset].nil? && !content[:symptom_onset].nil?
-                  "System changed symptom onset date from #{patient[:symptom_onset].strftime('%m/%d/%Y')} to #{content[:symptom_onset].strftime('%m/%d/%Y')}
-                  because monitoree was moved from isolation to exposure workflow. This allows the system to show monitoree on appropriate line list based on
-                  daily reports."
-                elsif patient[:symptom_onset].nil? && !content[:symptom_onset].nil?
-                  "System changed symptom onset date from blank to #{content[:symptom_onset].strftime('%m/%d/%Y')} because monitoree was moved from isolation to
-                  exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
-                elsif !patient[:symptom_onset].nil? && content[:symptom_onset].nil?
-                  "System cleared symptom onset date from #{patient[:symptom_onset].strftime('%m/%d/%Y')} to blank because monitoree was moved from isolation to
-                  exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
-                else
-                  'System changed symptom onset date. This allows the system to show monitoree on appropriate line list based on daily reports.'
-                end
-      History.monitoring_change(patient: patient, created_by: 'Sara Alert System', comment: comment)
-    end
+    comment = if !patient[:symptom_onset].nil? && !content[:symptom_onset].nil?
+                "System changed symptom onset date from #{patient[:symptom_onset].strftime('%m/%d/%Y')} to #{content[:symptom_onset].strftime('%m/%d/%Y')}
+                because monitoree was moved from isolation to exposure workflow. This allows the system to show monitoree on appropriate line list based on
+                daily reports."
+              elsif patient[:symptom_onset].nil? && !content[:symptom_onset].nil?
+                "System changed symptom onset date from blank to #{content[:symptom_onset].strftime('%m/%d/%Y')} because monitoree was moved from isolation to
+                exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
+              elsif !patient[:symptom_onset].nil? && content[:symptom_onset].nil?
+                "System cleared symptom onset date from #{patient[:symptom_onset].strftime('%m/%d/%Y')} to blank because monitoree was moved from isolation to
+                exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
+              else
+                'System changed symptom onset date. This allows the system to show monitoree on appropriate line list based on daily reports.'
+              end
+    History.monitoring_change(patient: patient, created_by: 'Sara Alert System', comment: comment)
   end
 
   def update_history(patient, params)

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -331,6 +331,9 @@ class PatientsController < ApplicationController
         update_fields(member, params)
         if params[:apply_to_group_cm_only_date].present?
           lde_date = params.permit(:apply_to_group_cm_only_date)[:apply_to_group_cm_only_date]
+          if member[:continuous_exposure]
+            History.monitoring_change(patient: member, created_by: 'Sara Alert System', comment: 'System turned off continuous exposure.')
+          end
           member.update(last_date_of_exposure: lde_date, continuous_exposure: false)
         end
         next unless params[:comment]
@@ -355,6 +358,9 @@ class PatientsController < ApplicationController
 
     # If the monitoree record was closed, set continuous exposure to be false and set the closed at time.
     if params_to_update.include?(:monitoring) && params.require(:patient).permit(:monitoring)[:monitoring] != patient.monitoring && patient.monitoring
+      if patient[:continuous_exposure]
+        History.monitoring_change(patient: patient, created_by: 'Sara Alert System', comment: 'System turned off continuous exposure.')
+      end
       patient.continuous_exposure = false
       patient.closed_at = DateTime.now
     end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -394,40 +394,27 @@ class PatientsController < ApplicationController
 
   def update_history(patient, params, household, propagation)
     diff_state = params[:diffState]&.map(&:to_sym)
-
-    if diff_state.include?(:monitoring)
-      History.monitoring_status(patient: patient, created_by: current_user.email, household: household, propagation: propagation,
-                                old_value: patient[:monitoring], new_value: params[:monitoring], reason: params[:reasoning])
-    end
-
-    # exposure risk assessment
-    # monitoring plan
-    # case status
-    # workflow
-    # public health action
-    # jurisdiction
-    # assigned_user
-    # notification status
-
-    if diff_state.include?(:symptom_onset)
-      History.symptom_onset(patient: patient, created_by: current_user.email, household: household, propagation: propagation,
-                                    old_value: patient[:symptom_onset], new_value: params[:symptom_onset])
-    end
-
-    if diff_state.include?(:last_date_of_exposure)
-      History.last_date_of_exposure(patient: patient, created_by: current_user.email, household: household, propagation: propagation,
-                                    old_value: patient[:last_date_of_exposure], new_value: params[:last_date_of_exposure])
-    end
-
-    if diff_state.include?(:continuous_exposure)
-      History.continuous_exposure(patient: patient, created_by: current_user.email, household: household, propagation: propagation,
-                                  old_value: patient[:continuous_exposure], new_value: params[:continuous_exposure])
-    end
-
-    if diff_state.include?(:extended_isolation)
-      History.extended_isolation(patient: patient, created_by: current_user.email, household: household, propagation: propagation,
-                                 old_value: patient[:extended_isolation], new_value: params[:extended_isolation], reason: params[:reasoning])
-    end
+    history = {
+      created_by: current_user.email,
+      patient: patient,
+      params: params,
+      household: household,
+      propagation: propagation,
+      reason: params[:reasoning]
+    }
+    History.monitoring_status(history) if diff_state.include?(:monitoring)
+    History.exposure_risk_assessment(history) if diff_state.include?(:exposure_risk_assessment)
+    History.monitoring_plan(history) if diff_state.include?(:monitoring_plan)
+    # History.case_status(history) if diff_state.include?(:case_status)
+    # History.workflow(history) if diff_state.include?(:isolation)
+    History.public_health_action(history) if diff_state.include?(:public_health_action)
+    History.jurisdiction(history) if diff_state.include?(:jurisdiction_path)
+    History.assigned_user(history) if diff_state.include?(:assigned_user)
+    # History.pause_notifications(history) if diff_state.include?(:pause_notifications)
+    History.symptom_onset(history) if diff_state.include?(:symptom_onset)
+    History.last_date_of_exposure(history) if diff_state.include?(:last_date_of_exposure)
+    History.continuous_exposure(history) if diff_state.include?(:continuous_exposure)
+    History.extended_isolation(history) if diff_state.include?(:extended_isolation)
   end
 
   def reset_symptom_onset(content, patient, initiator)

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -395,6 +395,12 @@ class PatientsController < ApplicationController
   def update_history(patient, params, household, propagation)
     diff_state = params[:diffState]&.map(&:to_sym)
 
+
+    if diff_state.include?(:symptom_onset)
+      History.symptom_onset(patient: patient, created_by: current_user.email, household: household, propagation: propagation,
+                                    old_value: patient[:symptom_onset], new_value: params[:symptom_onset])
+    end
+
     if diff_state.include?(:last_date_of_exposure)
       History.last_date_of_exposure(patient: patient, created_by: current_user.email, household: household, propagation: propagation,
                                     old_value: patient[:last_date_of_exposure], new_value: params[:last_date_of_exposure])
@@ -403,6 +409,11 @@ class PatientsController < ApplicationController
     if diff_state.include?(:continuous_exposure)
       History.continuous_exposure(patient: patient, created_by: current_user.email, household: household, propagation: propagation,
                                   old_value: patient[:continuous_exposure], new_value: params[:continuous_exposure])
+    end
+
+    if diff_state.include?(:extended_isolation)
+      History.extended_isolation(patient: patient, created_by: current_user.email, household: household, propagation: propagation,
+                                 old_value: patient[:extended_isolation], new_value: params[:extended_isolation], reason: params[:reasoning])
     end
   end
 

--- a/app/javascript/components/public_health/actions/CloseRecords.js
+++ b/app/javascript/components/public_health/actions/CloseRecords.js
@@ -59,7 +59,6 @@ class CloseRecords extends React.Component {
           diffState: diffState,
         })
         .then(() => {
-          console.log(diffState);
           location.href = window.BASE_PATH;
         })
         .catch(error => {

--- a/app/javascript/components/public_health/actions/CloseRecords.js
+++ b/app/javascript/components/public_health/actions/CloseRecords.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Button, Form, Modal } from 'react-bootstrap';
+import _ from 'lodash';
 import axios from 'axios';
 
 import reportError from '../../util/ReportError';
@@ -11,6 +12,7 @@ class CloseRecords extends React.Component {
     this.state = {
       apply_to_group: false,
       loading: false,
+      monitoring: false,
       monitoring_reasons: [
         'Completed Monitoring',
         'Meets Case Definition',
@@ -43,20 +45,21 @@ class CloseRecords extends React.Component {
 
   submit() {
     let idArray = this.props.patients.map(x => x['id']);
+    let diffState = Object.keys(this.state).filter(k => _.get(this.state, k) !== _.get(this.origState, k));
 
     this.setState({ loading: true }, () => {
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
       axios
         .post(window.BASE_PATH + '/patients/bulk_edit/status', {
           ids: idArray,
-          comment: true,
-          message: 'User changed monitoring status to "Not Monitoring".',
-          monitoring: false,
+          monitoring: this.state.monitoring,
           monitoring_reason: this.state.monitoring_reason,
           reasoning: this.state.monitoring_reason + (this.state.monitoring_reason !== '' && this.state.reasoning !== '' ? ', ' : '') + this.state.reasoning,
           apply_to_group: this.state.apply_to_group,
+          diffState: diffState,
         })
         .then(() => {
+          console.log(diffState);
           location.href = window.BASE_PATH;
         })
         .catch(error => {

--- a/app/javascript/components/public_health/actions/CloseRecords.js
+++ b/app/javascript/components/public_health/actions/CloseRecords.js
@@ -50,7 +50,7 @@ class CloseRecords extends React.Component {
         .post(window.BASE_PATH + '/patients/bulk_edit/status', {
           ids: idArray,
           comment: true,
-          message: 'monitoring status to "Not Monitoring".',
+          message: 'User changed monitoring status to "Not Monitoring".',
           monitoring: false,
           monitoring_reason: this.state.monitoring_reason,
           reasoning: this.state.monitoring_reason + (this.state.monitoring_reason !== '' && this.state.reasoning !== '' ? ', ' : '') + this.state.reasoning,

--- a/app/javascript/components/public_health/actions/UpdateCaseStatus.js
+++ b/app/javascript/components/public_health/actions/UpdateCaseStatus.js
@@ -164,7 +164,7 @@ class UpdateCaseStatus extends React.Component {
                   type="switch"
                   id="apply_to_group"
                   label="Apply this change to the entire household that these monitorees are responsible for, if it applies."
-                  checked={this.state.apply_to_group === true || false}
+                  checked={this.state.apply_to_group}
                   onChange={this.handleChange}
                 />
               </Form.Group>

--- a/app/javascript/components/public_health/actions/UpdateCaseStatus.js
+++ b/app/javascript/components/public_health/actions/UpdateCaseStatus.js
@@ -58,7 +58,7 @@ class UpdateCaseStatus extends React.Component {
             monitoring: false,
             isolation: undefined, // Make sure not to alter the existing isolation
             monitoring_reason: 'Meets Case Definition',
-            message: 'case status to "' + this.state.case_status + '", and chose to "' + event.target.value + '".',
+            message: 'User changed case status to "' + this.state.case_status + '", and chose to "' + event.target.value + '".',
           });
         }
         if (event.target.value === 'Continue Monitoring in Isolation Workflow') {
@@ -66,7 +66,7 @@ class UpdateCaseStatus extends React.Component {
             monitoring: true,
             isolation: true,
             monitoring_reason: 'Meets Case Definition',
-            message: 'case status to "' + this.state.case_status + '", and chose to "' + event.target.value + '".',
+            message: 'User changed case status to "' + this.state.case_status + '", and chose to "' + event.target.value + '".',
           });
         }
       } else if (event.target.value === 'Suspect' || event.target.value === 'Unknown' || event.target.value === 'Not a Case' || event.target.value === '') {
@@ -79,7 +79,7 @@ class UpdateCaseStatus extends React.Component {
           monitoring: this.state.initialMonitoring,
           isolation: this.state.initialIsolation,
           monitoring_reason: 'Meets Case Definition',
-          message: 'case status to "' + this.state.case_status + '", and chose to "' + event.target.value + '".',
+          message: 'User changed case status to "' + this.state.case_status + '", and chose to "' + event.target.value + '".',
         });
       }
     });

--- a/app/javascript/components/subject/CaseStatus.js
+++ b/app/javascript/components/subject/CaseStatus.js
@@ -14,7 +14,6 @@ class CaseStatus extends React.Component {
       showCaseStatusModal: false,
       confirmedOrProbable: this.props.patient.case_status === 'Confirmed' || this.props.patient.case_status === 'Probable',
       case_status: this.props.patient.case_status || '',
-      message: '',
       confirmed: '',
       isolation: this.props.patient.isolation,
       monitoring: this.props.patient.monitoring,
@@ -39,7 +38,6 @@ class CaseStatus extends React.Component {
     this.setState({ [event.target.id]: value, showCaseStatusModal: !hideModal, confirmedOrProbable }, () => {
       // specific case where case status is just changed with no modal
       if (hideModal) {
-        this.setState({ message: 'User changed case status to "' + this.state.case_status + '".' });
         this.submit();
       }
 
@@ -49,7 +47,6 @@ class CaseStatus extends React.Component {
           this.setState({
             monitoring: false,
             monitoring_reason: 'Meets Case Definition',
-            message: 'User changed case status to "' + this.state.case_status + '", and chose to "' + event.target.value + '".',
           });
         }
         if (event.target.value === 'Continue Monitoring in Isolation Workflow') {
@@ -57,7 +54,6 @@ class CaseStatus extends React.Component {
             monitoring: true,
             isolation: true,
             monitoring_reason: 'Meets Case Definition',
-            message: 'User changed case status to "' + this.state.case_status + '", and chose to "' + event.target.value + '".',
           });
         }
       } else if (!confirmedOrProbable) {
@@ -65,7 +61,6 @@ class CaseStatus extends React.Component {
           monitoring: true,
           isolation: false,
           public_health_action: 'None',
-          message: 'User changed case status to "' + this.state.case_status + '".',
         });
       }
     });
@@ -85,8 +80,6 @@ class CaseStatus extends React.Component {
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
       axios
         .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/status', {
-          comment: true,
-          message: this.state.message,
           case_status: this.state.case_status,
           isolation: this.state.isolation,
           monitoring: this.state.monitoring,

--- a/app/javascript/components/subject/CaseStatus.js
+++ b/app/javascript/components/subject/CaseStatus.js
@@ -39,7 +39,7 @@ class CaseStatus extends React.Component {
     this.setState({ [event.target.id]: value, showCaseStatusModal: !hideModal, confirmedOrProbable }, () => {
       // specific case where case status is just changed with no modal
       if (hideModal) {
-        this.setState({ message: 'case status to "' + this.state.case_status + '".' });
+        this.setState({ message: 'User changed case status to "' + this.state.case_status + '".' });
         this.submit();
       }
 
@@ -49,7 +49,7 @@ class CaseStatus extends React.Component {
           this.setState({
             monitoring: false,
             monitoring_reason: 'Meets Case Definition',
-            message: 'case status to "' + this.state.case_status + '", and chose to "' + event.target.value + '".',
+            message: 'User changed case status to "' + this.state.case_status + '", and chose to "' + event.target.value + '".',
           });
         }
         if (event.target.value === 'Continue Monitoring in Isolation Workflow') {
@@ -57,7 +57,7 @@ class CaseStatus extends React.Component {
             monitoring: true,
             isolation: true,
             monitoring_reason: 'Meets Case Definition',
-            message: 'case status to "' + this.state.case_status + '", and chose to "' + event.target.value + '".',
+            message: 'User changed case status to "' + this.state.case_status + '", and chose to "' + event.target.value + '".',
           });
         }
       } else if (!confirmedOrProbable) {
@@ -65,7 +65,7 @@ class CaseStatus extends React.Component {
           monitoring: true,
           isolation: false,
           public_health_action: 'None',
-          message: 'case status to "' + this.state.case_status + '".',
+          message: 'User changed case status to "' + this.state.case_status + '".',
         });
       }
     });

--- a/app/javascript/components/subject/ExtendedIsolation.js
+++ b/app/javascript/components/subject/ExtendedIsolation.js
@@ -27,7 +27,9 @@ class ExtendedIsolation extends React.Component {
         .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/status', {
           extended_isolation: this.state.extended_isolation,
           comment: true,
-          message: `extended isolation date to ${moment(this.state.extended_isolation).format('MM/DD/YYYY')}.`,
+          message: this.state.extended_isolation
+            ? `User changed extended isolation date to ${moment(this.state.extended_isolation).format('MM/DD/YYYY')}.`
+            : 'User cleared extended isolation date.',
           reasoning: this.state.reasoning,
           diffState: ['extended_isolation'],
         })
@@ -91,11 +93,11 @@ class ExtendedIsolation extends React.Component {
                         {`Are you sure you want to extend this case’s isolation through ${moment(this.state.extended_isolation).format('MM/DD/YYYY')}?`}
                         <br></br>
                         <br></br>
-                        {`After clicking “Submit”, the case will be moved to the "Reporting" or "Non-Reporting" line list. 
+                        {`After clicking “Submit”, the case will be moved to the "Reporting" or "Non-Reporting" line list.
                           This case cannot appear on the records Requiring Review Line List until after ${moment(this.state.extended_isolation).format(
                             'MM/DD/YYYY'
                           )}.
-                          If the record meets a recovery definition after ${moment(this.state.extended_isolation).format('MM/DD/YYYY')}, it will appear on the 
+                          If the record meets a recovery definition after ${moment(this.state.extended_isolation).format('MM/DD/YYYY')}, it will appear on the
                           Records Requiring Review Line List for review by public health to determine if it is safe to discontinue isolation.`}
                       </Form.Label>
                     ) : (

--- a/app/javascript/components/subject/ExtendedIsolation.js
+++ b/app/javascript/components/subject/ExtendedIsolation.js
@@ -22,22 +22,10 @@ class ExtendedIsolation extends React.Component {
 
   submit() {
     this.setState({ loading: true }, () => {
-      let message = '';
-      if (this.props.patient.extended_isolation && this.state.extended_isolation) {
-        message = `User changed extended isolation date from ${moment(this.props.patient.extended_isolation).format('MM/DD/YYYY')} to ${moment(
-          this.state.extended_isolation
-        ).format('MM/DD/YYYY')}.`;
-      } else if (!this.props.patient.extended_isolation && this.state.extended_isolation) {
-        message = `User changed extended isolation date from blank to ${moment(this.state.extended_isolation).format('MM/DD/YYYY')}.`;
-      } else if (this.props.patient.extended_isolation && !this.state.extended_isolation) {
-        message = `User cleared extended isolation date from ${moment(this.props.patient.extended_isolation).format('MM/DD/YYYY')} to blank.`;
-      }
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
       axios
         .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/status', {
           extended_isolation: this.state.extended_isolation,
-          comment: true,
-          message: message,
           reasoning: this.state.reasoning,
           diffState: ['extended_isolation'],
         })

--- a/app/javascript/components/subject/ExtendedIsolation.js
+++ b/app/javascript/components/subject/ExtendedIsolation.js
@@ -22,14 +22,22 @@ class ExtendedIsolation extends React.Component {
 
   submit() {
     this.setState({ loading: true }, () => {
+      let message = '';
+      if (this.props.patient.extended_isolation && this.state.extended_isolation) {
+        message = `User changed extended isolation date from ${moment(this.props.patient.extended_isolation).format('MM/DD/YYYY')} to ${moment(
+          this.state.extended_isolation
+        ).format('MM/DD/YYYY')}.`;
+      } else if (!this.props.patient.extended_isolation && this.state.extended_isolation) {
+        message = `User changed extended isolation date from blank to ${moment(this.state.extended_isolation).format('MM/DD/YYYY')}.`;
+      } else if (this.props.patient.extended_isolation && !this.state.extended_isolation) {
+        message = `User cleared extended isolation date from ${moment(this.props.patient.extended_isolation).format('MM/DD/YYYY')} to blank.`;
+      }
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
       axios
         .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/status', {
           extended_isolation: this.state.extended_isolation,
           comment: true,
-          message: this.state.extended_isolation
-            ? `User changed extended isolation date to ${moment(this.state.extended_isolation).format('MM/DD/YYYY')}.`
-            : 'User cleared extended isolation date.',
+          message: message,
           reasoning: this.state.reasoning,
           diffState: ['extended_isolation'],
         })

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -82,6 +82,13 @@ class LastDateExposure extends React.Component {
 
   submit(isLDE) {
     let diffState = Object.keys(this.state).filter(k => _.get(this.state, k) !== _.get(this.origState, k));
+    let message = '';
+    if (diffState.includes('last_date_of_exposure')) {
+      message = `User changed last date of exposure to ${moment(this.state.last_date_of_exposure).format('MM/DD/YYYY')}.`;
+    }
+    if (diffState.includes('continuous_exposure')) {
+      message = `User turned ${this.state.continuous_exposure ? 'on' : 'off'} continous exposure.`;
+    }
     diffState.push('continuous_exposure'); // Since exposure date updates change CE, always make sure this gets changed
     this.setState({ loading: true, continuous_exposure: diffState.includes('last_date_of_exposure') || isLDE ? false : this.state.continuous_exposure }, () => {
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
@@ -91,6 +98,8 @@ class LastDateExposure extends React.Component {
           continuous_exposure: this.state.continuous_exposure,
           apply_to_group: this.state.apply_to_group,
           apply_to_group_cm_only: this.state.apply_to_group_cm_only,
+          comment: true,
+          message: message,
           diffState: diffState,
         })
         .then(() => {

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -84,7 +84,9 @@ class LastDateExposure extends React.Component {
     let diffState = Object.keys(this.state).filter(k => _.get(this.state, k) !== _.get(this.origState, k));
     let message = '';
     if (diffState.includes('last_date_of_exposure')) {
-      message = `User changed last date of exposure to ${moment(this.state.last_date_of_exposure).format('MM/DD/YYYY')}.`;
+      message = `User changed last date of exposure from ${moment(this.props.patient.last_date_of_exposure).format('MM/DD/YYYY')} to ${moment(
+        this.state.last_date_of_exposure
+      ).format('MM/DD/YYYY')}.`;
     }
     if (diffState.includes('continuous_exposure')) {
       message = `User turned ${this.state.continuous_exposure ? 'on' : 'off'} continuous exposure.`;

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -82,15 +82,6 @@ class LastDateExposure extends React.Component {
 
   submit(isLDE) {
     let diffState = Object.keys(this.state).filter(k => _.get(this.state, k) !== _.get(this.origState, k));
-    let message = '';
-    if (diffState.includes('last_date_of_exposure')) {
-      message = `User changed last date of exposure from ${moment(this.props.patient.last_date_of_exposure).format('MM/DD/YYYY')} to ${moment(
-        this.state.last_date_of_exposure
-      ).format('MM/DD/YYYY')}.`;
-    }
-    if (diffState.includes('continuous_exposure')) {
-      message = `User turned ${this.state.continuous_exposure ? 'on' : 'off'} continuous exposure.`;
-    }
     diffState.push('continuous_exposure'); // Since exposure date updates change CE, always make sure this gets changed
     this.setState({ loading: true, continuous_exposure: diffState.includes('last_date_of_exposure') || isLDE ? false : this.state.continuous_exposure }, () => {
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
@@ -100,8 +91,6 @@ class LastDateExposure extends React.Component {
           continuous_exposure: this.state.continuous_exposure,
           apply_to_group: this.state.apply_to_group,
           apply_to_group_cm_only: this.state.apply_to_group_cm_only,
-          comment: true,
-          message: message,
           diffState: diffState,
         })
         .then(() => {

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -87,7 +87,7 @@ class LastDateExposure extends React.Component {
       message = `User changed last date of exposure to ${moment(this.state.last_date_of_exposure).format('MM/DD/YYYY')}.`;
     }
     if (diffState.includes('continuous_exposure')) {
-      message = `User turned ${this.state.continuous_exposure ? 'on' : 'off'} continous exposure.`;
+      message = `User turned ${this.state.continuous_exposure ? 'on' : 'off'} continuous exposure.`;
     }
     diffState.push('continuous_exposure'); // Since exposure date updates change CE, always make sure this gets changed
     this.setState({ loading: true, continuous_exposure: diffState.includes('last_date_of_exposure') || isLDE ? false : this.state.continuous_exposure }, () => {

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -276,12 +276,10 @@ class MonitoringStatus extends React.Component {
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
       axios
         .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/status', {
-          comment: true,
           monitoring: this.state.monitoring_status === 'Actively Monitoring',
           exposure_risk_assessment: this.state.exposure_risk_assessment,
           monitoring_plan: this.state.monitoring_plan,
           public_health_action: this.state.public_health_action,
-          message: `User changed ${this.state.message}.`,
           reasoning:
             (this.state.showMonitoringStatusModal && this.state.monitoring_status === 'Not Monitoring'
               ? this.state.monitoring_reason + (this.state.reasoning !== '' ? ', ' : '')

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -62,7 +62,7 @@ class MonitoringStatus extends React.Component {
     if (event?.target?.name && event.target.name === 'jurisdictionId') {
       // Jurisdiction is a weird case; the datalist and input work differently together
       this.setState({
-        message: 'User changed jurisdiction from "' + this.props.jurisdictionPaths[this.state.original_jurisdiction_id] + '" to "' + event.target.value + '"',
+        message: `jurisdiction from "${this.props.jurisdictionPaths[this.state.original_jurisdiction_id]}" to "${event.target.value}"`,
         message_warning: this.state.assigned_user === '' ? '' : 'Please also consider removing or updating the assigned user if it is no longer applicable.',
         jurisdiction_path: event?.target?.value ? event.target.value : '',
         monitoring_reasons: null,
@@ -74,7 +74,7 @@ class MonitoringStatus extends React.Component {
         (event?.target?.value && !isNaN(event.target.value) && parseInt(event.target.value) > 0 && parseInt(event.target.value) <= 9999)
       ) {
         this.setState({
-          message: 'User changed assigned user from "' + this.state.original_assigned_user + '"to"' + event.target.value + '"',
+          message: `assigned user from "${this.state.original_assigned_user}" to " ${event.target.value}"`,
           message_warning: '',
           assigned_user: event?.target?.value ? parseInt(event.target.value) : '',
           monitoring_reasons: null,
@@ -83,7 +83,7 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'exposure_risk_assessment') {
       this.setState({
         showExposureRiskAssessmentModal: true,
-        message: 'User changed exposure risk assessment to "' + event.target.value + '"',
+        message: `exposure risk assessment to "${event.target.value}"`,
         message_warning: '',
         exposure_risk_assessment: event?.target?.value ? event.target.value : '',
         monitoring_reasons: null,
@@ -91,7 +91,7 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'monitoring_plan') {
       this.setState({
         showMonitoringPlanModal: true,
-        message: 'User changed monitoring plan to "' + event.target.value + '"',
+        message: `monitoring plan to "${event.target.value}"`,
         message_warning: '',
         monitoring_plan: event?.target?.value ? event.target.value : '',
         monitoring_reasons: null,
@@ -99,7 +99,7 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'pause_notifications') {
       this.setState({
         showNotificationsModal: true,
-        message: 'User changed notification status to ' + (!this.state.pause_notifications ? 'paused' : 'resumed'),
+        message: `notification status to ${this.state.pause_notifications ? 'resumed' : 'paused'}`,
         message_warning: '',
         pause_notifications: !this.state.pause_notifications,
         monitoring_reasons: null,
@@ -108,7 +108,7 @@ class MonitoringStatus extends React.Component {
       if (this.state.patient.isolation) {
         this.setState({
           showPublicHealthActionModal: true,
-          message: 'User changed latest public health action to "' + event.target.value + '"',
+          message: `latest public health action to "${event.target.value}"`,
           message_warning:
             'The monitoree will be moved to the "Records Requiring Review" line list if they meet a recovery definition or will remain on the "Reporting" or "Non-Reporting" line list as appropriate until a recovery definition is met.',
           public_health_action: event?.target?.value ? event.target.value : '',
@@ -117,7 +117,7 @@ class MonitoringStatus extends React.Component {
       } else {
         this.setState({
           showPublicHealthActionModal: true,
-          message: 'User changed latest public health action to "' + event.target.value + '"',
+          message: `latest public health action to "${event.target.value}"`,
           message_warning:
             event.target.value === 'None'
               ? 'The monitoree will be moved back into the primary status line lists.'
@@ -129,7 +129,7 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'isolation_status') {
       this.setState({
         showIsolationModal: true,
-        message: 'User changed workflow from the "' + this.state.isolation_status + '" workflow to the "' + event.target.value + '" workflow',
+        message: `workflow from the "${this.state.isolation_status}" workflow to the "${event.target.value}" workflow`,
         message_warning:
           event.target.value === 'Isolation'
             ? 'This should only be done for cases you wish to monitor with Sara Alert to determine when they meet the recovery definition to discontinue isolation. The monitoree will be moved onto the Isolation workflow dashboard.'
@@ -141,7 +141,7 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'monitoring_status') {
       this.setState({
         showMonitoringStatusModal: true,
-        message: 'User changed monitoring status to "' + event.target.value + '"',
+        message: `monitoring status to "${event.target.value}"`,
         message_warning:
           event.target.value === 'Not Monitoring' ? 'This will move the selected record(s) to the Closed line list and turn Continuous Exposure OFF.' : '',
         monitoring: event.target.value === 'Actively Monitoring',
@@ -230,7 +230,7 @@ class MonitoringStatus extends React.Component {
   toggleJurisdictionModal() {
     let current = this.state.showJurisdictionModal;
     this.setState({
-      message: 'User changed jurisdiction from "' + this.props.jurisdictionPaths[this.state.original_jurisdiction_id] + '" to "' + this.state.jurisdiction_path + '"',
+      message: `jurisdiction from "${this.props.jurisdictionPaths[this.state.original_jurisdiction_id]}" to "${this.state.jurisdiction_path}"`,
       showJurisdictionModal: !current,
       jurisdiction_path: current ? this.props.jurisdictionPaths[this.state.original_jurisdiction_id] : this.state.jurisdiction_path,
       apply_to_group: false,
@@ -241,7 +241,7 @@ class MonitoringStatus extends React.Component {
   toggleAssignedUserModal() {
     let current = this.state.showassignedUserModal;
     this.setState({
-      message: 'User changed assigned user from "' + this.state.original_assigned_user + '" to "' + this.state.assigned_user + '"',
+      message: `assigned user from "${this.state.original_assigned_user}" to "${this.state.assigned_user}"`,
       showassignedUserModal: !current,
       assigned_user: current ? this.state.original_assigned_user : this.state.assigned_user,
       apply_to_group: false,
@@ -281,7 +281,7 @@ class MonitoringStatus extends React.Component {
           exposure_risk_assessment: this.state.exposure_risk_assessment,
           monitoring_plan: this.state.monitoring_plan,
           public_health_action: this.state.public_health_action,
-          message: this.state.message,
+          message: `User changed ${this.state.message}.`,
           reasoning:
             (this.state.showMonitoringStatusModal && this.state.monitoring_status === 'Not Monitoring'
               ? this.state.monitoring_reason + (this.state.reasoning !== '' ? ', ' : '')

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -62,7 +62,7 @@ class MonitoringStatus extends React.Component {
     if (event?.target?.name && event.target.name === 'jurisdictionId') {
       // Jurisdiction is a weird case; the datalist and input work differently together
       this.setState({
-        message: 'jurisdiction from "' + this.props.jurisdictionPaths[this.state.original_jurisdiction_id] + '" to "' + event.target.value + '"',
+        message: 'User changed jurisdiction from "' + this.props.jurisdictionPaths[this.state.original_jurisdiction_id] + '" to "' + event.target.value + '"',
         message_warning: this.state.assigned_user === '' ? '' : 'Please also consider removing or updating the assigned user if it is no longer applicable.',
         jurisdiction_path: event?.target?.value ? event.target.value : '',
         monitoring_reasons: null,
@@ -74,7 +74,7 @@ class MonitoringStatus extends React.Component {
         (event?.target?.value && !isNaN(event.target.value) && parseInt(event.target.value) > 0 && parseInt(event.target.value) <= 9999)
       ) {
         this.setState({
-          message: 'assigned user from "' + this.state.original_assigned_user + '"to"' + event.target.value + '"',
+          message: 'User changed assigned user from "' + this.state.original_assigned_user + '"to"' + event.target.value + '"',
           message_warning: '',
           assigned_user: event?.target?.value ? parseInt(event.target.value) : '',
           monitoring_reasons: null,
@@ -83,7 +83,7 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'exposure_risk_assessment') {
       this.setState({
         showExposureRiskAssessmentModal: true,
-        message: 'exposure risk assessment to "' + event.target.value + '"',
+        message: 'User changed exposure risk assessment to "' + event.target.value + '"',
         message_warning: '',
         exposure_risk_assessment: event?.target?.value ? event.target.value : '',
         monitoring_reasons: null,
@@ -91,7 +91,7 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'monitoring_plan') {
       this.setState({
         showMonitoringPlanModal: true,
-        message: 'monitoring plan to "' + event.target.value + '"',
+        message: 'User changed monitoring plan to "' + event.target.value + '"',
         message_warning: '',
         monitoring_plan: event?.target?.value ? event.target.value : '',
         monitoring_reasons: null,
@@ -99,7 +99,7 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'pause_notifications') {
       this.setState({
         showNotificationsModal: true,
-        message: 'notification status to ' + (!this.state.pause_notifications ? 'paused' : 'resumed'),
+        message: 'User changed notification status to ' + (!this.state.pause_notifications ? 'paused' : 'resumed'),
         message_warning: '',
         pause_notifications: !this.state.pause_notifications,
         monitoring_reasons: null,
@@ -108,7 +108,7 @@ class MonitoringStatus extends React.Component {
       if (this.state.patient.isolation) {
         this.setState({
           showPublicHealthActionModal: true,
-          message: 'latest public health action to "' + event.target.value + '"',
+          message: 'User changed latest public health action to "' + event.target.value + '"',
           message_warning:
             'The monitoree will be moved to the "Records Requiring Review" line list if they meet a recovery definition or will remain on the "Reporting" or "Non-Reporting" line list as appropriate until a recovery definition is met.',
           public_health_action: event?.target?.value ? event.target.value : '',
@@ -117,7 +117,7 @@ class MonitoringStatus extends React.Component {
       } else {
         this.setState({
           showPublicHealthActionModal: true,
-          message: 'latest public health action to "' + event.target.value + '"',
+          message: 'User changed latest public health action to "' + event.target.value + '"',
           message_warning:
             event.target.value === 'None'
               ? 'The monitoree will be moved back into the primary status line lists.'
@@ -129,7 +129,7 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'isolation_status') {
       this.setState({
         showIsolationModal: true,
-        message: 'workflow from the "' + this.state.isolation_status + '" workflow to the "' + event.target.value + '" workflow',
+        message: 'User changed workflow from the "' + this.state.isolation_status + '" workflow to the "' + event.target.value + '" workflow',
         message_warning:
           event.target.value === 'Isolation'
             ? 'This should only be done for cases you wish to monitor with Sara Alert to determine when they meet the recovery definition to discontinue isolation. The monitoree will be moved onto the Isolation workflow dashboard.'
@@ -141,7 +141,7 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'monitoring_status') {
       this.setState({
         showMonitoringStatusModal: true,
-        message: 'monitoring status to "' + event.target.value + '"',
+        message: 'User changed monitoring status to "' + event.target.value + '"',
         message_warning:
           event.target.value === 'Not Monitoring' ? 'This will move the selected record(s) to the Closed line list and turn Continuous Exposure OFF.' : '',
         monitoring: event.target.value === 'Actively Monitoring',
@@ -230,7 +230,7 @@ class MonitoringStatus extends React.Component {
   toggleJurisdictionModal() {
     let current = this.state.showJurisdictionModal;
     this.setState({
-      message: 'jurisdiction from "' + this.props.jurisdictionPaths[this.state.original_jurisdiction_id] + '" to "' + this.state.jurisdiction_path + '"',
+      message: 'User changed jurisdiction from "' + this.props.jurisdictionPaths[this.state.original_jurisdiction_id] + '" to "' + this.state.jurisdiction_path + '"',
       showJurisdictionModal: !current,
       jurisdiction_path: current ? this.props.jurisdictionPaths[this.state.original_jurisdiction_id] : this.state.jurisdiction_path,
       apply_to_group: false,
@@ -241,7 +241,7 @@ class MonitoringStatus extends React.Component {
   toggleAssignedUserModal() {
     let current = this.state.showassignedUserModal;
     this.setState({
-      message: 'assigned user from "' + this.state.original_assigned_user + '" to "' + this.state.assigned_user + '"',
+      message: 'User changed assigned user from "' + this.state.original_assigned_user + '" to "' + this.state.assigned_user + '"',
       showassignedUserModal: !current,
       assigned_user: current ? this.state.original_assigned_user : this.state.assigned_user,
       apply_to_group: false,

--- a/app/javascript/components/subject/PauseNotifications.js
+++ b/app/javascript/components/subject/PauseNotifications.js
@@ -26,18 +26,7 @@ class PauseNotifications extends React.Component {
           diffState: ['pause_notifications'],
         })
         .then(() => {
-          axios
-            .post(window.BASE_PATH + '/histories', {
-              patient_id: this.props.patient.id,
-              type: 'Monitoring Change',
-              comment: 'User ' + (this.props.patient.pause_notifications ? 'resumed' : 'paused') + ' notifications for this monitoree.',
-            })
-            .then(() => {
-              location.reload(true);
-            })
-            .catch(error => {
-              reportError(error);
-            });
+          location.reload(true);
         })
         .catch(error => {
           reportError(error);

--- a/app/javascript/components/subject/SymptomOnset.js
+++ b/app/javascript/components/subject/SymptomOnset.js
@@ -37,15 +37,25 @@ class SymptomOnset extends React.Component {
 
   submit() {
     this.setState({ loading: true }, () => {
+      let message = '';
+      if (this.props.patient.symptom_onset && this.state.symptom_onset) {
+        message = `User changed symptom onset date from ${moment(this.props.patient.symptom_onset).format('MM/DD/YYYY')} to ${moment(
+          this.state.symptom_onset
+        ).format('MM/DD/YYYY')}.`;
+      } else if (!this.props.patient.symptom_onset && this.state.symptom_onset) {
+        message = `User changed symptom onset date from blank to ${moment(this.state.symptom_onset).format('MM/DD/YYYY')}.`;
+      } else if (this.props.patient.symptom_onset && !this.state.symptom_onset) {
+        message = `User cleared symptom onset date from ${moment(this.props.patient.symptom_onset).format(
+          'MM/DD/YYYY'
+        )} to blank. The system will now populate this date.`;
+      }
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
       axios
         .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/status', {
           symptom_onset: this.state.symptom_onset,
           user_defined_symptom_onset: true,
           comment: true,
-          message: this.state.symptom_onset
-            ? `User changed symptom onset date to ${moment(this.state.symptom_onset).format('MM/DD/YYYY')}.`
-            : 'User cleared symptom onset date.',
+          message: message,
           diffState: ['symptom_onset', 'user_defined_symptom_onset'],
         })
         .then(() => {

--- a/app/javascript/components/subject/SymptomOnset.js
+++ b/app/javascript/components/subject/SymptomOnset.js
@@ -42,6 +42,10 @@ class SymptomOnset extends React.Component {
         .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/status', {
           symptom_onset: this.state.symptom_onset,
           user_defined_symptom_onset: true,
+          comment: true,
+          message: this.state.symptom_onset
+            ? `User changed symptom onset date to ${moment(this.state.symptom_onset).format('MM/DD/YYYY')}.`
+            : 'User cleared symptom onset date.',
           diffState: ['symptom_onset', 'user_defined_symptom_onset'],
         })
         .then(() => {
@@ -63,7 +67,7 @@ class SymptomOnset extends React.Component {
                 SYMPTOM ONSET
                 <InfoTooltip tooltipTextKey={this.props.patient.isolation ? 'isolationSymptomOnset' : 'exposureSymptomOnset'} location="right"></InfoTooltip>
                 <div style={{ display: 'inline' }}>
-                  <span data-for="user_defined_symptom_onset_tooltip" data-tip="" className="ml-1">
+                  <span data-for="user_defined_symptom_onset_tooltip" data-tip="" className="ml-2">
                     {this.props.patient.user_defined_symptom_onset ? <i className="fas fa-user"></i> : <i className="fas fa-desktop"></i>}
                   </span>
                   <ReactTooltip id="user_defined_symptom_onset_tooltip" multiline={true} place="right" type="dark" effect="solid" className="tooltip-container">

--- a/app/javascript/components/subject/SymptomOnset.js
+++ b/app/javascript/components/subject/SymptomOnset.js
@@ -37,25 +37,11 @@ class SymptomOnset extends React.Component {
 
   submit() {
     this.setState({ loading: true }, () => {
-      let message = '';
-      if (this.props.patient.symptom_onset && this.state.symptom_onset) {
-        message = `User changed symptom onset date from ${moment(this.props.patient.symptom_onset).format('MM/DD/YYYY')} to ${moment(
-          this.state.symptom_onset
-        ).format('MM/DD/YYYY')}.`;
-      } else if (!this.props.patient.symptom_onset && this.state.symptom_onset) {
-        message = `User changed symptom onset date from blank to ${moment(this.state.symptom_onset).format('MM/DD/YYYY')}.`;
-      } else if (this.props.patient.symptom_onset && !this.state.symptom_onset) {
-        message = `User cleared symptom onset date from ${moment(this.props.patient.symptom_onset).format(
-          'MM/DD/YYYY'
-        )} to blank. The system will now populate this date.`;
-      }
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
       axios
         .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/status', {
           symptom_onset: this.state.symptom_onset,
           user_defined_symptom_onset: true,
-          comment: true,
-          message: message,
           diffState: ['symptom_onset', 'user_defined_symptom_onset'],
         })
         .then(() => {

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -129,7 +129,7 @@ class Assessment < ApplicationRecord
         latest_assessment_at: patient.assessments.maximum(:created_at)
       )
     else
-      new_symptom_onset = patient.assessments.where(symptomatic: true).minimum(:created_at)
+      new_symptom_onset = patient.assessments.where(symptomatic: true).minimum(:created_at).to_date
       unless new_symptom_onset == patient[:symptom_onset]
         comment = if !patient[:symptom_onset].nil? && !new_symptom_onset.nil?
                     "System changed symptom onset date from #{patient[:symptom_onset].strftime('%m/%d/%Y')} to #{new_symptom_onset.strftime('%m/%d/%Y')}
@@ -154,7 +154,7 @@ class Assessment < ApplicationRecord
     # latest fever or fever reducer at only needs to be updated upon deletion as it is updated in the symptom model upon symptom creation
     if patient.user_defined_symptom_onset.present? && !patient.symptom_onset.nil?
       patient.update(
-        latest_assessment_at: patient.assessments.where.not(id: id).maximum(:created_at),
+        latest_assessment_at: patient.assessments.where.not(id: id).maximum(:created_at).to_date,
         latest_fever_or_fever_reducer_at: patient.assessments
                                                  .where.not(id: id)
                                                  .where_assoc_exists(:reported_condition, &:fever_or_fever_reducer)

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -129,7 +129,7 @@ class Assessment < ApplicationRecord
         latest_assessment_at: patient.assessments.maximum(:created_at)
       )
     else
-      new_symptom_onset = patient.assessments.where(symptomatic: true).minimum(:created_at).to_date
+      new_symptom_onset = patient.assessments.where(symptomatic: true).minimum(:created_at)&.to_date
       unless new_symptom_onset == patient[:symptom_onset]
         comment = if !patient[:symptom_onset].nil? && !new_symptom_onset.nil?
                     "System changed symptom onset date from #{patient[:symptom_onset].strftime('%m/%d/%Y')} to #{new_symptom_onset.strftime('%m/%d/%Y')}
@@ -154,7 +154,7 @@ class Assessment < ApplicationRecord
     # latest fever or fever reducer at only needs to be updated upon deletion as it is updated in the symptom model upon symptom creation
     if patient.user_defined_symptom_onset.present? && !patient.symptom_onset.nil?
       patient.update(
-        latest_assessment_at: patient.assessments.where.not(id: id).maximum(:created_at).to_date,
+        latest_assessment_at: patient.assessments.where.not(id: id).maximum(:created_at)&.to_date,
         latest_fever_or_fever_reducer_at: patient.assessments
                                                  .where.not(id: id)
                                                  .where_assoc_exists(:reported_condition, &:fever_or_fever_reducer)

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -131,10 +131,15 @@ class Assessment < ApplicationRecord
     else
       new_symptom_onset = patient.assessments.where(symptomatic: true).minimum(:created_at)
       unless new_symptom_onset == patient[:symptom_onset]
-        comment = if new_symptom_onset.nil?
-                    'System cleared symptom onset date because there are no longer any symptomatic reports.'
-                  else
-                    "System changed symptom onset date to #{new_symptom_onset.strftime('%m/%d/%Y')} because a symptomatic report was created or updated."
+        comment = if !patient[:symptom_onset].nil? && !new_symptom_onset.nil?
+                    "System changed symptom onset date from #{patient[:symptom_onset].strftime('%m/%d/%Y')} to #{new_symptom_onset.strftime('%m/%d/%Y')}
+                     because a report meeting the symptomatic logic was created or updated."
+                  elsif patient[:symptom_onset].nil? && !new_symptom_onset.nil?
+                    "System changed symptom onset date from blank to #{new_symptom_onset.strftime('%m/%d/%Y')}
+                     because a report meeting the symptomatic logic was created or updated."
+                  elsif !patient[:symptom_onset].nil? && new_symptom_onset.nil?
+                    "System cleared symptom onset date from #{patient[:symptom_onset].strftime('%m/%d/%Y')} to blank
+                     because a report meeting the symptomatic logic was created or updated."
                   end
         History.monitoring_change(patient: patient, created_by: 'Sara Alert System', comment: comment)
       end
@@ -158,7 +163,7 @@ class Assessment < ApplicationRecord
     else
       new_symptom_onset = patient.assessments.where.not(id: id).where(symptomatic: true).minimum(:created_at)
       unless new_symptom_onset == patient[:symptom_onset] || !new_symptom_onset.nil?
-        comment = 'System cleared symptom onset date because a symptomatic report was removed.'
+        comment = "System cleared symptom onset date from #{patient[:symptom_onset].strftime('%m/%d/%Y')} to blank because a symptomatic report was removed."
         History.monitoring_change(patient: patient, created_by: 'Sara Alert System', comment: comment)
       end
       patient.update(

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -107,6 +107,16 @@ class History < ApplicationRecord
     create_history(patient, created_by, HISTORY_TYPES[:record_automatically_closed], comment)
   end
 
+  def self.monitoring_status(patient: nil, created_by: 'Sara Alert System', household: :patient, propagation: :none, old_value: nil, new_value: nil, reason: nil)
+    return if old_value == new_value
+
+    formatted_old_value = old_value ? 'Monitoring' : 'Not Monitoring'
+    formatted_new_value = new_value ? 'Monitoring' : 'Not Monitoring'
+    comment = compose_message(formatted_old_value, formatted_new_value, household, propagation, 'Monitoring Status', 'date', reason)
+
+    create_history(patient, created_by, HISTORY_TYPES[:monitoring_change], comment)
+  end
+
   def self.symptom_onset(patient: nil, created_by: 'Sara Alert System', household: :patient, propagation: :none, old_value: nil, new_value: nil)
     return if old_value == new_value
 
@@ -175,8 +185,10 @@ class History < ApplicationRecord
     from_text = formatted_old_value.nil? ? 'blank' : formatted_old_value
     to_text = formatted_new_value.nil? ? 'blank' : formatted_new_value
 
-    comment = "#{creator} #{verb} #{field} from #{from_text} to #{to_text}#{compose_explanation(household, propagation, field, field_type)}."
-    comment += " Reason: #{reason}" unless reason.nil?
+    comment = "#{creator} #{verb} #{field} from \"#{from_text}\" to \"#{to_text}\""
+    comment += compose_explanation(household, propagation, field, field_type)
+    comment += "."
+    comment += " Reason: #{reason}" unless reason.blank?
     comment
   end
 

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -159,7 +159,7 @@ class History < ApplicationRecord
 
   def self.public_health_action(history)
     field = {
-      name: 'Public Health Action',
+      name: 'Latest Public Health Action',
       old_value: history[:patient][:public_health_action],
       new_value: history[:params][:public_health_action]
     }

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -228,7 +228,7 @@ class History < ApplicationRecord
     return if field[:old_value] == field[:new_value]
 
     comment = compose_message(history, field)
-    comment += ' The system will now populate this date.' if new_value.nil?
+    comment += ' The system will now populate this date.' if field[:new_value].nil?
     create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment)
   end
 
@@ -253,7 +253,7 @@ class History < ApplicationRecord
     return if field[:old_value] == field[:new_value]
 
     creator = history[:household] == :patient ? 'User' : 'System'
-    formatted_new_value = new_value ? 'on' : 'off'
+    formatted_new_value = field[:new_value] ? 'on' : 'off'
     comment = "#{creator} turned #{formatted_new_value} #{field}#{compose_explanation(history, field)}"
     create_history(patient, created_by, HISTORY_TYPES[:monitoring_change], comment)
   end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -215,7 +215,9 @@ class History < ApplicationRecord
     }
     return if field[:old_value] == field[:new_value]
 
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field))
+    creator = history[:household] == :patient ? 'User' : 'System'
+    comment = "#{creator} #{field[:new_value]} notifications for this monitoree#{compose_explanation(history, field)}."
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment)
   end
 
   def self.symptom_onset(history)
@@ -253,9 +255,8 @@ class History < ApplicationRecord
     return if field[:old_value] == field[:new_value]
 
     creator = history[:household] == :patient ? 'User' : 'System'
-    formatted_new_value = field[:new_value] ? 'on' : 'off'
-    comment = "#{creator} turned #{formatted_new_value} #{field}#{compose_explanation(history, field)}"
-    create_history(history[:patient], created_by, HISTORY_TYPES[:monitoring_change], comment)
+    comment = "#{creator} turned #{field[:new_value]} #{field[:name]}#{compose_explanation(history, field)}."
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment)
   end
 
   def self.extended_isolation(history)

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -107,6 +107,19 @@ class History < ApplicationRecord
     create_history(patient, created_by, HISTORY_TYPES[:record_automatically_closed], comment)
   end
 
+  def self.last_date_of_exposure(patient: nil, created_by: 'Sara Alert System', old_value: nil, new_value: nil, is_dependent: false)
+    return if old_value == new_value
+
+    comment = if old_value.present? && new_value.present?
+                "User changed last date of exposure from #{old_value.to_date.strftime('%m/%d/%Y')} to #{new_value.to_date.strftime('%m/%d/%Y')}."
+              elsif old_value.present? && new_value.nil?
+                "User cleared last date of exposure from #{old_value.to_date.strftime('%m/%d/%Y')} to blank."
+              elsif old_value.nil? && new_value.present?
+                "User changed last date of exposure from blank to #{new_value.to_date.strftime('%m/%d/%Y')}."
+              end
+    create_history(patient, created_by, HISTORY_TYPES[:monitoring_change], comment)
+  end
+
   # Information about this history
   def details
     {

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -107,6 +107,23 @@ class History < ApplicationRecord
     create_history(patient, created_by, HISTORY_TYPES[:record_automatically_closed], comment)
   end
 
+  def self.monitoring_actions(history, diff_state)
+    return if diff_state.nil?
+
+    History.monitoring_status(history) if diff_state.include?(:monitoring)
+    History.exposure_risk_assessment(history) if diff_state.include?(:exposure_risk_assessment)
+    History.monitoring_plan(history) if diff_state.include?(:monitoring_plan)
+    History.case_status(history) if diff_state.include?(:case_status)
+    History.public_health_action(history) if diff_state.include?(:public_health_action)
+    History.jurisdiction(history) if diff_state.include?(:jurisdiction_path)
+    History.assigned_user(history) if diff_state.include?(:assigned_user)
+    History.pause_notifications(history) if diff_state.include?(:pause_notifications)
+    History.symptom_onset(history) if diff_state.include?(:symptom_onset)
+    History.last_date_of_exposure(history) if diff_state.include?(:last_date_of_exposure)
+    History.continuous_exposure(history) if diff_state.include?(:continuous_exposure)
+    History.extended_isolation(history) if diff_state.include?(:extended_isolation)
+  end
+
   def self.monitoring_status(history)
     field = {
       name: 'Monitoring Status',

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -255,7 +255,7 @@ class History < ApplicationRecord
     creator = history[:household] == :patient ? 'User' : 'System'
     formatted_new_value = field[:new_value] ? 'on' : 'off'
     comment = "#{creator} turned #{formatted_new_value} #{field}#{compose_explanation(history, field)}"
-    create_history(patient, created_by, HISTORY_TYPES[:monitoring_change], comment)
+    create_history(history[:patient], created_by, HISTORY_TYPES[:monitoring_change], comment)
   end
 
   def self.extended_isolation(history)

--- a/test/system/roles/public_health/patient_page/history_verifier.rb
+++ b/test/system/roles/public_health/patient_page/history_verifier.rb
@@ -38,7 +38,7 @@ class PublicHealthPatientPageHistoryVerifier < ApplicationSystemTestCase
   end
 
   def verify_assigned_user(user_label, assigned_user, reasoning)
-    verify_historical_event(user_label, 'Monitoring Change', ['User changed Assigned user', assigned_user, reasoning])
+    verify_historical_event(user_label, 'Monitoring Change', ['User changed Assigned User', assigned_user, reasoning])
   end
 
   def verify_add_report(user_label)

--- a/test/system/roles/public_health/patient_page/history_verifier.rb
+++ b/test/system/roles/public_health/patient_page/history_verifier.rb
@@ -10,35 +10,35 @@ class PublicHealthPatientPageHistoryVerifier < ApplicationSystemTestCase
   USERS = @@system_test_utils.users
 
   def verify_monitoring_status(user_label, monitoring_status, monitoring_reason, reasoning)
-    verify_historical_event(user_label, 'Monitoring Change', ['User changed monitoring status', monitoring_status, monitoring_reason, reasoning])
+    verify_historical_event(user_label, 'Monitoring Change', ['User changed Monitoring Status', monitoring_status, monitoring_reason, reasoning])
   end
 
   def verify_exposure_risk_assessment(user_label, exposure_risk_assessment, reasoning)
-    verify_historical_event(user_label, 'Monitoring Change', ['User changed exposure risk assessment', exposure_risk_assessment, reasoning])
+    verify_historical_event(user_label, 'Monitoring Change', ['User changed Exposure Risk Assessment', exposure_risk_assessment, reasoning])
   end
 
   def verify_monitoring_plan(user_label, monitoring_plan, reasoning)
-    verify_historical_event(user_label, 'Monitoring Change', ['User changed monitoring plan', monitoring_plan, reasoning])
+    verify_historical_event(user_label, 'Monitoring Change', ['User changed Monitoring Plan', monitoring_plan, reasoning])
   end
 
   def verify_latest_public_health_action(user_label, latest_public_health_action, reasoning)
-    verify_historical_event(user_label, 'Monitoring Change', ['User changed latest public health action', latest_public_health_action, reasoning])
+    verify_historical_event(user_label, 'Monitoring Change', ['User changed Latest Public Health Action', latest_public_health_action, reasoning])
   end
 
   def verify_additional_public_health_action(user_label)
-    verify_historical_event(user_label, 'Monitoring Change', ['User added an additional public health action'])
+    verify_historical_event(user_label, 'Monitoring Change', ['User added an additional Public Health Action'])
   end
 
   def verify_current_workflow(user_label, current_workflow, reasoning)
-    verify_historical_event(user_label, 'Monitoring Change', ['User changed workflow', current_workflow, reasoning])
+    verify_historical_event(user_label, 'Monitoring Change', ['User changed Workflow', current_workflow, reasoning])
   end
 
   def verify_assigned_jurisdiction(user_label, jurisdiction, reasoning)
-    verify_historical_event(user_label, 'Monitoring Change', ['User changed jurisdiction', jurisdiction, reasoning])
+    verify_historical_event(user_label, 'Monitoring Change', ['User changed Jurisdiction', jurisdiction, reasoning])
   end
 
   def verify_assigned_user(user_label, assigned_user, reasoning)
-    verify_historical_event(user_label, 'Monitoring Change', ['User changed assigned user', assigned_user, reasoning])
+    verify_historical_event(user_label, 'Monitoring Change', ['User changed Assigned user', assigned_user, reasoning])
   end
 
   def verify_add_report(user_label)

--- a/test/system/roles/public_health/patient_page/history_verifier.rb
+++ b/test/system/roles/public_health/patient_page/history_verifier.rb
@@ -33,12 +33,12 @@ class PublicHealthPatientPageHistoryVerifier < ApplicationSystemTestCase
     verify_historical_event(user_label, 'Monitoring Change', ['User changed Workflow', current_workflow, reasoning])
   end
 
-  def verify_assigned_jurisdiction(user_label, jurisdiction, reasoning)
-    verify_historical_event(user_label, 'Monitoring Change', ['User changed Jurisdiction', jurisdiction, reasoning])
+  def verify_assigned_jurisdiction(user_label, jurisdiction, reasoning, creator = 'User')
+    verify_historical_event(user_label, 'Monitoring Change', ["#{creator} changed Jurisdiction", jurisdiction, reasoning])
   end
 
-  def verify_assigned_user(user_label, assigned_user, reasoning)
-    verify_historical_event(user_label, 'Monitoring Change', ['User changed Assigned User', assigned_user, reasoning])
+  def verify_assigned_user(user_label, assigned_user, reasoning, creator = 'User')
+    verify_historical_event(user_label, 'Monitoring Change', ["#{creator} changed Assigned User", assigned_user, reasoning])
   end
 
   def verify_add_report(user_label)

--- a/test/system/workflow/workflow_test.rb
+++ b/test/system/workflow/workflow_test.rb
@@ -136,7 +136,7 @@ class WorkflowTest < ApplicationSystemTestCase
     @@public_health_patient_page_history_verifier.verify_assigned_jurisdiction(enroller_user_label, newer_jurisdiction, '')
     @@system_test_utils.return_to_dashboard('exposure')
     @@public_health_dashboard.search_for_and_view_monitoree('transferred_in', group_member_label)
-    @@public_health_patient_page_history_verifier.verify_assigned_jurisdiction(enroller_user_label, newer_jurisdiction, '')
+    @@public_health_patient_page_history_verifier.verify_assigned_jurisdiction(enroller_user_label, newer_jurisdiction, '', 'System')
     @@system_test_utils.logout
   end
 
@@ -161,7 +161,7 @@ class WorkflowTest < ApplicationSystemTestCase
     assert page.has_content?(new_assigned_user)
     @@public_health_patient_page_history_verifier.verify_assigned_user(epi_enroller_user_label, new_assigned_user, '')
     click_on @@system_test_utils.get_displayed_name(MONITOREES[group_member_label])
-    assert page.has_no_content?("User changed assigned user from \"#{old_assigned_user}\" to \"#{new_assigned_user}\"")
+    assert page.has_no_content?("System changed assigned user from \"#{old_assigned_user}\" to \"#{new_assigned_user}\"")
 
     # edit parent assigned user and propagate to group member
     edited_monitoree_with_propogation_label = 'monitoree_16'
@@ -176,7 +176,7 @@ class WorkflowTest < ApplicationSystemTestCase
     @@public_health_patient_page_history_verifier.verify_assigned_user(epi_enroller_user_label, newer_assigned_user, '')
     click_on @@system_test_utils.get_displayed_name(MONITOREES[group_member_label])
     assert page.has_content?(newer_assigned_user)
-    @@public_health_patient_page_history_verifier.verify_assigned_user(epi_enroller_user_label, newer_assigned_user, '')
+    @@public_health_patient_page_history_verifier.verify_assigned_user(epi_enroller_user_label, newer_assigned_user, '', 'System')
     @@system_test_utils.logout
   end
 end


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-675

Log any changes to `last_date_of_exposure`, `symptom_onset`, `continuous_exposure`, `extended_isolation` dates in history. For symptom onset, log system changes as well and indicate if it was a user or system change.

# Important Changes

### Logging Symptom Onset Change
- [x] If the user sets the symptom onset
- [x] If the system resets the symptom onset after a) case is moved to exposure from isolation or b) user clears out field.
- [x] If the system sets the symptom onset based on an incoming assessment

### Logging LDE Change
- [x] If user changes the last date of exposure date

### Logging Continuous Exposure Change
- [x] If user toggles the continuous exposure toggle
- [x] If the system sets continuous exposure to false when a user manually closes out a record in exposure

### Logging Extended Isolation Change
- [x] If user changes the extended isolation date
- [x] If system sets extended isolation to nil when moving from isolation to exposure