### PR TITLE
SARAALERT-826: (Bugfix) Updating the UI eligibility icon logic to check for closed records.

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -624,10 +624,10 @@ class Patient < ApplicationRecord
       messages << { message: 'Monitoree was purged', datetime: nil }
     end
 
-    # Can't send messages to monitorees that are on the closed line list.
-    unless monitoring
+    # Can't send messages to monitorees that are on the closed line list and have no active dependents.
+    if !monitoring && active_dependents.empty?
       eligible = false
-      messages << { message: 'Monitoree is not currently being monitored.', datetime: closed_at }
+      messages << { message: 'Monitoree is not currently being monitored and has no actively monitored household members', datetime: closed_at }
     end
 
     # Can't send messages if notifications are paused

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -624,6 +624,12 @@ class Patient < ApplicationRecord
       messages << { message: 'Monitoree was purged', datetime: nil }
     end
 
+    # Can't send messages to monitorees that are on the closed line list.
+    unless monitoring
+      eligible = false
+      messages << { message: 'Monitoree was closed.', datetime: closed_at }
+    end
+
     # Can't send messages if notifications are paused
     if pause_notifications
       eligible = false

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -624,6 +624,13 @@ class Patient < ApplicationRecord
       messages << { message: 'Monitoree was purged', datetime: nil }
     end
 
+    # Can't send to household members
+    if id != responder_id
+      eligible = false
+      household = true
+      messages << { message: 'Monitoree is within a household, so the HoH will receive notifications instead', datetime: nil }
+    end
+
     # Can't send messages to monitorees that are on the closed line list and have no active dependents.
     if !monitoring && active_dependents.empty?
       eligible = false
@@ -634,13 +641,6 @@ class Patient < ApplicationRecord
     if pause_notifications
       eligible = false
       messages << { message: 'Monitoree\'s notifications are paused', datetime: nil }
-    end
-
-    # Can't send to household members
-    if id != responder_id
-      eligible = false
-      household = true
-      messages << { message: 'Monitoree is within a household, so the HoH will receive notifications instead', datetime: nil }
     end
 
     # Has an ineligible preferred contact method

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -627,7 +627,7 @@ class Patient < ApplicationRecord
     # Can't send messages to monitorees that are on the closed line list.
     unless monitoring
       eligible = false
-      messages << { message: 'Monitoree was closed.', datetime: closed_at }
+      messages << { message: 'Monitoree is not currently being monitored.', datetime: closed_at }
     end
 
     # Can't send messages if notifications are paused


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-826](https://tracker.codev.mitre.org/browse/SARAALERT-826)

# How to Replicate
1. Click on a record that is eligible for notifications.
2. Move the record to the closed line list by changing the Monitoring Status to "Not Monitoring."
3. Notice that the eligibility icon has not changed.

# Solution
Added a check to the logic that supports that eligibility icon to check the monitoring status.

# Important Changes
`app/models/patient.rb`
- Added check to see if the record is actively being monitored. 

# Testing
Replicate the above steps and notice the icon now updates appropriately. 
