### PR TITLE
GitHub Actions Update

### DIFF
--- a/.github/workflows/anchore-analysis.yml
+++ b/.github/workflows/anchore-analysis.yml
@@ -8,7 +8,7 @@
 
 name: Container Scan
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   Anchore-Build-Scan:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,6 +1,6 @@
 name: Static Analysis
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test-model-controller:


### PR DESCRIPTION
## Description
Running actions on only `push` rather than both on `push` and on `pull_request` as that was redundant. You may have noticed them running twice on PRs because of this.
