### PR TITLE
SARAALERT-710: Import validation for lab test type and result fields

### DIFF
--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -123,10 +123,10 @@ class ImportController < ApplicationController
 
   def lab_result(data, row_ind)
     {
-      lab_type: data[0],
+      lab_type: validate_enum_field(:lab_type, data[0], row_ind),
       specimen_collection: validate_field(:specimen_collection, data[1], row_ind),
       report: validate_field(:report, data[2], row_ind),
-      result: data[3]
+      result: validate_enum_field(:result, data[3], row_ind)
     }
   end
 

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -159,7 +159,9 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
                       'Self-monitoring with public health supervision',
                       'Self-monitoring with delegated supervision',
                       'Self-observation'],
-    case_status: ['Confirmed', 'Probable', 'Suspect', 'Unknown', 'Not a Case']
+    case_status: ['Confirmed', 'Probable', 'Suspect', 'Unknown', 'Not a Case'],
+    lab_type: ['PCR', 'Antigen', 'Total Antibody', 'IgG Antibody', 'IgM Antibody', 'IgA Antibody', 'Other'],
+    result: %w[positive negative indeterminate other]
   }.freeze
 
   NORMALIZED_ENUMS = VALID_ENUMS.transform_values do |values|
@@ -206,8 +208,10 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
     monitoring_plan: { label: 'Monitoring Plan', checks: [:enum] },
     symptom_onset: { label: 'Symptom Onset', checks: [:date] },
     case_status: { label: 'Case Status', checks: [:enum] },
+    lab_type: { label: 'Lab Test Type', checks: [:enum] },
     specimen_collection: { label: 'Lab Specimen Collection Date', checks: [:date] },
-    report: { label: 'Lab Report Date', checks: [:date] }
+    report: { label: 'Lab Report Date', checks: [:date] },
+    result: { label: 'Result', check: [:enum] }
   }.freeze
 
   def unformat_enum_field(value)


### PR DESCRIPTION
# Bugfix Description
Jira Ticket: SARAALERT-710

On import, any inputs in the Lab Test Type and Lab Results columns are now validated as enums and are validated while being cast to lower case and stripped of spaces. 

# Demo/Screenshots
Error messages now display if improper input was supplied for the Lab Type and Results columns.

![image](https://user-images.githubusercontent.com/42656458/96792596-b2dac200-13c8-11eb-9f27-7a41d507d968.png)

# How to Replicate

1. Create an import file with various type of input for the Lab Test Type & Result columns. Some with extra spaces, some with varying capitalization.
2. Import that file.
3. Obverse that the Lab Test Types and Results that had extra spaces and/or had some capitalized characters included did not import. 

# Solution
Lab Results and Test Types are now validated as enums on import. The value the user supplies is now checked against a set list of options that are valid for each data element. 

# Important Changes

`app/controllers/import_controller.rb`
- Included validation for Lab Test Type and Result as enums

`app/lib/import_export.rb`
- Included valid options for Lab Test Type and Results

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

- [ ] Create and import a file that has Lab Test Type and Result inputs that are valid options, but with extra white spaces and differing capitalization styles. Observe that the import processed properly and that each of the lab data elements imported correctly.
- [ ] Create and import a file that has Lab Test Type and Results inputs that are not valid options. Observe that the import process displays an error highlighting an issue with the relevant row numbers and columns.
