### PR TITLE
history typo fix

### DIFF
--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -266,6 +266,6 @@ class PatientMailer < ApplicationMailer
   def add_fail_history_blank_field(patient, type)
     History.report_reminder(patient: patient,
                             comment: "Sara Alert could not send a report reminder to this monitoree via \
-                                     #{patient.preferred_contact_method}, because the monitoree #{type} number was blank.")
+                                     #{patient.preferred_contact_method}, because the monitoree #{type} was blank.")
   end
 end


### PR DESCRIPTION
# Description
remove unnecessary 'number' when computing history message

![image](https://user-images.githubusercontent.com/35042815/97725376-7da73180-1aa4-11eb-8e27-fd726c6a7ce8.png)


