### PR TITLE
fixes sort behavior so all continuous exposure are at the bottom

### DIFF
--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -175,8 +175,8 @@ class PublicHealthController < ApplicationController
       patients = patients.order('CASE WHEN date_of_birth IS NULL THEN 1 ELSE 0 END, date_of_birth ' + dir)
     when 'end_of_monitoring'
       patients = patients.order('CASE
-        WHEN continuous_exposure = 1 THEN now()
-        WHEN last_date_of_exposure IS NULL THEN patients.created_at ELSE last_date_of_exposure END ' + dir)
+      WHEN continuous_exposure = 1 THEN ' + (dir == 'asc' ? 'now()' : 'DATE("1970-01-01")') +
+      ' WHEN last_date_of_exposure IS NULL THEN patients.created_at ELSE last_date_of_exposure END ' + dir)
     when 'extended_isolation'
       patients = patients.order('CASE WHEN extended_isolation IS NULL THEN 1 ELSE 0 END, extended_isolation ' + dir)
     when 'symptom_onset'

--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -203,8 +203,8 @@ const TOOLTIP_TEXT = {
   ),
   extendedIsolation: (
     <div>
-      Used by the system to determine eligibility to appear on the<i>Records Requiring Review</i>line list. A case cannot appear on the{' '}
-      <i>Records Requiring Review</i>line list until after the user-specified date. This field may be blank.
+      Used by the system to determine eligibility to appear on the <i>Records Requiring Review</i> line list. A case cannot appear on the{' '}
+      <i>Records Requiring Review</i> line list until after the user-specified date. This field may be blank.
     </div>
   ),
   // REQUIRES REVIEW RECOVERY LOGIC

--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -203,8 +203,8 @@ const TOOLTIP_TEXT = {
   ),
   extendedIsolation: (
     <div>
-      Used by the system to determine eligibility to appear on the <i>Records Requiring Review</i> line list. A case cannot appear on the{' '}
-      <i>Records Requiring Review</i> line list until after the user-specified date. This field may be blank.
+      Used by the system to determine eligibility to appear on the<i>Records Requiring Review</i>line list. A case cannot appear on the{' '}
+      <i>Records Requiring Review</i>line list until after the user-specified date. This field may be blank.
     </div>
   ),
   // REQUIRES REVIEW RECOVERY LOGIC


### PR DESCRIPTION
# Description
This PR addresses some behavior that was not the desired behavior. It does not fix a bug, merely changes the way sorting works.

Previously, monitorees that had `continuous exposure` would always be sorted to the most recent time. AKA they would show at the top/bottom if sorting by ascending/descending. The desired behavior is actually that they always show at the bottom, regardless of sorting direction.

As a result, a ternary operator is added in this PR. If the sorting is `ascending`, keep the `now()` behavior. Else use a time way in the past (so they are forced to the bottom). In this case, the epoch timestamp was chosen.


This PR also fixes a whitespace that was angering the linter.