### PR TITLE
additional check for if case_status is blank

### DIFF
--- a/app/javascript/components/subject/CaseStatus.js
+++ b/app/javascript/components/subject/CaseStatus.js
@@ -39,7 +39,7 @@ class CaseStatus extends React.Component {
           if (hideModal) {
             this.submit();
           }
-          if (!confirmedOrProbable) {
+          if (!confirmedOrProbable && this.state.case_status !== '') {
             this.setState({ isolation: false, public_health_action: 'None' });
           }
         });


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-763](https://tracker.codev.mitre.org/browse/SARAALERT-763)
Bug 2.2 is not behaving quite right in this JIRA ticket (see below to recreate)

# (Bugfix) How to Replicate
Select a monitoree in the isolation workflow with a case status that is not `blank`.  Change the case status to `blank` and the monitoree is no longer in the isolation workflow.

# (Bugfix) Solution
An additional check if the new case status is `blank` was missing in the current logic.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.
`CaseStatus.js`: added an additional check for if case status is blank

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
