### PR TITLE
SARAALERT-919: Updating logic for "Active Dependents"

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -566,7 +566,7 @@ class Patient < ApplicationRecord
     # Return UNLESS:
     # - in exposure: NOT closed AND within monitoring period OR
     # - in isolation: NOT closed (as patients on RRR linelist should receive notifications) OR
-    # - in ontinuous exposure OR
+    # - in continuous exposure OR
     # - is a HoH with actively monitored dependents
     # NOTE: We do not close out folks on the non-reporting line list in exposure (therefore monitoring will still be true for them),
     # so we also have to check that someone receiving messages is not past they're monitoring period unless they're  in isolation,

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -1204,5 +1204,22 @@ class PatientTest < ActiveSupport::TestCase
 
     assert_nil Patient.calc_current_age_fhir(nil)
   end
+
+  test 'refresh head of household' do
+    patient = create(:patient)
+    dependent = create(:patient, responder: patient)
+    assert patient.reload.head_of_household
+    assert_not dependent.reload.head_of_household
+
+    new_head = create(:patient)
+    dependent.update(responder: new_head)
+    assert_not patient.reload.head_of_household
+    assert new_head.reload.head_of_household
+    assert_not dependent.reload.head_of_household
+
+    dependent.destroy
+    assert_not patient.reload.head_of_household
+    assert_not new_head.reload.head_of_household
+  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -16,6 +16,111 @@ class PatientTest < ActiveSupport::TestCase
     ADMIN_OPTIONS['weekly_purge_date'] = @default_weekly_purge_date
   end
 
