### PR TITLE
SARAALERT-958: Handle API Proxy Users

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -31,7 +31,8 @@ class AdminController < ApplicationController
     return head :bad_request unless (!order_by.blank? && !sort_direction.blank?) || (order_by.blank? && sort_direction.blank?)
 
     # Get all users within the current user's jurisdiction
-    users = User.where(jurisdiction_id: current_user.jurisdiction.subtree_ids)
+    # NOTE: Does not include API proxy users as those are not managed by anyone other than USA admins and cannot be accessed by real users
+    users = User.where(is_api_proxy: false, jurisdiction_id: current_user.jurisdiction.subtree_ids)
                 .joins(:jurisdiction)
                 .select('users.id, users.email, users.api_enabled, users.locked_at, users.authy_id, users.failed_attempts, users.role, jurisdictions.path')
 

--- a/db/migrate/20201028204903_add_is_api_proxy_to_users.rb
+++ b/db/migrate/20201028204903_add_is_api_proxy_to_users.rb
@@ -1,0 +1,11 @@
+class AddIsApiProxyToUsers < ActiveRecord::Migration[6.0]
+  def up
+    add_column :users, :is_api_proxy, :boolean, default: false
+    # Update all existing API proxy users to have this field set to true
+    User.where(id: OauthApplication.where.not(user_id: nil).pluck(:user_id)).update_all(is_api_proxy: true)
+  end
+
+  def down
+    remove_column :users, :is_api_proxy
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_28_194626) do
+ActiveRecord::Schema.define(version: 2020_10_28_204903) do
 
   create_table "analytics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "jurisdiction_id"
@@ -461,6 +461,7 @@ ActiveRecord::Schema.define(version: 2020_10_28_194626) do
     t.boolean "authy_enforced", default: true
     t.boolean "api_enabled", default: false
     t.string "role", default: "none", null: false
+    t.boolean "is_api_proxy", default: false
     t.index ["authy_id"], name: "index_users_on_authy_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["jurisdiction_id"], name: "index_users_on_jurisdiction_id"

--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -221,7 +221,8 @@ namespace :admin do
         jurisdiction: jurisdiction,
         force_password_change: false,
         api_enabled: true,
-        role: 'public_health_enroller'
+        role: 'public_health_enroller',
+        is_api_proxy: true
       )
 
       # Lock access as no one should be logging into this user account.

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -86,8 +86,8 @@ class AdminControllerTest < ActionController::TestCase
       end
     end
 
-    # Assert that the total count is correct
-    assert_equal(parsed_response['total'], User.count)
+    # Assert that the total count is correct and that API proxy users were not included
+    assert_equal(parsed_response['total'], User.where(is_api_proxy: false).count)
 
     sign_out user
   end
@@ -129,12 +129,12 @@ class AdminControllerTest < ActionController::TestCase
 
     sort_direction = 'asc'
     get :users, params: { orderBy: order_by, sortDirection: sort_direction }
-    ordered_ids = User.where(jurisdiction_id: user.jurisdiction.subtree_ids).order(id: sort_direction).pluck(:id)
+    ordered_ids = User.where(is_api_proxy: false, jurisdiction_id: user.jurisdiction.subtree_ids).order(id: sort_direction).pluck(:id)
     assert_equal(ordered_ids, (JSON.parse(response.body)['user_rows'].map { |u| u['id'] }))
 
     sort_direction = 'desc'
     get :users, params: { orderBy: order_by, sortDirection: sort_direction }
-    ordered_ids = User.where(jurisdiction_id: user.jurisdiction.subtree_ids).order(id: sort_direction).pluck(:id)
+    ordered_ids = User.where(is_api_proxy: false, jurisdiction_id: user.jurisdiction.subtree_ids).order(id: sort_direction).pluck(:id)
     assert_equal(ordered_ids, (JSON.parse(response.body)['user_rows'].map { |u| u['id'] }))
 
     # Test sort by email
@@ -142,12 +142,12 @@ class AdminControllerTest < ActionController::TestCase
 
     sort_direction = 'asc'
     get :users, params: { orderBy: order_by, sortDirection: sort_direction }
