### PR TITLE
SARAALERT-915: Changes & fixes to API Update Handling 

### DIFF
--- a/API.md
+++ b/API.md
@@ -1364,7 +1364,7 @@ On success, the server will return the newly created resource with an id. This i
 ### Updating
 An update request creates a new current version for an existing resource.
 
-**PLEASE NOTE:** This means that if certain attributes of the resource are omitted in the `PUT` requests, they will be replaced with `nil` values, as is expected with `PUT` requests. The Sara Alert team is planning on supporting `PATCH` requests to support that kind of update in the future.
+**PLEASE NOTE:** This means that if certain attributes of the resource are omitted in the `PUT` requests, they will be replaced with `nil` values, as is expected with `PUT` requests. The Sara Alert team is planning on supporting `PATCH` requests in the future to support updates where only fields that should be changed need to be included.
 
 <a name="update-put-pat"/>
 

--- a/API.md
+++ b/API.md
@@ -1362,8 +1362,9 @@ On success, the server will return the newly created resource with an id. This i
 <a name="update"/>
 
 ### Updating
+An update request creates a new current version for an existing resource.
 
-The API supports updating existing monitorees.
+**PLEASE NOTE:** This means that if certain attributes of the resource are omitted in the `PUT` requests, they will be replaced with `nil` values, as is expected with `PUT` requests. The Sara Alert team is planning on supporting `PATCH` requests to support that kind of update in the future.
 
 <a name="update-put-pat"/>
 

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -114,9 +114,6 @@ class Fhir::R4::ApiController < ActionController::API
     if resource_type == 'patient'
       # Update patient history with detailed edit diff
       Patient.detailed_history_edit(patient_before, resource, resource.creator&.email, updates.keys, is_api_edit: true)
-
-      # Send closed email to patient if it is closed with this update, and if they are a reporter
-      PatientMailer.closed_email(resource).deliver_later if updates.key?(:closed_at) && resource.email.present? && resource.self_reporter_or_proxy?
     end
 
     status_ok(resource.as_fhir) && return

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -250,11 +250,9 @@ class PatientsController < ApplicationController
     # Reset symptom onset date if moving from isolation to exposure
     reset_symptom_onset(content, patient, :system) if !content[:isolation].nil? && !content[:isolation]
 
-    #Update patient history with detailed edit diff
+    # Update patient history with detailed edit diff
     patient_before = patient.dup
-    if patient.update(content)
-      Patient.detailed_history_edit(patient_before, patient, current_user, allowed_params)
-    end
+    Patient.detailed_history_edit(patient_before, patient, current_user, allowed_params) if patient.update(content)
 
     render json: patient
   end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -252,7 +252,7 @@ class PatientsController < ApplicationController
 
     # Update patient history with detailed edit diff
     patient_before = patient.dup
-    Patient.detailed_history_edit(patient_before, patient, current_user, allowed_params) if patient.update(content)
+    Patient.detailed_history_edit(patient_before, patient, current_user.email, allowed_params) if patient.update(content)
 
     render json: patient
   end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -823,12 +823,12 @@ class Patient < ApplicationRecord
   # Creates a diff between a patient before and after updates, and creates a detailed record edit History item with the changes.
   def self.detailed_history_edit(patient_before, patient_after, user_email, allowed_fields, is_api_edit: false)
     diffs = patient_diff(patient_before, patient_after, allowed_fields)
-    unless diffs.length.zero?
-      pretty_diff = diffs.collect { |d| "#{d[:attribute].to_s.humanize} (\"#{d[:before]}\" to \"#{d[:after]}\")" }
-      comment = is_api_edit ? "Monitoree record edited via API. " : "User edited a monitoree record. "
-      comment += "Changes were: #{pretty_diff.join(', ')}."
-      History.record_edit(patient: patient_after, created_by: user_email, comment: comment)
-    end
+    return if diffs.length.zero?
+
+    pretty_diff = diffs.collect { |d| "#{d[:attribute].to_s.humanize} (\"#{d[:before]}\" to \"#{d[:after]}\")" }
+    comment = is_api_edit ? 'Monitoree record edited via API. ' : 'User edited a monitoree record. '
+    comment += "Changes were: #{pretty_diff.join(', ')}."
+    History.record_edit(patient: patient_after, created_by: user_email, comment: comment)
   end
 
   # Construct a diff for a patient update to keep track of changes

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -276,8 +276,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     )
   end
 
