### PR TITLE
Report Eligibility calcs should fall back on created_at if no LDE

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -659,7 +659,8 @@ class Patient < ApplicationRecord
     # Exposure workflow specific conditions
     unless isolation
       # Monitoring period has elapsed
-      if (!last_date_of_exposure.nil? && last_date_of_exposure < reporting_period) && !continuous_exposure
+      start_of_exposure = last_date_of_exposure || created_at
+      if start_of_exposure < reporting_period && !continuous_exposure
         eligible = false
         messages << { message: "Monitoree\'s monitoring period has elapsed and continuous exposure is not enabled", datetime: nil }
       end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -549,7 +549,8 @@ class Patient < ApplicationRecord
     # NOTE: We do not close out folks on the non-reporting line list in exposure (therefore monitoring will still be true for them),
     # so we also have to check that someone receiving messages is not past they're monitoring period unless they're  in isolation,
     # continuous exposure, or have active dependents.
-    return unless (monitoring && (!last_date_of_exposure.nil? && last_date_of_exposure >= ADMIN_OPTIONS['monitoring_period_days'].days.ago.beginning_of_day)) ||
+    start_of_exposure = last_date_of_exposure || created_at
+    return unless (monitoring && start_of_exposure >= ADMIN_OPTIONS['monitoring_period_days'].days.ago.beginning_of_day) ||
                   (monitoring && isolation) ||
                   continuous_exposure ||
                   dependents_exclude_self.where('monitoring = ? OR continuous_exposure = ?', true, true).exists?


### PR DESCRIPTION
# Description

Make assessment eligibility logic (eligibility icon/send_assessments method) fall back on created_at if LDE is nil.

`app/models/patient.rb `
- Default to created_at if LDE is nil in send_assessment and eligibility calc