-    ordered_emails = User.where(jurisdiction_id: user.jurisdiction.subtree_ids).order(email: sort_direction).pluck(:email)
+    ordered_emails = User.where(is_api_proxy: false, jurisdiction_id: user.jurisdiction.subtree_ids).order(email: sort_direction).pluck(:email)
     assert_equal(ordered_emails, (JSON.parse(response.body)['user_rows'].map { |u| u['email'] }))
 
     sort_direction = 'desc'
     get :users, params: { orderBy: order_by, sortDirection: sort_direction }
-    ordered_emails = User.where(jurisdiction_id: user.jurisdiction.subtree_ids).order(email: sort_direction).pluck(:email)
+    ordered_emails = User.where(is_api_proxy: false, jurisdiction_id: user.jurisdiction.subtree_ids).order(email: sort_direction).pluck(:email)
     assert_equal(ordered_emails, (JSON.parse(response.body)['user_rows'].map { |u| u['email'] }))
 
     # Test sort by jurisdiction_path
@@ -155,14 +155,14 @@ class AdminControllerTest < ActionController::TestCase
 
     sort_direction = 'asc'
     get :users, params: { orderBy: order_by, sortDirection: sort_direction }
-    ordered_paths = User.where(jurisdiction_id: user.jurisdiction.subtree_ids).joins(:jurisdiction).select(
+    ordered_paths = User.where(is_api_proxy: false, jurisdiction_id: user.jurisdiction.subtree_ids).joins(:jurisdiction).select(
       'users.id, users.email, users.api_enabled, users.locked_at, users.authy_id, users.failed_attempts, jurisdictions.path '
     ).order(path: sort_direction).pluck(:path)
     assert_equal(ordered_paths, (JSON.parse(response.body)['user_rows'].map { |u| u['jurisdiction_path'] }))
 
     sort_direction = 'desc'
     get :users, params: { orderBy: order_by, sortDirection: sort_direction }
-    ordered_paths = User.where(jurisdiction_id: user.jurisdiction.subtree_ids).joins(:jurisdiction).select(
+    ordered_paths = User.where(is_api_proxy: false, jurisdiction_id: user.jurisdiction.subtree_ids).joins(:jurisdiction).select(
       'users.id, users.email, users.api_enabled, users.locked_at, users.authy_id, users.failed_attempts, jurisdictions.path '
     ).order(path: sort_direction).pluck(:path)
     assert_equal(ordered_paths, (JSON.parse(response.body)['user_rows'].map { |u| u['jurisdiction_path'] }))
@@ -172,12 +172,12 @@ class AdminControllerTest < ActionController::TestCase
 
     sort_direction = 'asc'
     get :users, params: { orderBy: order_by, sortDirection: sort_direction }
-    ordered_logins = User.where(jurisdiction_id: user.jurisdiction.subtree_ids).order(failed_attempts: sort_direction).pluck(:failed_attempts)
+    ordered_logins = User.where(is_api_proxy: false, jurisdiction_id: user.jurisdiction.subtree_ids).order(failed_attempts: sort_direction).pluck(:failed_attempts)
     assert_equal(ordered_logins, (JSON.parse(response.body)['user_rows'].map { |u| u['num_failed_logins'] }))
 
     sort_direction = 'desc'
     get :users, params: { orderBy: order_by, sortDirection: sort_direction }
-    ordered_logins = User.where(jurisdiction_id: user.jurisdiction.subtree_ids).order(failed_attempts: sort_direction).pluck(:failed_attempts)
+    ordered_logins = User.where(is_api_proxy: false, jurisdiction_id: user.jurisdiction.subtree_ids).order(failed_attempts: sort_direction).pluck(:failed_attempts)
     assert_equal(ordered_logins, (JSON.parse(response.body)['user_rows'].map { |u| u['num_failed_logins'] }))
 
     sign_out user

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -172,12 +172,14 @@ class AdminControllerTest < ActionController::TestCase
 
     sort_direction = 'asc'
     get :users, params: { orderBy: order_by, sortDirection: sort_direction }
-    ordered_logins = User.where(is_api_proxy: false, jurisdiction_id: user.jurisdiction.subtree_ids).order(failed_attempts: sort_direction).pluck(:failed_attempts)
+    ordered_logins = User.where(is_api_proxy: false, jurisdiction_id: user.jurisdiction.subtree_ids)
+                         .order(failed_attempts: sort_direction).pluck(:failed_attempts)
     assert_equal(ordered_logins, (JSON.parse(response.body)['user_rows'].map { |u| u['num_failed_logins'] }))
 
     sort_direction = 'desc'
     get :users, params: { orderBy: order_by, sortDirection: sort_direction }
-    ordered_logins = User.where(is_api_proxy: false, jurisdiction_id: user.jurisdiction.subtree_ids).order(failed_attempts: sort_direction).pluck(:failed_attempts)
+    ordered_logins = User.where(is_api_proxy: false, jurisdiction_id: user.jurisdiction.subtree_ids)
+                         .order(failed_attempts: sort_direction).pluck(:failed_attempts)
     assert_equal(ordered_logins, (JSON.parse(response.body)['user_rows'].map { |u| u['num_failed_logins'] }))
 
     sign_out user

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -364,7 +364,7 @@ state1_admin:
   api_enabled: false
   role: 'admin'
 state1_api_proxy:
-  id: 21
+  id: 25
   email: "state1_api_proxy@example.com"
   encrypted_password: <%= Devise::Encryptor.digest(User, '1234567ab!') %>
   sign_in_count: 0

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -363,3 +363,19 @@ state1_admin:
   authy_enforced: false
   api_enabled: false
   role: 'admin'
+state1_api_proxy:
+  id: 21
+  email: "state1_api_proxy@example.com"
+  encrypted_password: <%= Devise::Encryptor.digest(User, '1234567ab!') %>
+  sign_in_count: 0
+  failed_attempts: 3
+  force_password_change: false
+  jurisdiction_id: 2
+  password_changed_at: "<%= 50.days.ago %>"
+  created_at: "<%= 50.days.ago %>"
+  updated_at: "<%= 50.days.ago %>"
+  authy_enabled: false
+  authy_enforced: false
+  api_enabled: true
+  role: 'public_health_enroller'
+  is_api_proxy: true

--- a/test/system/roles/admin/admin_test_helper.rb
+++ b/test/system/roles/admin/admin_test_helper.rb
@@ -13,9 +13,14 @@ class AdminTestHelper < ApplicationSystemTestCase
 
   def view_users(user_label)
     jurisdiction_id = @@system_test_utils.login(user_label)
-    User.where(jurisdiction_id: Jurisdiction.find(jurisdiction_id).subtree_ids).each do |user|
+    User.where(is_api_proxy: false, jurisdiction_id: Jurisdiction.find(jurisdiction_id).subtree_ids).each do |user|
       @@admin_dashboard.search_for_user(user.email)
       @@admin_dashboard_verifier.verify_user(user, should_exist: true)
+    end
+    # API Proxy users in the jurisdiction hierarchy should be hidden
+    User.where(is_api_proxy: true, jurisdiction_id: Jurisdiction.find(jurisdiction_id).subtree_ids).each do |user|
+      @@admin_dashboard.search_for_user(user.email)
+      @@admin_dashboard_verifier.verify_user(user, should_exist: false)
     end
     User.where.not(jurisdiction_id: Jurisdiction.find(jurisdiction_id).subtree_ids).each do |user|
       @@admin_dashboard.search_for_user(user.email)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-958](https://tracker.codev.mitre.org/browse/SARAALERT-958)

"API proxy users" are user accounts specifically created for OAuth Apps using the API and the backend services workflow so that changes can be made under a specific email/associated user account. They cannot (and should not) be logged into by real people (already handled as they are locked upon creation without a password reset), nor should they be displayed on the Admin Panel or exported (handled in this PR). 

This PR does the following to achieve the above:
- Adds a new column to the User table called `is_api_proxy` that tracks whether the user is an API proxy user or not. This migration includes an update to all existing API proxy users.
- Updates the `admin:create_oauth_app_for_backend_services_workflow` rake task to set this new column to true when creating an API proxy user.
- Updates the Admin page to no longer show these users or include them in exports.

# Important Changes
`db/migrate/20201028204903_add_is_api_proxy_to_users.rb`
- Migration for adding new column. Please note the update to existing API proxy users.

`app/controllers/admin_controller.rb`
- Added check for new column to exclude these users from admin table. This same method is used to grab the users for export so this change handles both cases.

`lib/tasks/admin.rake`
- Setting new column to true when creating these users through the rake task.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Test by doing the following:
1. Before the migration, run the rake task with test data to create an API proxy user.
2. Verify that the user shows up on the Admin page and in Admin exports.
3. Run the migration, verify that ONLY the user that was an API proxy user now no longer shows up on the page or in the exports.
