### PR TITLE
SARAALERT-568: Preferred Contact Time for emails, send_assessment tests

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -509,18 +509,6 @@ class PatientsController < ApplicationController
     render json: { removeable: !duplicate_contact }
   end
 
-  def send_reminder
-    # Send a new report reminder to the monitoree
-    redirect_to(root_url) && return unless current_user.can_remind_patient?
-
-    patient = current_user.get_patient(params.permit(:id)[:id])
-    redirect_to(root_url) && return if patient.nil?
-
-    patient.send_assessment(force: true)
-
-    History.report_reminder(patient: patient, created_by: current_user)
-  end
-
   # Construct a diff for a patient update to keep track of changes
   def patient_diff(patient_before, patient_after)
     diffs = []

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -213,7 +213,8 @@ class Contact extends React.Component {
                 </Form.Group>
                 {(this.state.current.patient.preferred_contact_method === 'SMS Texted Weblink' ||
                   this.state.current.patient.preferred_contact_method === 'Telephone call' ||
-                  this.state.current.patient.preferred_contact_method === 'SMS Text-message') && (
+                  this.state.current.patient.preferred_contact_method === 'SMS Text-message' ||
+                  this.state.current.patient.preferred_contact_method === 'E-mailed Web Link') && (
                   <Form.Group as={Col} md="8" controlId="preferred_contact_time">
                     <Form.Label className="nav-input-label">
                       PREFERRED CONTACT TIME{schema?.fields?.preferred_contact_time?._exclusive?.required && ' *'}

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -532,7 +532,7 @@ class Patient < ApplicationRecord
 
   # Send a daily assessment to this monitoree (if currently eligible). By setting send_now to true, an assessment
   # will be sent immediately without any consideration of the monitoree's preferred_contact_time.
-  def send_assessment(send_now = false)
+  def send_assessment(send_now: false)
     return if ['Unknown', 'Opt-out', '', nil].include?(preferred_contact_method)
 
     return if !last_assessment_reminder_sent.nil? && last_assessment_reminder_sent > 12.hours.ago
@@ -566,7 +566,7 @@ class Patient < ApplicationRecord
       morning = (8..12)
       afternoon = (12..16)
       evening = (16..19)
-      case preferred_contact_time&.downcase 
+      case preferred_contact_time&.downcase
       when 'morning'
         return unless morning.include? hour
       when 'afternoon'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,6 @@ Rails.application.routes.draw do
   post '/patients/:id/status', to: 'patients#update_status'
   post '/patients/:id/status/clear', to: 'patients#clear_assessments'
   post '/patients/:id/status/clear/:assessment_id', to: 'patients#clear_assessment'
-  post '/patients/:id/reminder', to: 'patients#send_reminder'
   post '/patients/:id/update_hoh', to: 'patients#update_hoh'
 
   resources :patients, param: :submission_token do


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-568

Refactor of send_assessment method to simplify (and clarify) logic. Made emails follow similar timing checks to text and voice. Removed old send reminder route.

# Important Changes

`app/controllers/patients_controller.rb `
- Removed old send reminder method

`config/routes.rb`
- Removed old send reminder method route

`app/javascript/components/enrollment/steps/Contact.js `
- Made preferred contact time option pop up for email

`app/models/patient.rb`
- Refactor of send_assessment method to simplify (and clarify) logic. Made emails follow similar timing checks to text and voice.

# Testing

Enroll new monitoree, and give them preferred contact time. Run send assessment query in console. Test on demo.
