### PR TITLE
Saraalert 913 Hunspell

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Install hunspell library
         run: |
           sudo apt install hunspell
-          wget -o /usr/share/hunspell/es_PR.aff https://cgit.freedesktop.org/libreoffice/dictionaries/plain/es/es_PR.aff
-          wget -o /usr/share/hunspell/es_PR.dic https://cgit.freedesktop.org/libreoffice/dictionaries/plain/es/es_PR.dic
-          wget -o /usr/share/hunspell/fr.aff https://cgit.freedesktop.org/libreoffice/dictionaries/plain/fr_FR/fr.aff
-          wget -o /usr/share/hunspell/fr.dic https://cgit.freedesktop.org/libreoffice/dictionaries/plain/fr_FR/fr.dic
+          sudo wget -o /usr/share/hunspell/es_PR.aff https://cgit.freedesktop.org/libreoffice/dictionaries/plain/es/es_PR.aff
+          sudo wget -o /usr/share/hunspell/es_PR.dic https://cgit.freedesktop.org/libreoffice/dictionaries/plain/es/es_PR.dic
+          sudo wget -o /usr/share/hunspell/fr.aff https://cgit.freedesktop.org/libreoffice/dictionaries/plain/fr_FR/fr.aff
+          sudo wget -o /usr/share/hunspell/fr.dic https://cgit.freedesktop.org/libreoffice/dictionaries/plain/fr_FR/fr.dic
       - name: Run Bundle Install
         run: |
           bundle config path vendor/bundle

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -40,6 +40,10 @@ jobs:
       - name: Install hunspell library
         run: |
           sudo apt install hunspell
+          wget -o /usr/share/hunspell/es_PR.aff https://cgit.freedesktop.org/libreoffice/dictionaries/plain/es/es_PR.aff
+          wget -o /usr/share/hunspell/es_PR.dic https://cgit.freedesktop.org/libreoffice/dictionaries/plain/es/es_PR.dic
+          wget -o /usr/share/hunspell/fr.aff https://cgit.freedesktop.org/libreoffice/dictionaries/plain/fr_FR/fr.aff
+          wget -o /usr/share/hunspell/fr.dic https://cgit.freedesktop.org/libreoffice/dictionaries/plain/fr_FR/fr.dic
       - name: Run Bundle Install
         run: |
           bundle config path vendor/bundle

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -42,8 +42,8 @@ jobs:
           sudo apt install hunspell
           sudo wget -O /usr/share/hunspell/es_PR.aff https://cgit.freedesktop.org/libreoffice/dictionaries/plain/es/es_PR.aff
           sudo wget -O /usr/share/hunspell/es_PR.dic https://cgit.freedesktop.org/libreoffice/dictionaries/plain/es/es_PR.dic
-          sudo wget -O /usr/share/hunspell/fr.aff https://cgit.freedesktop.org/libreoffice/dictionaries/plain/fr_FR/fr.aff
-          sudo wget -O /usr/share/hunspell/fr.dic https://cgit.freedesktop.org/libreoffice/dictionaries/plain/fr_FR/fr.dic
+          sudo wget -O /usr/share/hunspell/fr_FR.aff https://cgit.freedesktop.org/libreoffice/dictionaries/plain/fr_FR/fr.aff
+          sudo wget -O /usr/share/hunspell/fr_FR.dic https://cgit.freedesktop.org/libreoffice/dictionaries/plain/fr_FR/fr.dic
       - name: Run Bundle Install
         run: |
           bundle config path vendor/bundle

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Install hunspell library
         run: |
           sudo apt install hunspell
