### PR TITLE
Add HoH designation to the monitoree column of the line list

### DIFF
--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -246,21 +246,22 @@ class PublicHealthController < ApplicationController
   end
 
   def linelist_specific_fields(workflow, tab)
-    return %i[jurisdiction assigned_user expected_purge_date reason_for_closure closed_at is_hoh] if tab == :closed
+    return %i[jurisdiction assigned_user expected_purge_date reason_for_closure closed_at] if tab == :closed
 
     if workflow == :isolation
-      return %i[jurisdiction assigned_user extended_isolation symptom_onset monitoring_plan latest_report status report_eligibility is_hoh] if tab == :all
+      return %i[jurisdiction assigned_user extended_isolation symptom_onset monitoring_plan latest_report status report_eligibility] if tab == :all
       return %i[transferred_from monitoring_plan transferred_at] if tab == :transferred_in
       return %i[transferred_to monitoring_plan transferred_at] if tab == :transferred_out
-      return %i[jurisdiction assigned_user extended_isolation symptom_onset monitoring_plan latest_report report_eligibility is_hoh]
+
+      return %i[jurisdiction assigned_user extended_isolation symptom_onset monitoring_plan latest_report report_eligibility]
     end
 
-    return %i[jurisdiction assigned_user end_of_monitoring risk_level monitoring_plan latest_report status report_eligibility is_hoh] if tab == :all
-    return %i[jurisdiction assigned_user end_of_monitoring risk_level public_health_action latest_report report_eligibility is_hoh] if tab == :pui
+    return %i[jurisdiction assigned_user end_of_monitoring risk_level monitoring_plan latest_report status report_eligibility] if tab == :all
+    return %i[jurisdiction assigned_user end_of_monitoring risk_level public_health_action latest_report report_eligibility] if tab == :pui
     return %i[transferred_from end_of_monitoring risk_level monitoring_plan transferred_at] if tab == :transferred_in
     return %i[transferred_to end_of_monitoring risk_level monitoring_plan transferred_at] if tab == :transferred_out
 
-    %i[jurisdiction assigned_user end_of_monitoring risk_level monitoring_plan latest_report report_eligibility is_hoh]
+    %i[jurisdiction assigned_user end_of_monitoring risk_level monitoring_plan latest_report report_eligibility]
   end
 
   private

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -237,6 +237,7 @@ class PublicHealthController < ApplicationController
       details[:latest_report] = patient[:latest_assessment_at]&.rfc2822 || '' if fields.include?(:latest_report)
       details[:status] = patient.status.to_s.gsub('_', ' ').gsub('exposure ', '')&.gsub('isolation ', '') if fields.include?(:status)
       details[:report_eligibility] = patient.report_eligibility if fields.include?(:report_eligibility)
+      details[:is_hoh] = patient.dependents_exclude_self.exists?
 
       linelist << details
     end
@@ -245,22 +246,21 @@ class PublicHealthController < ApplicationController
   end
 
   def linelist_specific_fields(workflow, tab)
-    return %i[jurisdiction assigned_user expected_purge_date reason_for_closure closed_at] if tab == :closed
+    return %i[jurisdiction assigned_user expected_purge_date reason_for_closure closed_at is_hoh] if tab == :closed
 
     if workflow == :isolation
-      return %i[jurisdiction assigned_user extended_isolation symptom_onset monitoring_plan latest_report status report_eligibility] if tab == :all
+      return %i[jurisdiction assigned_user extended_isolation symptom_onset monitoring_plan latest_report status report_eligibility is_hoh] if tab == :all
       return %i[transferred_from monitoring_plan transferred_at] if tab == :transferred_in
       return %i[transferred_to monitoring_plan transferred_at] if tab == :transferred_out
-
-      return %i[jurisdiction assigned_user extended_isolation symptom_onset monitoring_plan latest_report report_eligibility]
+      return %i[jurisdiction assigned_user extended_isolation symptom_onset monitoring_plan latest_report report_eligibility is_hoh]
     end
 
