### PR TITLE
Updating Send Purge Warnings Job to send email to verify run

### DIFF
--- a/app/jobs/send_purge_warnings_job.rb
+++ b/app/jobs/send_purge_warnings_job.rb
@@ -5,6 +5,29 @@ class SendPurgeWarningsJob < ApplicationJob
   queue_as :default
 
   def perform(*_args)
-    UserMailer.purge_notification.deliver_later
+    sent = []
+    not_sent = []
+
+    # Get admin users
+    recipients = User.with_any_role(:admin)
+    eligible = recipients.count
+
+    # Loop through and send each admin information about their purge eligible monitorees
+    recipients.each do |user|
+      # Skip for USA admins
+      next if user.jurisdiction&.name == 'USA'
+
+      # Get num purgeable underneath this admin's purview
+      num_purgeable_records = user.viewable_patients.purge_eligible.size
+
+      # Send email to use with info
+      UserMailer.purge_notification(user, num_purgeable_records).deliver_later
+      
+      sent << { id: user.id }
+    rescue StandardError => e
+      not_sent << { id: user.id, reason: e.message }
+    end
+
+    UserMailer.send_purge_warnings_job_email(sent, not_sent, eligible).deliver_now
   end
 end

--- a/app/jobs/send_purge_warnings_job.rb
+++ b/app/jobs/send_purge_warnings_job.rb
@@ -22,7 +22,7 @@ class SendPurgeWarningsJob < ApplicationJob
 
       # Send email to use with info
       UserMailer.purge_notification(user, num_purgeable_records).deliver_later
-      
+
       sent << { id: user.id }
     rescue StandardError => e
       not_sent << { id: user.id, reason: e.message }

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -20,6 +20,13 @@ class UserMailer < ApplicationMailer
     mail(to: ADMIN_OPTIONS['job_run_email'], subject: "Sara Alert Purge Job Results (#{ActionMailer::Base.default_url_options[:host]})")
   end
 
+  def send_purge_warnings_job_email(sent, not_sent, eligible)
+    @sent = sent
+    @not_sent = not_sent
+    @eligible = eligible
+    mail(to: ADMIN_OPTIONS['job_run_email'], subject: "Sara Alert Send Purge Warnings Job Results (#{ActionMailer::Base.default_url_options[:host]})")
+  end
+
   def close_job_email(closed, not_closed, eligible)
     @closed = closed
     @not_closed = not_closed
@@ -59,21 +66,14 @@ class UserMailer < ApplicationMailer
     end
   end
 
-  def purge_notification
-    recipients = User.with_any_role(:admin)
+  def purge_notification(user, num_purgeable_records)
+    @user = user
+    @num_purgeable_records = num_purgeable_records
     @expiration_date = Chronic.parse(ADMIN_OPTIONS['weekly_purge_date']).strftime('%A %B %d, at %l:%M %p %Z')
+    subject = @num_purgeable_records.zero? ? 'Sara Alert Notification' : 'Sara Alert User Records Expiring Soon'
 
-    recipients.each do |user|
-      next if user.jurisdiction&.name == 'USA'
-
-      @user = user
-      @num_purgeable_records = user.viewable_patients.purge_eligible.size
-
-      subject = @num_purgeable_records.zero? ? 'Sara Alert Notification' : 'Sara Alert User Records Expiring Soon'
-
-      mail(to: user.email.strip, subject: subject) do |format|
-        format.html { render layout: 'main_mailer' }
-      end
+    mail(to: user.email.strip, subject: subject) do |format|
+      format.html { render layout: 'main_mailer' }
     end
   end
 end

--- a/app/views/user_mailer/send_purge_warnings_job_email.html.erb
+++ b/app/views/user_mailer/send_purge_warnings_job_email.html.erb
@@ -1,0 +1,34 @@
+<h1>
+  Sara Alert Send Purge Warnings Job Results  (<%= ActionMailer::Base.default_url_options[:host] %>)
+</h1>
+<h2>
+  <%= DateTime.now.in_time_zone('Eastern Time (US & Canada)') %>
+</h2>
+<br />
+Total eligible for purge warning at runtime: <%= @eligible %>
+<br />
+Send during this job run: <b><%= @sent.count %></b>
+<br />
+Not sent during this job run (due to exceptions): <b><%= @not_sent.count %></b>
+<br />
+<h2>
+  Sent
+</h2>
+<br />
+ID
+<br />
+<% @sent.each do |s| %>
+  <%= s[:id] %>
+  <br />
+<% end %>
+<br />
+<h2>
+  Not Sent
+</h2>
+<br />
+ID, Reason
+<br />
+<% @not_sent.each do |ns| %>
+  <%= ns[:id] %>, <%= ns[:reason] %>
+  <br />
+<% end %>

--- a/test/jobs/send_purge_warnings_job_test.rb
+++ b/test/jobs/send_purge_warnings_job_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'test_case'
+
+class SendPurgeWarningsJobTest < ActiveSupport::TestCase
+  def setup
+    ADMIN_OPTIONS['job_run_email'] = 'test@test.com'
+  end
+
+  def teardown
+    ADMIN_OPTIONS['job_run_email'] = nil
+  end
+
+  test 'sends an purge notification job email with user IDs of users sent notification email' do
+    email = SendPurgeWarningsJob.perform_now
+    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    assert_not ActionMailer::Base.deliveries.empty?
+    assert_includes(email_body, 'Sara Alert Send Purge Warnings Job Results')
+  end
+
+  test 'sends emails to each admin user not in the USA jurisdiction' do
+  end
+
+  test 'sends correct email when no purge eligible monitorees for user' do
+  end
+
+  test 'sends correct email when there are purge eligible monitorees for user' do
+  end
+end


### PR DESCRIPTION
# Description
This PR update the  `SendPurgeWarningsJob` so it sends an email outlining if for any reason it fails or couldn't send an email to users. It required a bit of a refactor of where the logic lives which makes it more consistent with other jobs and `UserMailer` functions anyway.

# Important Changes
`app/jobs/send_purge_warnings_job.rb`
- Pulled in logic from `UserMailer` to iterate through users and send email with number emails sent, not sent, and eligible.

`app/mailers/user_mailer.rb`
 - Updated original `purge_notification` mailer method to have less logic (since it's been moved into the job). 
 - Added `send_purge_warnings_job_email` method.

`app/views/user_mailer/send_purge_warnings_job_email.html.erb`
- Added new email template.

`test/jobs/send_purge_warnings_job_test.rb`
- Adding tests for this job (WIP).


# Testing
- Test that the jobs runs properly and sends emails to all admin users who are not USA admins, and sends an email to the admin email.