### PR TITLE
Bugfix: add back in resume notifications confirmation language

### DIFF
--- a/app/javascript/components/subject/PauseNotifications.js
+++ b/app/javascript/components/subject/PauseNotifications.js
@@ -58,7 +58,6 @@ class PauseNotifications extends React.Component {
   }
 
   render() {
-    const notificationsAction = this.props.patient.pause_notifications ? 'resumed' : 'paused';
     return (
       <React.Fragment>
         <span data-for="notifications-tooltip" data-tip="">
@@ -68,7 +67,9 @@ class PauseNotifications extends React.Component {
             disabled={this.state.disableAndDisplayTooltip || this.state.loading}
             onClick={() =>
               this.handleSubmit(
-                `You are about to change this monitoree's notification status to ${notificationsAction}. This means that the system will stop sending the monitoree symptom report requests until notifications are resumed by a user.`
+                this.props.patient.pause_notifications
+                  ? `You are about to change this monitoree's notification status to resumed. This means that the system will start sending the monitoree symptom report requests during their preferred reporting time until they are no longer eligible or notifications are paused by a user.`
+                  : `You are about to change this monitoree's notification status to paused. This means that the system will stop sending the monitoree symptom report requests until notifications are resumed by a user.`
               )
             }>
             {this.props.patient.pause_notifications && (


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-851](https://tracker.codev.mitre.org/browse/SARAALERT-851)
"Resume Notifications" confirmation message needs to be updated

# (Bugfix) How to Replicate
Click the resume notifications button and notice the language does not make sense
![image](https://user-images.githubusercontent.com/35042815/97001624-a8bedd80-1506-11eb-8aeb-7ea665b14163.png)

# (Bugfix) Solution
Click the resume notifications button and notice the language now makes sense
![Screen Shot 2020-10-23 at 8 00 03 AM](https://user-images.githubusercontent.com/35042815/97001592-9cd31b80-1506-11eb-82de-99cb8c4a5abe.png)

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
