### PR TITLE
SARAALERT-787: Dockerize API

### DIFF
--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -302,14 +302,14 @@ class PublicHealthController < ApplicationController
         case filter[:dateOption]
         when 'before'
           compare_date = Chronic.parse(filter[:value])
-          patients = patients.where('latest_assessment_at < ?', compare_date)
+          patients = patients.where('Date(latest_assessment_at) < ?', compare_date)
         when 'after'
           compare_date = Chronic.parse(filter[:value])
-          patients = patients.where('latest_assessment_at > ?', compare_date)
+          patients = patients.where('Date(latest_assessment_at) > ?', compare_date)
         when 'within'
           compare_date_start = Chronic.parse(filter[:value][:start])
           compare_date_end = Chronic.parse(filter[:value][:end])
-          patients = patients.where('latest_assessment_at > ?', compare_date_start).where('latest_assessment_at < ?', compare_date_end)
+          patients = patients.where('Date(latest_assessment_at) > ?', compare_date_start).where('Date(latest_assessment_at) < ?', compare_date_end)
         end
       when 'hoh'
         patients = if filter[:value]
@@ -327,40 +327,40 @@ class PublicHealthController < ApplicationController
         case filter[:dateOption]
         when 'before'
           compare_date = Chronic.parse(filter[:value])
-          patients = patients.where('patients.created_at < ?', compare_date)
+          patients = patients.where('Date(patients.created_at) < ?', compare_date)
         when 'after'
           compare_date = Chronic.parse(filter[:value])
-          patients = patients.where('patients.created_at > ?', compare_date)
+          patients = patients.where('Date(patients.created_at) > ?', compare_date)
         when 'within'
           compare_date_start = Chronic.parse(filter[:value][:start])
           compare_date_end = Chronic.parse(filter[:value][:end])
-          patients = patients.where('patients.created_at > ?', compare_date_start).where('patients.created_at < ?', compare_date_end)
+          patients = patients.where('Date(patients.created_at) > ?', compare_date_start).where('Date(patients.created_at) < ?', compare_date_end)
         end
       when 'last-date-exposure'
         case filter[:dateOption]
         when 'before'
           compare_date = Chronic.parse(filter[:value])
-          patients = patients.where('last_date_of_exposure < ?', compare_date)
+          patients = patients.where('Date(last_date_of_exposure) < ?', compare_date)
         when 'after'
           compare_date = Chronic.parse(filter[:value])
-          patients = patients.where('last_date_of_exposure > ?', compare_date)
+          patients = patients.where('Date(last_date_of_exposure) > ?', compare_date)
         when 'within'
           compare_date_start = Chronic.parse(filter[:value][:start])
           compare_date_end = Chronic.parse(filter[:value][:end])
-          patients = patients.where('last_date_of_exposure > ?', compare_date_start).where('last_date_of_exposure < ?', compare_date_end)
+          patients = patients.where('Date(last_date_of_exposure) > ?', compare_date_start).where('Date(last_date_of_exposure) < ?', compare_date_end)
         end
       when 'symptom-onset'
         case filter[:dateOption]
         when 'before'
           compare_date = Chronic.parse(filter[:value])
-          patients = patients.where('symptom_onset < ?', compare_date)
+          patients = patients.where('Date(symptom_onset) < ?', compare_date)
         when 'after'
           compare_date = Chronic.parse(filter[:value])
-          patients = patients.where('symptom_onset > ?', compare_date)
+          patients = patients.where('Date(symptom_onset) > ?', compare_date)
         when 'within'
           compare_date_start = Chronic.parse(filter[:value][:start])
           compare_date_end = Chronic.parse(filter[:value][:end])
-          patients = patients.where('symptom_onset > ?', compare_date_start).where('symptom_onset < ?', compare_date_end)
+          patients = patients.where('Date(symptom_onset) > ?', compare_date_start).where('Date(symptom_onset) < ?', compare_date_end)
         end
       when 'continous-exposure'
         patients = patients.where(continuous_exposure: filter[:value].present? ? true : [nil, false])

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -5,6 +5,8 @@ services:
     image: ${SARA_ALERT_IMAGE}:latest
   sara-alert-assessment:
     image: ${SARA_ALERT_IMAGE}:latest
+  sara-alert-api:
+    image: ${SARA_ALERT_IMAGE}:latest
   sidekiq-enrollment-mailer:
     image: ${SARA_ALERT_IMAGE}:latest
   sidekiq-enrollment-export:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,21 @@ services:
     command: "bin/bundle exec rails s -u puma -p 3000 -b 0.0.0.0"
     volumes:
       - '~/tls:/app/disease-trakker/tls:ro'
+  sara-alert-api:
+    image: "${SARA_ALERT_IMAGE}:development-test"
+    environment:
+      - REDIS_URL=redis://redis-enrollment:6379/1
+    env_file:
+      - .env-prod-enrollment
+    restart: unless-stopped
+    networks:
+      - dt-net-enrollment
+    depends_on:
+      - redis-enrollment
+      - mysql-enrollment
+    command: "bin/bundle exec rails s -u puma -p 3000 -b 0.0.0.0"
+    volumes:
+      - '~/tls:/app/disease-trakker/tls:ro'
   mysql-enrollment:
     image: 'mariadb:latest'
     volumes:

--- a/nginx.conf
+++ b/nginx.conf
@@ -69,7 +69,7 @@ http {
     }
 
     location /fhir {
-      proxy_pass        http://sara-alert-api:3000/;
+      proxy_pass        http://sara-alert-api:3000;
       proxy_set_header  Host $host;
       proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header  X-Forwarded-Proto $scheme;
@@ -79,7 +79,7 @@ http {
     }
 
     location /oauth {
-      proxy_pass        http://sara-alert-api:3000/;
+      proxy_pass        http://sara-alert-api:3000;
       proxy_set_header  Host $host;
       proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header  X-Forwarded-Proto $scheme;

--- a/nginx.conf
+++ b/nginx.conf
@@ -67,6 +67,26 @@ http {
       proxy_set_header  X-Forwarded-Port $server_port;
       proxy_set_header  X-Forwarded-Host $host;
     }
+
+    location /fhir {
+      proxy_pass        http://sara-alert-api:3000/;
+      proxy_set_header  Host $host;
+      proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header  X-Forwarded-Proto $scheme;
+      proxy_set_header  X-Forwarded-Ssl on;
+      proxy_set_header  X-Forwarded-Port $server_port;
+      proxy_set_header  X-Forwarded-Host $host;
+    }
+
+    location /oauth {
+      proxy_pass        http://sara-alert-api:3000/;
+      proxy_set_header  Host $host;
+      proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header  X-Forwarded-Proto $scheme;
+      proxy_set_header  X-Forwarded-Ssl on;
+      proxy_set_header  X-Forwarded-Port $server_port;
+      proxy_set_header  X-Forwarded-Host $host;
+    }
   }
 
   server {


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-787](https://tracker.codev.mitre.org/browse/SARAALERT-787)

This adds separates out the API to run on a separate Sara Alert instance in a separate Docker container from the core application.

# Important Changes
`docker-compose.yml`
- Added a `service` for the API. Aside from the name, this is identical to `sara-alert-enrollment`. This means they the same MySQL database and Redis instance.

`docker-compose.prod.yml`
- Just the corresponding entry for the API service here that pulls the `latest` tag.

`nginx.conf`
- Now routes API and OAuth requests to the API instance, based on a URL path regex.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

There are no tests relevant to these changes. We will want to manually test this on the demo server before merging.
