### PR TITLE
Improve clarity of monitoring status modal

### DIFF
--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -112,7 +112,7 @@ class LastDateExposure extends React.Component {
         <Modal.Body>
           <p>{message}</p>
           {this.props.has_group_members && (
-            <Form.Group className="mt-3">
+            <Form.Group className="mb-2 px-4">
               <Form.Check
                 type="radio"
                 id="apply_to_monitoree_only"
@@ -123,7 +123,7 @@ class LastDateExposure extends React.Component {
             </Form.Group>
           )}
           {this.props.has_group_members && this.state.showExposureDateModal && (
-            <Form.Group className="mt-3">
+            <Form.Group className="mb-2 px-4">
               <Form.Check
                 type="radio"
                 id="apply_to_group_cm_only"
@@ -134,7 +134,7 @@ class LastDateExposure extends React.Component {
             </Form.Group>
           )}
           {this.props.has_group_members && (
-            <Form.Group className="mt-2">
+            <Form.Group className="mb-2 px-4">
               <Form.Check
                 type="radio"
                 id="apply_to_group"

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -141,7 +141,7 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'monitoring_status') {
       this.setState({
         showMonitoringStatusModal: true,
-        message: 'monitoring status to "' + event.target.value + '"',
+        message: 'Monitoring Status to "' + event.target.value + '"',
         message_warning:
           event.target.value === 'Not Monitoring' ? 'This will move the selected record(s) to the Closed line list and turn Continuous Exposure OFF.' : '',
         monitoring: event.target.value === 'Actively Monitoring' ? true : false,
@@ -325,7 +325,7 @@ class MonitoringStatus extends React.Component {
         </Modal.Header>
         <Modal.Body>
           <p>
-            Are you sure you want to change this monitoree&apos;s {this.state.message}? {this.state.message_warning && <b>{this.state.message_warning}</b>}
+            Are you sure you want to change {this.state.message}? {this.state.message_warning && <b>{this.state.message_warning}</b>}
           </p>
           {this.props.has_group_members && (
             <React.Fragment>

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -329,19 +329,19 @@ class MonitoringStatus extends React.Component {
           </p>
           {this.props.has_group_members && (
             <React.Fragment>
-              <Form.Group className="mt-2">
+              <Form.Group className="px-4">
                 <Form.Check
                   type="radio"
+                  className="mb-1"
                   name="apply_to_group"
                   id="apply_to_group_no"
                   label="This monitoree only"
                   onChange={this.handleChange}
                   checked={!this.state.apply_to_group}
                 />
-              </Form.Group>
-              <Form.Group className="mt-2">
                 <Form.Check
                   type="radio"
+                  className="mb-3"
                   name="apply_to_group"
                   id="apply_to_group_yes"
                   label="This monitoree and all household members"
@@ -377,17 +377,16 @@ class MonitoringStatus extends React.Component {
                 Would you like to update the <i>Last Date of Exposure</i> for all household members who have Continuous Exposure toggled ON and are being
                 monitored in the Exposure Workflow?
               </p>
-              <Form.Group>
+              <Form.Group className="px-4">
                 <Form.Check
                   type="radio"
+                  className="mb-2"
                   name="apply_to_group_cm_only"
                   id="apply_to_group_cm_only_no"
                   label="No, household members still have continuous exposure to another case"
                   onChange={this.handleChange}
                   checked={!this.state.apply_to_group_cm_only}
                 />
-              </Form.Group>
-              <Form.Group>
                 <Form.Check>
                   <Form.Check.Label>
                     <Form.Check.Input
@@ -397,10 +396,10 @@ class MonitoringStatus extends React.Component {
                       onChange={this.handleChange}
                       checked={this.state.apply_to_group_cm_only}
                     />
-                    <p>Yes, household members are no longer being exposed to a case</p>
+                    Yes, household members are no longer being exposed to a case
                     {/* FIX MY PLACEMENT */}
                     {this.state.apply_to_group_cm_only && (
-                      <React.Fragment>
+                      <div className="mt-1">
                         Update their <b>Last Date of Exposure</b> to:
                         <DateInput
                           id="apply_to_group_cm_only_date"
@@ -408,7 +407,7 @@ class MonitoringStatus extends React.Component {
                           onChange={date => this.setState({ apply_to_group_cm_only_date: date })}
                           placement="bottom"
                         />
-                      </React.Fragment>
+                      </div>
                     )}
                   </Form.Check.Label>
                 </Form.Check>

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -317,9 +317,22 @@ class MonitoringStatus extends React.Component {
           <Modal.Title>{title}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
+          {/* CHANGE ME */}
           <p>
             You are about to change this monitoree&apos;s {this.state.message} {this.state.message_warning && <b>{this.state.message_warning}</b>}
           </p>
+          {/* CHANGE ME */}
+          {this.props.has_group_members && (
+            <Form.Group className="mt-2">
+              <Form.Check
+                type="switch"
+                id="apply_to_group"
+                label="Apply this change to the entire household that this monitoree is responsible for"
+                onChange={this.handleChange}
+                checked={this.state.apply_to_group === true || false}
+              />
+            </Form.Group>
+          )}
           {this.state.monitoring_reasons && (
             <Form.Group>
               <Form.Label>Please select reason for status change:</Form.Label>
@@ -335,42 +348,39 @@ class MonitoringStatus extends React.Component {
               </Form.Control>
             </Form.Group>
           )}
-          {this.props.isolation && this.state.monitoring_reasons && this.props.in_a_group && (
-            <Form.Group>
-              <Form.Check
-                type="switch"
-                id="apply_to_group_cm_only"
-                label='Update Last Date of Exposure for all household members with Continuous Exposure whose Monitoring Status is "Actively Monitoring" in the Exposure workflow'
-                onChange={this.handleChange}
-                checked={this.state.apply_to_group_cm_only}
-              />
-            </Form.Group>
-          )}
-          {this.props.isolation && this.state.monitoring_reasons && this.props.in_a_group && this.state.apply_to_group_cm_only && (
-            <Form.Group>
-              <Form.Label className="nav-input-label">LAST DATE OF EXPOSURE</Form.Label>
-              <DateInput
-                id="apply_to_group_cm_only_date"
-                date={this.state.apply_to_group_cm_only_date}
-                onChange={date => this.setState({ apply_to_group_cm_only_date: date })}
-                placement="bottom"
-              />
-            </Form.Group>
-          )}
           <Form.Group>
             <Form.Label>Please include any additional details:</Form.Label>
             <Form.Control as="textarea" rows="2" id="reasoning" onChange={this.handleChange} />
           </Form.Group>
-          {this.props.has_group_members && (
-            <Form.Group className="mt-2">
-              <Form.Check
-                type="switch"
-                id="apply_to_group"
-                label="Apply this change to the entire household that this monitoree is responsible for"
-                onChange={this.handleChange}
-                checked={this.state.apply_to_group}
-              />
-            </Form.Group>
+          {this.props.isolation && this.state.monitoring_reasons && this.props.in_a_group && (
+            <React.Fragment>
+              <hr />
+              <p>
+                Would you like to update the <i>Last Date of Exposure</i> for all household members who have Continuous Exposure toggled ON and are being
+                monitored in the Exposure Workflow?
+              </p>
+              {/* CHANGE ME */}
+              <Form.Group>
+                <Form.Check
+                  type="switch"
+                  id="apply_to_group_cm_only"
+                  label='Update Last Date of Exposure for all household members with Continuous Exposure whose Monitoring Status is "Actively Monitoring" in the Exposure workflow'
+                  onChange={this.handleChange}
+                  checked={this.state.apply_to_group_cm_only === true || false}
+                />
+              </Form.Group>
+              {this.state.apply_to_group_cm_only && (
+                <Form.Group>
+                  <Form.Label className="nav-input-label">LAST DATE OF EXPOSURE</Form.Label>
+                  <DateInput
+                    id="apply_to_group_cm_only_date"
+                    date={this.state.apply_to_group_cm_only_date}
+                    onChange={date => this.setState({ apply_to_group_cm_only_date: date })}
+                    placement="bottom"
+                  />
+                </Form.Group>
+              )}
+            </React.Fragment>
           )}
         </Modal.Body>
         <Modal.Footer>

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -329,6 +329,7 @@ class MonitoringStatus extends React.Component {
           </p>
           {this.props.has_group_members && (
             <React.Fragment>
+              <p className="mb-2">Please select the records that you would like to apply this change to:</p>
               <Form.Group className="px-4">
                 <Form.Check
                   type="radio"
@@ -373,7 +374,7 @@ class MonitoringStatus extends React.Component {
           {this.props.isolation && this.state.monitoring_reasons && this.props.in_a_group && (
             <React.Fragment>
               <hr />
-              <p>
+              <p className="mb-2">
                 Would you like to update the <i>Last Date of Exposure</i> for all household members who have Continuous Exposure toggled ON and are being
                 monitored in the Exposure Workflow?
               </p>
@@ -396,17 +397,19 @@ class MonitoringStatus extends React.Component {
                       onChange={this.handleChange}
                       checked={this.state.apply_to_group_cm_only}
                     />
-                    Yes, household members are no longer being exposed to a case
+                    <p className="mb-1">Yes, household members are no longer being exposed to a case</p>
                     {this.state.apply_to_group_cm_only && (
-                      <div className="mt-1">
-                        Update their <b>Last Date of Exposure</b> to:
+                      <React.Fragment>
+                        <p className="mb-2">
+                          Update their <b>Last Date of Exposure</b> to:
+                        </p>
                         <DateInput
                           id="apply_to_group_cm_only_date"
                           date={this.state.apply_to_group_cm_only_date}
                           onChange={date => this.setState({ apply_to_group_cm_only_date: date })}
                           placement="bottom"
                         />
-                      </div>
+                      </React.Fragment>
                     )}
                   </Form.Check.Label>
                 </Form.Check>

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -144,7 +144,7 @@ class MonitoringStatus extends React.Component {
         message: 'monitoring status to "' + event.target.value + '"',
         message_warning:
           event.target.value === 'Not Monitoring' ? 'This will move the selected record(s) to the Closed line list and turn Continuous Exposure OFF.' : '',
-        monitoring: event.target.value === 'Actively Monitoring' ? true : false,
+        monitoring: event.target.value === 'Actively Monitoring',
         monitoring_status: event?.target?.value ? event.target.value : '',
         monitoring_reasons:
           event.target.value === 'Not Monitoring'
@@ -164,10 +164,10 @@ class MonitoringStatus extends React.Component {
             : null,
       });
     } else if (event?.target?.name && event.target.name === 'apply_to_group') {
-      let applyToGroup = event.target.id === 'apply_to_group_yes' ? true : false;
+      let applyToGroup = event.target.id === 'apply_to_group_yes';
       this.setState({ [event.target.name]: applyToGroup });
     } else if (event?.target?.name && event.target.name === 'apply_to_group_cm_only') {
-      let applyToGroup = event.target.id === 'apply_to_group_cm_only_yes' ? true : false;
+      let applyToGroup = event.target.id === 'apply_to_group_cm_only_yes';
       this.setState({ [event.target.name]: applyToGroup });
     } else if (event?.target?.id) {
       let value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
@@ -277,7 +277,7 @@ class MonitoringStatus extends React.Component {
       axios
         .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/status', {
           comment: true,
-          monitoring: this.state.monitoring_status === 'Actively Monitoring' ? true : false,
+          monitoring: this.state.monitoring_status === 'Actively Monitoring',
           exposure_risk_assessment: this.state.exposure_risk_assessment,
           monitoring_plan: this.state.monitoring_plan,
           public_health_action: this.state.public_health_action,

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -372,22 +372,22 @@ class MonitoringStatus extends React.Component {
                       onChange={this.handleChange}
                       checked={this.state.apply_to_group_cm_only}
                     />
-                    <p>Yes, household members are no longer being exposed to a case.</p>
+                    <p>Yes, household members are no longer being exposed to a case</p>
                   </Form.Check.Label>
-                  {/* FIX MY PLACEMENT */}
-                  {this.state.apply_to_group_cm_only && (
-                    <div>
-                      Update their <b>Last Date of Exposure</b> to:
-                      <DateInput
-                        id="apply_to_group_cm_only_date"
-                        date={this.state.apply_to_group_cm_only_date}
-                        onChange={date => this.setState({ apply_to_group_cm_only_date: date })}
-                        placement="bottom"
-                      />
-                      <br />
-                    </div>
-                  )}
                 </Form.Check>
+                {/* FIX MY PLACEMENT */}
+                {this.state.apply_to_group_cm_only && (
+                  <React.Fragment>
+                    Update their <b>Last Date of Exposure</b> to:
+                    <DateInput
+                      id="apply_to_group_cm_only_date"
+                      date={this.state.apply_to_group_cm_only_date}
+                      onChange={date => this.setState({ apply_to_group_cm_only_date: date })}
+                      placement="bottom"
+                    />
+                    <br />
+                  </React.Fragment>
+                )}
                 <Form.Check
                   type="radio"
                   name="apply_to_group_cm_only"

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -363,6 +363,16 @@ class MonitoringStatus extends React.Component {
                 monitored in the Exposure Workflow?
               </p>
               <Form.Group>
+                <Form.Check
+                  type="radio"
+                  name="apply_to_group_cm_only"
+                  id="lde_radio_no"
+                  label="No, household members still have continuous exposure to another case"
+                  onChange={this.handleChange}
+                  checked={!this.state.apply_to_group_cm_only}
+                />
+              </Form.Group>
+              <Form.Group>
                 <Form.Check>
                   <Form.Check.Label>
                     <Form.Check.Input
@@ -373,29 +383,20 @@ class MonitoringStatus extends React.Component {
                       checked={this.state.apply_to_group_cm_only}
                     />
                     <p>Yes, household members are no longer being exposed to a case</p>
+                    {/* FIX MY PLACEMENT */}
+                    {this.state.apply_to_group_cm_only && (
+                      <React.Fragment>
+                        Update their <b>Last Date of Exposure</b> to:
+                        <DateInput
+                          id="apply_to_group_cm_only_date"
+                          date={this.state.apply_to_group_cm_only_date}
+                          onChange={date => this.setState({ apply_to_group_cm_only_date: date })}
+                          placement="bottom"
+                        />
+                      </React.Fragment>
+                    )}
                   </Form.Check.Label>
                 </Form.Check>
-                {/* FIX MY PLACEMENT */}
-                {this.state.apply_to_group_cm_only && (
-                  <React.Fragment>
-                    Update their <b>Last Date of Exposure</b> to:
-                    <DateInput
-                      id="apply_to_group_cm_only_date"
-                      date={this.state.apply_to_group_cm_only_date}
-                      onChange={date => this.setState({ apply_to_group_cm_only_date: date })}
-                      placement="bottom"
-                    />
-                    <br />
-                  </React.Fragment>
-                )}
-                <Form.Check
-                  type="radio"
-                  name="apply_to_group_cm_only"
-                  id="lde_radio_no"
-                  label="No, household members still have continuous exposure to another case"
-                  onChange={this.handleChange}
-                  checked={!this.state.apply_to_group_cm_only}
-                />
               </Form.Group>
             </React.Fragment>
           )}

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -141,7 +141,7 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'monitoring_status') {
       this.setState({
         showMonitoringStatusModal: true,
-        message: 'Monitoring Status to "' + event.target.value + '"',
+        message: 'monitoring status to "' + event.target.value + '"',
         message_warning:
           event.target.value === 'Not Monitoring' ? 'This will move the selected record(s) to the Closed line list and turn Continuous Exposure OFF.' : '',
         monitoring: event.target.value === 'Actively Monitoring' ? true : false,

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -62,7 +62,7 @@ class MonitoringStatus extends React.Component {
     if (event?.target?.name && event.target.name === 'jurisdictionId') {
       // Jurisdiction is a weird case; the datalist and input work differently together
       this.setState({
-        message: 'jurisdiction from "' + this.props.jurisdictionPaths[this.state.original_jurisdiction_id] + '" to "' + event.target.value + '".',
+        message: 'jurisdiction from "' + this.props.jurisdictionPaths[this.state.original_jurisdiction_id] + '" to "' + event.target.value + '"',
         message_warning: this.state.assigned_user === '' ? '' : 'Please also consider removing or updating the assigned user if it is no longer applicable.',
         jurisdiction_path: event?.target?.value ? event.target.value : '',
         monitoring_reasons: null,
@@ -74,7 +74,7 @@ class MonitoringStatus extends React.Component {
         (event?.target?.value && !isNaN(event.target.value) && parseInt(event.target.value) > 0 && parseInt(event.target.value) <= 9999)
       ) {
         this.setState({
-          message: 'assigned user from "' + this.state.original_assigned_user + '"to"' + event.target.value + '".',
+          message: 'assigned user from "' + this.state.original_assigned_user + '"to"' + event.target.value + '"',
           message_warning: '',
           assigned_user: event?.target?.value ? parseInt(event.target.value) : '',
           monitoring_reasons: null,
@@ -83,7 +83,7 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'exposure_risk_assessment') {
       this.setState({
         showExposureRiskAssessmentModal: true,
-        message: 'exposure risk assessment to "' + event.target.value + '".',
+        message: 'exposure risk assessment to "' + event.target.value + '"',
         message_warning: '',
         exposure_risk_assessment: event?.target?.value ? event.target.value : '',
         monitoring_reasons: null,
@@ -91,7 +91,7 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'monitoring_plan') {
       this.setState({
         showMonitoringPlanModal: true,
-        message: 'monitoring plan to "' + event.target.value + '".',
+        message: 'monitoring plan to "' + event.target.value + '"',
         message_warning: '',
         monitoring_plan: event?.target?.value ? event.target.value : '',
         monitoring_reasons: null,
@@ -99,7 +99,7 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'pause_notifications') {
       this.setState({
         showNotificationsModal: true,
-        message: 'notification status to ' + (!this.state.pause_notifications ? 'paused.' : 'resumed.'),
+        message: 'notification status to ' + (!this.state.pause_notifications ? 'paused' : 'resumed'),
         message_warning: '',
         pause_notifications: !this.state.pause_notifications,
         monitoring_reasons: null,
@@ -108,7 +108,7 @@ class MonitoringStatus extends React.Component {
       if (this.state.patient.isolation) {
         this.setState({
           showPublicHealthActionModal: true,
-          message: 'latest public health action to "' + event.target.value + '".',
+          message: 'latest public health action to "' + event.target.value + '"',
           message_warning:
             'The monitoree will be moved to the "Records Requiring Review" line list if they meet a recovery definition or will remain on the "Reporting" or "Non-Reporting" line list as appropriate until a recovery definition is met.',
           public_health_action: event?.target?.value ? event.target.value : '',
@@ -117,7 +117,7 @@ class MonitoringStatus extends React.Component {
       } else {
         this.setState({
           showPublicHealthActionModal: true,
-          message: 'latest public health action to "' + event.target.value + '".',
+          message: 'latest public health action to "' + event.target.value + '"',
           message_warning:
             event.target.value === 'None'
               ? 'The monitoree will be moved back into the primary status line lists.'
@@ -129,7 +129,7 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'isolation_status') {
       this.setState({
         showIsolationModal: true,
-        message: 'workflow from the "' + this.state.isolation_status + '" workflow to the "' + event.target.value + '" workflow.',
+        message: 'workflow from the "' + this.state.isolation_status + '" workflow to the "' + event.target.value + '" workflow',
         message_warning:
           event.target.value === 'Isolation'
             ? 'This should only be done for cases you wish to monitor with Sara Alert to determine when they meet the recovery definition to discontinue isolation. The monitoree will be moved onto the Isolation workflow dashboard.'
@@ -141,8 +141,9 @@ class MonitoringStatus extends React.Component {
     } else if (event?.target?.id && event.target.id === 'monitoring_status') {
       this.setState({
         showMonitoringStatusModal: true,
-        message: 'monitoring status to "' + event.target.value + '".',
-        message_warning: event.target.value === 'Not Monitoring' ? 'This record will be moved to the closed line list.' : '',
+        message: 'monitoring status to "' + event.target.value + '"',
+        message_warning:
+          event.target.value === 'Not Monitoring' ? 'This will move the selected record(s) to the Closed line list and turn Continuous Exposure OFF.' : '',
         monitoring: event.target.value === 'Actively Monitoring' ? true : false,
         monitoring_status: event?.target?.value ? event.target.value : '',
         monitoring_reasons:
@@ -229,7 +230,7 @@ class MonitoringStatus extends React.Component {
   toggleJurisdictionModal() {
     let current = this.state.showJurisdictionModal;
     this.setState({
-      message: 'jurisdiction from "' + this.props.jurisdictionPaths[this.state.original_jurisdiction_id] + '" to "' + this.state.jurisdiction_path + '".',
+      message: 'jurisdiction from "' + this.props.jurisdictionPaths[this.state.original_jurisdiction_id] + '" to "' + this.state.jurisdiction_path + '"',
       showJurisdictionModal: !current,
       jurisdiction_path: current ? this.props.jurisdictionPaths[this.state.original_jurisdiction_id] : this.state.jurisdiction_path,
       apply_to_group: false,
@@ -240,7 +241,7 @@ class MonitoringStatus extends React.Component {
   toggleAssignedUserModal() {
     let current = this.state.showassignedUserModal;
     this.setState({
-      message: 'assigned user from "' + this.state.original_assigned_user + '" to "' + this.state.assigned_user + '".',
+      message: 'assigned user from "' + this.state.original_assigned_user + '" to "' + this.state.assigned_user + '"',
       showassignedUserModal: !current,
       assigned_user: current ? this.state.original_assigned_user : this.state.assigned_user,
       apply_to_group: false,
@@ -323,9 +324,8 @@ class MonitoringStatus extends React.Component {
           <Modal.Title>{title}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          {/* CHANGE ME */}
           <p>
-            You are about to change this monitoree&apos;s {this.state.message} {this.state.message_warning && <b>{this.state.message_warning}</b>}
+            Are you sure you want to change this monitoree&apos;s {this.state.message}? {this.state.message_warning && <b>{this.state.message_warning}</b>}
           </p>
           {this.props.has_group_members && (
             <React.Fragment>

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -397,7 +397,6 @@ class MonitoringStatus extends React.Component {
                       checked={this.state.apply_to_group_cm_only}
                     />
                     Yes, household members are no longer being exposed to a case
-                    {/* FIX MY PLACEMENT */}
                     {this.state.apply_to_group_cm_only && (
                       <div className="mt-1">
                         Update their <b>Last Date of Exposure</b> to:

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -162,6 +162,9 @@ class MonitoringStatus extends React.Component {
               ]
             : null,
       });
+    } else if (event?.target?.name && event.target.name === 'apply_to_group_cm_only') {
+      let applyToGroup = event.target.id === 'lde_radio_yes' ? true : false;
+      this.setState({ [event.target.name]: applyToGroup });
     } else if (event?.target?.id) {
       let value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
       this.setState({ [event.target.id]: event?.target?.value ? value : '' });
@@ -359,27 +362,41 @@ class MonitoringStatus extends React.Component {
                 Would you like to update the <i>Last Date of Exposure</i> for all household members who have Continuous Exposure toggled ON and are being
                 monitored in the Exposure Workflow?
               </p>
-              {/* CHANGE ME */}
               <Form.Group>
+                <Form.Check>
+                  <Form.Check.Label>
+                    <Form.Check.Input
+                      type="radio"
+                      name="apply_to_group_cm_only"
+                      id="lde_radio_yes"
+                      onChange={this.handleChange}
+                      checked={this.state.apply_to_group_cm_only}
+                    />
+                    <p>Yes, household members are no longer being exposed to a case.</p>
+                  </Form.Check.Label>
+                  {/* FIX MY PLACEMENT */}
+                  {this.state.apply_to_group_cm_only && (
+                    <div>
+                      Update their <b>Last Date of Exposure</b> to:
+                      <DateInput
+                        id="apply_to_group_cm_only_date"
+                        date={this.state.apply_to_group_cm_only_date}
+                        onChange={date => this.setState({ apply_to_group_cm_only_date: date })}
+                        placement="bottom"
+                      />
+                      <br />
+                    </div>
+                  )}
+                </Form.Check>
                 <Form.Check
-                  type="switch"
-                  id="apply_to_group_cm_only"
-                  label='Update Last Date of Exposure for all household members with Continuous Exposure whose Monitoring Status is "Actively Monitoring" in the Exposure workflow'
+                  type="radio"
+                  name="apply_to_group_cm_only"
+                  id="lde_radio_no"
+                  label="No, household members still have continuous exposure to another case"
                   onChange={this.handleChange}
-                  checked={this.state.apply_to_group_cm_only === true || false}
+                  checked={!this.state.apply_to_group_cm_only}
                 />
               </Form.Group>
-              {this.state.apply_to_group_cm_only && (
-                <Form.Group>
-                  <Form.Label className="nav-input-label">LAST DATE OF EXPOSURE</Form.Label>
-                  <DateInput
-                    id="apply_to_group_cm_only_date"
-                    date={this.state.apply_to_group_cm_only_date}
-                    onChange={date => this.setState({ apply_to_group_cm_only_date: date })}
-                    placement="bottom"
-                  />
-                </Form.Group>
-              )}
             </React.Fragment>
           )}
         </Modal.Body>

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -162,8 +162,11 @@ class MonitoringStatus extends React.Component {
               ]
             : null,
       });
+    } else if (event?.target?.name && event.target.name === 'apply_to_group') {
+      let applyToGroup = event.target.id === 'apply_to_group_yes' ? true : false;
+      this.setState({ [event.target.name]: applyToGroup });
     } else if (event?.target?.name && event.target.name === 'apply_to_group_cm_only') {
-      let applyToGroup = event.target.id === 'lde_radio_yes' ? true : false;
+      let applyToGroup = event.target.id === 'apply_to_group_cm_only_yes' ? true : false;
       this.setState({ [event.target.name]: applyToGroup });
     } else if (event?.target?.id) {
       let value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
@@ -324,17 +327,29 @@ class MonitoringStatus extends React.Component {
           <p>
             You are about to change this monitoree&apos;s {this.state.message} {this.state.message_warning && <b>{this.state.message_warning}</b>}
           </p>
-          {/* CHANGE ME */}
           {this.props.has_group_members && (
-            <Form.Group className="mt-2">
-              <Form.Check
-                type="switch"
-                id="apply_to_group"
-                label="Apply this change to the entire household that this monitoree is responsible for"
-                onChange={this.handleChange}
-                checked={this.state.apply_to_group === true || false}
-              />
-            </Form.Group>
+            <React.Fragment>
+              <Form.Group className="mt-2">
+                <Form.Check
+                  type="radio"
+                  name="apply_to_group"
+                  id="apply_to_group_no"
+                  label="This monitoree only"
+                  onChange={this.handleChange}
+                  checked={!this.state.apply_to_group}
+                />
+              </Form.Group>
+              <Form.Group className="mt-2">
+                <Form.Check
+                  type="radio"
+                  name="apply_to_group"
+                  id="apply_to_group_yes"
+                  label="This monitoree and all household members"
+                  onChange={this.handleChange}
+                  checked={this.state.apply_to_group}
+                />
+              </Form.Group>
+            </React.Fragment>
           )}
           {this.state.monitoring_reasons && (
             <Form.Group>
@@ -366,7 +381,7 @@ class MonitoringStatus extends React.Component {
                 <Form.Check
                   type="radio"
                   name="apply_to_group_cm_only"
-                  id="lde_radio_no"
+                  id="apply_to_group_cm_only_no"
                   label="No, household members still have continuous exposure to another case"
                   onChange={this.handleChange}
                   checked={!this.state.apply_to_group_cm_only}
@@ -378,7 +393,7 @@ class MonitoringStatus extends React.Component {
                     <Form.Check.Input
                       type="radio"
                       name="apply_to_group_cm_only"
-                      id="lde_radio_yes"
+                      id="apply_to_group_cm_only_yes"
                       onChange={this.handleChange}
                       checked={this.state.apply_to_group_cm_only}
                     />


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-780](https://tracker.codev.mitre.org/browse/SARAALERT-780)

Incorporates the changes described in these mockups: https://tracker.codev.mitre.org/secure/attachment/30816/monitoringstatusupdate.pptx 

# (Feature) Demo/Screenshots
Insert demo video or photos for a new or updated feature or capability.

![Screen Shot 2020-09-11 at 12 33 25 PM](https://user-images.githubusercontent.com/35042815/92950650-07cf0400-f42b-11ea-8ab2-7ecb144a578e.png)

New modal breaks up monitoring status from LDE changes.  Use a monitoree in the isolation workflow that is the head of household to view these changes.

These changes apply to all modals in `MonitoringStatus.js` which include monitoring status, monitoring plan, exposure risk assessment, jurisdiction, assigned user, public health action, isolation and notifications .  Be sure to check these modals to make sure everything makes sense as it did before.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`MonitoringStatus.js`: swap from toggle to radio buttons and language updates for the generic modal

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [x] Firefox
* [x] Safari
* [x] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