-    return %i[jurisdiction assigned_user end_of_monitoring risk_level monitoring_plan latest_report status report_eligibility] if tab == :all
-    return %i[jurisdiction assigned_user end_of_monitoring risk_level public_health_action latest_report report_eligibility] if tab == :pui
+    return %i[jurisdiction assigned_user end_of_monitoring risk_level monitoring_plan latest_report status report_eligibility is_hoh] if tab == :all
+    return %i[jurisdiction assigned_user end_of_monitoring risk_level public_health_action latest_report report_eligibility is_hoh] if tab == :pui
     return %i[transferred_from end_of_monitoring risk_level monitoring_plan transferred_at] if tab == :transferred_in
     return %i[transferred_to end_of_monitoring risk_level monitoring_plan transferred_at] if tab == :transferred_out
 
-    %i[jurisdiction assigned_user end_of_monitoring risk_level monitoring_plan latest_report report_eligibility]
+    %i[jurisdiction assigned_user end_of_monitoring risk_level monitoring_plan latest_report report_eligibility is_hoh]
   end
 
   private

--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -159,8 +159,8 @@ class CustomTable extends React.Component {
                       value = col.options[data[col.field]];
                     } else if (col.filter) {
                       // If this column has a filter, apply the filter to the value
-                      // Send along string of the ID if needed
-                      value = col.filter(data[col.field], data.id.toString());
+                      // Send along string of the ID and HoH bool if needed
+                      value = col.filter(data[col.field], data.id.toString(), data.is_hoh);
                     }
                     return <td key={index}>{value}</td>;
                   })}

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -302,8 +302,8 @@ class PatientsTable extends React.Component {
     if (isHoH) {
       return (
         <div>
+          <i className="fa-fw fas fa-h-square hoh-icon"></i>
           <a href={`/patients/${id}`}>{name}</a>
-          <i className="fa-fw fas fa-h-square pl-1"></i>
         </div>
       );
     }

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -301,10 +301,10 @@ class PatientsTable extends React.Component {
     }
     if (isHoH) {
       return (
-        <React.Fragment>
+        <div>
           <a href={`/patients/${id}`}>{name}</a>
           <i className="fa-fw fas fa-h-square pl-1"></i>
-        </React.Fragment>
+        </div>
       );
     }
     return <a href={`/patients/${id}`}>{name}</a>;

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -295,9 +295,17 @@ class PatientsTable extends React.Component {
     }
   }
 
-  linkPatient = (name, id) => {
+  linkPatient = (name, id, isHoH) => {
     if (this.state.query.tab === 'transferred_out') {
       return name;
+    }
+    if (isHoH) {
+      return (
+        <React.Fragment>
+          <a href={`/patients/${id}`}>{name}</a>
+          <i className="fa-fw fas fa-h-square pl-1"></i>
+        </React.Fragment>
+      );
     }
     return <a href={`/patients/${id}`}>{name}</a>;
   };

--- a/app/javascript/packs/stylesheets/datatables.scss
+++ b/app/javascript/packs/stylesheets/datatables.scss
@@ -123,3 +123,8 @@ button.dt-button:hover {
 div.dataTables_wrapper div.dataTables_info {
 	margin-bottom: 8px !important;
 }
+
+.hoh-icon {
+  float: right;
+  vertical-align: top;
+}


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-732](https://tracker.codev.mitre.org/browse/SARAALERT-732)
Add designation for HoH on the monitoree linelists - use H icon in the name column

# (Feature) Demo/Screenshots
![Screen Shot 2020-10-06 at 4 53 52 PM](https://user-images.githubusercontent.com/35042815/95259506-4a4eeb00-07f5-11eb-9e58-a0fec907505b.png)

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`public_health_controller.rb`
- Added is_hoh bool to the linelist fields, which is used to hide/show HoH icon

`CustomTable.js`
- Pass in additional HoH bool to the col filter method

`PatientsTable.js`
- Updated linkPatient method to add H icon for HoH

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [x] Firefox
* [x] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
