### PR TITLE
refactored a bug in the filtering

### DIFF
--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -177,9 +177,7 @@ class PublicHealthController < ApplicationController
       # `Continuous Exposure` values need a date associated with them so they always sort at the bottom. When sorting `desc`, using the epoch() time does the trick.
       # But for `asc`, we want to use a time that logically comes after any dates in the system.
       # System dates can be between now() and (30 days + the monitoring_period_days). The extra 1 (31 instead of 30) is to rule out any off-by-one errors.
-      patients = patients.order('CASE
-      WHEN continuous_exposure = 1 THEN ' + (dir == 'asc' ? 'DATE_ADD(NOW(), INTERVAL '+ (31 + ADMIN_OPTIONS['monitoring_period_days']).to_s + ' DAY)' : 'DATE("1970-01-01")') +
-      ' WHEN last_date_of_exposure IS NULL THEN patients.created_at ELSE last_date_of_exposure END ' + dir)
+      patients = patients.order('CASE WHEN continuous_exposure = 1 THEN 1 ELSE 0 END, CASE WHEN last_date_of_exposure IS NULL THEN patients.created_at ELSE last_date_of_exposure END ' + dir)
     when 'extended_isolation'
       patients = patients.order('CASE WHEN extended_isolation IS NULL THEN 1 ELSE 0 END, extended_isolation ' + dir)
     when 'symptom_onset'

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -174,8 +174,11 @@ class PublicHealthController < ApplicationController
     when 'dob'
       patients = patients.order('CASE WHEN date_of_birth IS NULL THEN 1 ELSE 0 END, date_of_birth ' + dir)
     when 'end_of_monitoring'
+      # `Continuous Exposure` values need a date associated with them so they always sort at the bottom. When sorting `desc`, using the epoch() time does the trick.
+      # But for `asc`, we want to use a time that logically comes after any dates in the system.
+      # System dates can be between now() and (30 days + the monitoring_period_days). The extra 1 (31 instead of 30) is to rule out any off-by-one errors.
       patients = patients.order('CASE
-      WHEN continuous_exposure = 1 THEN ' + (dir == 'asc' ? 'now()' : 'DATE("1970-01-01")') +
+      WHEN continuous_exposure = 1 THEN ' + (dir == 'asc' ? 'DATE_ADD(NOW(), INTERVAL '+ (31 + ADMIN_OPTIONS['monitoring_period_days']).to_s + ' DAY)' : 'DATE("1970-01-01")') +
       ' WHEN last_date_of_exposure IS NULL THEN patients.created_at ELSE last_date_of_exposure END ' + dir)
     when 'extended_isolation'
       patients = patients.order('CASE WHEN extended_isolation IS NULL THEN 1 ELSE 0 END, extended_isolation ' + dir)

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -174,9 +174,6 @@ class PublicHealthController < ApplicationController
     when 'dob'
       patients = patients.order('CASE WHEN date_of_birth IS NULL THEN 1 ELSE 0 END, date_of_birth ' + dir)
     when 'end_of_monitoring'
-      # `Continuous Exposure` values need a date associated with them so they always sort at the bottom. When sorting `desc`, using the epoch() time does the trick.
-      # But for `asc`, we want to use a time that logically comes after any dates in the system.
-      # System dates can be between now() and (30 days + the monitoring_period_days). The extra 1 (31 instead of 30) is to rule out any off-by-one errors.
       patients = patients.order('CASE WHEN continuous_exposure = 1 THEN 1 ELSE 0 END, CASE WHEN last_date_of_exposure IS NULL THEN patients.created_at ELSE last_date_of_exposure END ' + dir)
     when 'extended_isolation'
       patients = patients.order('CASE WHEN extended_isolation IS NULL THEN 1 ELSE 0 END, extended_isolation ' + dir)


### PR DESCRIPTION
There was a bug that allowed dates to occur after `Continuous Exposure` when sorting the linelists.

The desired behavior is to always have the ContinuousExposure values at the bottom when sorting. To accomplish this, they were given the date of `now()` when sorting. This works great as long as no dates can occur in the future. However, some dates are allowed to be in the future.

~~This PR changes the behavior so that, instead of assigning a value of `now()` to the `ContinuousExposure` items, they are instead assigned a date of `now() + 31 days + 14 days`. The 14 days is the monitoring period of covid19. The 31 days is 30 + 1. The 30 is the number of day the user can select the last date of exposure into the future, and the 1 is to prevent any off-by-one errors.~~

This PR cleans up the logic so all `ContinuousExposure` goes at the bottom.