### PR TITLE
SARAALERT-1007: Utilize RPOPLPUSH for split arch bridge with a queue; Parallelize report processing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,9 @@ gem 'local_time'
 # FHIR models
 gem 'fhir_models'
 
+# Split-arch queue support
+gem 'redis-queue'
+
 group :development, :test do
   gem 'brakeman'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,8 @@ GEM
       railties (>= 3.2)
       tilt
     redis (4.2.2)
+    redis-queue (0.1.0)
+      redis (>= 3.3.5, < 5)
     regexp_parser (1.8.1)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -427,6 +429,7 @@ DEPENDENCIES
   rack-test
   rails (~> 6.0.2, >= 6.0.2.1)
   react-rails
+  redis-queue
   rolify
   roo
   rspec-mocks

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -57,6 +57,7 @@ class ConsumeAssessmentsJob < ApplicationJob
           end
 
           queue.commit
+          next
         when 'no_answer_sms'
           # No need to wipe out last_assessment_reminder_sent so that another sms will be sent because the sms studio flow is kept open for 18hrs
           History.contact_attempt(patient: patient, comment: "Sara Alert texted this monitoree's primary telephone \
@@ -68,6 +69,7 @@ class ConsumeAssessmentsJob < ApplicationJob
           end
 
           queue.commit
+          next
         when 'error_voice'
           # If there was an error in completeing the call, nil out the last_reminder_sent field so the system will try calling again
           patient.update(last_assessment_reminder_sent: nil)
@@ -79,6 +81,7 @@ class ConsumeAssessmentsJob < ApplicationJob
           end
 
           queue.commit
+          next
         when 'error_sms'
           # If there was an error sending an SMS, nil out the last_reminder_sent field so the system will try calling again
           patient.update(last_assessment_reminder_sent: nil)
@@ -90,6 +93,7 @@ class ConsumeAssessmentsJob < ApplicationJob
           end
 
           queue.commit
+          next
         end
 
         threshold_condition = ThresholdCondition.where(type: 'ThresholdCondition').find_by(threshold_condition_hash: message['threshold_condition_hash'])

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -18,6 +18,7 @@ class ConsumeAssessmentsJob < ApplicationJob
         # Invalid message
         if message.nil?
           Rails.logger.info 'ConsumeAssessmentsJob: skipping nil message...'
+          queue.commit
           next
         end
 
@@ -32,6 +33,7 @@ class ConsumeAssessmentsJob < ApplicationJob
         # Failed to find patient
         if patient.nil?
           Rails.logger.info "ConsumeAssessmentsJob: skipping nil patient (token: #{message['patient_submission_token']})..."
+          queue.commit
           next
         end
 
@@ -39,6 +41,7 @@ class ConsumeAssessmentsJob < ApplicationJob
         # Only check for latest assessment if there is one
         if !patient.latest_assessment.nil? && (patient.latest_assessment.created_at > ADMIN_OPTIONS['reporting_limit'].minutes.ago)
           Rails.logger.info "ConsumeAssessmentsJob: skipping duplicate assessment (patient: #{patient.id})..."
+          queue.commit
           next
         end
 
@@ -101,6 +104,7 @@ class ConsumeAssessmentsJob < ApplicationJob
         # Invalid threshold condition hash
         if threshold_condition.nil?
           Rails.logger.info "ConsumeAssessmentsJob: skipping nil threshold (patient: #{patient.id}, hash: #{message['threshold_condition_hash']})..."
+          queue.commit
           next
         end
 

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -130,7 +130,7 @@ class ConsumeAssessmentsJob < ApplicationJob
           end
         end
       rescue JSON::ParserError
-        Rails.logger.info "ConsumeAssessmentsJob: skipping invalid message..." && next
+        Rails.logger.info 'ConsumeAssessmentsJob: skipping invalid message...' && next
       end
     end
   rescue Redis::ConnectionError, Redis::CannotConnectError => e

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -1,19 +1,25 @@
 # frozen_string_literal: true
 
 require 'redis'
+require 'redis-queue'
 
 # ConsumeAssessmentsJob: Pulls assessments created in the split instance and saves them
 class ConsumeAssessmentsJob < ApplicationJob
   queue_as :default
 
   def perform
-    Rails.application.config.redis.subscribe 'reports' do |on|
-      on.message do |_channel, msg|
-        # message = SaraSchema::Validator.validate(:assessment, JSON.parse(msg))
+    queue = Redis::Queue.new('q_bridge', 'bp_q_bridge', redis: Rails.application.config.redis)
+
+    while (msg = queue.pop)
+      begin
         message = JSON.parse(msg)&.slice('threshold_condition_hash', 'reported_symptoms_array',
                                          'patient_submission_token', 'experiencing_symptoms', 'response_status')
 
-        Rails.logger.info 'ConsumeAssessmentsJob: skipping nil message...' && next if message.nil?
+        # Invalid message
+        if message.nil?
+          Rails.logger.info 'ConsumeAssessmentsJob: skipping nil message...'
+          next
+        end
 
         patient = Patient.where(purged: false).find_by(submission_token: message['patient_submission_token'])
 
@@ -23,12 +29,16 @@ class ConsumeAssessmentsJob < ApplicationJob
           patient = Patient.find_by(submission_token: patient_lookup[:new_submission_token]) unless patient_lookup.nil?
         end
 
-        Rails.logger.info "ConsumeAssessmentsJob: skipping nil patient (token #{message['patient_submission_token']})..." && next if patient.nil?
+        # Failed to find patient
+        if patient.nil?
+          Rails.logger.info "ConsumeAssessmentsJob: skipping nil patient (token: #{message['patient_submission_token']})..."
+          next
+        end
 
         # Prevent duplicate patient assessment spam
         # Only check for latest assessment if there is one
         if !patient.latest_assessment.nil? && (patient.latest_assessment.created_at > ADMIN_OPTIONS['reporting_limit'].minutes.ago)
-          Rails.logger.info "ConsumeAssessmentsJob: skipping duplicate assessment (patient #{patient.id})..."
+          Rails.logger.info "ConsumeAssessmentsJob: skipping duplicate assessment (patient: #{patient.id})..."
           next
         end
 
@@ -46,18 +56,18 @@ class ConsumeAssessmentsJob < ApplicationJob
                                                                               of household and nobody answered the phone.")
           end
 
-          next
+          queue.commit
         when 'no_answer_sms'
           # No need to wipe out last_assessment_reminder_sent so that another sms will be sent because the sms studio flow is kept open for 18hrs
           History.contact_attempt(patient: patient, comment: "Sara Alert texted this monitoree's primary telephone \
-                                                             number #{patient.primary_telephone} during their preferred \
-                                                             contact time, but did not receive a response.")
+                                                              number #{patient.primary_telephone} during their preferred \
+                                                              contact time, but did not receive a response.")
           unless dependents.blank?
             create_contact_attempt_history_for_dependents(dependents, "Sara Alert texted this monitoree's head of \
                                                                               household and did not receive a response.")
           end
 
-          next
+          queue.commit
         when 'error_voice'
           # If there was an error in completeing the call, nil out the last_reminder_sent field so the system will try calling again
           patient.update(last_assessment_reminder_sent: nil)
@@ -68,29 +78,34 @@ class ConsumeAssessmentsJob < ApplicationJob
                                                                               to this monitoree's head of household.")
           end
 
-          next
+          queue.commit
         when 'error_sms'
           # If there was an error sending an SMS, nil out the last_reminder_sent field so the system will try calling again
           patient.update(last_assessment_reminder_sent: nil)
           History.contact_attempt(patient: patient, comment: "Sara Alert was unable to send an SMS to this monitoree's \
-                                                             primary telephone number #{patient.primary_telephone}.")
+                                                              primary telephone number #{patient.primary_telephone}.")
           unless dependents.blank?
             create_contact_attempt_history_for_dependents(dependents, "Sara Alert was unable to send an SMS to \
                                                                               this monitoree's head of household.")
           end
 
-          next
+          queue.commit
         end
 
         threshold_condition = ThresholdCondition.where(type: 'ThresholdCondition').find_by(threshold_condition_hash: message['threshold_condition_hash'])
-        Rails.logger.info "ConsumeAssessmentsJob: skipping nil threshold (patient #{patient.id})..." && next unless threshold_condition
+
+        # Invalid threshold condition hash
+        if threshold_condition.nil?
+          Rails.logger.info "ConsumeAssessmentsJob: skipping nil threshold (patient: #{patient.id}, hash: #{message['threshold_condition_hash']})..."
+          next
+        end
 
         if message['reported_symptoms_array']
           typed_reported_symptoms = Condition.build_symptoms(message['reported_symptoms_array'])
           reported_condition = ReportedCondition.new(symptoms: typed_reported_symptoms, threshold_condition_hash: message['threshold_condition_hash'])
           assessment = Assessment.new(reported_condition: reported_condition, patient: patient, who_reported: 'Monitoree')
           assessment.symptomatic = assessment.symptomatic? || message['experiencing_symptoms']
-          assessment.save
+          queue.commit if assessment.save
         else
           # If message['reported_symptoms_array'] is not populated then this assessment came in through
           # a generic channel ie: SMS where monitorees are asked YES/NO if they are experiencing symptoms
@@ -111,11 +126,11 @@ class ConsumeAssessmentsJob < ApplicationJob
             # that they reported for themselves, else we are creating an assessment for the dependent and
             # that means that it was the proxy who reported for them
             assessment.who_reported = patient.submission_token == dependent.submission_token ? 'Monitoree' : 'Proxy'
-            assessment.save
+            queue.commit if assessment.save
           end
         end
       rescue JSON::ParserError
-        next
+        Rails.logger.info "ConsumeAssessmentsJob: skipping invalid message..." && next
       end
     end
   rescue Redis::ConnectionError, Redis::CannotConnectError => e

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -138,7 +138,9 @@ class ConsumeAssessmentsJob < ApplicationJob
           end
         end
       rescue JSON::ParserError
-        Rails.logger.info 'ConsumeAssessmentsJob: skipping invalid message...' && next
+        Rails.logger.info 'ConsumeAssessmentsJob: skipping invalid message...'
+        queue.commit
+        next
       end
     end
   rescue Redis::ConnectionError, Redis::CannotConnectError => e

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,9 +13,7 @@ services:
     image: ${SARA_ALERT_IMAGE}:latest
   sidekiq-enrollment-default:
     image: ${SARA_ALERT_IMAGE}:latest
-  sidekiq-bridge-enrollment_1:
-    image: ${SARA_ALERT_IMAGE}:latest
-  sidekiq-bridge-enrollment_2:
+  sidekiq-bridge-enrollment:
     image: ${SARA_ALERT_IMAGE}:latest
   sidekiq-bridge-assessment:
     image: ${SARA_ALERT_IMAGE}:latest

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,8 +13,9 @@ services:
     image: ${SARA_ALERT_IMAGE}:latest
   sidekiq-enrollment-default:
     image: ${SARA_ALERT_IMAGE}:latest
-  sidekiq-bridge-enrollment:
+  sidekiq-bridge-enrollment_1:
+    image: ${SARA_ALERT_IMAGE}:latest
+  sidekiq-bridge-enrollment_2:
     image: ${SARA_ALERT_IMAGE}:latest
   sidekiq-bridge-assessment:
     image: ${SARA_ALERT_IMAGE}:latest
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,22 +125,7 @@ services:
       - redis-enrollment
       - sara-alert-enrollment
       - mysql-enrollment
-  sidekiq-bridge-enrollment_1:
-    image: "${SARA_ALERT_IMAGE}:development-test"
-    environment:
-      - REDIS_URL=redis://redis-bridge:6379/1
-    env_file:
-      - .env-prod-enrollment
-    restart: unless-stopped
-    networks:
-      - dt-net-bridge
-      - dt-net-enrollment
-    command: "bin/bundle exec rake reports:receive_and_process_reports"
-    depends_on:
-      - redis-bridge
-      - sara-alert-enrollment
-      - mysql-enrollment
-  sidekiq-bridge-enrollment_2:
+  sidekiq-bridge-enrollment:
     image: "${SARA_ALERT_IMAGE}:development-test"
     environment:
       - REDIS_URL=redis://redis-bridge:6379/1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,7 +125,22 @@ services:
       - redis-enrollment
       - sara-alert-enrollment
       - mysql-enrollment
-  sidekiq-bridge-enrollment:
+  sidekiq-bridge-enrollment_1:
+    image: "${SARA_ALERT_IMAGE}:development-test"
+    environment:
+      - REDIS_URL=redis://redis-bridge:6379/1
+    env_file:
+      - .env-prod-enrollment
+    restart: unless-stopped
+    networks:
+      - dt-net-bridge
+      - dt-net-enrollment
+    command: "bin/bundle exec rake reports:receive_and_process_reports"
+    depends_on:
+      - redis-bridge
+      - sara-alert-enrollment
+      - mysql-enrollment
+  sidekiq-bridge-enrollment_2:
     image: "${SARA_ALERT_IMAGE}:development-test"
     environment:
       - REDIS_URL=redis://redis-bridge:6379/1

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -3,6 +3,12 @@
 namespace :reports do
   desc "Receive and Process Reports"
   task receive_and_process_reports: :environment do
-    ConsumeAssessmentsJob.perform_now
+    min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { 4 }
+    min_threads_count.times do
+      Process.fork do
+        ConsumeAssessmentsJob.perform_now
+      end
+    end
+    Process.waitall
   end
 end

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -3,8 +3,8 @@
 namespace :reports do
   desc "Receive and Process Reports"
   task receive_and_process_reports: :environment do
-    min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { 4 }
-    min_threads_count.times do
+    consume_workers = ENV.fetch("CONSUME_WORKERS") { 8 }
+    consume_workers.times do
       Process.fork do
         ConsumeAssessmentsJob.perform_now
       end


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1007

Migrate from PUB/SUB approach to RPOPLPUSH for bridge. Parallelize consume job to increase throughput.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`Gemfile` & `Gemfile.lock`
- Added redis-queue gem

`app/jobs/consume_assessments_job.rb`
- Use queue
- More logging statements for invalid stuff

`app/jobs/produce_assessment_job.rb`
- Use queue

`lib/tasks/reports.rake`
- Fork `CONSUME_WORKERS` ConsumeAssessmentsJobs
