### PR TITLE
SARAALERT-896: add Amharic and Farsi to supported languages

### DIFF
--- a/app/javascript/data/supportedLanguages.json
+++ b/app/javascript/data/supportedLanguages.json
@@ -41,6 +41,14 @@
       }
     },
     {
+      "name": "Amharic",
+      "supported": {
+        "sms": false,
+        "email": false,
+        "phone": false
+      }
+    },
+    {
       "name": "Arabic",
       "supported": {
         "sms": false,
@@ -178,6 +186,14 @@
     },
     {
       "name": "Norwegian",
+      "supported": {
+        "sms": false,
+        "email": false,
+        "phone": false
+      }
+    },
+    {
+      "name": "Persian (Farsi)",
       "supported": {
         "sms": false,
         "email": false,


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-896](https://tracker.codev.mitre.org/browse/SARAALERT-896)

Primary and secondary language options include now include Amharic and Farsi/Persian

# (Feature) Demo/Screenshots
![Screen Shot 2020-11-09 at 9 00 42 AM](https://user-images.githubusercontent.com/35042815/98575650-7099f780-2287-11eb-90d0-4f0f08914874.png)

![Screen Shot 2020-11-09 at 9 08 44 AM](https://user-images.githubusercontent.com/35042815/98575653-71328e00-2287-11eb-8112-1d57e6317a43.png)

![Screen Shot 2020-11-09 at 9 13 31 AM](https://user-images.githubusercontent.com/35042815/98575655-71328e00-2287-11eb-98a4-f3d8abdc64df.png)

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`supportedLanguages.json`
- Added Ahmaric and Farsi to supportedLanguages json file

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
