### PR TITLE
SARAALERT-835: LDE/CE Validations

### DIFF
--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -68,7 +68,8 @@ class Enrollment extends React.Component {
         .then(response => {
           toast.success(message, {
             onClose: () =>
-              (location.href = window.BASE_PATH + (groupMember ? '/patients/' + response['data']['id'] + '/group' : '/patients/' + response['data']['id'])),
+              (location.href =
+                window.BASE_PATH + (groupMember ? '/patients/' + response['data']['responder_id'] + '/group' : '/patients/' + response['data']['id'])),
           });
         })
         .catch(err => {
@@ -142,7 +143,8 @@ class Enrollment extends React.Component {
           // Success, inform user and redirect to home
           toast.success(message, {
             onClose: () =>
-              (location.href = window.BASE_PATH + (groupMember ? '/patients/' + response['data']['id'] + '/group' : '/patients/' + response['data']['id'])),
+              (location.href =
+                window.BASE_PATH + (groupMember ? '/patients/' + response['data']['responder_id'] + '/group' : '/patients/' + response['data']['id'])),
           });
         }
       })

--- a/app/javascript/components/enrollment/steps/Review.js
+++ b/app/javascript/components/enrollment/steps/Review.js
@@ -91,7 +91,7 @@ class Review extends React.Component {
                 Finish
               </Button>
             )}
-            {this.props.submit && !this.props.parent_id && this.props.currentState.responder_id === this.props.currentState.id && this.props.canAddGroup && (
+            {this.props.submit && this.props.currentState.responder_id === this.props.currentState.id && this.props.canAddGroup && (
               <Button
                 variant="primary"
                 size="lg"


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-835

- modifies LDE/CE input validation behavior in enrollment so that instead of LDE being disabled when CE is checked, CE will be turned off when LDE is populated
- fixes 'Finish and Add a Household Member' button in enrollment so that household member will always be enrolled as a dependent of HoH and not another household member
- fixes exposure enrollment page validation when starting enrollment from isolation but changing to exposure from identification page

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11