-          sudo wget -o /usr/share/hunspell/es_PR.aff https://cgit.freedesktop.org/libreoffice/dictionaries/plain/es/es_PR.aff
-          sudo wget -o /usr/share/hunspell/es_PR.dic https://cgit.freedesktop.org/libreoffice/dictionaries/plain/es/es_PR.dic
-          sudo wget -o /usr/share/hunspell/fr.aff https://cgit.freedesktop.org/libreoffice/dictionaries/plain/fr_FR/fr.aff
-          sudo wget -o /usr/share/hunspell/fr.dic https://cgit.freedesktop.org/libreoffice/dictionaries/plain/fr_FR/fr.dic
+          sudo wget -O /usr/share/hunspell/es_PR.aff https://cgit.freedesktop.org/libreoffice/dictionaries/plain/es/es_PR.aff
+          sudo wget -O /usr/share/hunspell/es_PR.dic https://cgit.freedesktop.org/libreoffice/dictionaries/plain/es/es_PR.dic
+          sudo wget -O /usr/share/hunspell/fr.aff https://cgit.freedesktop.org/libreoffice/dictionaries/plain/fr_FR/fr.aff
+          sudo wget -O /usr/share/hunspell/fr.dic https://cgit.freedesktop.org/libreoffice/dictionaries/plain/fr_FR/fr.dic
       - name: Run Bundle Install
         run: |
           bundle config path vendor/bundle

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -37,6 +37,9 @@ jobs:
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gems-
+      - name: Install hunspell library
+        run: |
+          sudo apt install hunspell
       - name: Run Bundle Install
         run: |
           bundle config path vendor/bundle
@@ -53,4 +56,6 @@ jobs:
         run: bundle exec erblint --lint-all
       - name: Run ESLint
         run: ./node_modules/.bin/eslint app/javascript/components
+      - name: Run Spellcheck
+        run: bundle exec rails spellcheck
 

--- a/Gemfile
+++ b/Gemfile
@@ -94,6 +94,7 @@ group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'erb_lint'
   gem 'factory_bot_rails'
+  gem 'ffi-hunspell'
   gem 'gemsurance'
   gem 'rubocop'
 end
@@ -110,7 +111,6 @@ end
 group :test do
   gem 'capybara', '>= 2.15'
   gem 'fakeredis'
-  gem 'ffi-hunspell'
   gem 'minitest-retry'
   gem 'mocha'
   gem 'rack-test'

--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,7 @@ end
 group :test do
   gem 'capybara', '>= 2.15'
   gem 'fakeredis'
+  gem 'ffi-hunspell'
   gem 'minitest-retry'
   gem 'mocha'
   gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,8 @@ GEM
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.13.1)
+    ffi-hunspell (0.5.0)
+      ffi (~> 1.0)
     fhir_models (4.1.0)
       bcp47 (>= 0.3)
       date_time_precision (>= 0.8)
@@ -408,6 +410,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   fakeredis
+  ffi-hunspell
   fhir_models
   gemsurance
   jbuilder (~> 2.7)

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -37,7 +37,7 @@ en:
       updated: "Your password has been changed successfully. You are now signed in."
       updated_not_active: "Your password has been changed successfully."
     registrations:
-      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      destroyed: "Bye! Your account has been successfully canceled. We hope to see you again soon."
       signed_up: "Welcome! You have signed up successfully."
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -37,7 +37,7 @@ en:
       updated: "Your password has been changed successfully. You are now signed in."
       updated_not_active: "Your password has been changed successfully."
     registrations:
-      destroyed: "Bye! Your account has been successfully canceled. We hope to see you again soon."
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
       signed_up: "Welcome! You have signed up successfully."
       signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
       signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."

--- a/config/locales/devise.security_extension.en.yml
+++ b/config/locales/devise.security_extension.en.yml
@@ -12,7 +12,7 @@ en:
           other: must contain at least %{count} lower-case letters
         symbol:
           one: must contain at least one punctuation mark or symbol
