### PR TITLE
SARAALERT-745: Cannot add monitoree to household in enroller role

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -456,6 +456,21 @@ class PatientsController < ApplicationController
     History.report_reviewed(patient: patient, created_by: current_user.email, comment: comment)
   end
 
+  # Get all individuals whose responder_id = id, these people are "HOH eligible"
+  def self_reporting
+    redirect_to(root_url) && return unless current_user.can_edit_patient?
+
+    patients = if current_user.has_role?(:enroller)
+                 current_user.enrolled_patients.where('patients.responder_id = patients.id')
+               else
+                 current_user.viewable_patients.where('patients.responder_id = patients.id')
+               end
+    patients = patients.pluck(:id, :first_name, :last_name, :age, :user_defined_id_statelocal).map do |p|
+      { id: p[0], first_name: p[1], last_name: p[2], age: p[3], state_id: p[4] }
+    end
+    render json: { self_reporting: patients.sort_by { |p| p[:last_name] || 'ZZZ' }.to_json }
+  end
+
   # A patient is eligible to be removed from a household if their responder doesn't have the same contact
   # information of them
   def household_removeable

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -104,21 +104,6 @@ class PublicHealthController < ApplicationController
     render json: { total: patients.size }
   end
 
-  # Get all individuals whose responder_id = id, these people are "HOH eligible"
-  def self_reporting
-    redirect_to(root_url) && return unless current_user.can_edit_patient?
-
-    patients = if current_user.has_role?(:enroller)
-                 current_user.enrolled_patients.where('patients.responder_id = patients.id')
-               else
-                 current_user.viewable_patients.where('patients.responder_id = patients.id')
-               end
-    patients = patients.pluck(:id, :first_name, :last_name, :age, :user_defined_id_statelocal).map do |p|
-      { id: p[0], first_name: p[1], last_name: p[2], age: p[3], state_id: p[4] }
-    end
-    render json: { self_reporting: patients.sort_by { |p| p[:last_name] || 'ZZZ' }.to_json }
-  end
-
   protected
 
   def patients_by_type(workflow, tab)

--- a/app/javascript/components/subject/MoveToHousehold.js
+++ b/app/javascript/components/subject/MoveToHousehold.js
@@ -44,7 +44,7 @@ class MoveToHousehold extends React.Component {
     axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
     axios({
       method: 'get',
-      url: window.BASE_PATH + '/public_health/patients/self_reporting',
+      url: window.BASE_PATH + '/patients/households/self_reporting',
       params: {},
     })
       .then(response => {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
 
   resources :admin, only: [:index]
   get 'admin/users', to: 'admin#users'
-  
+
   post 'admin/create_user', to: 'admin#create_user'
   post 'admin/edit_user', to: 'admin#edit_user'
   post 'admin/reset_password', to: 'admin#reset_password'
@@ -67,6 +67,7 @@ Rails.application.routes.draw do
   post '/import/:workflow/:format', to: 'import#import'
   get '/import/download_guidance', to: 'import#download_guidance'
 
+  get '/patients/households/self_reporting', to: 'patients#self_reporting'
   get '/patients/:id/household_removeable', to: 'patients#household_removeable'
   post '/patients/bulk_edit/status', to: 'patients#bulk_update_status'
   post '/patients/:id/status', to: 'patients#update_status'
@@ -97,7 +98,6 @@ Rails.application.routes.draw do
   get '/public_health/patients', to: 'public_health#patients', as: :public_health_patients
   get '/public_health/patients/counts/workflow', to: 'public_health#workflow_counts', as: :workflow_counts
   get '/public_health/patients/counts/:workflow/:tab', to: 'public_health#tab_counts', as: :tab_counts
-  get '/public_health/patients/self_reporting', to: 'public_health#self_reporting', as: :self_reporting
 
   get '/analytics', to: 'analytics#index', as: :analytics
   get '/county_level_maps/:mapFile', to: 'analytics#clm_geo_json'


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-745](https://tracker.codev.mitre.org/browse/SARAALERT-745)

When logged in as enroller, an error occurs when trying to move a monitoree to a household.

# (Feature) Demo/Screenshots
Insert demo video or photos for a new or updated feature or capability.

# (Bugfix) How to Replicate
- login as enroller
- view a patient that is not part of a household
- click on 'Move To Household'

# (Bugfix) Solution
- moved household members endpoint from public health to patients controller

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
