### PR TITLE
Small Fixes for 1.15.0

### DIFF
--- a/app/javascript/components/subject/PauseNotifications.js
+++ b/app/javascript/components/subject/PauseNotifications.js
@@ -45,7 +45,7 @@ class PauseNotifications extends React.Component {
     let text = '';
     // monitoree record is closed
     if (!this.props.patient.monitoring) {
-      text = `Notifications cannot be ${notificationsAction} for records on the Closed line list since this monitoree is not eligible to receive notifications. If this monitoree requires monitoring, you may update this field after changing Monitoring Status to "Actively Monitoring"`;
+      text = `Notifications cannot be ${notificationsAction} for records on the Closed line list. You may update this field after changing Monitoring Status to "Actively Monitoring"`;
       // monitoree is a HH dependent
     } else if (this.props.patient.id !== this.props.patient.responder_id) {
       text = `Notifications cannot be ${notificationsAction} because the monitoree is within a Household, so the Head of Household will receive notifications instead. If notifications to the Head of Household should be ${notificationsAction}, you may update this field on the Head of Household record.`;

--- a/app/lib/roles.rb
+++ b/app/lib/roles.rb
@@ -12,4 +12,9 @@ module Roles
   def self.all_role_values
     constants.map { |c| const_get(c) }
   end
+
+  # Role values that users can be assigned to
+  def self.all_assignable_role_values
+    constants.map { |c| const_get(c) if c != :NONE }.compact
+  end
 end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,6 +1,6 @@
 <%= stylesheet_link_tag 'AdminTable' %>
 <%= react_component('admin/AdminTable', {
-                      role_types: Roles.all_role_values.reverse.map { |role| role.split('_').map(&:capitalize).join(' ') },
+                      role_types: Roles.all_assignable_role_values.reverse.map { |role| role.split('_').map(&:capitalize).join(' ') },
                       authenticity_token: form_authenticity_token,
                       is_usa_admin: current_user.can_send_admin_emails?
                     }) %>


### PR DESCRIPTION
# Description
This PR makes the following small updates for 1.15.0:
1. Updated Pause Notifications button tooltip text.
2. Removed "None" option from selectable roles on Admin Panel page.

# Important Changes
`app/javascript/components/subject/PauseNotifications.js`
- Changes for update 1.

`app/lib/roles.rb`
`app/views/admin/index.html.erb`
- Changes for update 2.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please test the following:
- [ ] Pause Notifications tooltip text is correct.
- [ ] "None" is no longer a role option when creating or editing users in the admin panel.
