### PR TITLE
Update Breadcrumbs for Admin Panel and Analytics

### DIFF
--- a/app/javascript/components/admin/AdminTable.js
+++ b/app/javascript/components/admin/AdminTable.js
@@ -562,7 +562,7 @@ class AdminTable extends React.Component {
 
   render() {
     return (
-      <div>
+      <div className="mx-2">
         <div className="d-flex justify-content-between mb-2">
           <div className="mb-1">
             <Button className="mr-1" size="md" onClick={this.handleAddUserClick}>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,4 +1,5 @@
 <%= stylesheet_link_tag 'AdminTable' %>
+<%= render partial: 'layouts/breadcrumb', locals: { jurisdiction_path: current_user.jurisdiction_path, crumbs: [{ value: 'Admin Panel', href: nil }] } %>
 <%= react_component('admin/AdminTable', {
                       role_types: Roles.all_assignable_role_values.reverse.map { |role| role.split('_').map(&:capitalize).join(' ') },
                       authenticity_token: form_authenticity_token,

--- a/app/views/analytics/index.html.erb
+++ b/app/views/analytics/index.html.erb
@@ -2,12 +2,7 @@
   <%= javascript_pack_tag 'moment' %>
   <%= javascript_pack_tag 'closest' %>
 <% end %>
-<% if current_user.role? Roles::ANALYST %>
-  <%= render partial: 'layouts/breadcrumb', locals: { jurisdiction_path: current_user.jurisdiction_path, crumbs: [{ value: 'Analytics', href: nil }] } %>
-<% else %>
-  <%= render partial: 'layouts/breadcrumb', locals: { jurisdiction_path: current_user.jurisdiction_path, crumbs: [{ value: 'Return to Exposure Dashboard', href: root_url }, { value: 'Analytics', href: nil }] } %>
-<% end %>
-
+<%= render partial: 'layouts/breadcrumb', locals: { jurisdiction_path: current_user.jurisdiction_path, crumbs: [{ value: 'Analytics', href: nil }] } %>
 <% if current_user.role?(Roles::ENROLLER) %>
   <%= react_component('analytics/EnrollerAnalytics', { current_user: current_user, stats: @stats }) %>
 <% end %>


### PR DESCRIPTION
# Description
Now that the Analytics can be access through their own tab, it does not need a breadcrumb pointing back to the root page. Additionally, this PR makes the Admin Panel consistent with other views by adding a breadcrumb and updating the margin on the AdminTable component for alignment.

# Screenshots
Analytics Before:
![image (22)](https://user-images.githubusercontent.com/11698457/97611023-06ae6200-19ec-11eb-903d-841942b5a1c8.png)

Analytics After:
![Screen Shot 2020-10-29 at 1 39 55 PM](https://user-images.githubusercontent.com/11698457/97611224-42492c00-19ec-11eb-8dfe-561d88015680.png)

Admin Before:
![Screen Shot 2020-10-29 at 1 39 22 PM](https://user-images.githubusercontent.com/11698457/97611152-29d91180-19ec-11eb-8658-e7a040529dd6.png)

Admin After:
![Screen Shot 2020-10-29 at 1 35 22 PM](https://user-images.githubusercontent.com/11698457/97611169-30678900-19ec-11eb-9b08-3df3d1f2ab7b.png)

# Important Changes
`app/views/admin/index.html.erb`
- Adding breadcrumb to Admin Panel.

`app/javascript/components/admin/AdminTable.js`
- Adding padding for alignment with breadcrumb.

`app/views/analytics/index.html.erb`
- Removing now unnecessary conditional and just always showing the same breadcrumb for analytics.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

To test:
- [x] Make sure Admin Panel has new breadcrumb bar and it aligns with table and buttons. It should not link to anything.
- [x] Make sure Analytics page still has breadcrumb that now only says "Analytics". It should not link to anything.
