### PR TITLE
(Bugfix) Addressing Edge Case for Close Patients Job

### DIFF
--- a/app/jobs/close_patients_job.rb
+++ b/app/jobs/close_patients_job.rb
@@ -18,9 +18,11 @@ class ClosePatientsJob < ApplicationJob
       patient[:closed_at] = DateTime.now
 
       # If the patient was enrolled already past their monitoring period based on their last date of exposure, specify special reason for closure
-      if (patient.last_date_of_exposure.beginning_of_day + ADMIN_OPTIONS['monitoring_period_days'].days) < patient.created_at.beginning_of_day
+      if !patient.last_date_of_exposure.nil? &&
+         ((patient.last_date_of_exposure.beginning_of_day + ADMIN_OPTIONS['monitoring_period_days'].days) < patient.created_at.beginning_of_day)
         patient[:monitoring_reason] = 'Enrolled more than 14 days after last date of exposure (system)'
-      elsif (patient.last_date_of_exposure.beginning_of_day + ADMIN_OPTIONS['monitoring_period_days'].days) == patient.created_at.beginning_of_day
+      elsif !patient.last_date_of_exposure.nil? &&
+            ((patient.last_date_of_exposure.beginning_of_day + ADMIN_OPTIONS['monitoring_period_days'].days) == patient.created_at.beginning_of_day)
         # If the patient was enrolled on their last day of monitoring based on their last date of exposure, specify special reason for closure
         patient[:monitoring_reason] = 'Enrolled on last day of monitoring period (system)'
       else

--- a/test/jobs/close_patients_job_test.rb
+++ b/test/jobs/close_patients_job_test.rb
@@ -12,6 +12,22 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
     ADMIN_OPTIONS['job_run_email'] = nil
   end
 
+  test 'handles case where last date of exposure is nil' do
+    patient = create(:patient,
+                     purged: false,
+                     isolation: false,
+                     monitoring: true,
+                     symptom_onset: nil,
+                     public_health_action: 'None',
+                     latest_assessment_at: Time.now,
+                     last_date_of_exposure: nil,
+                     created_at: 20.days.ago)
+    ClosePatientsJob.perform_now
+    # Reload attributes after job
+    patient.reload
+    assert_equal('Completed Monitoring (system)', patient.monitoring_reason)
+  end
+
   test 'updates appropriate fields on each closed record' do
     patient = create(:patient,
                      purged: false,


### PR DESCRIPTION
# Description
Currently it is possible for a record to have a nil last date of exposure AND continuous exposure set to false. We are currently working on preventing this in 1.15. However, as of right now, this causes an issue in the close job for those records due to a missing nil check. This PR adds the check and also adds a test to cover this case in the future.

# Important Changes
`app/jobs/close_patients_job.rb`
- Added nil check.

`test/jobs/close_patients_job_test.rb`
- Added test to cover this case.

# Testing
New test should cover this, but run the close job when there is a monitoree with a nil LDE, continuous exposure set to false, and that was created more than 14 days ago. 
