### PR TITLE
SARAALERT-811: Do not send enrollment notifications to non-reporters

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -145,9 +145,7 @@ class PatientsController < ApplicationController
     if patient.save
 
       # Send enrollment notification only to responders
-      if patient.self_reporter_or_proxy?
-        patient.send_enrollment_notification
-      end
+      patient.send_enrollment_notification if patient.self_reporter_or_proxy?
 
       # Create a history for the enrollment
       History.enrollment(patient: patient, created_by: current_user.email)

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -143,7 +143,11 @@ class PatientsController < ApplicationController
     patient.submission_token = SecureRandom.hex(20) # 160 bits
     # Attempt to save and continue; else if failed redirect to index
     if patient.save
-      patient.send_enrollment_notification
+
+      # Send enrollment notification only to responders
+      if patient.self_reporter_or_proxy?
+        patient.send_enrollment_notification
+      end
 
       # Create a history for the enrollment
       History.enrollment(patient: patient, created_by: current_user.email)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-811](https://tracker.codev.mitre.org/browse/SARAALERT-811)

Only self-reporters and HoHs should be receiving enrollment notifications. Currently, dependents will receive an empty email notification, for example, which should not be the case. 

# Important Changes
`app/controllers/patients_controller.rb`
- Adds a check before sending an enrollment notification.

# Testing
To test this fix, run locally on `master` and enroll a new monitoree with email as preferred contact method and a provided email, and then a household member underneath that monitoree (with the same preferences - email can be different).  You'll see an email go out to both the HoH and the dependent, but the dependent email will be empty. If you then do the same on this PR branch, you'll notice the dependent will no longer get an email/notification.
