### PR TITLE
Disable CE when closed; CE Tooltips

### DIFF
--- a/app/javascript/components/assessment/steps/SymptomsAssessment.js
+++ b/app/javascript/components/assessment/steps/SymptomsAssessment.js
@@ -87,7 +87,7 @@ class SymptomsAssessment extends React.Component {
         type="checkbox"
         id={`${symp.name}${this.props.idPre ? '_idpre' + this.props.idPre : ''}`}
         key={`key_${symp.name}${this.props.idPre ? '_idpre' + this.props.idPre : ''}`}
-        checked={symp.value === true || false}
+        checked={symp.value}
         disabled={noSymptomsChecked}
         label={
           <div>

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -263,7 +263,7 @@ class Exposure extends React.Component {
               type="switch"
               id="continuous_exposure"
               className="ml-1"
-              checked={this.state.current.patient.continuous_exposure === true || false}
+              checked={this.state.current.patient.continuous_exposure}
               onChange={this.handleChange}
             />
           </Form.Group>
@@ -275,7 +275,7 @@ class Exposure extends React.Component {
               type="switch"
               id="contact_of_known_case"
               label="CLOSE CONTACT WITH A KNOWN CASE"
-              checked={this.state.current.patient.contact_of_known_case === true || false}
+              checked={this.state.current.patient.contact_of_known_case}
               onChange={this.handleChange}
             />
           </Form.Group>
@@ -300,7 +300,7 @@ class Exposure extends React.Component {
               type="switch"
               id="travel_to_affected_country_or_area"
               label="TRAVEL FROM AFFECTED COUNTRY OR AREA"
-              checked={this.state.current.patient.travel_to_affected_country_or_area === true || false}
+              checked={this.state.current.patient.travel_to_affected_country_or_area}
               onChange={this.handleChange}
             />
           </Form.Group>
@@ -312,7 +312,7 @@ class Exposure extends React.Component {
               type="switch"
               id="was_in_health_care_facility_with_known_cases"
               label="WAS IN HEALTH CARE FACILITY WITH KNOWN CASES"
-              checked={this.state.current.patient.was_in_health_care_facility_with_known_cases === true || false}
+              checked={this.state.current.patient.was_in_health_care_facility_with_known_cases}
               onChange={this.handleChange}
             />
           </Form.Group>
@@ -337,7 +337,7 @@ class Exposure extends React.Component {
               type="switch"
               id="laboratory_personnel"
               label="LABORATORY PERSONNEL"
-              checked={this.state.current.patient.laboratory_personnel === true || false}
+              checked={this.state.current.patient.laboratory_personnel}
               onChange={this.handleChange}
             />
           </Form.Group>
@@ -362,7 +362,7 @@ class Exposure extends React.Component {
               type="switch"
               id="healthcare_personnel"
               label="HEALTHCARE PERSONNEL"
-              checked={this.state.current.patient.healthcare_personnel === true || false}
+              checked={this.state.current.patient.healthcare_personnel}
               onChange={this.handleChange}
             />
           </Form.Group>
@@ -387,7 +387,7 @@ class Exposure extends React.Component {
               type="switch"
               id="crew_on_passenger_or_cargo_flight"
               label="CREW ON PASSENGER OR CARGO FLIGHT"
-              checked={this.state.current.patient.crew_on_passenger_or_cargo_flight === true || false}
+              checked={this.state.current.patient.crew_on_passenger_or_cargo_flight}
               onChange={this.handleChange}
             />
           </Form.Group>
@@ -398,7 +398,7 @@ class Exposure extends React.Component {
               type="switch"
               id="member_of_a_common_exposure_cohort"
               label="MEMBER OF A COMMON EXPOSURE COHORT"
-              checked={this.state.current.patient.member_of_a_common_exposure_cohort === true || false}
+              checked={this.state.current.patient.member_of_a_common_exposure_cohort}
               onChange={this.handleChange}
             />
           </Form.Group>
@@ -494,7 +494,7 @@ class Exposure extends React.Component {
                               name="jurisdiction_id"
                               label="Apply this change to the entire household that this monitoree is responsible for"
                               onChange={this.handlePropagatedFieldChange}
-                              checked={this.state.current.propagatedFields.jurisdiction_id === true || false}
+                              checked={this.state.current.propagatedFields.jurisdiction_id}
                             />
                           </Form.Group>
                         )}
@@ -538,7 +538,7 @@ class Exposure extends React.Component {
                               name="assigned_user"
                               label="Apply this change to the entire household that this monitoree is responsible for"
                               onChange={this.handlePropagatedFieldChange}
-                              checked={this.state.current.propagatedFields.assigned_user === true || false}
+                              checked={this.state.current.propagatedFields.assigned_user}
                             />
                           </Form.Group>
                         )}

--- a/app/javascript/components/enrollment/steps/Identification.js
+++ b/app/javascript/components/enrollment/steps/Identification.js
@@ -379,19 +379,13 @@ class Identification extends React.Component {
               <Form.Row className="pt-1">
                 <Form.Group as={Col} md="auto">
                   <Form.Label className="nav-input-label">RACE (SELECT ALL THAT APPLY)</Form.Label>
-                  <Form.Check
-                    type="switch"
-                    id="white"
-                    label="WHITE"
-                    checked={this.state.current.patient.white === true || false}
-                    onChange={this.handleChange}
-                  />
+                  <Form.Check type="switch" id="white" label="WHITE" checked={this.state.current.patient.white} onChange={this.handleChange} />
                   <Form.Check
                     className="pt-2"
                     type="switch"
                     id="black_or_african_american"
                     label="BLACK OR AFRICAN AMERICAN"
-                    checked={this.state.current.patient.black_or_african_american === true || false}
+                    checked={this.state.current.patient.black_or_african_american}
                     onChange={this.handleChange}
                   />
                   <Form.Check
@@ -399,23 +393,16 @@ class Identification extends React.Component {
                     type="switch"
                     id="american_indian_or_alaska_native"
                     label="AMERICAN INDIAN OR ALASKA NATIVE"
-                    checked={this.state.current.patient.american_indian_or_alaska_native === true || false}
+                    checked={this.state.current.patient.american_indian_or_alaska_native}
                     onChange={this.handleChange}
                   />
-                  <Form.Check
-                    className="pt-2"
-                    type="switch"
-                    id="asian"
-                    label="ASIAN"
-                    checked={this.state.current.patient.asian === true || false}
-                    onChange={this.handleChange}
-                  />
+                  <Form.Check className="pt-2" type="switch" id="asian" label="ASIAN" checked={this.state.current.patient.asian} onChange={this.handleChange} />
                   <Form.Check
                     className="pt-2"
                     type="switch"
                     id="native_hawaiian_or_other_pacific_islander"
                     label="NATIVE HAWAIIAN OR OTHER PACIFIC ISLANDER"
-                    checked={this.state.current.patient.native_hawaiian_or_other_pacific_islander === true || false}
+                    checked={this.state.current.patient.native_hawaiian_or_other_pacific_islander}
                     onChange={this.handleChange}
                   />
                 </Form.Group>

--- a/app/javascript/components/public_health/actions/CloseRecords.js
+++ b/app/javascript/components/public_health/actions/CloseRecords.js
@@ -96,7 +96,7 @@ class CloseRecords extends React.Component {
               type="switch"
               id="apply_to_group"
               label="Apply this change to the entire household that these monitorees are responsible for, if it applies."
-              checked={this.state.apply_to_group === true || false}
+              checked={this.state.apply_to_group}
               onChange={this.handleChange}
             />
           </Form.Group>

--- a/app/javascript/components/public_health/actions/UpdateCaseStatus.js
+++ b/app/javascript/components/public_health/actions/UpdateCaseStatus.js
@@ -167,7 +167,7 @@ class UpdateCaseStatus extends React.Component {
                   type="switch"
                   id="apply_to_group"
                   label="Apply this change to the entire household that these monitorees are responsible for, if it applies."
-                  checked={this.state.apply_to_group === true || false}
+                  checked={this.state.apply_to_group}
                   onChange={this.handleChange}
                 />
               </Form.Group>

--- a/app/javascript/components/subject/CaseStatus.js
+++ b/app/javascript/components/subject/CaseStatus.js
@@ -127,7 +127,7 @@ class CaseStatus extends React.Component {
                   id="apply_to_group"
                   label="Apply this change to the entire household that this monitoree is responsible for"
                   onChange={this.handleChange}
-                  checked={this.state.apply_to_group === true || false}
+                  checked={this.state.apply_to_group}
                 />
               </Form.Group>
             )}
@@ -173,7 +173,7 @@ class CaseStatus extends React.Component {
                   id="apply_to_group"
                   label="Apply this change to the entire household that this monitoree is responsible for"
                   onChange={this.handleChange}
-                  checked={this.state.apply_to_group === true || false}
+                  checked={this.state.apply_to_group}
                 />
               </Form.Group>
             )}
@@ -208,7 +208,7 @@ class CaseStatus extends React.Component {
                   id="apply_to_group"
                   label="Apply this change to the entire household that this monitoree is responsible for"
                   onChange={this.handleChange}
-                  checked={this.state.apply_to_group === true || false}
+                  checked={this.state.apply_to_group}
                 />
               </Form.Group>
             )}

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
-import { Form, Row, Col, Button, Modal } from 'react-bootstrap';
+import { Form, Row, Col, Button, Modal, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import _ from 'lodash';
 import axios from 'axios';
 import moment from 'moment';
@@ -204,14 +204,41 @@ class LastDateExposure extends React.Component {
             </Row>
             <Row className="pt-2">
               <Col>
-                <Form.Check
-                  size="lg"
-                  label="CONTINUOUS EXPOSURE"
-                  type="switch"
-                  id="continuous_exposure"
-                  checked={this.state.continuous_exposure === true || false}
-                  onChange={() => this.toggleContinuousMonitoringModal()}
-                />
+                {!this.props.patient.monitoring && (
+                  <OverlayTrigger
+                    key="tooltip-ot-ce"
+                    placement="left"
+                    overlay={
+                      <Tooltip id="tooltip-ce">
+                        Continuous Exposure cannot be toggled for records on the Closed line list. If this monitoree requires monitoring due to a Continuous
+                        Exposure, you may update this field after changing Monitoring Status to &quot;Actively Monitoring&quot;
+                      </Tooltip>
+                    }>
+                    <span className="d-inline-block">
+                      <Form.Check
+                        size="lg"
+                        label="CONTINUOUS EXPOSURE"
+                        id="continuous_exposure"
+                        disabled={!this.props.patient.monitoring}
+                        checked={this.state.continuous_exposure === true || false}
+                        onChange={() => this.toggleContinuousMonitoringModal()}
+                      />
+                    </span>
+                  </OverlayTrigger>
+                )}
+                {this.props.patient.monitoring && (
+                  <span className="d-inline-block">
+                    <Form.Check
+                      size="lg"
+                      label="CONTINUOUS EXPOSURE"
+                      id="continuous_exposure"
+                      disabled={!this.props.patient.monitoring}
+                      checked={this.state.continuous_exposure === true || false}
+                      onChange={() => this.toggleContinuousMonitoringModal()}
+                    />
+                  </span>
+                )}
+                <InfoTooltip tooltipTextKey="continuousExposure" location="right"></InfoTooltip>
               </Col>
             </Row>
           </Col>

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -30,6 +30,7 @@ class LastDateExposure extends React.Component {
     this.closeExposureDateModal = this.closeExposureDateModal.bind(this);
     this.toggleContinuousMonitoringModal = this.toggleContinuousMonitoringModal.bind(this);
     this.createModal = this.createModal.bind(this);
+    this.createCEToggle = this.createCEToggle.bind(this);
   }
 
   toggleContinuousMonitoringModal() {
@@ -161,6 +162,19 @@ class LastDateExposure extends React.Component {
     );
   }
 
+  createCEToggle() {
+    return (
+      <Form.Check
+        size="lg"
+        label="CONTINUOUS EXPOSURE"
+        id="continuous_exposure"
+        disabled={!this.props.patient.monitoring}
+        checked={this.state.continuous_exposure}
+        onChange={() => this.toggleContinuousMonitoringModal()}
+      />
+    );
+  }
+
   render() {
     return (
       <React.Fragment>
@@ -214,30 +228,10 @@ class LastDateExposure extends React.Component {
                         Exposure, you may update this field after changing Monitoring Status to &quot;Actively Monitoring&quot;
                       </Tooltip>
                     }>
-                    <span className="d-inline-block">
-                      <Form.Check
-                        size="lg"
-                        label="CONTINUOUS EXPOSURE"
-                        id="continuous_exposure"
-                        disabled={!this.props.patient.monitoring}
-                        checked={this.state.continuous_exposure === true || false}
-                        onChange={() => this.toggleContinuousMonitoringModal()}
-                      />
-                    </span>
+                    <span className="d-inline-block">{this.createCEToggle()}</span>
                   </OverlayTrigger>
                 )}
-                {this.props.patient.monitoring && (
-                  <span className="d-inline-block">
-                    <Form.Check
-                      size="lg"
-                      label="CONTINUOUS EXPOSURE"
-                      id="continuous_exposure"
-                      disabled={!this.props.patient.monitoring}
-                      checked={this.state.continuous_exposure === true || false}
-                      onChange={() => this.toggleContinuousMonitoringModal()}
-                    />
-                  </span>
-                )}
+                {this.props.patient.monitoring && <span className="d-inline-block">{this.createCEToggle()}</span>}
                 <InfoTooltip tooltipTextKey="continuousExposure" location="right"></InfoTooltip>
               </Col>
             </Row>

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -342,7 +342,7 @@ class MonitoringStatus extends React.Component {
                 id="apply_to_group_cm_only"
                 label='Update Last Date of Exposure for all household members with Continuous Exposure whose Monitoring Status is "Actively Monitoring" in the Exposure workflow'
                 onChange={this.handleChange}
-                checked={this.state.apply_to_group_cm_only === true || false}
+                checked={this.state.apply_to_group_cm_only}
               />
             </Form.Group>
           )}
@@ -368,7 +368,7 @@ class MonitoringStatus extends React.Component {
                 id="apply_to_group"
                 label="Apply this change to the entire household that this monitoree is responsible for"
                 onChange={this.handleChange}
-                checked={this.state.apply_to_group === true || false}
+                checked={this.state.apply_to_group}
               />
             </Form.Group>
           )}

--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -107,6 +107,13 @@ const TOOLTIP_TEXT = {
     </div>
   ),
 
+  continuousExposure: (
+    <div>
+      Allows a user to indicate that a monitoree has an ongoing exposure to one or more cases. If checked, the monitoring period will be extended indefinitely
+      until unchecked or the <i>Last Date of Exposure</i> is updated.
+    </div>
+  ),
+
   // REPORTS
 
   exposureNeedsReviewColumn: (


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-796

Disabled CE when record is closed. Added tooltips for more information about CE. CE toggle is now a checkbox.

# (Feature) Demo/Screenshots

<img width="462" alt="Screen Shot 2020-09-15 at 3 32 18 PM" src="https://user-images.githubusercontent.com/14923551/93256057-c4490280-f768-11ea-8307-a1cac0444b56.png">
<img width="574" alt="Screen Shot 2020-09-15 at 3 34 28 PM" src="https://user-images.githubusercontent.com/14923551/93256189-f9edeb80-f768-11ea-8878-722a7ad5586d.png">

# Important Changes

`app/javascript/components/subject/LastDateExposure.js `
- Disabled CE when record is closed. Added tooltips for more information about CE. CE toggle is now a checkbox.

`app/javascript/components/util/InfoTooltip.js `
- New CE tooltip

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [x] Safari
* [x] IE11
