### PR TITLE
SARAALERT-835: Handle monitoree LDE state

### DIFF
--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -200,48 +200,29 @@ class Enrollment extends React.Component {
             <Identification goto={this.goto} next={this.next} setEnrollmentState={this.setEnrollmentState} currentState={this.state.enrollmentState} />
           </Carousel.Item>
           <Carousel.Item>
-            <Address
-              goto={this.goto}
-              next={this.next}
-              previous={this.previous}
-              setEnrollmentState={this.setEnrollmentState}
-              currentState={this.state.enrollmentState}
-            />
+            <Address currentState={this.state.enrollmentState} setEnrollmentState={this.setEnrollmentState} previous={this.previous} next={this.next} />
           </Carousel.Item>
           <Carousel.Item>
-            <Contact
-              goto={this.goto}
-              next={this.next}
-              previous={this.previous}
-              setEnrollmentState={this.setEnrollmentState}
-              currentState={this.state.enrollmentState}
-            />
+            <Contact currentState={this.state.enrollmentState} setEnrollmentState={this.setEnrollmentState} previous={this.previous} next={this.next} />
           </Carousel.Item>
           <Carousel.Item>
-            <Arrival
-              goto={this.goto}
-              next={this.next}
-              previous={this.previous}
-              setEnrollmentState={this.setEnrollmentState}
-              currentState={this.state.enrollmentState}
-            />
+            <Arrival currentState={this.state.enrollmentState} setEnrollmentState={this.setEnrollmentState} previous={this.previous} next={this.next} />
           </Carousel.Item>
           <Carousel.Item>
             <AdditionalPlannedTravel
-              goto={this.goto}
-              next={this.next}
-              previous={this.previous}
-              setEnrollmentState={this.setEnrollmentState}
               currentState={this.state.enrollmentState}
+              setEnrollmentState={this.setEnrollmentState}
+              previous={this.previous}
+              next={this.next}
             />
           </Carousel.Item>
           <Carousel.Item>
             <Exposure
-              goto={this.goto}
-              next={this.next}
-              previous={this.previous}
-              setEnrollmentState={this.setEnrollmentState}
               currentState={this.state.enrollmentState}
+              setEnrollmentState={this.setEnrollmentState}
+              previous={this.previous}
+              next={this.next}
+              patient={this.props.patient}
               has_group_members={this.props.has_group_members}
               jurisdictionPaths={this.props.jurisdictionPaths}
               assignedUsers={this.props.assignedUsers}
@@ -250,12 +231,11 @@ class Enrollment extends React.Component {
           </Carousel.Item>
           <Carousel.Item>
             <Review
+              currentState={this.state.enrollmentState}
+              previous={this.previous}
               goto={this.goto}
               submit={this.submit}
-              previous={this.previous}
-              setEnrollmentState={this.setEnrollmentState}
-              currentState={this.state.enrollmentState}
-              parentId={this.props.parent_id}
+              parent_id={this.props.parent_id}
               canAddGroup={this.props.can_add_group}
               jurisdictionPaths={this.props.jurisdictionPaths}
             />

--- a/app/javascript/components/enrollment/steps/AdditionalPlannedTravel.js
+++ b/app/javascript/components/enrollment/steps/AdditionalPlannedTravel.js
@@ -247,11 +247,6 @@ class AdditionalPlannedTravel extends React.Component {
                 Next
               </Button>
             )}
-            {this.props.submit && (
-              <Button variant="outline-primary" size="lg" className="float-right btn-square px-5" onClick={this.props.submit}>
-                Finish
-              </Button>
-            )}
           </Card.Body>
         </Card>
       </React.Fragment>
@@ -297,10 +292,9 @@ const schema = yup.object().shape({
 
 AdditionalPlannedTravel.propTypes = {
   currentState: PropTypes.object,
-  previous: PropTypes.func,
   setEnrollmentState: PropTypes.func,
+  previous: PropTypes.func,
   next: PropTypes.func,
-  submit: PropTypes.func,
 };
 
 export default AdditionalPlannedTravel;

--- a/app/javascript/components/enrollment/steps/AdditionalPlannedTravel.js
+++ b/app/javascript/components/enrollment/steps/AdditionalPlannedTravel.js
@@ -74,7 +74,7 @@ class AdditionalPlannedTravel extends React.Component {
           <Card.Header as="h5">Additional Planned Travel</Card.Header>
           <Card.Body>
             <Form>
-              <Form.Row className="pt-2">
+              <Form.Row>
                 <Form.Group as={Col} md="8" controlId="additional_planned_travel_type">
                   <Form.Label className="nav-input-label">TRAVEL TYPE{schema?.fields?.additional_planned_travel_type?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control
@@ -157,7 +157,7 @@ class AdditionalPlannedTravel extends React.Component {
                   </Form.Group>
                 )}
               </Form.Row>
-              <Form.Row className="pt-2">
+              <Form.Row>
                 <Form.Group as={Col} md="8" controlId="additional_planned_travel_port_of_departure">
                   <Form.Label className="nav-input-label">
                     PORT OF DEPARTURE{schema?.fields?.additional_planned_travel_port_of_departure?._exclusive?.required && ' *'}
@@ -216,7 +216,7 @@ class AdditionalPlannedTravel extends React.Component {
                   </Form.Control.Feedback>
                 </Form.Group>
               </Form.Row>
-              <Form.Row className="pt-2 pb-3">
+              <Form.Row className="pb-2">
                 <Form.Group as={Col} md="24" controlId="additional_planned_travel_related_notes">
                   <Form.Label className="nav-input-label">
                     ADDITIONAL PLANNED TRAVEL NOTES{schema?.fields?.additional_planned_travel_related_notes?._exclusive?.required && ' *'}

--- a/app/javascript/components/enrollment/steps/Address.js
+++ b/app/javascript/components/enrollment/steps/Address.js
@@ -580,11 +580,6 @@ class Address extends React.Component {
                 Next
               </Button>
             )}
-            {this.props.submit && (
-              <Button variant="outline-primary" size="lg" className="float-right btn-square px-5" onClick={this.props.submit}>
-                Finish
-              </Button>
-            )}
           </Card.Body>
         </Card>
       </React.Fragment>
@@ -708,10 +703,9 @@ const schemaForeign = yup.object().shape({
 
 Address.propTypes = {
   currentState: PropTypes.object,
-  previous: PropTypes.func,
   setEnrollmentState: PropTypes.func,
+  previous: PropTypes.func,
   next: PropTypes.func,
-  submit: PropTypes.func,
 };
 
 export default Address;

--- a/app/javascript/components/enrollment/steps/Address.js
+++ b/app/javascript/components/enrollment/steps/Address.js
@@ -163,7 +163,7 @@ class Address extends React.Component {
                       </Form.Control.Feedback>
                     </Form.Group>
                   </Form.Row>
-                  <Form.Row className="pt-2">
+                  <Form.Row>
                     <Form.Group as={Col} md={8} controlId="address_line_2">
                       <Form.Label className="nav-input-label">ADDRESS 2{schemaDomestic?.fields?.address_line_2?._exclusive?.required && ' *'}</Form.Label>
                       <Form.Control
@@ -191,7 +191,7 @@ class Address extends React.Component {
                       </Form.Control.Feedback>
                     </Form.Group>
                   </Form.Row>
-                  <Form.Row className="pt-2">
+                  <Form.Row>
                     <Form.Group as={Col} md={8} controlId="address_county">
                       <Form.Label className="nav-input-label">
                         COUNTY (DISTRICT) {schemaDomestic?.fields?.address_county?._exclusive?.required && ' *'}
@@ -285,7 +285,7 @@ class Address extends React.Component {
                       </Form.Control.Feedback>
                     </Form.Group>
                   </Form.Row>
-                  <Form.Row className="pt-2">
+                  <Form.Row>
                     <Form.Group as={Col} md={8} controlId="monitored_address_line_2">
                       <Form.Label className="nav-input-label">
                         ADDRESS 2{schemaDomestic?.fields?.monitored_address_line_2?._exclusive?.required && ' *'}
@@ -315,7 +315,7 @@ class Address extends React.Component {
                       </Form.Control.Feedback>
                     </Form.Group>
                   </Form.Row>
-                  <Form.Row className="pt-2 pb-3">
+                  <Form.Row className="pb-2">
                     <Form.Group as={Col} md={8} controlId="monitored_address_county">
                       <Form.Label className="nav-input-label">
                         COUNTY (DISTRICT) {schemaDomestic?.fields?.monitored_address_county?._exclusive?.required && ' *'}
@@ -387,7 +387,7 @@ class Address extends React.Component {
                       </Form.Control.Feedback>
                     </Form.Group>
                   </Form.Row>
-                  <Form.Row className="pt-2">
+                  <Form.Row>
                     <Form.Group as={Col} md={8} controlId="foreign_address_line_2">
                       <Form.Label className="nav-input-label">
                         ADDRESS 2{schemaForeign?.fields?.foreign_address_line_2?._exclusive?.required && ' *'}
@@ -417,7 +417,7 @@ class Address extends React.Component {
                       </Form.Control.Feedback>
                     </Form.Group>
                   </Form.Row>
-                  <Form.Row className="pt-2">
+                  <Form.Row>
                     <Form.Group as={Col} md={8} controlId="foreign_address_line_3">
                       <Form.Label className="nav-input-label">
                         ADDRESS 3{schemaForeign?.fields?.foreign_address_line_3?._exclusive?.required && ' *'}
@@ -457,7 +457,7 @@ class Address extends React.Component {
                       <h5>Address at Destination in USA Where Monitored</h5>
                     </Form.Group>
                   </Form.Row>
-                  <Form.Row className="pt-2 pb-2">
+                  <Form.Row className="pb-2">
                     <Form.Group as={Col} md={24} className="my-auto">
                       <span className="font-weight-light">
                         (If monitoree is planning on travel within the US, enter the <b>first</b> location where they may be contacted)
@@ -518,7 +518,7 @@ class Address extends React.Component {
                       </Form.Control.Feedback>
                     </Form.Group>
                   </Form.Row>
-                  <Form.Row className="pt-2">
+                  <Form.Row>
                     <Form.Group as={Col} md={8} controlId="foreign_monitored_address_line_2">
                       <Form.Label className="nav-input-label">
                         ADDRESS 2{schemaForeign?.fields?.foreign_monitored_address_line_2?._exclusive?.required && ' *'}
@@ -550,7 +550,7 @@ class Address extends React.Component {
                       </Form.Control.Feedback>
                     </Form.Group>
                   </Form.Row>
-                  <Form.Row className="pt-2 pb-3">
+                  <Form.Row className="pb-2">
                     <Form.Group as={Col} md={8} controlId="foreign_monitored_address_county">
                       <Form.Label className="nav-input-label">
                         COUNTY (DISTRICT) {schemaForeign?.fields?.foreign_monitored_address_county?._exclusive?.required && ' *'}

--- a/app/javascript/components/enrollment/steps/Arrival.js
+++ b/app/javascript/components/enrollment/steps/Arrival.js
@@ -72,7 +72,7 @@ class Arrival extends React.Component {
           <Card.Header as="h5">Monitoree Arrival Information</Card.Header>
           <Card.Body>
             <Form>
-              <Form.Row className="pt-2">
+              <Form.Row>
                 <Form.Group as={Col} md="8" controlId="port_of_origin">
                   <Form.Label className="nav-input-label">PORT OF ORIGIN{schema?.fields?.port_of_origin?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control
@@ -106,7 +106,7 @@ class Arrival extends React.Component {
                   </Form.Control.Feedback>
                 </Form.Group>
               </Form.Row>
-              <Form.Row className="pt-2">
+              <Form.Row>
                 <Form.Group as={Col} md="8" controlId="flight_or_vessel_number">
                   <Form.Label className="nav-input-label">
                     FLIGHT OR VESSEL NUMBER{schema?.fields?.flight_or_vessel_number?._exclusive?.required && ' *'}
@@ -136,7 +136,7 @@ class Arrival extends React.Component {
                   </Form.Control.Feedback>
                 </Form.Group>
               </Form.Row>
-              <Form.Row className="pt-2">
+              <Form.Row>
                 <Form.Group as={Col} md="8" controlId="port_of_entry_into_usa">
                   <Form.Label className="nav-input-label">
                     PORT OF ENTRY INTO USA{schema?.fields?.port_of_entry_into_usa?._exclusive?.required && ' *'}
@@ -172,7 +172,7 @@ class Arrival extends React.Component {
                   </Form.Control.Feedback>
                 </Form.Group>
               </Form.Row>
-              <Form.Row className="pt-2">
+              <Form.Row>
                 <Form.Group as={Col} md="8" controlId="source_of_report">
                   <Form.Label className="nav-input-label">SOURCE OF REPORT{schema?.fields?.source_of_report?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control
@@ -212,7 +212,7 @@ class Arrival extends React.Component {
                   </Form.Group>
                 )}
               </Form.Row>
-              <Form.Row className="pt-2 pb-3">
+              <Form.Row className="pb-2">
                 <Form.Group as={Col} md="24" controlId="travel_related_notes">
                   <Form.Label className="nav-input-label">TRAVEL RELATED NOTES{schema?.fields?.travel_related_notes?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control

--- a/app/javascript/components/enrollment/steps/Arrival.js
+++ b/app/javascript/components/enrollment/steps/Arrival.js
@@ -241,11 +241,6 @@ class Arrival extends React.Component {
                 Next
               </Button>
             )}
-            {this.props.submit && (
-              <Button variant="outline-primary" size="lg" className="float-right btn-square px-5" onClick={this.props.submit}>
-                Finish
-              </Button>
-            )}
           </Card.Body>
         </Card>
       </React.Fragment>
@@ -298,10 +293,9 @@ const schema = yup.object().shape({
 
 Arrival.propTypes = {
   currentState: PropTypes.object,
-  previous: PropTypes.func,
   setEnrollmentState: PropTypes.func,
+  previous: PropTypes.func,
   next: PropTypes.func,
-  submit: PropTypes.func,
 };
 
 export default Arrival;

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -402,11 +402,6 @@ class Contact extends React.Component {
                 Next
               </Button>
             )}
-            {this.props.submit && (
-              <Button variant="outline-primary" size="lg" className="float-right btn-square px-5" onClick={this.props.submit}>
-                Finish
-              </Button>
-            )}
           </Card.Body>
         </Card>
       </React.Fragment>
@@ -473,10 +468,9 @@ var schema = yup.object().shape({
 
 Contact.propTypes = {
   currentState: PropTypes.object,
-  previous: PropTypes.func,
   setEnrollmentState: PropTypes.func,
+  previous: PropTypes.func,
   next: PropTypes.func,
-  submit: PropTypes.func,
 };
 
 export default Contact;

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -19,9 +19,8 @@ class Contact extends React.Component {
 
   componentDidMount() {
     if (this.state.isEditMode) {
-      // Update the Schema Validator by simulating the user changing their preferred_contact_method
-      // to what their actual preferred_contact_method really is. This is to trigger schema validation when
-      // editing.
+      // Update the Schema Validator by simulating the user changing their preferred_contact_method to what their actual preferred_contact_method really is.
+      // This is to trigger schema validation when editing.
       this.updatePrimaryContactMethodValidations({
         currentTarget: {
           id: 'preferred_contact_method',
@@ -70,7 +69,7 @@ class Contact extends React.Component {
           primary_telephone: yup
             .string()
             .phone()
-            .required('Please provide a primary telephone number, or change Preferred Reporting Method.')
+            .required('Please provide a Primary Telephone Number, or change Preferred Reporting Method.')
             .max(200, 'Max length exceeded, please limit to 200 characters.'),
           secondary_telephone: yup
             .string()
@@ -80,9 +79,9 @@ class Contact extends React.Component {
           secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
           email: yup
             .string()
-            .email('Please enter a valid email.')
+            .email('Please enter a valid Email.')
             .max(200, 'Max length exceeded, please limit to 200 characters.'),
-          confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
+          confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm Email must match.'),
           preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
         });
       } else if (event?.currentTarget.value === 'E-mailed Web Link') {
@@ -99,13 +98,13 @@ class Contact extends React.Component {
           secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
           email: yup
             .string()
-            .email('Please enter a valid email.')
-            .required('Please provide an email or change Preferred Reporting Method')
+            .email('Please enter a valid Email.')
+            .required('Please provide an Email or change Preferred Reporting Method')
             .max(200, 'Max length exceeded, please limit to 200 characters.'),
           confirm_email: yup
             .string()
-            .required('Please confirm email.')
-            .oneOf([yup.ref('email'), null], 'Confirm email must match.'),
+            .required('Please confirm Email.')
+            .oneOf([yup.ref('email'), null], 'Confirm Email must match.'),
           preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
         });
       } else {
@@ -122,9 +121,9 @@ class Contact extends React.Component {
           secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
           email: yup
             .string()
-            .email('Please enter a valid email.')
+            .email('Please enter a valid Email.')
             .max(200, 'Max length exceeded, please limit to 200 characters.'),
-          confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
+          confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm Email must match.'),
           preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
         });
       }
@@ -140,7 +139,7 @@ class Contact extends React.Component {
               return yup
                 .string()
                 .phone()
-                .required('Please provide a primary telephone number, or change Preferred Reporting Method.');
+                .required('Please provide a Primary Telephone Number, or change Preferred Reporting Method.');
             }
           }),
         secondary_telephone: yup
@@ -151,9 +150,9 @@ class Contact extends React.Component {
         secondary_telephone_type: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
         email: yup
           .string()
-          .email('Please enter a valid email.')
+          .email('Please enter a valid Email.')
           .max(200, 'Max length exceeded, please limit to 200 characters.'),
-        confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm email must match.'),
+        confirm_email: yup.string().oneOf([yup.ref('email'), null], 'Confirm Email must match.'),
         preferred_contact_method: yup.string().max(200, 'Max length exceeded, please limit to 200 characters.'),
       });
     }
@@ -449,12 +448,12 @@ var schema = yup.object().shape({
     .nullable(),
   email: yup
     .string()
-    .email('Please enter a valid email.')
+    .email('Please enter a valid Email.')
     .max(200, 'Max length exceeded, please limit to 200 characters.')
     .nullable(),
   confirm_email: yup
     .string()
-    .oneOf([yup.ref('email'), null], 'Confirm email must match.')
+    .oneOf([yup.ref('email'), null], 'Confirm Email must match.')
     .nullable(),
   preferred_contact_method: yup
     .string()

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -188,7 +188,7 @@ class Contact extends React.Component {
           <Card.Header as="h5">Monitoree Contact Information</Card.Header>
           <Card.Body>
             <Form>
-              <Form.Row className="pt-2 pb-3">
+              <Form.Row className="pb-3">
                 <Form.Group as={Col} md="8" controlId="preferred_contact_method">
                   <Form.Label className="nav-input-label">
                     PREFERRED REPORTING METHOD{schema?.fields?.preferred_contact_method?._exclusive?.required && ' *'}
@@ -231,7 +231,7 @@ class Contact extends React.Component {
                       <option>Afternoon</option>
                       <option>Evening</option>
                     </Form.Control>
-                    <Form.Row className="pt-2">
+                    <Form.Row>
                       <Form.Group as={Col} md="auto">
                         Morning:
                         <br />
@@ -253,7 +253,7 @@ class Contact extends React.Component {
                   </Form.Group>
                 )}
               </Form.Row>
-              <Form.Row className="pt-2">
+              <Form.Row>
                 <Form.Group as={Col} md="11" controlId="primary_telephone">
                   <Form.Label className="nav-input-label">PRIMARY TELEPHONE NUMBER{schema?.fields?.primary_telephone?._exclusive?.required && ' *'}</Form.Label>
                   <PhoneInput
@@ -282,7 +282,7 @@ class Contact extends React.Component {
                   </Form.Control.Feedback>
                 </Form.Group>
               </Form.Row>
-              <Form.Row className="pt-2">
+              <Form.Row>
                 <Form.Group as={Col} md="11" controlId="primary_telephone_type">
                   <Form.Label className="nav-input-label">PRIMARY PHONE TYPE{schema?.fields?.primary_telephone_type?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control
@@ -346,7 +346,7 @@ class Contact extends React.Component {
                     )}
                 </Form.Group>
               </Form.Row>
-              <Form.Row className="pt-2">
+              <Form.Row>
                 <Form.Group as={Col} md="auto">
                   Smartphone:
                   <br />
@@ -362,7 +362,7 @@ class Contact extends React.Component {
                   <span className="font-weight-light">Has telephone but cannot use SMS or web-based reporting tool</span>
                 </Form.Group>
               </Form.Row>
-              <Form.Row className="pt-3 pb-3">
+              <Form.Row className="pt-3 pb-2">
                 <Form.Group as={Col} md="8" controlId="email">
                   <Form.Label className="nav-input-label">E-MAIL ADDRESS{schema?.fields?.email?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -220,6 +220,7 @@ class Exposure extends React.Component {
               placement="bottom"
               isInvalid={!!this.state.errors['last_date_of_exposure']}
               customClass="form-control-lg"
+              isClearable
             />
             <Form.Control.Feedback className="d-block" type="invalid">
               {this.state.errors['last_date_of_exposure']}

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -18,7 +18,6 @@ class Exposure extends React.Component {
       current: { ...this.props.currentState },
       errors: {},
       modified: {},
-      isEditMode: window.location.href.includes('edit'),
       jurisdictionPath: this.props.jurisdictionPaths[this.props.currentState.patient.jurisdiction_id],
       originalJurisdictionId: this.props.currentState.patient.jurisdiction_id,
       originalAssignedUser: this.props.currentState.patient.assigned_user,
@@ -32,25 +31,23 @@ class Exposure extends React.Component {
   }
 
   componentDidMount() {
-    if (this.state.isEditMode) {
-      // Update the Schema Validator based on workflow.
-      if (this.props.patient.isolation) {
-        schema = yup.object().shape({
-          ...staticValidations,
-          symptom_onset: yup
-            .date('Date must correspond to the "mm/dd/yyyy" format.')
-            .max(
-              moment()
-                .add(30, 'days')
-                .toDate(),
-              'Date can not be more than 30 days in the future.'
-            )
-            .required('Please enter a Symptom Onset Date.')
-            .nullable(),
-        });
-      } else {
-        this.updateLDEandCEValidations(this.props.patient);
-      }
+    // Update the Schema Validator based on workflow.
+    if (this.props.patient.isolation) {
+      schema = yup.object().shape({
+        ...staticValidations,
+        symptom_onset: yup
+          .date('Date must correspond to the "mm/dd/yyyy" format.')
+          .max(
+            moment()
+              .add(30, 'days')
+              .toDate(),
+            'Date can not be more than 30 days in the future.'
+          )
+          .required('Please enter a Symptom Onset Date.')
+          .nullable(),
+      });
+    } else {
+      this.updateLDEandCEValidations(this.props.patient);
     }
   }
 

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -271,12 +271,12 @@ class Exposure extends React.Component {
           </Form.Group>
         </Form.Row>
         <Form.Row>
-          <Form.Group as={Col} md="24" controlId="exposure_notes" className="pt-2">
+          <Form.Group as={Col} md="24" controlId="exposure_notes" className="mb-2">
             <Form.Label className="nav-input-label ml-1">NOTES{schema?.fields?.exposure_notes?._exclusive?.required && ' *'}</Form.Label>
             <Form.Control
               isInvalid={this.state.errors['exposure_notes']}
               as="textarea"
-              rows="5"
+              rows="4"
               size="lg"
               className="form-square"
               placeholder="enter additional information about case"
@@ -296,7 +296,7 @@ class Exposure extends React.Component {
     return (
       <React.Fragment>
         <Form.Row>
-          <Form.Group as={Col} md="7" controlId="last_date_of_exposure">
+          <Form.Group as={Col} md="7" controlId="last_date_of_exposure" className="mb-2">
             <Form.Label className="nav-input-label">
               LAST DATE OF EXPOSURE{schema?.fields?.last_date_of_exposure?._exclusive?.required && ' *'}
               <InfoTooltip tooltipTextKey="lastDateOfExposure" location="right"></InfoTooltip>
@@ -322,7 +322,7 @@ class Exposure extends React.Component {
               {this.state.errors['last_date_of_exposure']}
             </Form.Control.Feedback>
           </Form.Group>
-          <Form.Group as={Col} md="10" controlId="potential_exposure_location">
+          <Form.Group as={Col} md="10" controlId="potential_exposure_location" className="mb-2">
             <Form.Label className="nav-input-label">EXPOSURE LOCATION{schema?.fields?.potential_exposure_location?._exclusive?.required && ' *'}</Form.Label>
             <Form.Control
               isInvalid={this.state.errors['potential_exposure_location']}
@@ -335,7 +335,7 @@ class Exposure extends React.Component {
               {this.state.errors['potential_exposure_location']}
             </Form.Control.Feedback>
           </Form.Group>
-          <Form.Group as={Col} md="7" controlId="potential_exposure_country">
+          <Form.Group as={Col} md="7" controlId="potential_exposure_country" className="mb-2">
             <Form.Label className="nav-input-label">EXPOSURE COUNTRY{schema?.fields?.potential_exposure_country?._exclusive?.required && ' *'}</Form.Label>
             <Form.Control
               isInvalid={this.state.errors['potential_exposure_country']}
@@ -370,7 +370,7 @@ class Exposure extends React.Component {
             </Form.Control.Feedback>
           </Form.Group>
         </Form.Row>
-        <Form.Label className="nav-input-label pb-2">EXPOSURE RISK FACTORS (USE COMMAS TO SEPARATE MULTIPLE SPECIFIED VALUES)</Form.Label>
+        <Form.Label className="nav-input-label pb-1">EXPOSURE RISK FACTORS (USE COMMAS TO SEPARATE MULTIPLE SPECIFIED VALUES)</Form.Label>
         <Form.Row>
           <Form.Group as={Col} md="auto" className="mb-0 my-auto pb-2">
             <Form.Check
@@ -519,12 +519,12 @@ class Exposure extends React.Component {
           </Form.Group>
         </Form.Row>
         <Form.Row>
-          <Form.Group as={Col} md="24" controlId="exposure_notes" className="pt-4">
+          <Form.Group as={Col} md="24" controlId="exposure_notes" className="pt-3 mb-2">
             <Form.Label className="nav-input-label">NOTES{schema?.fields?.exposure_notes?._exclusive?.required && ' *'}</Form.Label>
             <Form.Control
               isInvalid={this.state.errors['exposure_notes']}
               as="textarea"
-              rows="5"
+              rows="4"
               size="lg"
               className="form-square"
               placeholder="enter additional information about monitoree’s potential exposure"
@@ -548,18 +548,18 @@ class Exposure extends React.Component {
           {this.props.currentState.isolation && <Card.Header as="h5">Monitoree Case Information</Card.Header>}
           <Card.Body>
             <Form>
-              <Form.Row className="pt-2 pb-4 h-100">
+              <Form.Row className="pb-3 h-100">
                 <Form.Group as={Col} className="my-auto">
                   {!this.props.currentState.isolation && this.exposureFields()}
                   {this.props.currentState.isolation && this.isolationFields()}
                   <Form.Row className="pt-2 g-border-bottom-2" />
                   <Form.Row className="pt-2">
-                    <Form.Group as={Col}>
+                    <Form.Group as={Col} className="mb-2">
                       <Form.Label className="nav-input-label">PUBLIC HEALTH RISK ASSESSMENT AND MANAGEMENT</Form.Label>
                     </Form.Group>
                   </Form.Row>
                   <Form.Row>
-                    <Form.Group as={Col} md="18" controlId="jurisdiction_id" className="pt-2">
+                    <Form.Group as={Col} md="18" controlId="jurisdiction_id" className="mb-2 pt-2">
                       <Form.Label className="nav-input-label">ASSIGNED JURISDICTION{schema?.fields?.jurisdiction_id?._exclusive?.required && ' *'}</Form.Label>
                       <Form.Control
                         isInvalid={this.state.errors['jurisdiction_id']}
@@ -599,7 +599,7 @@ class Exposure extends React.Component {
                           </Form.Group>
                         )}
                     </Form.Group>
-                    <Form.Group as={Col} md="6" controlId="assigned_user" className="pt-2">
+                    <Form.Group as={Col} md="6" controlId="assigned_user" className="mb-2 pt-2">
                       <Form.Label className="nav-input-label">
                         ASSIGNED USER{schema?.fields?.assigned_user?._exclusive?.required && ' *'}
                         <InfoTooltip tooltipTextKey="assignedUser" location="top"></InfoTooltip>
@@ -643,7 +643,7 @@ class Exposure extends React.Component {
                           </Form.Group>
                         )}
                     </Form.Group>
-                    <Form.Group as={Col} md="8" controlId="exposure_risk_assessment" className="pt-2">
+                    <Form.Group as={Col} md="8" controlId="exposure_risk_assessment" className="mb-2 pt-2">
                       <Form.Label className="nav-input-label">
                         RISK ASSESSMENT{schema?.fields?.exposure_risk_assessment?._exclusive?.required && ' *'}
                       </Form.Label>
@@ -664,7 +664,7 @@ class Exposure extends React.Component {
                         {this.state.errors['exposure_risk_assessment']}
                       </Form.Control.Feedback>
                     </Form.Group>
-                    <Form.Group as={Col} md="16" controlId="monitoring_plan" className="pt-2">
+                    <Form.Group as={Col} md="16" controlId="monitoring_plan" className="mb-2 pt-2">
                       <Form.Label className="nav-input-label">MONITORING PLAN{schema?.fields?.monitoring_plan?._exclusive?.required && ' *'}</Form.Label>
                       <Form.Control
                         isInvalid={this.state.errors['monitoring_plan']}

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -230,11 +230,7 @@ class Exposure extends React.Component {
               customClass="form-control-lg"
               isClearable
               disabled={this.state.current.patient.continuous_exposure}
-              tooltipText={
-                this.state.current.patient.continuous_exposure
-                  ? 'Last Date of Exposure cannot be populated when Continuous Exposure is turned ON. Please turn OFF Continuous Exposure if the Last Date of Exposure is to be populated.'
-                  : null
-              }
+              tooltipText={this.state.current.patient.continuous_exposure ? 'Please turn OFF Continuous Exposure to populate the Last Date of Exposure.' : null}
               tooltipKey="tooltip-lde"
               tooltipPlacement="top"
             />

--- a/app/javascript/components/enrollment/steps/Identification.js
+++ b/app/javascript/components/enrollment/steps/Identification.js
@@ -202,7 +202,7 @@ class Identification extends React.Component {
           <Card.Header as="h5">Monitoree Identification</Card.Header>
           <Card.Body>
             <Form>
-              <Form.Row className="pt-2">
+              <Form.Row>
                 <Form.Group as={Col} controlId="workflow">
                   <Form.Label className="nav-input-label">WORKFLOW *</Form.Label>
                   <Select
@@ -219,7 +219,7 @@ class Identification extends React.Component {
                   />
                 </Form.Group>
               </Form.Row>
-              <Form.Row className="pt-2">
+              <Form.Row>
                 <Form.Group as={Col} controlId="first_name">
                   <Form.Label className="nav-input-label">FIRST NAME{schema?.fields?.first_name?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control
@@ -260,7 +260,7 @@ class Identification extends React.Component {
                   </Form.Control.Feedback>
                 </Form.Group>
               </Form.Row>
-              <Form.Row className="pt-2">
+              <Form.Row>
                 <Form.Group as={Col} md="auto" controlId="date_of_birth">
                   <Form.Label className="nav-input-label">DATE OF BIRTH{schema?.fields?.date_of_birth?._exclusive?.required && ' *'}</Form.Label>
                   <DateInput
@@ -404,7 +404,7 @@ class Identification extends React.Component {
               <Form.Row className="pt-3 ml-0">
                 <div className="nav-input-label">LANGUAGE</div>
               </Form.Row>
-              <Form.Row className="pb-3 pt-1 ml-0">Languages that are not fully supported are indicated by a (*) in the below list.</Form.Row>
+              <Form.Row className="pb-3 ml-0">Languages that are not fully supported are indicated by a (*) in the below list.</Form.Row>
               <Form.Row>
                 <Form.Group as={Col} controlId="primary_language" id="primary_language_wrapper">
                   <Form.Label className="nav-input-label">
@@ -468,7 +468,7 @@ class Identification extends React.Component {
                   />
                 </Form.Group>
               </Form.Row>
-              <Form.Row className="pt-2">
+              <Form.Row>
                 <Form.Group as={Col} md={12} controlId="nationality">
                   <Form.Label className="nav-input-label">NATIONALITY{schema?.fields?.nationality?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control
@@ -483,7 +483,7 @@ class Identification extends React.Component {
                   </Form.Control.Feedback>
                 </Form.Group>
               </Form.Row>
-              <Form.Row className="pt-2">
+              <Form.Row className="pb-2">
                 <Form.Group as={Col} md={8} controlId="user_defined_id_statelocal">
                   <Form.Label className="nav-input-label">STATE/LOCAL ID{schema?.fields?.user_defined_id_statelocal?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control

--- a/app/javascript/components/enrollment/steps/Identification.js
+++ b/app/javascript/components/enrollment/steps/Identification.js
@@ -527,19 +527,9 @@ class Identification extends React.Component {
                 </Form.Group>
               </Form.Row>
             </Form>
-            {this.props.previous && (
-              <Button variant="outline-primary" size="lg" className="btn-square px-5" onClick={this.props.previous}>
-                Previous
-              </Button>
-            )}
             {this.props.next && (
               <Button variant="outline-primary" size="lg" className="float-right btn-square px-5" onClick={() => this.validate(this.props.next)}>
                 Next
-              </Button>
-            )}
-            {this.props.submit && (
-              <Button variant="outline-primary" size="lg" className="float-right btn-square px-5" onClick={this.props.submit}>
-                Finish
               </Button>
             )}
           </Card.Body>
@@ -604,9 +594,7 @@ const schema = yup.object().shape({
 
 Identification.propTypes = {
   currentState: PropTypes.object,
-  previous: PropTypes.func,
   next: PropTypes.func,
-  submit: PropTypes.func,
 };
 
 export default Identification;

--- a/app/javascript/components/enrollment/steps/Identification.js
+++ b/app/javascript/components/enrollment/steps/Identification.js
@@ -556,7 +556,7 @@ const schema = yup.object().shape({
     .nullable(),
   date_of_birth: yup
     .date('Date must correspond to the "mm/dd/yyyy" format.')
-    .required('Please enter a date of birth.')
+    .required('Please enter a Date of Birth.')
     .max(new Date(), 'Date can not be in the future.')
     .nullable(),
   age: yup.number().nullable(),

--- a/app/javascript/components/enrollment/steps/Review.js
+++ b/app/javascript/components/enrollment/steps/Review.js
@@ -112,9 +112,8 @@ class Review extends React.Component {
 
 Review.propTypes = {
   currentState: PropTypes.object,
-  goto: PropTypes.func,
   previous: PropTypes.func,
-  next: PropTypes.func,
+  goto: PropTypes.func,
   submit: PropTypes.func,
   parent_id: PropTypes.string,
   canAddGroup: PropTypes.bool,

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -24,46 +24,12 @@ class LastDateExposure extends React.Component {
       showContinuousExposureModal: false,
     };
     this.origState = Object.assign({}, this.state);
-    this.submit = this.submit.bind(this);
     this.handleChange = this.handleChange.bind(this);
-    this.openLastDateOfExposureModal = this.openLastDateOfExposureModal.bind(this);
+    this.submit = this.submit.bind(this);
     this.openContinuousExposureModal = this.openContinuousExposureModal.bind(this);
-    this.createModal = this.createModal.bind(this);
+    this.openLastDateOfExposureModal = this.openLastDateOfExposureModal.bind(this);
     this.closeModal = this.closeModal.bind(this);
-    this.createCEToggle = this.createCEToggle.bind(this);
-  }
-
-  openContinuousExposureModal() {
-    this.setState({
-      showContinuousExposureModal: true,
-      last_date_of_exposure: null,
-      continuous_exposure: !this.props.patient.continuous_exposure,
-      apply_to_group: false,
-      apply_to_group_cm_only: false,
-    });
-  }
-
-  openLastDateOfExposureModal(date) {
-    if (date && date !== this.props.patient.last_date_of_exposure) {
-      this.setState({
-        showLastDateOfExposureModal: true,
-        last_date_of_exposure: date,
-        continuous_exposure: false,
-        apply_to_group: false,
-        apply_to_group_cm_only: false,
-      });
-    }
-  }
-
-  closeModal() {
-    this.setState({
-      last_date_of_exposure: this.props.patient.last_date_of_exposure,
-      continuous_exposure: !!this.props.patient.continuous_exposure,
-      showLastDateOfExposureModal: false,
-      showContinuousExposureModal: false,
-      apply_to_group: false,
-      apply_to_group_cm_only: false,
-    });
+    this.createModal = this.createModal.bind(this);
   }
 
   handleChange(event) {
@@ -99,6 +65,39 @@ class LastDateExposure extends React.Component {
         .catch(error => {
           reportError(error);
         });
+    });
+  }
+
+  openContinuousExposureModal() {
+    this.setState({
+      showContinuousExposureModal: true,
+      last_date_of_exposure: null,
+      continuous_exposure: !this.props.patient.continuous_exposure,
+      apply_to_group: false,
+      apply_to_group_cm_only: false,
+    });
+  }
+
+  openLastDateOfExposureModal(date) {
+    if (date && date !== this.props.patient.last_date_of_exposure) {
+      this.setState({
+        showLastDateOfExposureModal: true,
+        last_date_of_exposure: date,
+        continuous_exposure: false,
+        apply_to_group: false,
+        apply_to_group_cm_only: false,
+      });
+    }
+  }
+
+  closeModal() {
+    this.setState({
+      last_date_of_exposure: this.props.patient.last_date_of_exposure,
+      continuous_exposure: !!this.props.patient.continuous_exposure,
+      showLastDateOfExposureModal: false,
+      showContinuousExposureModal: false,
+      apply_to_group: false,
+      apply_to_group_cm_only: false,
     });
   }
 
@@ -180,19 +179,6 @@ class LastDateExposure extends React.Component {
     );
   }
 
-  createCEToggle() {
-    return (
-      <Form.Check
-        size="lg"
-        label="CONTINUOUS EXPOSURE"
-        id="continuous_exposure"
-        disabled={!this.props.patient.monitoring}
-        checked={this.state.continuous_exposure}
-        onChange={() => this.openContinuousExposureModal()}
-      />
-    );
-  }
-
   render() {
     return (
       <React.Fragment>
@@ -208,7 +194,7 @@ class LastDateExposure extends React.Component {
           this.createModal(
             'Continuous Exposure',
             `Are you sure you want to turn ${this.state.continuous_exposure ? 'ON' : 'OFF'} Continuous Exposure? The Last Date of Exposure will ${
-              this.state.continuous_exposure ? 'be turned OFF' : 'need to be populated'
+              this.state.continuous_exposure ? 'be cleared' : 'need to be populated'
             } and Continuous Exposure will be turned ${this.state.continuous_exposure ? 'ON' : 'OFF'} for the selected record${
               this.props.has_group_members ? '(s):' : '.'
             }`,
@@ -244,20 +230,26 @@ class LastDateExposure extends React.Component {
             </Row>
             <Row className="pt-2">
               <Col>
-                {!this.props.patient.monitoring && (
-                  <OverlayTrigger
-                    key="tooltip-ot-ce"
-                    placement="left"
-                    overlay={
-                      <Tooltip id="tooltip-ce">
-                        Continuous Exposure cannot be turned on or off for records on the Closed line list. If this monitoree requires monitoring due to a
-                        Continuous Exposure, you may update this field after changing Monitoring Status to &quot;Actively Monitoring&quot;
-                      </Tooltip>
-                    }>
-                    <span className="d-inline-block">{this.createCEToggle()}</span>
-                  </OverlayTrigger>
-                )}
-                {this.props.patient.monitoring && <span className="d-inline-block">{this.createCEToggle()}</span>}
+                <OverlayTrigger
+                  key="tooltip-ot-ce"
+                  placement="left"
+                  overlay={
+                    <Tooltip id="tooltip-ce" style={this.props.patient.monitoring ? { display: 'none' } : {}}>
+                      Continuous Exposure cannot be turned on or off for records on the Closed line list. If this monitoree requires monitoring due to a
+                      Continuous Exposure, you may update this field after changing Monitoring Status to &quot;Actively Monitoring&quot;
+                    </Tooltip>
+                  }>
+                  <span className="d-inline-block">
+                    <Form.Check
+                      size="lg"
+                      label="CONTINUOUS EXPOSURE"
+                      id="continuous_exposure"
+                      disabled={!this.props.patient.monitoring}
+                      checked={this.state.continuous_exposure}
+                      onChange={() => this.openContinuousExposureModal()}
+                    />
+                  </span>
+                </OverlayTrigger>
                 <InfoTooltip tooltipTextKey="continuousExposure" location="right"></InfoTooltip>
               </Col>
             </Row>

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -156,6 +156,7 @@ class LastDateExposure extends React.Component {
                   .format('YYYY-MM-DD')}
                 onChange={date => this.setState({ last_date_of_exposure: date })}
                 placement="top"
+                customClass="form-control-lg"
               />
             </div>
           )}

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -130,7 +130,7 @@ class LastDateExposure extends React.Component {
                   update_continuous_exposure ? 'that are not on the closed line list' : ''
                 } where Continuous Exposure is turned ON`}
                 onChange={this.handleChange}
-                checked={this.state.apply_to_group_cm_only === true}
+                checked={this.state.apply_to_group_cm_only}
               />
             </Form.Group>
           )}
@@ -141,7 +141,7 @@ class LastDateExposure extends React.Component {
                 id="apply_to_group"
                 label={`This monitoree and all household members ${update_continuous_exposure ? 'that are not on the closed line list' : ''}`}
                 onChange={this.handleChange}
-                checked={this.state.apply_to_group === true}
+                checked={this.state.apply_to_group}
               />
             </Form.Group>
           )}

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -186,8 +186,11 @@ class LastDateExposure extends React.Component {
         {this.state.showLastDateOfExposureModal &&
           this.createModal(
             'Last Date of Exposure',
-            `Are you sure you want to modify the Last Date of Exposure to ${this.state.last_date_of_exposure}? The Last Date of Exposure will be updated and
-          Continuous Exposure will be turned OFF for the selected record${this.props.has_group_members ? '(s):' : '.'}`,
+            `Are you sure you want to modify the Last Date of Exposure to ${moment(this.state.last_date_of_exposure).format(
+              'MM/DD/YYYY'
+            )}? The Last Date of Exposure will be updated and Continuous Exposure will be turned OFF for the selected record${
+              this.props.has_group_members ? '(s):' : '.'
+            }`,
             this.closeModal,
             this.submit
           )}

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -238,6 +238,7 @@ class LastDateExposure extends React.Component {
                   onChange={this.openLastDateOfExposureModal}
                   placement="top"
                   customClass="form-control-lg"
+                  isClearable
                 />
               </Col>
             </Row>

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -110,19 +110,6 @@ class LastDateExposure extends React.Component {
         </Modal.Header>
         <Modal.Body>
           <p>{message}</p>
-          {!!this.props.patient.continuous_exposure && !this.state.continuous_exposure && (
-            <div className="mb-3">
-              <DateInput
-                id="last_date_of_exposure"
-                date={this.state.last_date_of_exposure}
-                maxDate={moment()
-                  .add(30, 'days')
-                  .format('YYYY-MM-DD')}
-                onChange={date => this.setState({ last_date_of_exposure: date })}
-                placement="top"
-              />
-            </div>
-          )}
           {this.props.has_group_members && (
             <Form.Group className="mb-2 px-4">
               <Form.Check
@@ -157,6 +144,20 @@ class LastDateExposure extends React.Component {
                 checked={this.state.apply_to_group === true}
               />
             </Form.Group>
+          )}
+          {!!this.props.patient.continuous_exposure && !this.state.continuous_exposure && (
+            <div className="mt-2">
+              <Form.Label className="nav-input-label">Update Last Date of Exposure to:</Form.Label>
+              <DateInput
+                id="last_date_of_exposure"
+                date={this.state.last_date_of_exposure}
+                maxDate={moment()
+                  .add(30, 'days')
+                  .format('YYYY-MM-DD')}
+                onChange={date => this.setState({ last_date_of_exposure: date })}
+                placement="top"
+              />
+            </div>
           )}
         </Modal.Body>
         <Modal.Footer>

--- a/app/javascript/components/util/DateInput.js
+++ b/app/javascript/components/util/DateInput.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import DatePicker from 'react-datepicker';
 import MaskedInput from 'react-text-mask';
 import moment from 'moment';
@@ -42,35 +43,46 @@ class DateInput extends React.Component {
               : 'date-input__calendar_icon_lg'
           }`}></i>
         {this.props.isClearable && this.props.date && (
-          <button className={`close ${this.props.isInvalid ? 'date-input__clear-btn-invalid' : 'date-input__clear-btn'}`} onClick={this.clearDate}>
+          <button
+            className={`close ${this.props.isInvalid ? 'date-input__clear-btn-invalid' : 'date-input__clear-btn'}`}
+            onClick={this.clearDate}
+            disabled={this.props.disabled}>
             <i className="fas fa-times"></i>
           </button>
         )}
-        <DatePicker
-          id={this.props.id}
-          selected={this.props.date && moment(this.props.date, 'YYYY-MM-DD').toDate()}
-          minDate={this.props.minDate && moment(this.props.minDate, 'YYYY-MM-DD').toDate()}
-          maxDate={this.props.maxDate && moment(this.props.maxDate, 'YYYY-MM-DD').toDate()}
-          onChange={this.handleDateChange}
-          popperPlacement={this.props.placement || 'auto'}
-          placeholderText="mm/dd/yyyy"
-          ref={this.datePickerRef}
-          onChangeRaw={this.handleRawChange}
-          className={this.props.customClass}
-          customInput={
-            <MaskedInput
-              mask={[/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]}
-              keepCharPositions
-              className={`${
-                this.props.customClass?.includes('sm')
-                  ? 'date-input__input_sm'
-                  : this.props.customClass?.includes('md')
-                  ? 'date-input__input_md'
-                  : 'date-input__input_lg'
-              } react-datepicker-ignore-onclickoutside form-control ${this.props.customClass} ${this.props.isInvalid ? ' is-invalid' : ''}`}
+        <OverlayTrigger
+          key={this.props.tooltipKey || ''}
+          placement={this.props.tooltipPlacement || 'auto'}
+          overlay={<Tooltip style={this.props.tooltipText ? {} : { display: 'none' }}>{this.props.tooltipText}</Tooltip>}>
+          <div>
+            <DatePicker
+              id={this.props.id}
+              selected={this.props.date && moment(this.props.date, 'YYYY-MM-DD').toDate()}
+              minDate={this.props.minDate && moment(this.props.minDate, 'YYYY-MM-DD').toDate()}
+              maxDate={this.props.maxDate && moment(this.props.maxDate, 'YYYY-MM-DD').toDate()}
+              onChange={this.handleDateChange}
+              popperPlacement={this.props.placement || 'auto'}
+              placeholderText="mm/dd/yyyy"
+              ref={this.datePickerRef}
+              onChangeRaw={this.handleRawChange}
+              className={this.props.customClass}
+              customInput={
+                <MaskedInput
+                  mask={[/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]}
+                  keepCharPositions
+                  className={`${
+                    this.props.customClass?.includes('sm')
+                      ? 'date-input__input_sm'
+                      : this.props.customClass?.includes('md')
+                      ? 'date-input__input_md'
+                      : 'date-input__input_lg'
+                  } react-datepicker-ignore-onclickoutside form-control ${this.props.customClass} ${this.props.isInvalid ? ' is-invalid' : ''}`}
+               />
+              }
+              disabled={this.props.disabled}
             />
-          }
-        />
+          </div>
+        </OverlayTrigger>
       </div>
     );
   }
@@ -98,6 +110,10 @@ DateInput.propTypes = {
   isInvalid: PropTypes.bool,
   isClearable: PropTypes.bool,
   customClass: PropTypes.string,
+  disabled: PropTypes.bool,
+  tooltipText: PropTypes.string,
+  tooltipKey: PropTypes.string,
+  tooltipPlacement: PropTypes.oneOf(['top', 'bottom', 'left', 'right', 'auto']),
 };
 
 export default DateInput;

--- a/test/system/roles/enroller/enrollment/form_validator.rb
+++ b/test/system/roles/enroller/enrollment/form_validator.rb
@@ -23,11 +23,11 @@ class EnrollmentFormValidator < ApplicationSystemTestCase
     @@system_test_utils.go_to_next_page
     verify_text_displayed('Please enter a First Name')
     verify_text_displayed('Please enter a Last Name')
-    verify_text_displayed('Please enter a date of birth')
+    verify_text_displayed('Please enter a Date of Birth')
     @@enrollment_form.populate_enrollment_step(:identification, identification)
     verify_text_not_displayed('Please enter a First Name')
     verify_text_not_displayed('Please enter a Last Name')
-    verify_text_not_displayed('Please enter a date of birth')
+    verify_text_not_displayed('Please enter a Date of Birth')
   end
 
   def verify_input_validation_for_address(address)
@@ -56,54 +56,51 @@ class EnrollmentFormValidator < ApplicationSystemTestCase
   def verify_input_validation_for_contact_info(contact_info)
     select 'Telephone call', from: 'preferred_contact_method'
     click_on 'Next'
-    verify_text_not_displayed('Please provide an email or change Preferred Reporting Method')
-    verify_text_not_displayed('Please confirm email')
-    verify_text_displayed('Please provide a primary telephone number, or change Preferred Reporting Method.')
+    verify_text_not_displayed('Please provide an Email or change Preferred Reporting Method')
+    verify_text_not_displayed('Please confirm Email')
+    verify_text_displayed('Please provide a Primary Telephone Number, or change Preferred Reporting Method.')
     select 'SMS Text-message', from: 'preferred_contact_method'
     click_on 'Next'
-    verify_text_not_displayed('Please provide an email or change Preferred Reporting Method')
-    verify_text_not_displayed('Please confirm email')
-    verify_text_displayed('Please provide a primary telephone number, or change Preferred Reporting Method.')
+    verify_text_not_displayed('Please provide an Email or change Preferred Reporting Method')
+    verify_text_not_displayed('Please confirm Email')
+    verify_text_displayed('Please provide a Primary Telephone Number, or change Preferred Reporting Method.')
     select 'E-mailed Web Link', from: 'preferred_contact_method'
     click_on 'Next'
-    verify_text_displayed('Please provide an email or change Preferred Reporting Method')
-    verify_text_displayed('Please confirm email')
-    verify_text_not_displayed('Please provide a primary telephone number, or change Preferred Reporting Method.')
+    verify_text_displayed('Please provide an Email or change Preferred Reporting Method')
+    verify_text_displayed('Please confirm Email')
+    verify_text_not_displayed('Please provide a Primary Telephone Number, or change Preferred Reporting Method.')
     fill_in 'email', with: 'email@eample.com'
     click_on 'Next'
-    verify_text_not_displayed('Please provide an email or change Preferred Reporting Method')
-    verify_text_displayed('Please confirm email')
-    verify_text_not_displayed('Please provide a primary telephone number, or change Preferred Reporting Method.')
+    verify_text_not_displayed('Please provide an Email or change Preferred Reporting Method')
+    verify_text_displayed('Please confirm Email')
+    verify_text_not_displayed('Please provide a Primary Telephone Number, or change Preferred Reporting Method.')
     @@enrollment_form.populate_enrollment_step(:contact_info, contact_info)
-    verify_text_not_displayed('Please provide an email or change Preferred Reporting Method')
-    verify_text_not_displayed('Please confirm email')
-    verify_text_not_displayed('Please provide a primary telephone number, or change Preferred Reporting Method.')
+    verify_text_not_displayed('Please provide an Email or change Preferred Reporting Method')
+    verify_text_not_displayed('Please confirm Email')
+    verify_text_not_displayed('Please provide a Primary Telephone Number, or change Preferred Reporting Method.')
   end
 
   def verify_input_validation_for_arrival_info(arrival_info)
     @@enrollment_form.populate_enrollment_step(:arrival_info, arrival_info)
-    verify_text_not_displayed('Please enter a valid date of departure')
   end
 
   def verify_input_validation_for_additional_planned_travel(additional_planned_travel)
     @@enrollment_form.populate_enrollment_step(:additional_planned_travel, additional_planned_travel)
-    verify_text_not_displayed('Please enter a valid start date')
-    verify_text_not_displayed('Please enter a valid end date')
   end
 
   def verify_input_validation_for_potential_exposure_info(potential_exposure_info)
     @@system_test_utils.go_to_next_page
-    verify_text_displayed('Please enter a last date of exposure')
+    verify_text_displayed('Please enter a Last Date of Exposure')
     fill_in 'last_date_of_exposure', with: rand(30).days.ago.strftime('%m/%d/%Y')
     fill_in 'jurisdiction_id', with: ''
     click_on 'Next'
-    verify_text_displayed('Please enter a valid jurisdiction')
+    verify_text_displayed('Please enter a valid Assigned Jurisdiction')
     fill_in 'jurisdiction_id', with: 'fake jurisdiction'
     click_on 'Next'
-    verify_text_displayed('Please enter a valid jurisdiction')
+    verify_text_displayed('Please enter a valid Assigned Jurisdiction')
     fill_in 'jurisdiction_id', with: 'USA'
     click_on 'Next'
-    verify_text_displayed('Please enter a valid jurisdiction')
+    verify_text_displayed('Please enter a valid Assigned Jurisdiction')
     fill_in 'jurisdiction_id', with: 'USA, State 1, County 1'
     fill_in 'assigned_user', with: '-8.5'
     assert_not_equal('-8.5', page.find_field('assignedUser').value)
@@ -114,7 +111,7 @@ class EnrollmentFormValidator < ApplicationSystemTestCase
     fill_in 'assigned_user', with: 'W(#*&R#(W&'
     assert_not_equal('W(#*&R#(W&', page.find_field('assignedUser').value)
     @@enrollment_form.populate_enrollment_step(:potential_exposure_info, potential_exposure_info)
-    verify_text_not_displayed('Please enter a last date of exposure')
+    verify_text_not_displayed('Please enter a Last Date of Exposure')
   end
 
   def verify_text_displayed(text)

--- a/test/system/roles/enroller/enrollment/form_validator.rb
+++ b/test/system/roles/enroller/enrollment/form_validator.rb
@@ -90,7 +90,7 @@ class EnrollmentFormValidator < ApplicationSystemTestCase
 
   def verify_input_validation_for_potential_exposure_info(potential_exposure_info)
     @@system_test_utils.go_to_next_page
-    verify_text_displayed('Please enter a Last Date of Exposure')
+    verify_text_displayed('Please enter a Last Date of Exposure OR turn on Continuous Exposure')
     fill_in 'last_date_of_exposure', with: rand(30).days.ago.strftime('%m/%d/%Y')
     fill_in 'jurisdiction_id', with: ''
     click_on 'Next'
@@ -111,7 +111,7 @@ class EnrollmentFormValidator < ApplicationSystemTestCase
     fill_in 'assigned_user', with: 'W(#*&R#(W&'
     assert_not_equal('W(#*&R#(W&', page.find_field('assignedUser').value)
     @@enrollment_form.populate_enrollment_step(:potential_exposure_info, potential_exposure_info)
-    verify_text_not_displayed('Please enter a Last Date of Exposure')
+    verify_text_not_displayed('Please enter a Last Date of Exposure OR turn on Continuous Exposure')
   end
 
   def verify_text_displayed(text)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-835](https://tracker.codev.mitre.org/browse/SARAALERT-835)

Essentially, we want to make sure that a given monitoree must have a valid LDE OR continuous exposure turned on. 

- Allow a monitoree to be enrolled into exposure workflow without having to add an LDE ONLY IF they select continuous exposure.
- When continuous exposure is turned off for a monitoree, they should be prompted to enter an LDE. It should NOT be possible for a monitoree to have both no LDE and continuous exposure turned off.
- When continuous exposure is turned on, the user should be prompted and the LDE should be cleared out. If a monitoree has continuous exposure turned on, there should not also be a LDE. 

# (Feature) Demo/Screenshots

![Screen Shot 2020-10-06 at 6 34 41 PM](https://user-images.githubusercontent.com/9956561/95267185-a66c3c00-0802-11eb-8df3-a55d0089a287.png)
![Screen Shot 2020-10-06 at 12 14 12 PM](https://user-images.githubusercontent.com/9956561/95228557-7d7d8400-07cd-11eb-80cc-532538fae6fb.png)
![Screen Shot 2020-10-05 at 6 24 17 PM](https://user-images.githubusercontent.com/9956561/95138832-2e860f00-0739-11eb-8837-b75c596dc278.png)
![Screen Shot 2020-10-06 at 12 13 44 PM](https://user-images.githubusercontent.com/9956561/95228572-82dace80-07cd-11eb-987a-540f6a044d04.png)
![Screen Shot 2020-10-07 at 11 25 59 AM](https://user-images.githubusercontent.com/9956561/95353453-483a6a00-0891-11eb-9fa6-a94ba5cbd4af.png)

# Important Changes

`LastDateExposure.js`
- updated modal messages depending on LDE and CE state
- added date input prompt for when CE is toggle off
- refactored yup schema validations to be dynamic based on LDE/CE values

`Exposure.js`
- updated LDE/CE validation so that only one or the other may be populated
- checking CE will clear LDE and unchecking CE will repopulate LDE with previous enrollment state
- LDE is disabled when CE is checked and added tooltip message to explain to user why
- added CE info tooltip

`Enrollment.js`
- cleaned up individual enrollment step component props

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11
