### PR TITLE
Refactor validation error messages

### DIFF
--- a/app/models/concerns/date_validator.rb
+++ b/app/models/concerns/date_validator.rb
@@ -2,14 +2,13 @@
 
 # Validates that a given date (attribute) is valid
 class DateValidator < ActiveModel::EachValidator
-  include ValidationHelper
   def validate_each(record, attribute, value)
     # If value is unsuccessfully typecast to a date, it will be nil, so validate on the value before cast
     value ||= record.public_send("#{attribute}_before_type_cast")
     return if value.blank? || value.instance_of?(Date)
 
     unless value.match(/\d{4}-\d{2}-\d{2}/)
-      err_msg = "'#{value}' is not a valid date for '#{VALIDATION[attribute][:label]}'"
+      err_msg = 'is not a valid date'
       if value.match(%r{\d{2}/\d{2}/\d{4}})
         record.errors.add(attribute, "#{err_msg} due to ambiguity between 'MM/DD/YYYY' and 'DD/MM/YYYY', please use the 'YYYY-MM-DD' format instead")
       else
@@ -21,7 +20,7 @@ class DateValidator < ActiveModel::EachValidator
     begin
       Date.parse(value)
     rescue ArgumentError
-      record.errors.add(attribute, "'#{value}' is not a valid date for '#{VALIDATION[attribute][:label]}'")
+      record.errors.add(attribute, 'is not a valid date')
     end
   end
 end

--- a/app/models/concerns/email_validator.rb
+++ b/app/models/concerns/email_validator.rb
@@ -2,12 +2,11 @@
 
 # Validates that a given email (attribute) is valid
 class EmailValidator < ActiveModel::EachValidator
-  include ValidationHelper
   def validate_each(record, attribute, value)
     return if value.blank?
 
     return if ValidEmail2::Address.new(value).valid?
 
-    record.errors.add(attribute, "'#{value}' is not a valid Email Address for '#{VALIDATION[attribute][:label]}'")
+    record.errors.add(attribute, 'is not a valid Email Address')
   end
 end

--- a/app/models/concerns/phone_number_validator.rb
+++ b/app/models/concerns/phone_number_validator.rb
@@ -2,13 +2,12 @@
 
 # Validates that a given phone number (attribute) is valid
 class PhoneNumberValidator < ActiveModel::EachValidator
-  include ValidationHelper
   def validate_each(record, attribute, value)
     return if value.blank?
 
     phone = Phonelib.parse(value, 'US')
     return unless phone.national(false).nil? || phone.national(false).length != 10
 
-    record.errors.add(attribute, "'#{value}' is not a valid phone number for '#{VALIDATION[attribute][:label]}'")
+    record.errors.add(attribute, 'is not a valid phone number')
   end
 end

--- a/app/models/concerns/primary_contact_validator.rb
+++ b/app/models/concerns/primary_contact_validator.rb
@@ -4,10 +4,10 @@
 class PrimaryContactValidator < ActiveModel::Validator
   def validate(record)
     if record.email.blank? && record.preferred_contact_method == 'E-mailed Web Link'
-      record.errors.add(:email, "'Email' is required when Primary Contact Method is 'E-mailed Web Link'")
+      record.errors.add(:email, "is required when 'Primary Contact Method' is 'E-mailed Web Link'")
     end
     return unless record.primary_telephone.blank? && ['SMS Texted Weblink', 'Telephone call', 'SMS Text-message'].include?(record.preferred_contact_method)
 
-    record.errors.add(:primary_telephone, "'Primary Telephone' is required when Primary Contact Method is '#{record.preferred_contact_method}'")
+    record.errors.add(:primary_telephone, "is required when 'Primary Contact Method' is '#{record.preferred_contact_method}'")
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -56,7 +56,7 @@ class Patient < ApplicationRecord
      sex].each do |enum_field|
     validates enum_field, on: :api, inclusion: {
       in: VALID_ENUMS[enum_field],
-      message: "%<value>s is not an acceptable value for '#{VALIDATION[enum_field][:label]}', acceptable values are: '#{VALID_ENUMS[enum_field].join("', '")}'"
+      message: "is not an acceptable value, acceptable values are: '#{VALID_ENUMS[enum_field].join("', '")}'"
     }, allow_blank: true
   end
 
@@ -78,19 +78,17 @@ class Patient < ApplicationRecord
      date_of_birth
      first_name
      last_name].each do |required_field|
-    validates required_field, on: :api, presence: { message: "Required field '#{VALIDATION[required_field][:label]}' is missing" }
+    validates required_field, on: :api, presence: { message: 'is required' }
   end
 
   validates :symptom_onset,
             on: :api,
-            presence: { message: "Required field '#{VALIDATION[:symptom_onset][:label]}' is missing."\
-                                 " '#{VALIDATION[:symptom_onset][:label]}' is required when 'Isolation' is 'true'" },
+            presence: { message: "is required when 'Isolation' is 'true'" },
             if: -> { isolation }
 
   validates :last_date_of_exposure,
             on: :api,
-            presence: { message: "Required field '#{VALIDATION[:last_date_of_exposure][:label]}' is missing."\
-                                 " '#{VALIDATION[:last_date_of_exposure][:label]}' is required when 'Isolation' is 'false'" },
+            presence: { message: "is required when 'Isolation' is 'false'" },
             if: -> { !isolation }
 
   validates :email, on: :api, email: true

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -744,7 +744,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal json_response['issue'].length, 3
     assert_match(Regexp.new("#{bad_phone}.*Primary Telephone"), json_response['issue'][0]['diagnostics'])
     assert_match(Regexp.new("#{bad_birth_date}.*Date of Birth"), json_response['issue'][1]['diagnostics'])