-
-
   test 'GENERAL: should be unauthorized via show' do
     get '/fhir/r4/Patient/1'
     assert_response :unauthorized
@@ -725,11 +723,11 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
 
   test 'SYSTEM FLOW: should update Patient via update and set omitted fields to nil ' do
     # Possible update request that omits all fields that can be updated except for the "active" field.
-    patient_update =  {
-      "id" => @patient_2.id,
-      "identifier" => "100000",
-      "active" => false,
-      "resourceType" => "Patient"
+    patient_update = {
+      'id' => @patient_2.id,
+      'identifier' => '100000',
+      'active' => false,
+      'resourceType' => 'Patient'
     }
 
     put(
@@ -745,24 +743,24 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_not p.nil?
     assert_equal 'Patient', json_response['resourceType']
     assert_nil json_response['name']
-    assert_equal [], json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-method' }
-    assert_equal [], json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-time' }
-    assert_equal [], json_response['extension'].filter { |e| e['url'].include? 'last-exposure-date' }
-    assert_equal [], json_response['extension'].filter { |e| e['url'].include? 'symptom-onset-date' }
+    assert_equal([], json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-method' })
+    assert_equal([], json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-time' })
+    assert_equal([], json_response['extension'].filter { |e| e['url'].include? 'last-exposure-date' })
+    assert_equal([], json_response['extension'].filter { |e| e['url'].include? 'symptom-onset-date' })
     assert_equal false, json_response['active']
   end
 
   test 'SYSTEM FLOW: should properly close Patient record via update' do
     # Possible update request that omits many fields but sets active to false
-    patient_update =  {
-      "id" => @patient_2.id,
-      "identifier" => "100000",
-      "active" => false,
-      "resourceType" => "Patient",
-      "telecom" => [
+    patient_update = {
+      'id' => @patient_2.id,
+      'identifier' => '100000',
+      'active' => false,
+      'resourceType' => 'Patient',
+      'telecom' => [
         {
-          "system": "email",
-          "value": "2966977816fake@example.com",
+          "system": 'email',
+          "value": '2966977816fake@example.com',
           "rank": 1
         }
       ]
@@ -1556,11 +1554,11 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
 
   test 'USER FLOW: should update Patient via update and set omitted fields to nil' do
     # Possible update request that omits all fields that can be updated except for the "active" field.
-    patient_update =  {
-      "id" => @patient_2.id,
-      "identifier" => "100000",
-      "active" => false,
-      "resourceType" => "Patient"
+    patient_update = {
+      'id' => @patient_2.id,
+      'identifier' => '100000',
+      'active' => false,
+      'resourceType' => 'Patient'
     }
 
     put(
@@ -1576,24 +1574,24 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_not p.nil?
     assert_equal 'Patient', json_response['resourceType']
     assert_nil json_response['name']
-    assert_equal [], json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-method' }
-    assert_equal [], json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-time' }
-    assert_equal [], json_response['extension'].filter { |e| e['url'].include? 'last-exposure-date' }
-    assert_equal [], json_response['extension'].filter { |e| e['url'].include? 'symptom-onset-date' }
+    assert_equal([], json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-method' })
+    assert_equal([], json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-time' })
+    assert_equal([], json_response['extension'].filter { |e| e['url'].include? 'last-exposure-date' })
+    assert_equal([], json_response['extension'].filter { |e| e['url'].include? 'symptom-onset-date' })
     assert_equal false, json_response['active']
   end
 
   test 'USER FLOW: should properly close Patient record via update' do
     # Possible update request that omits many fields but sets active to false
-    patient_update =  {
-      "id" => @patient_2.id,
-      "identifier" => "100000",
-      "active" => false,
-      "resourceType" => "Patient",
-      "telecom" => [
+    patient_update = {
+      'id' => @patient_2.id,
+      'identifier' => '100000',
+      'active' => false,
+      'resourceType' => 'Patient',
+      'telecom' => [
         {
-          "system": "email",
-          "value": "2966977816fake@example.com",
+          "system": 'email',
+          "value": '2966977816fake@example.com',
           "rank": 1
         }
       ]

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -725,7 +725,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     # Possible update request that omits all fields that can be updated except for the "active" field.
     patient_update = {
       'id' => @patient_2.id,
-      'identifier' => '100000',
       'active' => false,
       'resourceType' => 'Patient'
     }
@@ -754,7 +753,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     # Possible update request that omits many fields but sets active to false
     patient_update = {
       'id' => @patient_2.id,
-      'identifier' => '100000',
       'active' => false,
       'resourceType' => 'Patient',
       'telecom' => [
@@ -1556,7 +1554,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     # Possible update request that omits all fields that can be updated except for the "active" field.
     patient_update = {
       'id' => @patient_2.id,
-      'identifier' => '100000',
       'active' => false,
       'resourceType' => 'Patient'
     }
@@ -1585,7 +1582,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     # Possible update request that omits many fields but sets active to false
     patient_update = {
       'id' => @patient_2.id,
-      'identifier' => '100000',
       'active' => false,
       'resourceType' => 'Patient',
       'telecom' => [

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -10,7 +10,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     setup_user_applications
     setup_system_applications
     setup_patients
-    ActionMailer::Base.deliveries.clear
   end
 
   # Sets up applications registered for user flow
@@ -782,9 +781,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
 
     # Closed at date should have been set to today
     assert_equal DateTime.now.to_date, p.closed_at&.to_date
-
-    # Should have enqueued closed email to this patient since they are a reporter
-    assert_enqueued_email_with PatientMailer, :closed_email, args: [p]
   end
 
   test 'SYSTEM FLOW: should be bad request via update due to bad fhir' do
@@ -1611,9 +1607,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
 
     # Closed at date should have been set to today
     assert_equal DateTime.now.to_date, p.closed_at&.to_date
-
-    # Should have enqueued closed email to this patient since they are a reporter
-    assert_enqueued_email_with PatientMailer, :closed_email, args: [p]
   end
 
   test 'USER FLOW: should be bad request via update due to bad fhir' do


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-915](https://tracker.codev.mitre.org/browse/SARAALERT-915)

This PR does two main things:

1. Makes sure that when `monitoring` is updated to be false through the API (aka when the record is closed via the API), other necessary actions/updates occur. Specifically, `closed_at` is updated, a closed email goes out if the patient was a reporter, and a detailed history item is created.
2. Changes the `update` method to set omitted fields to `nil` as is expected for a `PUT`. We plan on supporting `PATCH` in the future. This change also fixed the bug where `monitoring` could not be set to false.

NOTE: As this is, there are obvious questions about validating which fields should be allowed to be set to `nil` if omitted. I believe the API data validation PR here should catch those: https://github.com/SaraAlert/SaraAlert/pull/455. @ngfreiter Please correct me if I'm wrong here.

# Important Changes
`API.md`
- Documentation update to emphasize how PUT requests work since they may not realize omitted fields are considered `nil` updates.

`app/controllers/fhir/r4/api_controller.rb`
- (Bugfix) Removing select filter on updates so that if fields are omitted they are considered `nil`, and so that if `monitoring` is false it is still included.
- Updated `closed_at` and sending email (if applicable) when record is closed.
- Creating a detailed History item with all updates.

`app/controllers/patients_controller.rb`
`app/models/patient.rb`
- We already had logic for creating History items with a diff explanation, so I pulled that code out of the controller and moved it into a class method on the `Patient` model.

`test/controllers/fhir/r4/api_controller_test.rb`
- Added tests for verifying appropriate updates/actions occur when record is closed via API.
- Added tests to verify omitted fields are updated to be `nil` on PUT requests.

# Testing
- [ ] Test that you can set `monitoring` to be false on an existing record now. 
- [ ] Test that omitted fields are set to `nil` on the record.
- [ ] Test that history item is created on API update with detailed changes.
- [ ] Test that history item is created on UI update with detailed changes (verifying existing functionality still works).

# Notes
As part of this ticket, it became clear that we need to make sure that all changes/updates that need to occur as a result of other changes are happening with the API updates as they already do with import and UI updates. Specifically, thinking about the update logic done in the `update_fields` method [here](https://github.com/SaraAlert/SaraAlert/blob/master/app/controllers/patients_controller.rb#L348). This should be consolidated so we can do the same checks on import, API update, and update from the frontend. Will be making a ticket to track for next sprint.
