### PR TITLE
allows the user to set 'Exposure Risk Assessment' to null

### DIFF
--- a/app/javascript/components/subject/MonitoringStatus.js
+++ b/app/javascript/components/subject/MonitoringStatus.js
@@ -81,9 +81,10 @@ class MonitoringStatus extends React.Component {
         });
       }
     } else if (event?.target?.id && event.target.id === 'exposure_risk_assessment') {
+      const exposureRiskAssessmentPrompt = event.target.value ? `"${event.target.value}"` : 'blank';
       this.setState({
         showExposureRiskAssessmentModal: true,
-        message: `exposure risk assessment to "${event.target.value}"`,
+        message: `exposure risk assessment to ${exposureRiskAssessmentPrompt}`,
         message_warning: '',
         exposure_risk_assessment: event?.target?.value ? event.target.value : '',
         monitoring_reasons: null,
@@ -496,7 +497,7 @@ class MonitoringStatus extends React.Component {
                     id="exposure_risk_assessment"
                     onChange={this.handleChange}
                     value={this.state.exposure_risk_assessment}>
-                    <option disabled></option>
+                    <option></option>
                     <option>High</option>
                     <option>Medium</option>
                     <option>Low</option>


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-837

When changing the `Exposure Risk Assessment` it had been impossible to change back to `null/blank` after selecting an Exposure Risk Assessment Value. This PR removes that disabled flag. It also ensures the resultant prompt is worded properly (not saying `"Are you sure you want to set the value to ''?"`).

# Important Changes

`app/javascript/components/subject/MonitoringStatus.js`
- Removes the `disabled` flag for `Exposure Risk Assessment` select

# Other Notes:
The existing logic for this `<select/>` prompts the user "Are you sure you want to change XXX to YYY?". This lead to the prompt asking `Are you sure you want to exposure risk assessment to ""?`. This is obviously not ideal. I reached out to the ticket reporter Lauren Buttling and asked her opinion on the exact wording. She said "I think we use 'Blank' for other History messages so I think we should stick with that language"

Therefore, when null-ing out this field, the dialog box now says `Are you sure you want to change exposure risk assessment to blank?`

# Testing
This fix was tested on the following browsers:
* [x] Chrome