### PR TITLE
Add support for Full Assigned Jurisdiction Path to API

### DIFF
--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -463,7 +463,7 @@ class Fhir::R4::ApiController < ActionController::API
   # Determine if the patient's jurisdiction is valid for the requesting application
   def jurisdiction_valid_for_client?(patient)
     allowed_jurisdiction_ids = current_client_application.jurisdiction&.subtree&.pluck(:id) ||
-                               current_client_application.user&.jurisdiction&.subtree&.pluck(:id)
+                               current_resource_owner&.jurisdiction&.subtree&.pluck(:id)
 
     if allowed_jurisdiction_ids.nil?
       patient.errors.add(:jurisdiction, 'Client application does not have a jurisdiction')
@@ -478,7 +478,7 @@ class Fhir::R4::ApiController < ActionController::API
 
   # If no jurisdiction specified for a patient, default to the client's jurisdiction
   def default_patient_jurisdiction
-    current_client_application.jurisdiction || current_client_application.user&.jurisdiction
+    current_client_application.jurisdiction || current_resource_owner&.jurisdiction
   end
 
   # Determine the patient data that is accessible by either the current resource owner

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -466,12 +466,12 @@ class Fhir::R4::ApiController < ActionController::API
                                current_resource_owner&.jurisdiction&.subtree&.pluck(:id)
 
     if allowed_jurisdiction_ids.nil?
-      patient.errors.add(:jurisdiction, 'Client application does not have a jurisdiction')
+      patient.errors.add(:jurisdiction_id, 'Client application does not have a jurisdiction')
       false
     elsif !patient.jurisdiction.nil? && allowed_jurisdiction_ids.include?(patient.jurisdiction[:id])
       true
     else
-      patient.errors.add(:jurisdiction, "Jurisdiction must be within the client application's jursdiction")
+      patient.errors.add(:jurisdiction_id, "Jurisdiction must be within the client application's jurisdiction")
       false
     end
   end

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -94,7 +94,7 @@ class Fhir::R4::ApiController < ActionController::API
         :'system/Patient.*'
       )
 
-      updates = Patient.from_fhir(contents, default_patient_jurisdiction)
+      updates = Patient.from_fhir(contents, default_patient_jurisdiction_id)
 
       resource = get_patient(params.permit(:id)[:id])
 
@@ -155,7 +155,7 @@ class Fhir::R4::ApiController < ActionController::API
       )
 
       # Construct a Sara Alert Patient
-      resource = Patient.new(Patient.from_fhir(contents, default_patient_jurisdiction))
+      resource = Patient.new(Patient.from_fhir(contents, default_patient_jurisdiction_id))
       # Responder is self
       resource.responder = resource
 
@@ -505,8 +505,8 @@ class Fhir::R4::ApiController < ActionController::API
   end
 
   # Default jurisdiction to assign to new monitorees
-  def default_patient_jurisdiction
-    current_resource_owner&.jurisdiction || current_client_application.jurisdiction
+  def default_patient_jurisdiction_id
+    current_resource_owner&.jurisdiction&.id || current_client_application&.jurisdiction&.id
   end
 
   # Determine the patient data that is accessible by either the current resource owner

--- a/app/helpers/patient_helper.rb
+++ b/app/helpers/patient_helper.rb
@@ -179,7 +179,7 @@ module PatientHelper # rubocop:todo Metrics/ModuleLength
   # Use the default if there is no path specified.
   def self.from_full_assigned_jurisdiction_path_extension(patient, default_jurisdiction)
     jurisdiction_path = from_string_extension(patient, 'full-assigned-jurisdiction-path')
-    jurisdiction_path ? Jurisdiction.where(path: jurisdiction_path).first : default_jurisdiction
+    jurisdiction_path ? Jurisdiction.find_by(path: jurisdiction_path) : default_jurisdiction
   end
 
   def normalize_state_names(pat)

--- a/app/helpers/patient_helper.rb
+++ b/app/helpers/patient_helper.rb
@@ -177,9 +177,9 @@ module PatientHelper # rubocop:todo Metrics/ModuleLength
 
   # Convert from FHIR extension for Full Assigned Jurisdiction Path.
   # Use the default if there is no path specified.
-  def self.from_full_assigned_jurisdiction_path_extension(patient, default_jurisdiction)
+  def self.from_full_assigned_jurisdiction_path_extension(patient, default_jurisdiction_id)
     jurisdiction_path = from_string_extension(patient, 'full-assigned-jurisdiction-path')
-    jurisdiction_path ? Jurisdiction.find_by(path: jurisdiction_path) : default_jurisdiction
+    jurisdiction_path ? Jurisdiction.find_by(path: jurisdiction_path)&.id : default_jurisdiction_id
   end
 
   def normalize_state_names(pat)

--- a/app/helpers/patient_helper.rb
+++ b/app/helpers/patient_helper.rb
@@ -164,6 +164,24 @@ module PatientHelper # rubocop:todo Metrics/ModuleLength
     patient&.extension&.select { |e| e.url.include?('isolation') }&.first&.valueBoolean == true
   end
 