+  test 'active dependents does NOT include dependents that are purged' do
+    responder = create(:patient, purged: false, monitoring: true)
+    dependent = create(:patient, purged: true, monitoring: false)
+    dependent.update!(responder_id: responder.id)
+
+    assert_not responder.active_dependents.pluck(:id).include?(dependent.id)
+  end
+
+  test 'active dependents does NOT include dependents where monitoring is false' do
+    responder = create(:patient, purged: false, monitoring: true)
+    dependent = create(:patient, purged: false, monitoring: false)
+    dependent.update!(responder_id: responder.id)
+
+    assert_not responder.active_dependents.pluck(:id).include?(dependent.id)
+  end
+
+  test 'active dependents does NOT include dependents where they are one day past their last day of monitoring based on LDE' do
+    responder = create(:patient, purged: false, monitoring: true)
+    dependent = create(:patient, purged: false, monitoring: true, last_date_of_exposure: 15.days.ago)
+    dependent.update!(responder_id: responder.id)
+
+    assert_not responder.active_dependents.pluck(:id).include?(dependent.id)
+  end
+
+  test 'active dependents does NOT include dependents where they are one day past their last day of monitoring based on created_at' do
+    responder = create(:patient, purged: false, monitoring: true)
+    dependent = create(:patient, purged: false, monitoring: true, last_date_of_exposure: nil, created_at: 15.days.ago)
+    dependent.update!(responder_id: responder.id)
+
+    assert_not responder.active_dependents.pluck(:id).include?(dependent.id)
+  end
+
+  test 'active dependents defaults to using last_date_of_exposure unless it is nil' do
+    responder = create(:patient, purged: false, monitoring: true)
+    dependent = create(:patient, purged: false, monitoring: true, last_date_of_exposure: 12.days.ago, created_at: 15.days.ago)
+    dependent.update!(responder_id: responder.id)
+
+    # Should be included because LDE is within monitoring period
+    assert responder.active_dependents.pluck(:id).include?(dependent.id)
+  end
+
+  test 'active dependents does NOT include dependents where they are way past their last day of monitoring' do
+    responder = create(:patient, purged: false, monitoring: true)
+    dependent = create(:patient, purged: false, monitoring: true, last_date_of_exposure: 20.days.ago, created_at: 12.days.ago)
+    dependent.update!(responder_id: responder.id)
+
+    assert_not responder.active_dependents.pluck(:id).include?(dependent.id)
+  end
+
+  test 'active dependents DOES include dependents where they are on their last day of monitoring' do
+    responder = create(:patient, purged: false, monitoring: true)
+    dependent = create(:patient, purged: false, monitoring: true, last_date_of_exposure: 14.days.ago, created_at: 12.days.ago)
+    dependent.update!(responder_id: responder.id)
+
+    assert responder.active_dependents.pluck(:id).include?(dependent.id)
+  end
+
+  test 'active dependents DOES include dependents that are monitored in isolation, regardless of LDE or created_at' do
+    responder = create(:patient, purged: false, monitoring: true)
+    dependent = create(:patient, purged: false, monitoring: true, isolation: true, last_date_of_exposure: nil, created_at: 20.days.ago)
+    dependent.update!(responder_id: responder.id)
+
+    assert responder.active_dependents.pluck(:id).include?(dependent.id)
+  end
+
+  test 'active dependents DOES include dependents that are monitored in continuous exposure, regardless of LDE or created_at' do
+    responder = create(:patient, purged: false, monitoring: true)
+    dependent = create(:patient, purged: false, monitoring: true, continuous_exposure: true, last_date_of_exposure: nil, created_at: 20.days.ago)
+    dependent.update!(responder_id: responder.id)
+
+    assert responder.active_dependents.pluck(:id).include?(dependent.id)
+  end
+
+  test 'active dependents does NOT include dependents that are NOT monitored in isolation' do
+    responder = create(:patient, purged: false, monitoring: true)
+    dependent = create(:patient, purged: false, monitoring: false, isolation: true, last_date_of_exposure: nil, created_at: 20.days.ago)
+    dependent.update!(responder_id: responder.id)
+
+    assert_not responder.active_dependents.pluck(:id).include?(dependent.id)
+  end
+
+  test 'active dependents does NOT include dependents that are NOT monitored in continuous exposure' do
+    responder = create(:patient, purged: false, monitoring: true)
+    dependent = create(:patient, purged: false, monitoring: false, continuous_exposure: true, last_date_of_exposure: nil, created_at: 20.days.ago)
+    dependent.update!(responder_id: responder.id)
+
+    assert_not responder.active_dependents.pluck(:id).include?(dependent.id)
+  end
+
+  test 'active_dependents DOES include the responder if the responder meets the criteria' do
+    responder = create(:patient, purged: false, monitoring: true, last_date_of_exposure: 10.days.ago, created_at: 12.days.ago)
+    dependent = create(:patient, purged: false, monitoring: true, last_date_of_exposure: 10.days.ago, created_at: 12.days.ago)
+    dependent.update!(responder_id: responder.id)
+
+    assert responder.active_dependents.pluck(:id).include?(responder.id)
+  end
+
+  test 'active_dependents_exclude_self does NOT include the responder no matter what' do
+    responder = create(:patient, purged: false, monitoring: true, last_date_of_exposure: 10.days.ago, created_at: 12.days.ago)
+    dependent = create(:patient, purged: false, monitoring: true, last_date_of_exposure: 10.days.ago, created_at: 12.days.ago)
+    dependent.update!(responder_id: responder.id)
+
+    assert_not responder.active_dependents_exclude_self.pluck(:id).include?(responder.id)
+  end
+
   test 'close eligible does not include purged records' do
     # Control test
     patient = create(:patient,
@@ -1098,23 +1203,6 @@ class PatientTest < ActiveSupport::TestCase
     assert_equal age, Patient.calc_current_age_fhir(birth_year.to_s)
 
     assert_nil Patient.calc_current_age_fhir(nil)
-  end
-
-  test 'refresh head of household' do
-    patient = create(:patient)
-    dependent = create(:patient, responder: patient)
-    assert patient.reload.head_of_household
-    assert_not dependent.reload.head_of_household
-
-    new_head = create(:patient)
-    dependent.update(responder: new_head)
-    assert_not patient.reload.head_of_household
-    assert new_head.reload.head_of_household
-    assert_not dependent.reload.head_of_household
-
-    dependent.destroy
-    assert_not patient.reload.head_of_household
-    assert_not new_head.reload.head_of_household
   end
 end
 # rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-919](https://tracker.codev.mitre.org/browse/SARAALERT-919)

This PR updates the definition of an "active dependent" to be more accurate. This will make sure dependents aren't receiving notifications when they should not be and that HoH aren't being kept in the system when they should be purged.

For a given monitoree whose responder is another monitoree in the system, they must meet the following criteria to be considered an active dependent:

- Not purged and not closed 
**AND**
- Any of the following:
    - In isolation
    - In continuous exposure
    - Within monitoring period (based on LDE, if no LDE uses date of creation)

NOTE: The `active_dependents` method is used in a few other important places that should be known in order to understand the effects of this change:
- `ConsumeAssessmentsJob`: https://github.com/SaraAlert/SaraAlert/blob/master/app/jobs/consume_assessments_job.rb#L88
- `PurgeJob`: https://github.com/SaraAlert/SaraAlert/blob/master/app/jobs/purge_job.rb#L15
- `PatientMailer` methods: https://github.com/SaraAlert/SaraAlert/blob/master/app/mailers/patient_mailer.rb#L78


# Important Changes
`app/models/patient.rb`
- Updated the `active_dependents` method on the `Patient` model with this new criteria.
- Added new `active_dependents_exclude_self` method with the same criteria but that excludes the responder ID if included.
- Updated logic in `send_assessment` method to first check that a record is being monitored before checking `continuous_exposure`, and to use new `active_dependents_exclude_self` method.
- Updated `report_eligibility` method to use these new/updated methods.

`test/models/patient_test.rb`
- Added a bunch of tests for `active_dependents` method.

# Testing
Best tested by creating Patients in various cases and verifying that they should/should not be considered an active dependent. 

# Notes
@holmesie Feel free to squash commits when merging.

Also, I decided to use the same monitoring period logic we were already using in `send_assessment`, but if there are timezone implications we need to consider that I may be missing, please comment.