### PR TITLE
SARAALERT-699: Fix admin table sort persistence

### DIFF
--- a/app/javascript/components/admin/AdminTable.js
+++ b/app/javascript/components/admin/AdminTable.js
@@ -336,6 +336,17 @@ class AdminTable extends React.Component {
   };
 
   /**
+   * Called when table is to be updated because of a search or sorting change
+   * @param {Object} query - sorting components of query from custom table
+   */
+  handleTableUpdate = query => {
+    const previous = this.state.query;
+    this.setState({ query: { ...previous, ...query } }, () => {
+      this.getTableData(this.state.query);
+    });
+  };
+
+  /**
    * Callback called when child Table component detects a selection change.
    * Updates the selected rows and enables/disables actions accordingly.
    * @param {Number[]} selectedRows - Array of selected row indices.
@@ -605,7 +616,7 @@ class AdminTable extends React.Component {
           columnData={this.state.table.colData}
           rowData={this.state.table.rowData}
           totalRows={this.state.table.totalRows}
-          handleTableUpdate={query => this.getTableData({ ...this.state.query, ...query })}
+          handleTableUpdate={this.handleTableUpdate}
           handleSelect={this.handleSelect}
           handleEdit={this.handleEditClick}
           handleEntriesChange={this.handleEntriesChange}

--- a/app/javascript/components/admin/AdminTable.js
+++ b/app/javascript/components/admin/AdminTable.js
@@ -340,10 +340,14 @@ class AdminTable extends React.Component {
    * @param {Object} query - sorting components of query from custom table
    */
   handleTableUpdate = query => {
-    const previous = this.state.query;
-    this.setState({ query: { ...previous, ...query } }, () => {
-      this.getTableData(this.state.query);
-    });
+    this.setState(
+      state => ({
+        query: { ...state, ...query },
+      }),
+      () => {
+        this.getTableData(this.state.query);
+      }
+    );
   };
 
   /**

--- a/app/javascript/components/admin/AdminTable.js
+++ b/app/javascript/components/admin/AdminTable.js
@@ -336,13 +336,13 @@ class AdminTable extends React.Component {
   };
 
   /**
-   * Called when table is to be updated because of a search or sorting change
-   * @param {Object} query - sorting components of query from custom table
+   * Called when table is to be updated because of a search or sorting change.
+   * @param {Object} query - Updated query for table data after change.
    */
   handleTableUpdate = query => {
     this.setState(
       state => ({
-        query: { ...state, ...query },
+        query: { ...state.query, ...query },
       }),
       () => {
         this.getTableData(this.state.query);


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-699

It is expected that when an Admin user sorts the table based on one of the columns, when that user does some action that updates the table (such as add a new user, view the next page of users, or search across the Admin table) the table records remain sorted based.

# (Bugfix) How to Replicate

Sort the Admin table by Jurisdiction so users with USA jurisdiction appear at the top.
Search for USA in search box.
Observe that the table is no longer sorted based on jurisdiction and won't be until the user clicks on it again.

# (Bugfix) Solution

Whenever a column in the admin table was sorted, the state was not actually updated, so whenever another filter was applied, the sorting params would be lost. This is now fixed by updating the state with the sorting params.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`AdminTable.js`
- Updated component state with sorting params

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [X] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11