+  def to_string_extension(value, extension_id)
+    value.nil? ? nil : FHIR::Extension.new(
+      url: "http://saraalert.org/StructureDefinition/#{extension_id}",
+      valueString: value
+    )
+  end
+
+  def self.from_string_extension(patient, extension_id)
+    patient&.extension&.select { |e| e.url.include?(extension_id) }&.first&.valueString
+  end
+
+  # Convert from FHIR extension for Full Assigned Jurisdiction Path.
+  # Use the default if there is no path specified.
+  def self.from_full_assigned_jurisdiction_path_extension(patient, default_jurisdiction)
+    jurisdiction_path = from_string_extension(patient, 'full-assigned-jurisdiction-path')
+    jurisdiction_path ? Jurisdiction.where(path: jurisdiction_path).first : default_jurisdiction
+  end
+
   def normalize_state_names(pat)
     pat.monitored_address_state = normalize_and_get_state_name(pat.monitored_address_state) || pat.monitored_address_state
     pat.address_state = normalize_and_get_state_name(pat.address_state) || pat.address_state

--- a/app/helpers/validation_helper.rb
+++ b/app/helpers/validation_helper.rb
@@ -118,6 +118,7 @@ module ValidationHelper # rubocop:todo Metrics/ModuleLength
     secondary_telephone_type: { label: 'Secondary Telephone Type', checks: [:enum] },
     preferred_contact_time: { label: 'Preferred Contact Time', checks: [:enum] },
     email: { label: 'Email', checks: [:email] },
+    jurisdiction_id: { label: 'Jurisdiction ID', checks: [] },
     date_of_departure: { label: 'Date of Departure', checks: [:date] },
     date_of_arrival: { label: 'Date of Arrival', checks: [:date] },
     additional_planned_travel_type: { label: 'Additional Planned Travel Type', checks: [:enum] },

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -5,5 +5,4 @@ class OauthApplication < ApplicationRecord
   include ::Doorkeeper::Orm::ActiveRecord::Mixins::Application
   has_many :jwt_identifiers, foreign_key: 'application_id', dependent: :destroy
   belongs_to :jurisdiction, optional: true
-  belongs_to :user, optional: true
 end

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -4,4 +4,6 @@
 class OauthApplication < ApplicationRecord
   include ::Doorkeeper::Orm::ActiveRecord::Mixins::Application
   has_many :jwt_identifiers, foreign_key: 'application_id', dependent: :destroy
+  belongs_to :jurisdiction, optional: true
+  belongs_to :user, optional: true
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -860,14 +860,15 @@ class Patient < ApplicationRecord
         to_preferred_contact_time_extension(preferred_contact_time),
         to_symptom_onset_date_extension(symptom_onset),
         to_last_exposure_date_extension(last_date_of_exposure),
-        to_isolation_extension(isolation)
+        to_isolation_extension(isolation),
+        to_string_extension(jurisdiction.jurisdiction_path_string, 'full-assigned-jurisdiction-path')
       ].reject(&:nil?)
     )
   end
 
   # Create a hash of atttributes that corresponds to a Sara Alert Patient (and can be used to
   # create new ones, or update existing ones), using the given FHIR::Patient.
-  def self.from_fhir(patient)
+  def self.from_fhir(patient, default_jurisdiction)
     {
       monitoring: patient&.active.nil? ? false : patient.active,
       first_name: patient&.name&.first&.given&.first,
@@ -903,7 +904,8 @@ class Patient < ApplicationRecord
       preferred_contact_time: PatientHelper.from_preferred_contact_time_extension(patient),
       symptom_onset: PatientHelper.from_symptom_onset_date_extension(patient),
       last_date_of_exposure: PatientHelper.from_last_exposure_date_extension(patient),
-      isolation: PatientHelper.from_isolation_extension(patient)
+      isolation: PatientHelper.from_isolation_extension(patient),
+      jurisdiction: PatientHelper.from_full_assigned_jurisdiction_path_extension(patient, default_jurisdiction)
     }
   end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -868,7 +868,7 @@ class Patient < ApplicationRecord
 
   # Create a hash of atttributes that corresponds to a Sara Alert Patient (and can be used to
   # create new ones, or update existing ones), using the given FHIR::Patient.
-  def self.from_fhir(patient, default_jurisdiction)
+  def self.from_fhir(patient, default_jurisdiction_id)
     {
       monitoring: patient&.active.nil? ? false : patient.active,
       first_name: patient&.name&.first&.given&.first,
@@ -905,7 +905,7 @@ class Patient < ApplicationRecord
       symptom_onset: PatientHelper.from_symptom_onset_date_extension(patient),
       last_date_of_exposure: PatientHelper.from_last_exposure_date_extension(patient),
       isolation: PatientHelper.from_isolation_extension(patient),
-      jurisdiction: PatientHelper.from_full_assigned_jurisdiction_path_extension(patient, default_jurisdiction)
+      jurisdiction_id: PatientHelper.from_full_assigned_jurisdiction_path_extension(patient, default_jurisdiction_id)
     }
   end
 

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -668,6 +668,8 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal 3, json_response['telecom'].count
     assert_equal 'Boehm62', json_response['name'].first['family']
     assert response.headers['Location'].ends_with?(json_response['id'].to_s)
