### PR TITLE
Eligibility Tooltip Fixes

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -663,7 +663,8 @@ class Patient < ApplicationRecord
     # Exposure workflow specific conditions
     unless isolation
       # Monitoring period has elapsed
-      if (!last_date_of_exposure.nil? && last_date_of_exposure < reporting_period) && !continuous_exposure && active_dependents.empty?
+      no_active_dependents = dependents_exclude_self.where(monitoring: true).empty?
+      if (!last_date_of_exposure.nil? && last_date_of_exposure < reporting_period) && !continuous_exposure && no_active_dependents
         eligible = false
         messages << { message: "Monitoree\'s monitoring period has elapsed and continuous exposure is not enabled", datetime: nil }
       end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -641,7 +641,11 @@ class Patient < ApplicationRecord
     # Can't send messages to monitorees that are on the closed line list and have no active dependents.
     if !monitoring && active_dependents.empty?
       eligible = false
-      messages << { message: 'Monitoree is not currently being monitored and has no actively monitored household members', datetime: closed_at }
+
+      # If this person has dependents (is a HoH)
+      is_hoh = !dependents_exclude_self.empty?
+      message = "Monitoree is not currently being monitored #{is_hoh ? 'and has no actively monitored household members' : ''}"
+      messages << { message: message, datetime: nil }
     end
 
     # Can't send messages if notifications are paused
@@ -659,7 +663,7 @@ class Patient < ApplicationRecord
     # Exposure workflow specific conditions
     unless isolation
       # Monitoring period has elapsed
-      if (!last_date_of_exposure.nil? && last_date_of_exposure < reporting_period) && !continuous_exposure
+      if (!last_date_of_exposure.nil? && last_date_of_exposure < reporting_period) && !continuous_exposure && active_dependents.empty?
         eligible = false
         messages << { message: "Monitoree\'s monitoring period has elapsed and continuous exposure is not enabled", datetime: nil }
       end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -643,7 +643,7 @@ class Patient < ApplicationRecord
       eligible = false
 
       # If this person has dependents (is a HoH)
-      is_hoh = !dependents_exclude_self.empty?
+      is_hoh = dependents_exclude_self.exists?
       message = "Monitoree is not currently being monitored #{is_hoh ? 'and has no actively monitored household members' : ''}"
       messages << { message: message, datetime: nil }
     end
@@ -663,7 +663,7 @@ class Patient < ApplicationRecord
     # Exposure workflow specific conditions
     unless isolation
       # Monitoring period has elapsed
-      no_active_dependents = dependents_exclude_self.where(monitoring: true).empty?
+      no_active_dependents = !dependents_exclude_self.where(monitoring: true).exists?
       if (!last_date_of_exposure.nil? && last_date_of_exposure < reporting_period) && !continuous_exposure && no_active_dependents
         eligible = false
         messages << { message: "Monitoree\'s monitoring period has elapsed and continuous exposure is not enabled", datetime: nil }

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -516,6 +516,10 @@ class PatientTest < ActiveSupport::TestCase
     assert_not patient.report_eligibility[:eligible]
     assert patient.report_eligibility[:messages].join(' ').include? 'paused'
 
+    patient = create(:patient, monitoring: false)
+    assert_not patient.report_eligibility[:eligible]
+    assert patient.report_eligibility[:messages].join(' ').include? 'Monitoree is not currently being monitored'
+
     patient = create(:patient, id: 100)
     patient.update(responder_id: 42)
     assert_not patient.report_eligibility[:eligible]


### PR DESCRIPTION
# Description
- Updates language for when a record is closed and not part of a household.
- Updated logic so that if a HoH is past their monitoring period but has monitored dependents they are still eligible.
