### PR TITLE
Download email text formatting

### DIFF
--- a/app/views/user_mailer/download_email.html.erb
+++ b/app/views/user_mailer/download_email.html.erb
@@ -21,7 +21,8 @@
     Please note that this export is one-time use only. The system will delete an export file once you've downloaded that file.
     These downloads will be invalid if you attempt another export of this type before retrieving the file(s). Exports will not work if forwarded to another user. You must be logged into Sara Alert to access exports.
     <br />
-    If your export exceeded <%=@batch_size%> records, you will see separate files below with each containing data for no more than <%=@batch_size%> monitorees. 
+    <br />
+    If your export exceeded <%= number_with_delimiter(@batch_size) %> records, you will see separate files below with each containing data for no more than <%= number_with_delimiter(@batch_size) %> monitorees. 
     Each file (e.g., monitorees, assessments, etc) belonging to the same batch will have the same number at the end of the filename.
     </p>
   </p>


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-820](https://tracker.codev.mitre.org/browse/SARAALERT-820)

Add a blank line between paragraphs and format the numbers with commas in the download email text.

# (Feature) Demo/Screenshots
![Screen Shot 2020-09-17 at 10 43 01 AM](https://user-images.githubusercontent.com/35042815/93486926-ba431300-f8d2-11ea-8f91-1763eb8f015c.png)

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`download_email.html.erb`: added text formatting

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Run `UserMailer.download_email(User.first, 'full_history_all', [{lookup: 'blah', filename: 'blah'}], 10000).deliver_now` in the rails console and the email will open in chrome for viewing.
