### PR TITLE
Update latest public health action tooltip message in isolation

### DIFF
--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -107,7 +107,10 @@ const TOOLTIP_TEXT = {
   ),
 
   latestPublicHealthActionInIsolation: (
-    <div>Used to note the public health recommendation provided to a monitoree. This element does not impact the line list on which this record appears.</div>
+    <div>
+      Used to note the public health recommendation provided to a monitoree. In the isolation workflow, this element does not impact the line list on which this
+      record appears.
+    </div>
   ),
 
   assignedUser: (


### PR DESCRIPTION
# Description

Updates latest public health action tooltip message in isolation to be more clear

# (Feature) Demo/Screenshots

![Screen Shot 2020-10-09 at 1 04 31 PM](https://user-images.githubusercontent.com/9956561/95611592-05fb5f00-0a30-11eb-837f-8444d3df6bb4.png)

`InfoTooltip.js`
- update latest public health action tooltip message in isolation

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [ ] Firefox
* [ ] Safari
* [x] IE11