### PR TITLE
Improve public health controller linelist load through caching

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -277,7 +277,9 @@ class PatientsController < ApplicationController
     end
 
     # Change all of the patients in the household, including the current patient to have new_hoh_id as the responder
-    current_user_patients.where(id: patients_to_update).update_all(responder_id: new_hoh_id)
+    current_user_patients.where(id: patients_to_update).each do |patient|
+      patient.update(responder_id: new_hoh_id)
+    end
   end
 
   def bulk_update_status

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -219,7 +219,8 @@ class PublicHealthController < ApplicationController
                                'patients.date_of_birth, patients.assigned_user, patients.exposure_risk_assessment, patients.monitoring_plan, '\
                                'patients.public_health_action, patients.monitoring_reason, patients.closed_at, patients.last_date_of_exposure, '\
                                'patients.created_at, patients.updated_at, patients.latest_assessment_at, patients.latest_transfer_at, '\
-                               'patients.continuous_exposure, patients.head_of_household, jurisdictions.name AS jurisdiction_name, jurisdictions.path AS jurisdiction_path')
+                               'patients.continuous_exposure, patients.head_of_household, jurisdictions.name AS jurisdiction_name, '\
+                               'jurisdictions.path AS jurisdiction_path')
 
     # execute query and get total count
     total = patients.total_entries

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -219,7 +219,7 @@ class PublicHealthController < ApplicationController
                                'patients.date_of_birth, patients.assigned_user, patients.exposure_risk_assessment, patients.monitoring_plan, '\
                                'patients.public_health_action, patients.monitoring_reason, patients.closed_at, patients.last_date_of_exposure, '\
                                'patients.created_at, patients.updated_at, patients.latest_assessment_at, patients.latest_transfer_at, '\
-                               'patients.continuous_exposure, jurisdictions.name AS jurisdiction_name, jurisdictions.path AS jurisdiction_path')
+                               'patients.continuous_exposure, patients.head_of_household, jurisdictions.name AS jurisdiction_name, jurisdictions.path AS jurisdiction_path')
 
     # execute query and get total count
     total = patients.total_entries

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -252,7 +252,7 @@ class PublicHealthController < ApplicationController
       details[:latest_report] = patient[:latest_assessment_at]&.rfc2822 || '' if fields.include?(:latest_report)
       details[:status] = patient.status.to_s.gsub('_', ' ').gsub('exposure ', '')&.gsub('isolation ', '') if fields.include?(:status)
       details[:report_eligibility] = patient.report_eligibility if fields.include?(:report_eligibility)
-      details[:is_hoh] = patient.dependents_exclude_self.where(purged: false).exists?
+      details[:is_hoh] = patient.head_of_household?
 
       linelist << details
     end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -861,7 +861,6 @@ class Patient < ApplicationRecord
   # so we just throw it away
   def inform_responder(*)
     initial_responder = responder_id_was
-    self_reporter = self_reporter_or_proxy?
     # Yield to save or destroy, depending on which callback invokes this method
     yield
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -857,9 +857,7 @@ class Patient < ApplicationRecord
     dependents_exclude_self.size.positive?
   end
 
-  # After remove callback passes a parameter which is the object that was just removed, we don't need it
-  # so we just throw it away
-  def inform_responder(*)
+  def inform_responder
     initial_responder = responder_id_was
     # Yield to save or destroy, depending on which callback invokes this method
     yield

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -863,6 +863,7 @@ class Patient < ApplicationRecord
     yield
 
     return if responder.nil?
+
     # update the initial responder if it changed
     Patient.find(initial_responder).refresh_head_of_household if !initial_responder.nil? && initial_responder != responder.id
     # update the current responder

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -861,10 +861,14 @@ class Patient < ApplicationRecord
   # so we just throw it away
   def inform_responder(*)
     initial_responder = responder_id_was
-    # Yield to save
+    self_reporter = self_reporter_or_proxy?
+    # Yield to save or destroy, depending on which callback invokes this method
     yield
-    Patient.find(initial_responder).refresh_head_of_household unless initial_responder.nil? || initial_responder == responder.id
-    # After save responder may have changed
+
+    return if responder.nil?
+    # update the initial responder if it changed
+    Patient.find(initial_responder).refresh_head_of_household if !initial_responder.nil? && initial_responder != responder.id
+    # update the current responder
     responder.refresh_head_of_household
   end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -854,7 +854,7 @@ class Patient < ApplicationRecord
   def head_of_household?
     return head_of_household unless head_of_household.nil?
 
