### PR TITLE
'Eligible For Purge After X Date' now correctly sorts

### DIFF
--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -174,7 +174,9 @@ class PublicHealthController < ApplicationController
     when 'dob'
       patients = patients.order('CASE WHEN date_of_birth IS NULL THEN 1 ELSE 0 END, date_of_birth ' + dir)
     when 'end_of_monitoring'
-      patients = patients.order('CASE WHEN last_date_of_exposure IS NULL THEN 1 ELSE 0 END, last_date_of_exposure ' + dir)
+      patients = patients.order('CASE
+        WHEN continuous_exposure = 1 THEN now()
+        WHEN last_date_of_exposure IS NULL THEN patients.created_at ELSE last_date_of_exposure END ' + dir)
     when 'extended_isolation'
       patients = patients.order('CASE WHEN extended_isolation IS NULL THEN 1 ELSE 0 END, extended_isolation ' + dir)
     when 'symptom_onset'
@@ -186,7 +188,8 @@ class PublicHealthController < ApplicationController
     when 'public_health_action'
       patients = patients.order('CASE WHEN public_health_action IS NULL THEN 1 ELSE 0 END, public_health_action ' + dir)
     when 'expected_purge_date'
-      patients = patients.order('CASE WHEN last_date_of_exposure IS NULL THEN 1 ELSE 0 END, last_date_of_exposure ' + dir)
+      patients = patients.order('CASE WHEN closed_at IS NULL THEN 1 ELSE 0 END, updated_at ' + dir)
+        # Eligible purge date is a derivative field from `updated_at`
     when 'reason_for_closure'
       patients = patients.order('CASE WHEN monitoring_reason IS NULL THEN 1 ELSE 0 END, monitoring_reason ' + dir)
     when 'closed_at'

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -189,7 +189,7 @@ class PublicHealthController < ApplicationController
       patients = patients.order('CASE WHEN public_health_action IS NULL THEN 1 ELSE 0 END, public_health_action ' + dir)
     when 'expected_purge_date'
       patients = patients.order('CASE WHEN closed_at IS NULL THEN 1 ELSE 0 END, updated_at ' + dir)
-        # Eligible purge date is a derivative field from `updated_at`
+      # Eligible purge date is a derivative field from `updated_at`
     when 'reason_for_closure'
       patients = patients.order('CASE WHEN monitoring_reason IS NULL THEN 1 ELSE 0 END, monitoring_reason ' + dir)
     when 'closed_at'

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -385,7 +385,7 @@ namespace :demo do
       patient[:isolation] = days_ago > 10 ? rand < 0.9 : rand < 0.4
       patient[:case_status] = patient[:isolation] ? ['Confirmed', 'Probable', 'Suspect', 'Unknown', 'Not a Case'].sample : nil
       patient[:monitoring] = rand < 0.95
-      patient[:closed_at] = patient[:updated_at] unless patient[:monitoring].nil?
+      patient[:closed_at] = patient[:updated_at] unless patient[:monitoring]
       patient[:monitoring_reason] = ['Completed Monitoring', 'Meets Case Definition', 'Lost to follow-up during monitoring period',
                                      'Lost to follow-up (contact never established)', 'Transferred to another jurisdiction',
                                      'Person Under Investigation (PUI)', 'Case confirmed', 'Past monitoring period',


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-825

Some date fields were not properly sorting. This was caused by the fact that some values might be strings instead of dates. 

# Important Changes
`app/controllers/public_health_controller.rb`
- Changed the query behavior for `end_of_monitoring` and `eligible purge date` to properly sort the different date values (and the other strings that can appear there). If the values are the same (i.e. the same string), they will sort with the created_at date.