-          other: must contain at least %{count} puncutation marks or symbols
+          other: must contain at least %{count} punctuation marks or symbols
         upper:
           one: must contain at least one upper-case letter
           other: must contain at least %{count} upper-case letters

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,14 +119,14 @@ en:
         daily2-s: ' Is this person '
         daily3: 'experiencing any of the following symptoms: '
         daily4: ' Please reply with "Yes" or "No"'
-        try-again: "I'm sorry, I didn’t quite get that. Please reply with \"Yes\" or \"No\". If you have any questions, please contact your local health department."
+        try-again: "I'm sorry, I didn't quite get that. Please reply with \"Yes\" or \"No\". If you have any questions, please contact your local health department."
         thanks: 'Thank you for completing your daily report!'
       weblink:
         intro1: 'This is the Sara Alert system please complete the report for'
         intro2: 'at the link provided.'
     phone:
       intro: 'Hello, this is Sara, the automated public health assistant calling for your daily report.'
-      try-again: "I'm sorry, I didn’t quite get that. Let’s try again."
+      try-again: "I'm sorry, I didn't quite get that. Let's try again."
       thanks: 'Thank you for completing your daily report! Goodbye.'
       age: 'Age'
       daily1: ' This is the report for: '

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -50,7 +50,7 @@ fr:
         name: 'Nez qui coule'
         notes: ''
       temperature:
-        name: 'Temperature'
+        name: 'Température'
         notes: 'Veuillez entrer votre température actuelle en degrés Fahrenheit'
       other:
         name: 'Other'

--- a/lib/tasks/spellcheck.rake
+++ b/lib/tasks/spellcheck.rake
@@ -74,7 +74,7 @@ if Rails.env.test? || Rails.env.development?
   def customize_dictionary(dict_name, dict)
     customize_en_us_dictionary(dict) if dict_name == :en_US
     customize_es_pr_dictionary(dict) if dict_name == :es_PR
-    customize_fr_dictionary(dict) if dict_name == :fr
+    customize_fr_dictionary(dict) if dict_name == :fr_FR
   end
 
 
@@ -141,7 +141,7 @@ if Rails.env.test? || Rails.env.development?
         'config/locales/es-PR.yml',
         'config/locales/es.yml'
       ],
-      'fr': [
+      'fr_FR': [
         'config/locales/fr.yml'
       ]
     }

--- a/lib/tasks/spellcheck.rake
+++ b/lib/tasks/spellcheck.rake
@@ -125,6 +125,7 @@ if Rails.env.test? || Rails.env.development?
   # Exits with code 1 if one or more spelling errors are found.
   def main
     num_errors = 0