-    dependents_exclude_self.size.positive?
+    dependents_exclude_self.where(purged: false).size.positive?
   end
 
   def inform_responder
@@ -871,7 +871,7 @@ class Patient < ApplicationRecord
   end
 
   def refresh_head_of_household
-    hoh = dependents_exclude_self.size.positive?
+    hoh = dependents_exclude_self.where(purged: false).size.positive?
     update(head_of_household: hoh) unless head_of_household == hoh
   end
 end

--- a/db/migrate/20201015215616_add_head_of_household_to_patient.rb
+++ b/db/migrate/20201015215616_add_head_of_household_to_patient.rb
@@ -1,0 +1,5 @@
+class AddHeadOfHouseholdToPatient < ActiveRecord::Migration[6.0]
+  def change
+    add_column :patients, :head_of_household, :boolean, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_09_142558) do
+ActiveRecord::Schema.define(version: 2020_10_15_215616) do
 
   create_table "analytics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "jurisdiction_id"
@@ -339,6 +339,7 @@ ActiveRecord::Schema.define(version: 2020_10_09_142558) do
     t.string "sexual_orientation"
     t.boolean "user_defined_symptom_onset"
     t.date "extended_isolation"
+    t.boolean "head_of_household"
     t.index ["assigned_user"], name: "index_patients_on_assigned_user"
     t.index ["creator_id"], name: "index_patients_on_creator_id"
     t.index ["date_of_birth"], name: "index_patients_on_date_of_birth"

--- a/test/factories/patient.rb
+++ b/test/factories/patient.rb
@@ -4,8 +4,9 @@ FactoryBot.define do
   factory :patient do
     creator { create(:user) }
     after(:build) do |patient|
-      patient.update(jurisdiction: patient.creator.jurisdiction)
-      patient.update(responder: patient)
+      update_hash = { jurisdiction: patient.creator.jurisdiction }
+      update_hash[:responder] = patient if patient.responder.nil?
+      patient.update(update_hash)
     end
   end
 end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -1112,7 +1112,6 @@ class PatientTest < ActiveSupport::TestCase
     assert new_head.reload.head_of_household
     assert_not dependent.reload.head_of_household
 
-
     dependent.destroy
     assert_not patient.reload.head_of_household
     assert_not new_head.reload.head_of_household

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -1104,11 +1104,14 @@ class PatientTest < ActiveSupport::TestCase
     patient = create(:patient)
     dependent = create(:patient, responder: patient)
     assert patient.reload.head_of_household
+    assert_not dependent.reload.head_of_household
 
     new_head = create(:patient)
     dependent.update(responder: new_head)
     assert_not patient.reload.head_of_household
     assert new_head.reload.head_of_household
+    assert_not dependent.reload.head_of_household
+
 
     dependent.destroy
     assert_not patient.reload.head_of_household

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -1099,5 +1099,20 @@ class PatientTest < ActiveSupport::TestCase
 
     assert_nil Patient.calc_current_age_fhir(nil)
   end
+
+  test 'refresh head of household' do
+    patient = create(:patient)
+    dependent = create(:patient, responder: patient)
+    assert patient.reload.head_of_household
+
+    new_head = create(:patient)
+    dependent.update(responder: new_head)
+    assert_not patient.reload.head_of_household
+    assert new_head.reload.head_of_household
+
+    dependent.destroy
+    assert_not patient.reload.head_of_household
+    assert_not new_head.reload.head_of_household
+  end
 end
 # rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-930
Adds new column to `patient` table, `head_of_household` that stores a boolean. This column is updated with `around_save` and `around_destroy` callbacks on the `Patient` model where an updated patient "informs" its old/new head of household that it is a head of household.

In the case where a dependent has not been updated to trigger setting this new attribute, the query performance is improved to `COUNT` instead of loading the dependents to show the icon.

# Important Changes

`app/model/patient.rb`
- Pay attention to the `around_save` and `around_destroy`.

# Testing
I've added a test with the three cases (create, update, destroy) of manipulating heads of household.
