### PR TITLE
SARAALERT-793: Case Status field should not auto-populate for dependents upon enrollment

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -700,7 +700,6 @@ class PatientsController < ApplicationController
       isolation
       jurisdiction_id
       assigned_user
-      case_status
       continuous_exposure
     ]
   end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-793](https://tracker.codev.mitre.org/browse/SARAALERT-793)
Case Status field should not auto-populate for dependents upon enrollment

# (Bugfix) How to Replicate
Go to an existing monitoree and click `edit details`.  From there, click `Finish and Add a Household Member` and go through the enrollment process.  For isolation workflow, a case status option will show up in the carousel, this should have the case status of the HoH.  For exposure, continue through the carousel and submit - the new monitoree will have the same case status as the HoH.

# (Bugfix) Solution
In `patients_controller.rb`, there is a `group_member_subset` list that indicates all the fields that should be copied over from the HoH.  Removing `case_status` from this list fixes this bug.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`patients_controller.rb`
- Removed `case_status` from `group_member_subset` list

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
