### PR TITLE
SARA-883 histories filter

### DIFF
--- a/app/javascript/components/history/HistoryComponent.js
+++ b/app/javascript/components/history/HistoryComponent.js
@@ -160,7 +160,7 @@ class HistoryComponent extends React.Component {
                 isMulti
                 name="Creator Filters"
                 options={historyCreators}
-                className="basic-multi-select w-25"
+                className="basic-multi-select w-25 pl-1"
                 classNamePrefix="select"
                 placeholder="Filter by Creator"
                 theme={theme => ({

--- a/app/javascript/components/history/HistoryComponent.js
+++ b/app/javascript/components/history/HistoryComponent.js
@@ -142,20 +142,6 @@ class HistoryComponent extends React.Component {
               <Select
                 closeMenuOnSelect={false}
                 isMulti
-                name="Filters"
-                options={filterOptions}
-                className="basic-multi-select w-25"
-                classNamePrefix="select"
-                placeholder="Filter by Type"
-                theme={theme => ({
-                  ...theme,
-                  borderRadius: 0,
-                })}
-                onChange={this.handleTypeFilterChange}
-              />
-              <Select
-                closeMenuOnSelect={false}
-                isMulti
                 name="Creator Filters"
                 options={historyCreators}
                 className="basic-multi-select w-25 pl-1"
@@ -166,6 +152,20 @@ class HistoryComponent extends React.Component {
                   borderRadius: 0,
                 })}
                 onChange={this.handleCreatorFilterChange}
+              />
+              <Select
+                closeMenuOnSelect={false}
+                isMulti
+                name="Filters"
+                options={filterOptions}
+                className="basic-multi-select w-25"
+                classNamePrefix="select"
+                placeholder="Filter by Type"
+                theme={theme => ({
+                  ...theme,
+                  borderRadius: 0,
+                })}
+                onChange={this.handleTypeFilterChange}
               />
             </Row>
             {historiesArray}

--- a/app/javascript/components/history/HistoryComponent.js
+++ b/app/javascript/components/history/HistoryComponent.js
@@ -18,8 +18,6 @@ class HistoryComponent extends React.Component {
       loading: false,
       comment: '',
       filters: { typeFilters: [], creatorFilters: [] },
-      selectedTypeFilters: [],
-      selectedCreatorFilters: [],
       filteredHistories: this.props.histories,
       pageOfHistories: [],
     };

--- a/app/javascript/components/history/HistoryComponent.js
+++ b/app/javascript/components/history/HistoryComponent.js
@@ -158,7 +158,7 @@ class HistoryComponent extends React.Component {
                 isMulti
                 name="Filters"
                 options={filterOptions}
-                className="basic-multi-select w-25"
+                className="basic-multi-select w-25 pl-2"
                 classNamePrefix="select"
                 placeholder="Filter by Type"
                 theme={theme => ({

--- a/app/javascript/components/history/HistoryComponent.js
+++ b/app/javascript/components/history/HistoryComponent.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 import { PropTypes } from 'prop-types';
 import { Card, Row } from 'react-bootstrap';
 import Pagination from 'jw-react-pagination';
@@ -16,7 +17,9 @@ class HistoryComponent extends React.Component {
     this.state = {
       loading: false,
       comment: '',
-      selectedFilters: [],
+      filters: { typeFilters: [], creatorFilters: [] },
+      selectedTypeFilters: [],
+      selectedCreatorFilters: [],
       filteredHistories: this.props.histories,
       pageOfHistories: [],
     };
@@ -53,9 +56,14 @@ class HistoryComponent extends React.Component {
 
   filterHistories = () => {
     let filteredHistories = [...this.props.histories];
-    if (this.state.selectedFilters.length !== 0) {
+    if (this.state.filters.typeFilters.length !== 0) {
       filteredHistories = filteredHistories.filter(history => {
-        return this.state.selectedFilters.includes(history.history_type);
+        return this.state.filters.typeFilters.includes(history.history_type);
+      });
+    }
+    if (this.state.filters.creatorFilters.length !== 0) {
+      filteredHistories = filteredHistories.filter(history => {
+        return this.state.filters.creatorFilters.includes(history.created_by);
       });
     }
     this.setState({
@@ -63,10 +71,16 @@ class HistoryComponent extends React.Component {
     });
   };
 
-  handleFilterChange = inputValue => {
+  handleFilterChange = (inputValue, filterCategory) => {
+    let filters = this.state.filters;
     let selectedFilters = [];
     if (Array.isArray(inputValue) && inputValue.length) {
       selectedFilters = inputValue.map(x => x.value);
+    }
+    if (filterCategory == 'History Type') {
+      filters.typeFilters = selectedFilters;
+    } else if (filterCategory == 'History Creator') {
+      filters.creatorFilters = selectedFilters;
     }
     this.setState(
       {
@@ -77,6 +91,10 @@ class HistoryComponent extends React.Component {
       }
     );
   };
+
+  handleTypeFilterChange = inputValue => this.handleFilterChange(inputValue, 'History Type');
+
+  handleCreatorFilterChange = inputValue => this.handleFilterChange(inputValue, 'History Creator');
 
   render() {
     const historiesArray = this.state.pageOfHistories.map(history => <History key={history.id} history={history} />);
@@ -101,6 +119,14 @@ class HistoryComponent extends React.Component {
         ],
       },
     ];
+    const historyCreators = [
+      {
+        label: 'History Creator',
+        options: _.uniq(this.props.histories.map(x => x.created_by)).map(x => {
+          return { value: x, label: x };
+        }),
+      },
+    ];
 
     return (
       <React.Fragment>
@@ -122,12 +148,26 @@ class HistoryComponent extends React.Component {
                 options={filterOptions}
                 className="basic-multi-select w-25"
                 classNamePrefix="select"
-                placeholder="Filters"
+                placeholder="Filter by Type"
                 theme={theme => ({
                   ...theme,
                   borderRadius: 0,
                 })}
-                onChange={this.handleFilterChange}
+                onChange={this.handleTypeFilterChange}
+              />
+              <Select
+                closeMenuOnSelect={false}
+                isMulti
+                name="Creator Filters"
+                options={historyCreators}
+                className="basic-multi-select w-25"
+                classNamePrefix="select"
+                placeholder="Filter by Creator"
+                theme={theme => ({
+                  ...theme,
+                  borderRadius: 0,
+                })}
+                onChange={this.handleCreatorFilterChange}
               />
             </Row>
             {historiesArray}


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-883

Adds a filter option to see only history objects created by a specific user or by the SARA-Alert system 

# (Feature) Demo/Screenshots
Insert demo video or photos for a new or updated feature or capability.


# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/javascript/components/history/HistoryComponent.js`
- Example change (ex: refactored import function)

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [Y] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.

Spin up the service, login as a public health user or another role which lets you see the patient view, select a patient. The filter option will be in the histories interface near the bottom of the page. You may need to add a comment to the patient to fully test the filter, since if all histories associated with that patient are from the system, it won't provide filter options beyond the system. 