### PR TITLE
(Bugfix) 1.13 Close Job Logic Update

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -411,7 +411,7 @@ class Patient < ApplicationRecord
       .select do |patient|
         # Submitted an assessment today AND is at the end of or past their monitoring period
         (!patient.latest_assessment_at.nil? &&
-          patient.latest_assessment_at >= patient.curr_date_in_timezone.beginning_of_day &&
+          patient.latest_assessment_at.getlocal(patient.address_timezone_offset) >= patient.curr_date_in_timezone.beginning_of_day &&
           patient.end_of_monitoring_period?)
       end
   end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -176,47 +176,30 @@ class PatientTest < ActiveSupport::TestCase
     assert_equal(0, Patient.close_eligible.select { |p| p.id == patient.id }.count)
   end
 
-  test 'close eligible does include records that have NOT reported in the last 24 hours and were created within the past 24 hours' do
-    # Control test
+  test 'close eligible does include records that have NOT reported today (based on their timezone)' do
     patient = create(:patient,
                      purged: false,
                      isolation: false,
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal('-05:00'),
                      created_at: 2.days.ago,
                      last_date_of_exposure: 20.days.ago)
 
     assert_equal(1, Patient.close_eligible.select { |p| p.id == patient.id }.count)
 
-    # Test with latest_assessment_at set to two days ago and created_at set to 5 hours ago
     patient = create(:patient,
                      purged: false,
                      isolation: false,
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: 2.days.ago,
-                     created_at: 5.hours.ago,
-                     last_date_of_exposure: 20.days.ago)
-
-    assert_equal(1, Patient.close_eligible.select { |p| p.id == patient.id }.count)
-  end
-
-  test 'close eligible does include records that have reported in the last 24 hours' do
-    # This was tested in most control tests, but testing when latest_assessment_at was 23 hours ago
-    patient = create(:patient,
-                     purged: false,
-                     isolation: false,
-                     monitoring: true,
-                     symptom_onset: nil,
-                     public_health_action: 'None',
-                     latest_assessment_at: 23.hours.ago,
+                     latest_assessment_at: 1.day.ago.getlocal('-05:00'),
                      created_at: 2.days.ago,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(1, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(0, Patient.close_eligible.select { |p| p.id == patient.id }.count)
   end
 
   test 'close eligible does not include records still within their monitoring period' do

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -176,7 +176,35 @@ class PatientTest < ActiveSupport::TestCase
     assert_equal(0, Patient.close_eligible.select { |p| p.id == patient.id }.count)
   end
 
-  test 'close eligible does include records that have NOT reported today (based on their timezone)' do
+  test 'close eligible does NOT include records that have never reported' do
+    # Control test
+    patient = create(:patient,
+                     purged: false,
+                     isolation: false,
+                     monitoring: true,
+                     symptom_onset: nil,
+                     public_health_action: 'None',
+                     latest_assessment_at: Time.now.getlocal('-05:00'),
+                     created_at: 2.days.ago,
+                     last_date_of_exposure: 20.days.ago)
+
+    assert_equal(1, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+
+    patient = create(:patient,
+                     purged: false,
+                     isolation: false,
+                     monitoring: true,
+                     symptom_onset: nil,
+                     public_health_action: 'None',
+                     latest_assessment_at: nil,
+                     created_at: 2.days.ago,
+                     last_date_of_exposure: 20.days.ago)
+
+    assert_equal(0, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+  end
+
+  test 'close eligible does NOT include records that have NOT reported today (based on their timezone)' do
+    # Control test
     patient = create(:patient,
                      purged: false,
                      isolation: false,


### PR DESCRIPTION
# Description
The current logic for the close job for 1.13 uses the asymptomatic scope logic, but that is not enough as we need to check that a monitoree has submitted an assessment _that day_ before closing them out. This of course needs to be based on their timezone as well. Without this more strict check on the `latest_assessment_at`, folks could get closed out on their last day of monitoring if they submitted an assessment within the past 24 hours, when really they needed to have submitted an assessment that day. 

# Important Changes
`app/models/patient.rb`
- Updated logic in `close_eligible` method to handle this case.

`test/models/patient_test.rb`
- Removed now obselete tests and added new ones.

# Testing
The automated tests are still passing, and more testing on demo will need to be done as well. For testing locally, you can set up a patient with a specific timezone and status, and run the job, and make sure the do/do not get closed out depending on what you're testing.
