### PR TITLE
SARAALERT-947: Add history to Household changes

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -249,6 +249,30 @@ class PatientsController < ApplicationController
     new_hoh_id = params.permit(:new_hoh_id)[:new_hoh_id]
     current_patient_id = params.permit(:id)[:id]
     household_ids = params[:household_ids] || []
+    current_patient = current_user.get_patient(current_patient_id)
+    old_hoh = current_user.get_patient(current_patient.responder_id)
+    new_hoh = current_user.get_patient(new_hoh_id)
+
+    # Determine if the user was removed from a household, added to a household, or a new HoH was selected
+    if new_hoh_id == current_patient.id
+      comment = "User removed #{current_patient.last_name}, #{current_patient.first_name} from the household. #{old_hoh.last_name}, #{old_hoh.first_name}"\
+                ' will no longer be responsible for handling their reporting.'
+      history = History.monitoring_change(patient: old_hoh, created_by: current_user.email, comment: comment)
+      comment = "User removed monitoree from a household. #{old_hoh.last_name}, #{old_hoh.first_name} will"\
+                ' no longer be responsible for handling their reporting.'
+    elsif household_ids != []
+      comment = "User changed head of household from #{old_hoh.last_name}, #{old_hoh.first_name} to #{new_hoh.last_name},"\
+                " #{new_hoh.first_name}. #{new_hoh.last_name}, #{new_hoh.first_name} will now be responsible for handling the reporting for the household."
+      history = History.monitoring_change(patient: new_hoh, created_by: current_user.email, comment: comment)
+    else
+      comment = "User added #{current_patient.last_name}, #{current_patient.first_name} to the household. #{new_hoh.last_name}, #{new_hoh.first_name}"\
+                ' will now be responsible for handling the reporting on their behalf.'
+      history = History.monitoring_change(patient: new_hoh, created_by: current_user.email, comment: comment)
+      comment = "User added monitoree to a household. #{new_hoh.last_name}, #{new_hoh.first_name} will now be responsible"\
+                ' for handling the reporting on their behalf.'
+    end
+    history = History.monitoring_change(patient: current_patient, created_by: current_user.email, comment: comment)
+
     # update_all below does not invoke ActiveRecord callbacks and will not automatically check if this incomming
     # id exists. Patient.exists?(nil) => false
     redirect_to(root_url) && return unless Patient.exists?(new_hoh_id.to_i)

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -257,21 +257,21 @@ class PatientsController < ApplicationController
     if new_hoh_id == current_patient.id
       comment = "User removed #{current_patient.last_name}, #{current_patient.first_name} from the household. #{old_hoh.last_name}, #{old_hoh.first_name}"\
                 ' will no longer be responsible for handling their reporting.'
-      history = History.monitoring_change(patient: old_hoh, created_by: current_user.email, comment: comment)
+      History.monitoring_change(patient: old_hoh, created_by: current_user.email, comment: comment)
       comment = "User removed monitoree from a household. #{old_hoh.last_name}, #{old_hoh.first_name} will"\
                 ' no longer be responsible for handling their reporting.'
     elsif household_ids != []
       comment = "User changed head of household from #{old_hoh.last_name}, #{old_hoh.first_name} to #{new_hoh.last_name},"\
                 " #{new_hoh.first_name}. #{new_hoh.last_name}, #{new_hoh.first_name} will now be responsible for handling the reporting for the household."
-      history = History.monitoring_change(patient: new_hoh, created_by: current_user.email, comment: comment)
+      History.monitoring_change(patient: new_hoh, created_by: current_user.email, comment: comment)
     else
       comment = "User added #{current_patient.last_name}, #{current_patient.first_name} to the household. #{new_hoh.last_name}, #{new_hoh.first_name}"\
                 ' will now be responsible for handling the reporting on their behalf.'
-      history = History.monitoring_change(patient: new_hoh, created_by: current_user.email, comment: comment)
+      History.monitoring_change(patient: new_hoh, created_by: current_user.email, comment: comment)
       comment = "User added monitoree to a household. #{new_hoh.last_name}, #{new_hoh.first_name} will now be responsible"\
                 ' for handling the reporting on their behalf.'
     end
-    history = History.monitoring_change(patient: current_patient, created_by: current_user.email, comment: comment)
+    History.monitoring_change(patient: current_patient, created_by: current_user.email, comment: comment)
 
     # update_all below does not invoke ActiveRecord callbacks and will not automatically check if this incomming
     # id exists. Patient.exists?(nil) => false


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-947

The system does not log when a user is added or removed from a household or when the Head of Household is changed.

# Screenshots
![image](https://user-images.githubusercontent.com/7842704/97914636-31ffbc80-1d1e-11eb-95eb-4d99d60059b8.png)

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

There are 3 items we need to test and we will need a household with at least 3 people in it. 
1) Create your own household by adding monitorees to a household. Verify the messages in the history show that the user was added to a household.
2) With your household of [A<HoH>, B, C, ...] change the HoH from A to B. Verify that A and B both have a message in the history stating that the HoH was changed. Verify that [C, ...] do not have a message.
3) Choose a member of the household and remove them from that household. Verify the message in the history that the user has been removed from the household. 
