### PR TITLE
Making Enrollment Notification Logic Consistent in API

### DIFF
--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -184,8 +184,8 @@ class Fhir::R4::ApiController < ActionController::API
     status_bad_request && return unless resource.save
 
     if resource_type == 'patient'
-      # Send enrollment notification
-      resource.send_enrollment_notification
+      # Send enrollment notification only to responders
+      resource.send_enrollment_notification if resource.self_reporter_or_proxy?
 
       # Create a history for the enrollment
       History.enrollment(patient: resource, created_by: resource.creator&.email, comment: 'Monitoree enrolled via API.')


### PR DESCRIPTION
# Description
Enrollment notifications should only be received by self-reporters. This PR just makes that logic consistent in the API.

