### PR TITLE
Update schema onChange so that toggle between isolation/exposure pers…

### DIFF
--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -72,6 +72,7 @@ class Exposure extends React.Component {
         this.props.setEnrollmentState({ ...this.state.modified });
       }
     );
+    this.schema = this.getSchema(this.props.currentState.isolation);
   }
 
   handleDateChange(field, date) {
@@ -143,7 +144,7 @@ class Exposure extends React.Component {
       <React.Fragment>
         <Form.Row>
           <Form.Group as={Col} md="7" controlId="symptom_onset">
-            <Form.Label className="nav-input-label">SYMPTOM ONSET DATE{this.schema?.fields?.symptom_onset?._exclusive?.required && ' *'}</Form.Label>
+            <Form.Label className="nav-input-label">SYMPTOM ONSET DATE{this.schema?.fields?.symptom_onset?._exclusive?.required || ' *'}</Form.Label>
             <DateInput
               id="symptom_onset"
               date={this.state.current.patient.symptom_onset}


### PR DESCRIPTION
Currently the "*" for required field does not show up when using Enrollment component to add a patient directly to Isolation.

I think I tracked this down to the "isolation" attribute in the current state getting reset as the user navigates through to next steps in Enrollment so the fix involves updating the schema on change.