### PR TITLE
Updates to the Head of Household Icon

### DIFF
--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -16,6 +16,7 @@ import {
   TabContent,
   Tooltip,
 } from 'react-bootstrap';
+import ReactTooltip from 'react-tooltip';
 import axios from 'axios';
 import moment from 'moment-timezone';
 
@@ -302,7 +303,14 @@ class PatientsTable extends React.Component {
     if (isHoH) {
       return (
         <div>
-          <i className="fa-fw fas fa-h-square hoh-icon"></i>
+          <span data-for={`${id}-hoh`} data-tip="" className="badge-hoh ml-1">
+            <Badge variant="dark">
+              <span>HoH</span>
+            </Badge>
+          </span>
+          <ReactTooltip id={`${id}-hoh`} multiline={true} place="right" type="dark" effect="solid" className="tooltip-container">
+            <span>Monitoree is Head of Household that reports on behalf of household members</span>
+          </ReactTooltip>
           <a href={`/patients/${id}`}>{name}</a>
         </div>
       );

--- a/app/javascript/packs/stylesheets/bootstrap.scss
+++ b/app/javascript/packs/stylesheets/bootstrap.scss
@@ -99,6 +99,11 @@ select.form-control {
   font-size: 90% !important;
 }
 
+.badge-hoh {
+  float: right;
+  vertical-align: top;
+}
+
 .table .concern {
   color: red;
 }

--- a/app/javascript/packs/stylesheets/datatables.scss
+++ b/app/javascript/packs/stylesheets/datatables.scss
@@ -123,8 +123,3 @@ button.dt-button:hover {
 div.dataTables_wrapper div.dataTables_info {
 	margin-bottom: 8px !important;
 }
-
-.hoh-icon {
-  float: right;
-  vertical-align: top;
-}


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-732](https://tracker.codev.mitre.org/browse/SARAALERT-732)

Update Head of Household designation in the linelist to reduce confusion of people thinking it means hospital.  Also add a tooltip that says: "Monitoree is Head of Household that reports on behalf of household members"

# (Feature) Demo/Screenshots
![Screen Shot 2020-10-08 at 8 49 17 AM](https://user-images.githubusercontent.com/35042815/95460619-2ef1f600-0943-11eb-9ce5-54f13831ae66.png)

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`PatientsTable.js`
- removed `H` icon and inserted a `HoH` badge instead with a clarifying tooltip

`bootstrap.scss`
- moved styling from `datatables.scss` to here because now it modifies the bootstrap badge

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [x] Firefox
* [x] Safari
* [x] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