+    assert_equal 'USA, State 1',
+                 json_response['extension'].find { |e| e['url'] == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }['valueString']
   end
 
   test 'SYSTEM FLOW: should calculate Patient age via create' do
@@ -1602,6 +1604,8 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal 3, json_response['telecom'].count
     assert_equal 'Boehm62', json_response['name'].first['family']
     assert response.headers['Location'].ends_with?(json_response['id'].to_s)
+    assert_equal 'USA, State 1',
+                 json_response['extension'].find { |e| e['url'] == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }['valueString']
   end
 
   test 'USER FLOW: should calculate Patient age via create' do

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -921,7 +921,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
     json_response = JSON.parse(response.body)
     assert_equal 1, json_response['issue'].length
-    assert(json_response['issue'][0]['diagnostics'].starts_with?('Jurisdiction must be within'))
+    assert(json_response['issue'][0]['diagnostics'].include?('Jurisdiction must be within'))
   end
 
   test 'SYSTEM FLOW: should be forbidden via update' do
@@ -1864,7 +1864,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
     json_response = JSON.parse(response.body)
     assert_equal 1, json_response['issue'].length
-    assert(json_response['issue'][0]['diagnostics'].starts_with?('Jurisdiction must be within'))
+    assert(json_response['issue'][0]['diagnostics'].include?('Jurisdiction must be within'))
   end
 
   test 'USER FLOW: should be forbidden via update' do

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -27,64 +27,55 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     @user_patient_read_write_app = OauthApplication.create(
       name: 'user-test-patient-rw',
       redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
-      scopes: 'user/Patient.*',
-      user_id: @user.id
+      scopes: 'user/Patient.*'
     )
 
     @user_patient_read_app = OauthApplication.create(
       name: 'user-test-patient-r',
       redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
-      scopes: 'user/Patient.read',
-      user_id: @user.id
+      scopes: 'user/Patient.read'
     )
 
     @user_patient_write_app = OauthApplication.create(
       name: 'user-test-patient-w',
       redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
-      scopes: 'user/Patient.write',
-      user_id: @user.id
+      scopes: 'user/Patient.write'
     )
 
     @user_observation_read_app = OauthApplication.create(
       name: 'user-test-observation-r',
       redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
-      scopes: 'user/Observation.read',
-      user_id: @user.id
+      scopes: 'user/Observation.read'
     )
 
     @user_response_read_app = OauthApplication.create(
       name: 'user-test-response-r',
       redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
-      scopes: 'user/QuestionnaireResponse.read',
-      user_id: @user.id
+      scopes: 'user/QuestionnaireResponse.read'
     )
 
     @user_patient_rw_observation_r_app = OauthApplication.create(
       name: 'user-test-patient-rw-observation-r',
       redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
-      scopes: 'user/Patient.* user/Observation.read',
-      user_id: @user.id
+      scopes: 'user/Patient.* user/Observation.read'
     )
 
     @user_patient_rw_response_r_app = OauthApplication.create(
       name: 'user-test-patient-rw-response-r',
       redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
-      scopes: 'user/Patient.* user/QuestionnaireResponse.read',
-      user_id: @user.id
+      scopes: 'user/Patient.* user/QuestionnaireResponse.read'
     )
 
     @user_observation_r_response_r_app = OauthApplication.create(
       name: 'user-test-observation-r-response-r',
       redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
-      scopes: 'user/QuestionnaireResponse.read user/Observation.read',
-      user_id: @user.id
+      scopes: 'user/QuestionnaireResponse.read user/Observation.read'
     )
 
     @user_everything_app = OauthApplication.create(
       name: 'user-test-everything',
       redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
-      scopes: 'user/Patient.* user/QuestionnaireResponse.read user/Observation.read',
-      user_id: @user.id
+      scopes: 'user/Patient.* user/QuestionnaireResponse.read user/Observation.read'
     )
 
     # Create access tokens


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-689

This adds support for the field 'Full Assigned Jurisdiction Path' to the API. There is a corresponding PR in the FHIR IG repo: https://github.com/SaraAlert/saraalert-fhir-ig/pull/4. Also note that this is not the completion of SARAALERT-689. The task includes many more fields, but this one is going in first, because it's a priority for 1.16.0.

# Important Changes
`api_controller.rb`
- Added a step to validate the requested jurisdiction on `update` and `create`, validation based on the client application's jurisdiction.
- Remove previous code that sets the patient's jurisdiction to the resource creator's jurisdiction

`patient.rb`
- Mapping to and from FHIR

`patient_helper.rb`
- Helpers for the FHIR mapping. Note the generic string extension mappers will be reused when I add more fields.

`oauth_application.rb`
- Added references to the jurisdiction and the user that the application belongs to for the sake of cleaner code (instead of searching by their IDs every time).

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

- Run unit tests. Everything in `api_controller_test.rb` should pass.
- Manually test by using the POST, PUT, and GET endpoints for a patient. Here's an example of what the extension should look like:
```
"extension": [
  {
    "url": "http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path",
    "valueString": "USA, State 1"
  }
]
```
