### PR TITLE
SARAALERT-853: Address 1.14 testing bugs

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -384,6 +384,17 @@ class PatientsController < ApplicationController
       end
     end
 
+    # Reset public health action if case status is change to suspect, unknown, not a case
+    if params_to_update.include?(:case_status) && ['Suspect', 'Unknown', 'Not a Case'].include?(params.require(:patient).permit(:case_status)[:case_status]) &&
+       patient[:public_health_action] != 'None'
+      History.monitoring_change(patient: patient, created_by: 'Sara Alert System', comment: "System changed Latest Public Health Action from
+                                                                                             \"#{patient[:public_health_action]}\" to \"None\" so that
+                                                                                             the monitoree will appear on the appropriate line list in the
+                                                                                             exposure workflow to continue monitoring.")
+      params_to_update << :public_health_action
+      params[:patient][:public_health_action] = 'None'
+    end
+
     # If the symptom onset was cleared by the user
     if params_to_update.include?(:symptom_onset) && params.require(:patient).permit(:symptom_onset)[:symptom_onset].nil?
       params_to_update.concat(%i[user_defined_symptom_onset symptom_onset])

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -387,10 +387,10 @@ class PatientsController < ApplicationController
     # Reset public health action if case status is change to suspect, unknown, not a case
     if params_to_update.include?(:case_status) && ['Suspect', 'Unknown', 'Not a Case'].include?(params.require(:patient).permit(:case_status)[:case_status]) &&
        patient[:public_health_action] != 'None'
-      History.monitoring_change(patient: patient, created_by: 'Sara Alert System', comment: "System changed Latest Public Health Action from
-                                                                                             \"#{patient[:public_health_action]}\" to \"None\" so that
-                                                                                             the monitoree will appear on the appropriate line list in the
-                                                                                             exposure workflow to continue monitoring.")
+      message = patient[:monitoring] ? "System changed Latest Public Health Action from \"#{patient[:public_health_action]}\" to \"None\" so that the monitoree
+                                        will appear on the appropriate line list in the exposure workflow to continue monitoring."
+                                     : "System changed Latest Public Health Action from \"#{patient[:public_health_action]}\" to \"None\"."
+      History.monitoring_change(patient: patient, created_by: 'Sara Alert System', comment: message)
       params_to_update << :public_health_action
       params[:patient][:public_health_action] = 'None'
     end

--- a/app/javascript/components/subject/CaseStatus.js
+++ b/app/javascript/components/subject/CaseStatus.js
@@ -168,10 +168,17 @@ class CaseStatus extends React.Component {
             <Modal.Title>{title}</Modal.Title>
           </Modal.Header>
           <Modal.Body>
-            <p>
-              This case will be moved to the exposure workflow and will be placed in the symptomatic, non-reporting, or asymptomatic line list as appropriate to
-              continue exposure monitoring.
-            </p>
+            {this.props.patient.monitoring ? (
+              <p>
+                This case will be moved to the exposure workflow and will be placed in the Symptomatic, Non-Reporting, or Asymptomatic line list as appropriate
+                to continue exposure monitoring.
+              </p>
+            ) : (
+              <p>
+                This case will be moved to the exposure workflow and will be placed in the Closed line list. If this individual should be actively monitored,
+                please update the record’s Monitoring Status.
+              </p>
+            )}
             {this.props.has_group_members && this.renderRadioButtons()}
           </Modal.Body>
           <Modal.Footer>

--- a/app/javascript/components/subject/CaseStatus.js
+++ b/app/javascript/components/subject/CaseStatus.js
@@ -18,7 +18,6 @@ class CaseStatus extends React.Component {
       monitoring: this.props.patient.monitoring,
       monitoring_reason: this.props.patient.monitoring_reason,
       monitoring_option: '',
-      public_health_action: this.props.patient.public_health_action,
       apply_to_group: false,
       loading: false,
     };
@@ -44,7 +43,7 @@ class CaseStatus extends React.Component {
               this.submit();
             }
             if (!confirmedOrProbable && this.state.case_status !== '') {
-              this.setState({ isolation: false, public_health_action: 'None' });
+              this.setState({ isolation: false });
             }
           });
         } else if (event.target.id === 'monitoring_option') {
@@ -91,7 +90,6 @@ class CaseStatus extends React.Component {
           monitoring: this.state.monitoring,
           monitoring_reason: this.state.monitoring_reason,
           apply_to_group: this.state.apply_to_group,
-          public_health_action: this.state.public_health_action,
           diffState: diffState,
         })
         .then(() => {

--- a/app/javascript/components/subject/ExtendedIsolation.js
+++ b/app/javascript/components/subject/ExtendedIsolation.js
@@ -82,34 +82,54 @@ class ExtendedIsolation extends React.Component {
             </Modal.Header>
             <Modal.Body>
               <Form.Group>
-                {this.state.extended_isolation ? (
+                {this.props.patient.monitoring ? (
                   <React.Fragment>
-                    {moment(this.state.extended_isolation).isSameOrAfter(moment().format('MM/DD/YYYY')) ? (
-                      <Form.Label className="mb-2">
-                        {`Are you sure you want to extend this case’s isolation through ${moment(this.state.extended_isolation).format('MM/DD/YYYY')}?`}
-                        <br></br>
-                        <br></br>
-                        {`After clicking “Submit”, the case will be moved to the "Reporting" or "Non-Reporting" line list.
-                          This case cannot appear on the records Requiring Review Line List until after ${moment(this.state.extended_isolation).format(
-                            'MM/DD/YYYY'
-                          )}.
-                          If the record meets a recovery definition after ${moment(this.state.extended_isolation).format('MM/DD/YYYY')}, it will appear on the
-                          Records Requiring Review Line List for review by public health to determine if it is safe to discontinue isolation.`}
-                      </Form.Label>
+                    {this.state.extended_isolation ? (
+                      <React.Fragment>
+                        {moment(this.state.extended_isolation).isSameOrAfter(moment().format('MM/DD/YYYY')) ? (
+                          <Form.Label className="mb-2">
+                            {`Are you sure you want to extend this case’s isolation through ${moment(this.state.extended_isolation).format('MM/DD/YYYY')}?`}
+                            <br></br>
+                            <br></br>
+                            {`After clicking “Submit”, the case will be moved to the "Reporting" or "Non-Reporting" line list.
+                              This case cannot appear on the records Requiring Review Line List until after ${moment(this.state.extended_isolation).format(
+                                'MM/DD/YYYY'
+                              )}.
+                              If the record meets a recovery definition after ${moment(this.state.extended_isolation).format(
+                                'MM/DD/YYYY'
+                              )}, it will appear on the
+                              Records Requiring Review Line List for review by public health to determine if it is safe to discontinue isolation.`}
+                          </Form.Label>
+                        ) : (
+                          <Form.Label className="mb-2">
+                            {`The date you have entered has already passed. Are you sure you want to update the "Extend Isolation To" date to ${moment(
+                              this.state.extended_isolation
+                            ).format(
+                              'MM/DD/YYYY'
+                            )}? Since the specified date has already passed, this case is eligible to appear on the Records Requiring Review Line List if a recovery definition is met.`}
+                          </Form.Label>
+                        )}
+                      </React.Fragment>
                     ) : (
                       <Form.Label className="mb-2">
-                        {`The date you have entered has already passed. Are you sure you want to update the "Extend Isolation To" date to ${moment(
-                          this.state.extended_isolation
-                        ).format(
-                          'MM/DD/YYYY'
-                        )}? Since the specified date has already passed, this case is eligible to appear on the Records Requiring Review Line List if a recovery definition is met.`}
+                        {`Are you sure you want to clear the "Extend Isolation To" date? Since the date is cleared, this case is eligible to appear on the Records Requiring Review Line List if a recovery definition is met.`}
                       </Form.Label>
                     )}
                   </React.Fragment>
                 ) : (
-                  <Form.Label className="mb-2">
-                    {`Are you sure you want to clear the "Extend Isolation To" date? Since the date is cleared, this case is eligible to appear on the Records Requiring Review Line List if a recovery definition is met.`}
-                  </Form.Label>
+                  <React.Fragment>
+                    {this.state.extended_isolation ? (
+                      <Form.Label className="mb-2">
+                        {`Are you sure you want to change the Extend Isolation Date to ${moment(this.state.extended_isolation).format(
+                          'MM/DD/YYYY'
+                        )}? Since this record is on the Closed line list, updating this value will not move this record to another line list. If this individual should be actively monitored, please update the record’s Monitoring Status.`}
+                      </Form.Label>
+                    ) : (
+                      <Form.Label className="mb-2">
+                        {`Are you sure you want to clear the "Extend Isolation To" date? Since this record is on the Closed line list, updating this value will not move this record to another line list. If this individual should be actively monitored, please update the record’s Monitoring Status.`}
+                      </Form.Label>
+                    )}
+                  </React.Fragment>
                 )}
               </Form.Group>
               <p>Please include any additional details:</p>

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -127,7 +127,7 @@ class LastDateExposure extends React.Component {
               <Form.Check
                 type="radio"
                 id="apply_to_group_cm_only"
-                label="This monitoree and only household members where Continuous Exposure is toggled ON"
+                label="This monitoree and only household members where Continuous Exposure is turned ON"
                 onChange={this.handleChange}
                 checked={this.state.apply_to_group_cm_only === true}
               />
@@ -181,14 +181,16 @@ class LastDateExposure extends React.Component {
         {this.state.showExposureDateModal &&
           this.createModal(
             'Last Date of Exposure',
-            `Are you sure you want to modify the Last Date of Exposure to ${this.state.last_date_of_exposure}? The Last Date of Exposure will be updated and Continuous Exposure will be toggled off for the selected record`,
+            `Are you sure you want to modify the Last Date of Exposure to ${this.state.last_date_of_exposure}? The Last Date of Exposure will be updated and Continuous Exposure will be turned OFF for the selected record`,
             this.closeExposureDateModal,
             () => this.submit(true)
           )}
         {this.state.showContinuousMonitoringModal &&
           this.createModal(
             'Continuous Exposure',
-            'Are you sure you want to modify Continuous Exposure? Continuous Exposure will be toggled for the selected record',
+            `Are you sure you want to modify Continuous Exposure? Continuous Exposure will be turned ${
+              this.state.continuous_exposure ? 'ON' : 'OFF'
+            } for the selected record`,
             this.toggleContinuousMonitoringModal,
             () => this.submit(false)
           )}
@@ -224,7 +226,7 @@ class LastDateExposure extends React.Component {
                     placement="left"
                     overlay={
                       <Tooltip id="tooltip-ce">
-                        Continuous Exposure cannot be toggled for records on the Closed line list. If this monitoree requires monitoring due to a Continuous
+                        Continuous Exposure cannot be turned for records on the Closed line list. If this monitoree requires monitoring due to a Continuous
                         Exposure, you may update this field after changing Monitoring Status to &quot;Actively Monitoring&quot;
                       </Tooltip>
                     }>

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -105,7 +105,16 @@ class MonitoringStatus extends React.Component {
         monitoring_reasons: null,
       });
     } else if (event?.target?.id && event.target.id === 'public_health_action') {
-      if (this.state.patient.isolation) {
+      if (!this.state.patient.monitoring) {
+        this.setState({
+          showPublicHealthActionModal: true,
+          message: `latest public health action to "${event.target.value}"`,
+          message_warning:
+            'Since this record is on the "Closed" line list, updating this value will not move this record to another line list. If this individual should be actively monitored, please update the record\'s Monitoring Status.',
+          public_health_action: event?.target?.value ? event.target.value : '',
+          monitoring_reasons: null,
+        });
+      } else if (this.state.patient.isolation) {
         this.setState({
           showPublicHealthActionModal: true,
           message: `latest public health action to "${event.target.value}"`,
@@ -143,7 +152,9 @@ class MonitoringStatus extends React.Component {
         showMonitoringStatusModal: true,
         message: `monitoring status to "${event.target.value}"`,
         message_warning:
-          event.target.value === 'Not Monitoring' ? 'This will move the selected record(s) to the Closed line list and turn Continuous Exposure OFF.' : '',
+          event.target.value === 'Not Monitoring'
+            ? 'This will move the selected record(s) to the Closed line list and turn Continuous Exposure OFF.'
+            : 'This will move the selected record(s) from the Closed line list to the appropriate Active Monitoring line list',
         monitoring: event.target.value === 'Actively Monitoring',
         monitoring_status: event?.target?.value ? event.target.value : '',
         monitoring_reasons:
@@ -373,7 +384,7 @@ class MonitoringStatus extends React.Component {
             <React.Fragment>
               <hr />
               <p className="mb-2">
-                Would you like to update the <i>Last Date of Exposure</i> for all household members who have Continuous Exposure toggled ON and are being
+                Would you like to update the <i>Last Date of Exposure</i> for all household members who have Continuous Exposure turned ON and are being
                 monitored in the Exposure Workflow?
               </p>
               <Form.Group className="px-4">

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -430,20 +430,14 @@ class MonitoringStatus extends React.Component {
           <Button variant="secondary btn-square" onClick={toggle}>
             Cancel
           </Button>
-          {this.state.monitoring_reasons && !this.state.monitoring_reason ? (
-            <Button variant="primary btn-square" disabled>
-              Submit
-            </Button>
-          ) : (
-            <Button variant="primary btn-square" onClick={submit} disabled={this.state.loading}>
-              {this.state.loading && (
-                <React.Fragment>
-                  <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
-                </React.Fragment>
-              )}
-              Submit
-            </Button>
-          )}
+          <Button variant="primary btn-square" onClick={submit} disabled={this.state.loading}>
+            {this.state.loading && (
+              <React.Fragment>
+                <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
+              </React.Fragment>
+            )}
+            Submit
+          </Button>
         </Modal.Footer>
       </Modal>
     );

--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -34,7 +34,7 @@ class MonitoringStatus extends React.Component {
       assigned_user: props.patient.assigned_user ? props.patient.assigned_user : '',
       original_assigned_user: props.patient.assigned_user ? props.patient.assigned_user : '',
       monitoring_reasons: null,
-      monitoring_reason: props.patient.monitoring_reason ? props.patient.monitoring_reason : '',
+      monitoring_reason: '',
       public_health_action: props.patient.public_health_action ? props.patient.public_health_action : '',
       apply_to_group: false,
       isolation: props.patient.isolation,

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -165,7 +165,7 @@ class History < ApplicationRecord
     }
     return if field[:old_value] == field[:new_value]
 
-    if !history[:params][:monitoring].nil? && !history[:params][:monitoring]
+    if !history[:params][:monitoring].blank? && !history[:params][:monitoring]
       history[:note] = ', and chose to "End Monitoring"'
     elsif !history[:patient][:isolation].present? && history[:params][:isolation].present?
       history[:note] = ', and chose to "Continue Monitoring in Isolation Workflow"'


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-853](https://tracker.codev.mitre.org/browse/SARAALERT-853)

Address bugs 1, 2, 3, and 5 here:
https://mitre.sharepoint.com/:p:/s/CoVDT/EV_Gowrz3RBFrFwwB_bKnJkB3F95f7_z8674ndyCst0mcg?e=B9tXcx

# (Bugfix) How to Replicate
See ppt

# (Bugfix) Solution
Bug 1
- clearing PH action after case status change between not a case/unkown/suspect happens in the back end instead of front end now for custom history message
Bug 2
- add separate messages for modals when monitoree is closed
Bug 3
- replaced "toggled" with "turned"
- added "on/off" to modal message
Bug 5
- do not use monitoree's existing monitoring_reason for future Monitoring Status changes

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`example_file.js`
- Example change (ex: refactored import function)

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
