### PR TITLE
UI fix for IE11

### DIFF
--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -185,7 +185,7 @@ class CustomTable extends React.Component {
         {this.props.rowData.length === 0 && <div className="text-center">No data available in table.</div>}
         <div className="d-flex justify-content-between">
           <Form inline className="align-middle">
-            <Row>
+            <Row style={{ width: '430px' }}>
               <Col>
                 <InputGroup>
                   <InputGroup.Prepend>

--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -185,7 +185,7 @@ class CustomTable extends React.Component {
         {this.props.rowData.length === 0 && <div className="text-center">No data available in table.</div>}
         <div className="d-flex justify-content-between">
           <Form inline className="align-middle">
-            <Row style={{ width: '430px' }}>
+            <Row className="fixed-row-size">
               <Col>
                 <InputGroup>
                   <InputGroup.Prepend>

--- a/app/javascript/packs/stylesheets/custom_table.scss
+++ b/app/javascript/packs/stylesheets/custom_table.scss
@@ -18,3 +18,7 @@
 .pointer-cursor {
     cursor: pointer;
 }
+
+.fixed-row-size {
+    width: 430px;
+}


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-692

Fixing UI issue where the pagination drop down for the Custom Table wasn't sizing properly in Internet Explorer.

# (Feature) Demo/Screenshots
_Original issue_:
![image](https://user-images.githubusercontent.com/42656458/94957354-9af3da80-04bb-11eb-927a-70a2fffa2766.png)

_Resolved and displays as_:
![image](https://user-images.githubusercontent.com/42656458/94958588-ca0b4b80-04bd-11eb-953f-e888a786b5e1.png)

# How to Replicate

1. Run Sara Alert 
2. Open up Sara Alert on Internet Explorer and login as either an Admin or Public Health User
3. Scroll to the bottom of the table and you will find the pagination drop down renders improperly as shown in the above screenshot 

# Solution
Updated the Custom Table class to ensure the row that encloses the pagination drop down is sized large enough.

# Important Changes

`CustomTable.js`
- Set a fixed size for the row that encloses the pagination drop down so it is large enough for each browser.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [x] Firefox
* [x] Safari
* [x] IE11

1. Run Sara Alert 
2. Open up Sara Alert on Internet Explorer and login as either an Admin or Public Health User
3. Scroll to the bottom of the table and verify the pagination drop down renders properly  
