### PR TITLE
Limits Character limit for Close-Contact Notes 

### DIFF
--- a/app/javascript/components/close_contact/CloseContact.js
+++ b/app/javascript/components/close_contact/CloseContact.js
@@ -123,7 +123,7 @@ class CloseContact extends React.Component {
                   maxLength="2000"
                   onChange={this.handleChange}
                 />
-                <Form.Label className="close-contact-character-limit"> {2000 - this.state.notes.length} characters remaining </Form.Label>
+                <Form.Label className="notes-character-limit"> {2000 - this.state.notes.length} characters remaining </Form.Label>
               </Form.Group>
             </Row>
           </Form>

--- a/app/javascript/components/close_contact/CloseContact.js
+++ b/app/javascript/components/close_contact/CloseContact.js
@@ -120,6 +120,7 @@ class CloseContact extends React.Component {
                   className="form-square"
                   value={this.state.notes || ''}
                   placeholder={this.closeContactNotePlaceholder}
+                  maxlength="2000"
                   onChange={this.handleChange}
                 />
               </Form.Group>

--- a/app/javascript/components/close_contact/CloseContact.js
+++ b/app/javascript/components/close_contact/CloseContact.js
@@ -123,7 +123,7 @@ class CloseContact extends React.Component {
                   maxLength="2000"
                   onChange={this.handleChange}
                 />
-                <Form.Label class="close-contact-character-limit"> {2000 - this.state.notes?.length} characters remaining</Form.Label>
+                <Form.Label class="close-contact-character-limit"> {2000 - this.state.notes.length} characters remaining </Form.Label>
               </Form.Group>
             </Row>
           </Form>

--- a/app/javascript/components/close_contact/CloseContact.js
+++ b/app/javascript/components/close_contact/CloseContact.js
@@ -123,7 +123,7 @@ class CloseContact extends React.Component {
                   maxLength="2000"
                   onChange={this.handleChange}
                 />
-                <Form.Label class="close-contact-character-limit"> {2000 - this.state.notes.length} characters remaining </Form.Label>
+                <Form.Label className="close-contact-character-limit"> {2000 - this.state.notes.length} characters remaining </Form.Label>
               </Form.Group>
             </Row>
           </Form>

--- a/app/javascript/components/close_contact/CloseContact.js
+++ b/app/javascript/components/close_contact/CloseContact.js
@@ -120,9 +120,10 @@ class CloseContact extends React.Component {
                   className="form-square"
                   value={this.state.notes || ''}
                   placeholder={this.closeContactNotePlaceholder}
-                  maxlength="2000"
+                  maxLength="2000"
                   onChange={this.handleChange}
                 />
+                <Form.Label class="close-contact-character-limit"> {2000 - this.state.notes?.length} characters remaining</Form.Label>
               </Form.Group>
             </Row>
           </Form>

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -303,6 +303,7 @@ class Exposure extends React.Component {
               size="lg"
               className="form-square"
               placeholder="enter additional information about case"
+              maxLength="2000"
               value={this.state.current.patient.exposure_notes || ''}
               onChange={this.handleChange}
             />
@@ -545,6 +546,7 @@ class Exposure extends React.Component {
               size="lg"
               className="form-square"
               placeholder="enter additional information about monitoree’s potential exposure"
+              maxLength="2000"
               value={this.state.current.patient.exposure_notes || ''}
               onChange={this.handleChange}
             />

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -306,6 +306,7 @@ class Exposure extends React.Component {
               value={this.state.current.patient.exposure_notes || ''}
               onChange={this.handleChange}
             />
+            <Form.Label className="notes-character-limit"> {2000 - (this.state.current.patient.exposure_notes || '').length} characters remaining </Form.Label>
             <Form.Control.Feedback className="d-block" type="invalid">
               {this.state.errors['exposure_notes']}
             </Form.Control.Feedback>
@@ -547,6 +548,7 @@ class Exposure extends React.Component {
               value={this.state.current.patient.exposure_notes || ''}
               onChange={this.handleChange}
             />
+            <Form.Label className="notes-character-limit"> {2000 - (this.state.current.patient.exposure_notes || '').length} characters remaining </Form.Label>
             <Form.Control.Feedback className="d-block" type="invalid">
               {this.state.errors['exposure_notes']}
             </Form.Control.Feedback>

--- a/app/javascript/packs/stylesheets/layout.scss
+++ b/app/javascript/packs/stylesheets/layout.scss
@@ -11,3 +11,10 @@
 .tooltip-container {
   width: 300px;
 }
+
+.close-contact-character-limit {
+  font-size: 10px;
+  color: dimgray;
+  font-style: italic;
+  float: right;
+}

--- a/app/javascript/packs/stylesheets/layout.scss
+++ b/app/javascript/packs/stylesheets/layout.scss
@@ -12,7 +12,7 @@
   width: 300px;
 }
 
-.close-contact-character-limit {
+.notes-character-limit {
   font-size: 10px;
   color: dimgray;
   font-style: italic;


### PR DESCRIPTION
Jira Ticket: SARAALERT-887

This PR sets a limit for the characters allowed in the Close Contact Notes section. If a Close Contact was enrolled, and their notes section was (previously) over 2,000 characters than the user would run into errors enrolling them. By limiting the characters to a length of 2,000 any overflow errors are avoided.
![image](https://user-images.githubusercontent.com/17532163/95606397-47880c00-0a28-11eb-8166-8c4d6694b0ba.png)

# Important Changes
`SaraAlert/app/javascript/components/close_contact/CloseContact.js`
- added character limit