+    # { <dictionary filename>: [<glob>, ..., <glob>], ... }
     locale_globs = {
       'en_US': [
         'config/locales/*.en.yml',

--- a/lib/tasks/spellcheck.rake
+++ b/lib/tasks/spellcheck.rake
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# Hunspell GitHub: https://github.com/hunspell/hunspell
+# ffi-hunspell Ruby Gem GitHub: https://github.com/postmodern/ffi-hunspell
+# ffi-hunspell Ruby Gem Docs: https://rubydoc.info/gems/ffi-hunspell/frames
+# Hunspell Dictionary Source: https://cgit.freedesktop.org/libreoffice/dictionaries/tree/
+
+
 if Rails.env.test?
   require 'yaml'
   require 'ffi/hunspell' # inject Hunspell class to Ruby namespace

--- a/lib/tasks/spellcheck.rake
+++ b/lib/tasks/spellcheck.rake
@@ -124,6 +124,7 @@ if Rails.env.test? || Rails.env.development?
   # Exits with code 0 if no spelling errors are found.
   # Exits with code 1 if one or more spelling errors are found.
   def main
+    puts FFI::Hunspell.directories
     num_errors = 0
     locale_globs = {
       'en_US': [

--- a/lib/tasks/spellcheck.rake
+++ b/lib/tasks/spellcheck.rake
@@ -82,6 +82,11 @@ if Rails.env.test? || Rails.env.development?
   def customize_es_pr_dictionary(dict)
     dict.add('Sara')
     dict.add('Alert')
+    dict.add('Fahrenheit')
+    dict.add('infórmeles')
+    dict.add('intentemoslo')
+    dict.add('oxímetro')
+    dict.add('recordándole')
   end
 
 
@@ -89,6 +94,7 @@ if Rails.env.test? || Rails.env.development?
   def customize_fr_dictionary(dict)
     dict.add('Sara')
     dict.add('Alert')
+    dict.add('Other')
   end
 
 

--- a/lib/tasks/spellcheck.rake
+++ b/lib/tasks/spellcheck.rake
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+if Rails.env.test?
+  require 'yaml'
+  require 'ffi/hunspell' # inject Hunspell class to Ruby namespace
+
+
+  # Flatten the map while preserviing the paths to the the leaf values for
+  # ease of locating errors to be fixed
+  #
+  # Source:
+  # https://stackoverflow.com/questions/48836464/how-to-flatten-a-hash-making-each-key-a-unique-value
+  def recursive_parsing(object, tmp = [])
+    case object
+    when Array
+      object.each.with_index(1).with_object({}) do |(element, i), result|
+        result.merge! recursive_parsing(element, tmp + [i])
+      end
+    when Hash
+      object.each_with_object({}) do |(key, value), result|
+        result.merge! recursive_parsing(value, tmp + [key])
+      end
+    else
+      { tmp.join(' => ') => object }
+    end
+  end
+
+
+  # Check each of the words provided to check if it is spelled correctly
+  # for the hunspell checker (using the en_US dictionary).
+  #
+  # returns a boolean indicating if any words were found to be mispelled
+  def check_locale(filepath)
+    num_errors = 0
+    locale_hash = recursive_parsing(YAML.load_file(filepath))
+
+    FFI::Hunspell.dict('en_US') do |dict|
+      customize_en_us_dictionary(dict)
+      locale_hash.each do |key, sentence|
+        # Ignore any variables for spell checking
+        sentence.gsub!(/%{\w+}/, '')
+        # Track if we already printed the YAML path and the sentence.
+        already_put_context = false
+        words = sentence.scan(/[\w'-]+/)
+        words.each do |word|
+          # Safety check if word is not actually a String.
+          next if !word.is_a? String
+          # dict.check? returns true if correctly spelled and false if incorrect.
+          next if dict.check?(word)
+          # Detected an error, so print the error and suggested fixes.
+          if !already_put_context
+            puts "\n\t#{key}"
+            puts "\t#{sentence}"
+            already_put_context = true
+          end
+          puts "\t\tSPELLING ERROR: #{word}"
+          puts "\t\t\tSUGGESTIONS: #{dict.suggest(word)}"
+          num_errors += 1
+        end
+      end
+    end
+    puts "\n\tFound #{num_errors} errors when checking locale file #{filepath}"
+    num_errors
+  end
+
+
+  # Add in custom words that do not already exist in the Hunspell dictionary
+  # right now this is just for the en_US dictionary, but in the future may
+  # spellcheck other languages as well.
+  def customize_en_us_dictionary(dict)
+    dict.add('admin')
+    dict.add('admin_authenticator')
+    dict.add('apps')
+    dict.add('Authy')
+    dict.add('captcha')
+    dict.add('code_verifier')
+    dict.add('HTTPS')
+    dict.add('OAuth')
+    dict.add('OAuth2')
+    dict.add('pkce')
+    dict.add('pre-authorization')
+    dict.add('resource_owner_authenticator')
+    dict.add('resource_owner_from_credentials')
+    dict.add('S256')
+    dict.add('SMS')
+    dict.add('SSL')
+    dict.add('UID')
+    dict.add('unconfigured')
+    dict.add('uri')
+    dict.add('urls')
+    dict.add('webpage')
+  end
+
+
+  # Main method for the script.
+  # Each command line argument is treated as a file path or potential glob
+  # and spell checking is run on all files provided.
+  # Exits with code 0 if no spelling errors are found.
+  # Exits with code 1 if one or more spelling errors are found.
+  def main
+    num_errors = 0
+    locale_globs = [
+      'config/locales/*.en.yml',
+      'config/locales/en.yml'
+    ]
+    locale_globs.each do |glob|
+      Dir.glob(glob).each do|filepath|
+        puts "CHECKING LOCALE: #{filepath}"
+        num_errors += check_locale(filepath)
+        puts "\n\n"
+      end
+    end
+    puts "Found #{num_errors} errors when checking all locale files"
+    exit(1) if num_errors > 0
+  end
+
+  task spellcheck: :environment do
+    main
+  end
+end

--- a/lib/tasks/spellcheck.rake
+++ b/lib/tasks/spellcheck.rake
@@ -124,7 +124,6 @@ if Rails.env.test? || Rails.env.development?
   # Exits with code 0 if no spelling errors are found.
   # Exits with code 1 if one or more spelling errors are found.
   def main
-    puts FFI::Hunspell.directories
     num_errors = 0
     locale_globs = {
       'en_US': [

--- a/lib/tasks/spellcheck.rake
+++ b/lib/tasks/spellcheck.rake
@@ -104,6 +104,7 @@ if Rails.env.test? || Rails.env.development?
     dict.add('admin_authenticator')
     dict.add('apps')
     dict.add('Authy')
+    dict.add('cancelled')
     dict.add('captcha')
     dict.add('code_verifier')
     dict.add('HTTPS')

--- a/lib/tasks/spellcheck.rake
+++ b/lib/tasks/spellcheck.rake
@@ -6,10 +6,9 @@
 # Hunspell Dictionary Source: https://cgit.freedesktop.org/libreoffice/dictionaries/tree/
 
 
-if Rails.env.test?
+if Rails.env.test? || Rails.env.development?
   require 'yaml'
   require 'ffi/hunspell' # inject Hunspell class to Ruby namespace
-
 
   # Flatten the map while preserviing the paths to the the leaf values for
   # ease of locating errors to be fixed


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-913

This PR is for spelling fixes found by Hunspell checking. 

Creates a new rake task that will run spell checking on locales and add in a static GitHub actions test that runs the task. 

The rake task runs spellchecking on all locales (en_US, es_PR, fr_FR) except so.yml because I did not find a dictionary for it. If we do find one then it would be easy to add it in. The GitHub action runs under the static analysis group. If one or more spelling errors are detected then the test will fail itself. To ease correction of issues the script will also produce descriptive output of where the error was found in the YAML hierarchy (see example snippet below).

```
...
CHECKING LOCALE: config/locales/es-PR.yml with dictionary es_PR

	es-PR => assessments => symptoms => pulse-ox => name
	oxímetro de pulso
		SPELLING ERROR: oxímetro
			SUGGESTIONS: ["taxímetro"]

	es-PR => assessments => symptoms => pulse-ox => notes
	Ingrese la lectura más baja del oxímetro de pulso en las últimas 24 horas
		SPELLING ERROR: oxímetro
			SUGGESTIONS: ["taxímetro"]
...
```

# Important Changes

`config/locales/*.yml`
- Made spelling corrections that were found with the Hunspell checker. 

`lib/tasks/spellcheck.rb`
- The added rake task to run spell checking

`Gemfile`
- added in ffi-hunspell gem under test & dev

`.github/workflows/static.yml`
- added step to run spellchecking task

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

To test locally you will need to install hunspell. `brew install hunspell`
And possibly need to download the [en_US, es_PR, fr dictionaries](https://cgit.freedesktop.org/libreoffice/dictionaries/tree/) (diff & aff) to `/Users/<uid>/Library/Spelling`
- `en`, `es`, and `fr` are available from the link but `so` is not