### PR TITLE
SARAALERT-886: Prevent records from continuous exposure of household members that are closed.

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -368,6 +368,9 @@ class PatientsController < ApplicationController
       patient.closed_at = DateTime.now
     end
 
+    # Do not allow continuous exposure to updated for closed records
+    params_to_update.delete(:continuous_exposure) if params_to_update.include?(:continuous_exposure) && !patient.monitoring
+
     # If moving patient to exposure from isolation
     if params_to_update.include?(:isolation) && !params.require(:patient).permit(:isolation)[:isolation]
       # NOTE: In the case where a patient is being moved back to the exposure workflow, the symptom onset should be overwritten

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -104,6 +104,7 @@ class LastDateExposure extends React.Component {
 
   createModal(title, message, toggle, submit) {
     message += this.props.has_group_members ? '(s):' : '.';
+    const update_continuous_exposure = title === 'Continuous Exposure';
     return (
       <Modal size="lg" show centered onHide={toggle}>
         <Modal.Header>
@@ -127,7 +128,9 @@ class LastDateExposure extends React.Component {
               <Form.Check
                 type="radio"
                 id="apply_to_group_cm_only"
-                label="This monitoree and only household members that are not on the closed line list where Continuous Exposure is turned ON"
+                label={`This monitoree and only household members ${
+                  update_continuous_exposure ? 'that are not on the closed line list' : ''
+                } where Continuous Exposure is turned ON`}
                 onChange={this.handleChange}
                 checked={this.state.apply_to_group_cm_only === true}
               />
@@ -138,7 +141,7 @@ class LastDateExposure extends React.Component {
               <Form.Check
                 type="radio"
                 id="apply_to_group"
-                label="This monitoree and all household members that are not on the closed line list"
+                label={`This monitoree and all household members ${update_continuous_exposure ? 'that are not on the closed line list' : ''}`}
                 onChange={this.handleChange}
                 checked={this.state.apply_to_group === true}
               />

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -127,7 +127,7 @@ class LastDateExposure extends React.Component {
               <Form.Check
                 type="radio"
                 id="apply_to_group_cm_only"
-                label="This monitoree and only household members where Continuous Exposure is toggled ON"
+                label="This monitoree and only household members that are not on the closed line list where Continuous Exposure is turned ON"
                 onChange={this.handleChange}
                 checked={this.state.apply_to_group_cm_only === true}
               />
@@ -138,7 +138,7 @@ class LastDateExposure extends React.Component {
               <Form.Check
                 type="radio"
                 id="apply_to_group"
-                label="This monitoree and all household members"
+                label="This monitoree and all household members that are not on the closed line list"
                 onChange={this.handleChange}
                 checked={this.state.apply_to_group === true}
               />


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-886

It should not be possible for continuous exposure to be turned on for a closed record. This is prevented in other ways, but we needed to handle the case where a user chooses to update all household members when updating the continuous exposure for a record in a household. This PR handles that case by updating the language when updating continuous exposure for household members to specify non-closed members, and from preventing the change from happening to closed records. 

# Screenshots
New language in modal when updating continuous exposure:
![Screen Shot 2020-10-02 at 12 49 10 PM](https://user-images.githubusercontent.com/11698457/94948759-d9829880-04ad-11eb-86bc-8b33bb9fbf0a.png)

Language is unchanged when updating LDE.

# Important Changes
`app/controllers/patients_controller.rb`
- Updated `update_fields()` method to prevent continuous exposure from being updated for closed records.

`app/javascript/components/subject/LastDateExposure.js`
- Updated language in modal when changing continuous exposure to specify that it only changes for records that are not closed. 

# Testing
To test, please do the following:
1. Find a record that is part of a household. 
2. Update another member of the household to be closed.
3. Update continuous exposure for the original record and choose the option to apply to all household members. (Should see new language). 
4. Should notice record in household that was closed was not updated. 