### PR TITLE
Pre-fills the Exposure Notes section when Enrolling Close Contact

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -47,7 +47,8 @@ class PatientsController < ApplicationController
                            primary_telephone: @close_contact.nil? ? '' : @close_contact.primary_telephone,
                            email: @close_contact.nil? ? '' : @close_contact.email,
                            contact_of_known_case: !@close_contact.nil?,
-                           contact_of_known_case_id: @close_contact.nil? ? '' : @close_contact.patient_id)
+                           contact_of_known_case_id: @close_contact.nil? ? '' : @close_contact.patient_id,
+                           exposure_notes: @close_contact.nil? ? '' : @close_contact.notes)
   end
 
   # Similar to 'new', except used for creating a new group member

--- a/app/javascript/components/close_contact/CloseContact.js
+++ b/app/javascript/components/close_contact/CloseContact.js
@@ -20,6 +20,10 @@ class CloseContact extends React.Component {
       enrolled_id: this.props.close_contact.enrolled_id || null,
       contact_attempts: this.props.close_contact.contact_attempts || 0,
     };
+    console.log('this.state');
+    console.log(this.state);
+    console.log('this.props');
+    console.log(this.props);
     this.closeContactNotePlaceholder = this.props.patient.isolation
       ? 'enter additional information about case'
       : 'enter additional information about monitoree’s potential exposure';

--- a/app/javascript/components/close_contact/CloseContact.js
+++ b/app/javascript/components/close_contact/CloseContact.js
@@ -20,10 +20,6 @@ class CloseContact extends React.Component {
       enrolled_id: this.props.close_contact.enrolled_id || null,
       contact_attempts: this.props.close_contact.contact_attempts || 0,
     };
-    console.log('this.state');
-    console.log(this.state);
-    console.log('this.props');
-    console.log(this.props);
     this.closeContactNotePlaceholder = this.props.patient.isolation
       ? 'enter additional information about case'
       : 'enter additional information about monitoree’s potential exposure';

--- a/app/javascript/components/close_contact/CloseContact.js
+++ b/app/javascript/components/close_contact/CloseContact.js
@@ -20,6 +20,9 @@ class CloseContact extends React.Component {
       enrolled_id: this.props.close_contact.enrolled_id || null,
       contact_attempts: this.props.close_contact.contact_attempts || 0,
     };
+    this.closeContactNotePlaceholder = this.props.patient.isolation
+      ? 'enter additional information about case'
+      : 'enter additional information about monitoree’s potential exposure';
     this.toggleModal = this.toggleModal.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.submit = this.submit.bind(this);
@@ -110,7 +113,15 @@ class CloseContact extends React.Component {
             <Row>
               <Form.Group as={Col}>
                 <Form.Label className="nav-input-label">Notes</Form.Label>
-                <Form.Control as="textarea" rows="5" id="notes" className="form-square" value={this.state.notes || ''} onChange={this.handleChange} />
+                <Form.Control
+                  as="textarea"
+                  rows="5"
+                  id="notes"
+                  className="form-square"
+                  value={this.state.notes || ''}
+                  placeholder={this.closeContactNotePlaceholder}
+                  onChange={this.handleChange}
+                />
               </Form.Group>
             </Row>
           </Form>

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -28,6 +28,10 @@ class Contact extends React.Component {
           value: this.state.current.patient.preferred_contact_method,
         },
       });
+    }
+    // There are two instances when a user might already have an email that we'd want to prefill the confirm email field
+    // One is editing an existing monitoree. The other is when enrolling a close contact
+    if (this.state.current.patient.email) {
       this.setState(state => {
         const current = { ...state.current };
         current.patient.confirm_email = state.current.patient.email;


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-747

Per user request, it would be nice if, when enrolling a Close Contact, the Close Contact's notes were pre-populated into the Exposure Notes in the final card in the enrollment carousel. 
# Important Changes

`app/javascript/components/close_contact/CloseContact.js`
- Added placeholder text depending on the Monitoree's Workflow. The logic is quite simple.
``` 
 this.closeContactNotePlaceholder = this.props.patient.isolation
        ? 'enter additional information about case'
        : 'enter additional information about monitoree’s potential exposure';
```
`app/controllers/patients_controller.rb`
- Now pre-fills the exposure notes when enrolling a Close Contact that has Notes

`app/javascript/components/enrollment/steps/Contact.js`
- Now checks for the existence of an email address to decide whether to prefill the `confirm_email` field. Before, it was only when editing an existing monitoree, but enrolling a Close Contact should prefill their email to the `confirm_email` as welll.