-    assert_match(Regexp.new('Required.*Date of Birth'), json_response['issue'][2]['diagnostics'])
+    assert_match(Regexp.new('Date of Birth'), json_response['issue'][2]['diagnostics'])
   end
 
   test 'SYSTEM FLOW: should be unauthorized via update' do
@@ -903,7 +903,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal json_response['issue'].length, 3
     assert_match(Regexp.new("#{bad_phone}.*Primary Telephone"), json_response['issue'][0]['diagnostics'])
     assert_match(Regexp.new("#{bad_birth_date}.*Date of Birth"), json_response['issue'][1]['diagnostics'])
-    assert_match(Regexp.new('Required.*Date of Birth'), json_response['issue'][2]['diagnostics'])
+    assert_match(Regexp.new('Date of Birth'), json_response['issue'][2]['diagnostics'])
   end
 
   test 'SYSTEM FLOW: should be forbidden via update' do
@@ -1661,7 +1661,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal json_response['issue'].length, 3
     assert_match(Regexp.new("#{bad_phone}.*Primary Telephone"), json_response['issue'][0]['diagnostics'])
     assert_match(Regexp.new("#{bad_birth_date}.*Date of Birth"), json_response['issue'][1]['diagnostics'])
-    assert_match(Regexp.new('Required.*Date of Birth'), json_response['issue'][2]['diagnostics'])
+    assert_match(Regexp.new('Date of Birth'), json_response['issue'][2]['diagnostics'])
   end
 
   test 'USER FLOW: should be unauthorized via update' do
@@ -1829,7 +1829,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal json_response['issue'].length, 3
     assert_match(Regexp.new("#{bad_phone}.*Primary Telephone"), json_response['issue'][0]['diagnostics'])
     assert_match(Regexp.new("#{bad_birth_date}.*Date of Birth"), json_response['issue'][1]['diagnostics'])
-    assert_match(Regexp.new('Required.*Date of Birth'), json_response['issue'][2]['diagnostics'])
+    assert_match(Regexp.new('Date of Birth'), json_response['issue'][2]['diagnostics'])
   end
 
   test 'USER FLOW: should be forbidden via update' do

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -1398,7 +1398,7 @@ class PatientTest < ActiveSupport::TestCase
           address_line_1: '123 Test Street',
           address_state: 'Oregon',
           address_zip: '11111',
-          date_of_birth: '2000-11-11',
+          date_of_birth: 25.years.ago,
           first_name: 'Test',
           last_name: 'Tester',
           last_date_of_exposure: 4.days.ago.to_date,
@@ -1544,7 +1544,7 @@ class PatientTest < ActiveSupport::TestCase
   test 'validates date_of_birth is a valid date in api context' do
     patient = valid_patient
 
-    patient.date_of_birth = '2000-01-01'
+    patient.date_of_birth = 25.years.ago
     assert patient.valid?(:api)
 
     patient.date_of_birth = '01-15-2000'
@@ -1558,7 +1558,7 @@ class PatientTest < ActiveSupport::TestCase
   test 'validates last_date_of_exposure is a valid date in api context' do
     patient = valid_patient
 
-    patient.last_date_of_exposure = '2000-01-01'
+    patient.last_date_of_exposure = Time.now - 1.day
     assert patient.valid?(:api)
 
     patient.last_date_of_exposure = '01-15-2000'
@@ -1572,7 +1572,7 @@ class PatientTest < ActiveSupport::TestCase
   test 'validates symptom_onset is a valid date in api context' do
     patient = valid_patient
 
-    patient.symptom_onset = '2000-01-01'
+    patient.symptom_onset = Time.now - 1.day
     assert patient.valid?(:api)
 
     patient.symptom_onset = ''
@@ -1708,7 +1708,7 @@ class PatientTest < ActiveSupport::TestCase
     assert patient.valid?(:api)
 
     patient.isolation = true
-    patient.symptom_onset = '2000-01-01'
+    patient.symptom_onset = Time.now - 1.day
     assert patient.valid?(:api)
 
     patient.isolation = true
@@ -1725,7 +1725,7 @@ class PatientTest < ActiveSupport::TestCase
     assert patient.valid?(:api)
 
     patient.isolation = false
-    patient.last_date_of_exposure = '2000-01-01'
+    patient.last_date_of_exposure = Time.now - 1.day
     assert patient.valid?(:api)
 
     patient.isolation = false


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-962

This PR refactors the API validation error messages added in #455 to more closely follow the style of the validation error messages added in #413. Specifically, the error messages on the model now all only describe the error, they do not include the invalid value, or the attribute that the error is on. 

Note that this just begins to address 962, it doesn't refactor all validation. I've just broken it out so that we can maintain consistency for error messages on the model.

# Important Changes

`api_controller.rb`
- Added function to add attribute and value information to error messages.

`patient.rb` and `app/models/concerns/*_validator.rb`
- Removed attribute and value information from the error messages.

`patient_test.rb`
- Fixes failing tests that were using invalid `last_date_of_exposure` and `symptom_onset` values.

# Testing

* All unit tests should now pass.
* To get validation errors, test the PUT and POST endpoints with a Patient with invalid values. The following types of values can be tested:
    * Inclusion (ex: `preferred-contact-time`)
    * Dates (ex: `birthDate`) - It's good to test something that is a valid date, but in the future, since this will test that this PR is working correctly with the validators added in #413
    * Phone numbers (ex: `telecom.value` if `telecom.system` is `phone`)
    * Emails (ex: `telecom.value` if `telecom.system` is `email`)