### PR TITLE
History component fixes

### DIFF
--- a/app/javascript/components/history/HistoryComponent.js
+++ b/app/javascript/components/history/HistoryComponent.js
@@ -21,7 +21,7 @@ class HistoryComponent extends React.Component {
       filteredHistories: this.props.histories,
       pageOfHistories: [],
     };
-    this.historyCreators = [
+    this.creatorFilterData = [
       {
         label: 'History Creator',
         options: _.uniq(props.histories.map(x => x.created_by)).map(x => {
@@ -30,7 +30,7 @@ class HistoryComponent extends React.Component {
       },
     ];
 
-    this.filterOptions = [
+    this.typeFilterData = [
       {
         label: 'History Type',
         options: [],
@@ -38,7 +38,7 @@ class HistoryComponent extends React.Component {
     ];
 
     for (const historyType in this.props.history_types) {
-      this.filterOptions[0].options.push({
+      this.typeFilterData[0].options.push({
         value: _.startCase(historyType), // converts `monitoree_data_downloaded` to `Monitoree Data Downloaded`
         label: this.props.history_types[`${historyType}`],
       });
@@ -131,7 +131,7 @@ class HistoryComponent extends React.Component {
                 closeMenuOnSelect={false}
                 isMulti
                 name="Creator Filters"
-                options={this.historyCreators}
+                options={this.creatorFilterData}
                 className="basic-multi-select w-25 pl-1"
                 classNamePrefix="select"
                 placeholder="Filter by Creator"
@@ -145,7 +145,7 @@ class HistoryComponent extends React.Component {
                 closeMenuOnSelect={false}
                 isMulti
                 name="Filters"
-                options={this.filterOptions}
+                options={this.typeFilterData}
                 className="basic-multi-select w-25 pl-2"
                 classNamePrefix="select"
                 placeholder="Filter by Type"

--- a/app/javascript/components/history/HistoryComponent.js
+++ b/app/javascript/components/history/HistoryComponent.js
@@ -106,27 +106,6 @@ class HistoryComponent extends React.Component {
 
   render() {
     const historiesArray = this.state.pageOfHistories.map(history => <History key={history.id} history={history} />);
-
-    const filterOptions = [
-      {
-        label: 'History Type',
-        options: [
-          { value: 'Comment', label: 'Comment' },
-          { value: 'Contact Attempt', label: 'Contact Attempt' },
-          { value: 'Enrollment', label: 'Enrollment' },
-          { value: 'Lab Result', label: 'Lab Result' },
-          { value: 'Lab Result Edit', label: 'Lab Result Edit' },
-          { value: 'Monitoree Data Downloaded', label: 'Monitoree Data Downloaded' },
-          { value: 'Monitoring Change', label: 'Monitoring Change' },
-          { value: 'Report Created', label: 'Report Created' },
-          { value: 'Report Note', label: 'Report Note' },
-          { value: 'Report Reminder', label: 'Report Reminder' },
-          { value: 'Report Reviewed', label: 'Report Reviewed' },
-          { value: 'Report Updated', label: 'Report Updated' },
-          { value: 'Reports Reviewed', label: 'Reports Reviewed' },
-        ],
-      },
-    ];
     const historyCreators = [
       {
         label: 'History Creator',
@@ -167,7 +146,7 @@ class HistoryComponent extends React.Component {
                 closeMenuOnSelect={false}
                 isMulti
                 name="Filters"
-                options={filterOptions}
+                options={this.filterOptions}
                 className="basic-multi-select w-25 pl-2"
                 classNamePrefix="select"
                 placeholder="Filter by Type"

--- a/app/javascript/components/history/HistoryComponent.js
+++ b/app/javascript/components/history/HistoryComponent.js
@@ -21,6 +21,14 @@ class HistoryComponent extends React.Component {
       filteredHistories: this.props.histories,
       pageOfHistories: [],
     };
+    this.historyCreators = [
+      {
+        label: 'History Creator',
+        options: _.uniq(props.histories.map(x => x.created_by)).map(x => {
+          return { value: x, label: x };
+        }),
+      },
+    ];
 
     this.filterOptions = [
       {
@@ -106,15 +114,6 @@ class HistoryComponent extends React.Component {
 
   render() {
     const historiesArray = this.state.pageOfHistories.map(history => <History key={history.id} history={history} />);
-    const historyCreators = [
-      {
-        label: 'History Creator',
-        options: _.uniq(this.props.histories.map(x => x.created_by)).map(x => {
-          return { value: x, label: x };
-        }),
-      },
-    ];
-
     return (
       <React.Fragment>
         <Card className="mx-2 mt-3 mb-4 card-square">
@@ -132,7 +131,7 @@ class HistoryComponent extends React.Component {
                 closeMenuOnSelect={false}
                 isMulti
                 name="Creator Filters"
-                options={historyCreators}
+                options={this.historyCreators}
                 className="basic-multi-select w-25 pl-1"
                 classNamePrefix="select"
                 placeholder="Filter by Creator"


### PR DESCRIPTION
# Description
In the past 2 weeks, there have been several changes to the HistoryComponent page. Somehow, the git diff between these PRs was slightly messed up and certain code was not included (when it should have been). This PR re-adds this correct code. It also slightly modifies inefficient behavior.

It is possible that when `1.16` is merged into `master`, git will get upset at a similar diff occurring in both places. If such a thing happens, the following code should be included/used to resolve any merge conflicts.

```
/// ... line 145-ish in HistoryComponent.js
      <Select
                closeMenuOnSelect={false}
                isMulti
                name="Filters"
                options={this.filterOptions} // <--this is where any merge-conflicts may or may not occur.
                className="basic-multi-select w-25 pl-2"
                classNamePrefix="select"
                placeholder="Filter by Type"
                theme={theme => ({
                  ...theme,
                  borderRadius: 0,
                })}
                onChange={this.handleTypeFilterChange}
              />
```

The correct bit of code is `this.filterOptions` *NOT* `filterOptions`.

It isn't a guarantee that there will be any issues, but should any arise, this is the solution.