### PR TITLE
Calculate patient age api create

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -549,6 +549,8 @@ class Patient < ApplicationRecord
   end
 
   def self.calc_current_age_fhir(birth_date)
+    return nil if birth_date.nil?
+
     begin
       date_of_birth = DateTime.strptime(birth_date, '%Y-%m-%d')
     rescue ArgumentError

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -545,7 +545,25 @@ class Patient < ApplicationRecord
 
   # Return the calculated age based on the date of birth
   def calc_current_age
-    dob = date_of_birth || Date.today
+    Patient.calc_current_age_base(provided_date_of_birth: date_of_birth)
+  end
+
+  def self.calc_current_age_fhir(birth_date)
+    begin
+      date_of_birth = DateTime.strptime(birth_date, '%Y-%m-%d')
+    rescue ArgumentError
+      begin
+        date_of_birth = DateTime.strptime(birth_date, '%Y-%m')
+      rescue ArgumentError
+        # Raise if this fails because provided date of birth is not in the valid FHIR date format
+        date_of_birth = DateTime.strptime(birth_date, '%Y')
+      end
+    end
+    Patient.calc_current_age_base(provided_date_of_birth: date_of_birth)
+  end
+
+  def self.calc_current_age_base(provided_date_of_birth: nil)
+    dob = provided_date_of_birth || Date.today
     today = Date.today
     age = today.year - dob.year
     age -= 1 if
@@ -694,6 +712,7 @@ class Patient < ApplicationRecord
       secondary_telephone: Phonelib.parse(patient&.telecom&.select { |t| t&.system == 'phone' }&.second&.value, 'US').full_e164,
       email: patient&.telecom&.select { |t| t&.system == 'email' }&.first&.value,
       date_of_birth: patient&.birthDate,
+      age: Patient.calc_current_age_fhir(patient&.birthDate),
       address_line_1: patient&.address&.first&.line&.first,
       address_line_2: patient&.address&.first&.line&.second,
       address_city: patient&.address&.first&.city,

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -694,6 +694,7 @@ class Patient < ApplicationRecord
       secondary_telephone: Phonelib.parse(patient&.telecom&.select { |t| t&.system == 'phone' }&.second&.value, 'US').full_e164,
       email: patient&.telecom&.select { |t| t&.system == 'email' }&.first&.value,
       date_of_birth: patient&.birthDate,
+      age: ((Time.zone.now - patient&.birthDate.to_time) / 1.year.seconds).floor,
       address_line_1: patient&.address&.first&.line&.first,
       address_line_2: patient&.address&.first&.line&.second,
       address_city: patient&.address&.first&.city,

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -694,7 +694,6 @@ class Patient < ApplicationRecord
       secondary_telephone: Phonelib.parse(patient&.telecom&.select { |t| t&.system == 'phone' }&.second&.value, 'US').full_e164,
       email: patient&.telecom&.select { |t| t&.system == 'email' }&.first&.value,
       date_of_birth: patient&.birthDate,
-      age: ((Time.zone.now - patient&.birthDate.to_time) / 1.year.seconds).floor,
       address_line_1: patient&.address&.first&.line&.first,
       address_line_2: patient&.address&.first&.line&.second,
       address_city: patient&.address&.first&.city,

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -116,6 +116,14 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert response.headers['Location'].ends_with?(json_response['id'].to_s)
   end
 
+  test 'should calculate Patient age via create' do
+    post '/fhir/r4/Patient', params: @patient_1.to_json, headers: { 'Authorization': "Bearer #{@token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    assert_response :created
+    json_response = JSON.parse(response.body)
+    patient = Patient.find(json_response['id'])
+    assert_equal 25, patient.age
+  end
+
   test 'should be 415 when bad content type header via create' do
     post '/fhir/r4/Patient', params: @patient_1.to_json, headers: { 'Authorization': "Bearer #{@token_rw.token}", 'Content-Type': 'foo/bar' }
     assert_response :unsupported_media_type

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -793,4 +793,22 @@ class PatientTest < ActiveSupport::TestCase
 
     assert_equal status, patient.status
   end
+
+  test 'calc current age (instance)' do
+    number = rand(100)
+    patient = create(:patient, date_of_birth: number.years.ago)
+    assert_equal number, patient.calc_current_age
+  end
+
+  test 'calc current age fhir' do
+    number = rand(100)
+    patient = create(:patient, date_of_birth: number.years.ago)
+    age = patient.calc_current_age
+
+    birth_year = Date.today.year - age
+
+    assert_equal age, Patient.calc_current_age_fhir("#{birth_year}-01-01")
+    assert_equal age, Patient.calc_current_age_fhir("#{birth_year}-01")
+    assert_equal age, Patient.calc_current_age_fhir("#{birth_year}")
+  end
 end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -809,7 +809,7 @@ class PatientTest < ActiveSupport::TestCase
 
     assert_equal age, Patient.calc_current_age_fhir("#{birth_year}-01-01")
     assert_equal age, Patient.calc_current_age_fhir("#{birth_year}-01")
-    assert_equal age, Patient.calc_current_age_fhir("#{birth_year}")
+    assert_equal age, Patient.calc_current_age_fhir(birth_year.to_s)
 
     assert_nil Patient.calc_current_age_fhir(nil)
   end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -810,5 +810,7 @@ class PatientTest < ActiveSupport::TestCase
     assert_equal age, Patient.calc_current_age_fhir("#{birth_year}-01-01")
     assert_equal age, Patient.calc_current_age_fhir("#{birth_year}-01")
     assert_equal age, Patient.calc_current_age_fhir("#{birth_year}")
+
+    assert_nil Patient.calc_current_age_fhir(nil)
   end
 end


### PR DESCRIPTION
This is taking over from #375 because I couldn't push changes to @Sepiidae fork.

This PR will calculate the age of the patient on create when using the FHIR API. 

To accomplish this I've added new functions in `models/patient.rb` which attempt to parse the provided date of birth in the 3 valid FHIR `date` formats. (Found [here](https://www.hl7.org/fhir/datatypes.html#date)) and switched the current calculate date to use a static method so the code for calculating the date is not duplicated.