### PR TITLE
SARAALERT-1003: add advanced filter by relative date

### DIFF
--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -72,7 +72,8 @@ class PublicHealthController < ApplicationController
         {
           filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, options: []),
           value: filter.permit(:value)[:value] || filter.require(:value) || false,
-          dateOption: filter.permit(:dateOption)[:dateOption]
+          dateOption: filter.permit(:dateOption)[:dateOption],
+          relativeOption: filter.permit(:relativeOption)[:relativeOption]
         }
       end
       patients = advanced_filter(patients, advanced) unless advanced.nil?

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -365,6 +365,42 @@ class PublicHealthController < ApplicationController
           compare_date_end = Chronic.parse(filter[:value][:end])
           patients = patients.where('Date(symptom_onset) > ?', compare_date_start).where('Date(symptom_onset) < ?', compare_date_end)
         end
+      when 'symptom-onset-relative'
+        case filter[:relativeOption]
+        when 'today'
+          patients = patients.where('Date(symptom_onset) = ?', Date.today)
+        when 'tomorrow'
+          patients = patients.where('Date(symptom_onset) = ?', Date.tomorrow)
+        when 'yesterday'
+          patients = patients.where('Date(symptom_onset) = ?', Date.yesterday)
+        when 'custom'
+          case filter[:value][:when]
+          when 'past'
+            case filter[:value][:unit]
+            when 'days'
+              number = filter[:value][:number].to_i
+              patients = patients.where('symptom_onset >= ?',  number.days.ago).where('symptom_onset <= ?', Date.today)
+            when 'weeks'
+              number = filter[:value][:number].to_i
+              patients = patients.where('symptom_onset >= ?',  number.weeks.ago).where('symptom_onset <= ?', Date.today)
+            when 'months'
+              number = filter[:value][:number].to_i
+              patients = patients.where('symptom_onset >= ?',  number.months.ago).where('symptom_onset <= ?', Date.today)
+            end
+          when 'next'
+            case filter[:value][:unit]
+            when 'days'
+              number = filter[:value][:number].to_i
+              patients = patients.where('symptom_onset <= ?',  number.days.from_now).where('symptom_onset >= ?', Date.today)
+            when 'weeks'
+              number = filter[:value][:number].to_i
+              patients = patients.where('symptom_onset <= ?',  number.weeks.from_now).where('symptom_onset >= ?', Date.today)
+            when 'months'
+              number = filter[:value][:number].to_i
+              patients = patients.where('symptom_onset <= ?',  number.months.from_now).where('symptom_onset >= ?', Date.today)
+            end
+          end
+        end
       when 'continous-exposure'
         patients = patients.where(continuous_exposure: filter[:value].present? ? true : [nil, false])
       when 'telephone-number'

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -328,25 +328,25 @@ class PublicHealthController < ApplicationController
             case filter[:value][:unit]
             when 'days'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(latest_assessment_at) >= ?',  number.days.ago).where('Date(latest_assessment_at) <= ?', Date.today)
-            when 'weeks' 
+              patients = patients.where('Date(latest_assessment_at) >= ?', number.days.ago).where('Date(latest_assessment_at) <= ?', Date.today)
+            when 'weeks'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(latest_assessment_at) >= ?',  number.weeks.ago).where('Date(latest_assessment_at) <= ?', Date.today)
+              patients = patients.where('Date(latest_assessment_at) >= ?', number.weeks.ago).where('Date(latest_assessment_at) <= ?', Date.today)
             when 'months'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(latest_assessment_at) >= ?',  number.months.ago).where('Date(latest_assessment_at) <= ?', Date.today)
+              patients = patients.where('Date(latest_assessment_at) >= ?', number.months.ago).where('Date(latest_assessment_at) <= ?', Date.today)
             end
           when 'next'
             case filter[:value][:unit]
             when 'days'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(latest_assessment_at) <= ?',  number.days.from_now).where('Date(latest_assessment_at) >= ?', Date.today)
+              patients = patients.where('Date(latest_assessment_at) <= ?', number.days.from_now).where('Date(latest_assessment_at) >= ?', Date.today)
             when 'weeks'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(latest_assessment_at) <= ?',  number.weeks.from_now).where('Date(latest_assessment_at) >= ?', Date.today)
+              patients = patients.where('Date(latest_assessment_at) <= ?', number.weeks.from_now).where('Date(latest_assessment_at) >= ?', Date.today)
             when 'months'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(latest_assessment_at) <= ?',  number.months.from_now).where('Date(latest_assessment_at) >= ?', Date.today)
+              patients = patients.where('Date(latest_assessment_at) <= ?', number.months.from_now).where('Date(latest_assessment_at) >= ?', Date.today)
             end
           end
         end
@@ -389,25 +389,25 @@ class PublicHealthController < ApplicationController
             case filter[:value][:unit]
             when 'days'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(patients.created_at) >= ?',  number.days.ago).where('Date(patients.created_at) <= ?', Date.today)
-            when 'weeks' 
+              patients = patients.where('Date(patients.created_at) >= ?', number.days.ago).where('Date(patients.created_at) <= ?', Date.today)
+            when 'weeks'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(patients.created_at) >= ?',  number.weeks.ago).where('Date(patients.created_at) <= ?', Date.today)
+              patients = patients.where('Date(patients.created_at) >= ?', number.weeks.ago).where('Date(patients.created_at) <= ?', Date.today)
             when 'months'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(patients.created_at) >= ?',  number.months.ago).where('Date(patients.created_at) <= ?', Date.today)
+              patients = patients.where('Date(patients.created_at) >= ?', number.months.ago).where('Date(patients.created_at) <= ?', Date.today)
             end
           when 'next'
             case filter[:value][:unit]
             when 'days'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(patients.created_at) <= ?',  number.days.from_now).where('Date(patients.created_at) >= ?', Date.today)
+              patients = patients.where('Date(patients.created_at) <= ?', number.days.from_now).where('Date(patients.created_at) >= ?', Date.today)
             when 'weeks'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(patients.created_at) <= ?',  number.weeks.from_now).where('Date(patients.created_at) >= ?', Date.today)
+              patients = patients.where('Date(patients.created_at) <= ?', number.weeks.from_now).where('Date(patients.created_at) >= ?', Date.today)
             when 'months'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(patients.created_at) <= ?',  number.months.from_now).where('Date(patients.created_at) >= ?', Date.today)
+              patients = patients.where('Date(patients.created_at) <= ?', number.months.from_now).where('Date(patients.created_at) >= ?', Date.today)
             end
           end
         end
@@ -438,25 +438,25 @@ class PublicHealthController < ApplicationController
             case filter[:value][:unit]
             when 'days'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(last_date_of_exposure) >= ?',  number.days.ago).where('Date(last_date_of_exposure) <= ?', Date.today)
-            when 'weeks' 
+              patients = patients.where('Date(last_date_of_exposure) >= ?', number.days.ago).where('Date(last_date_of_exposure) <= ?', Date.today)
+            when 'weeks'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(last_date_of_exposure) >= ?',  number.weeks.ago).where('Date(last_date_of_exposure) <= ?', Date.today)
+              patients = patients.where('Date(last_date_of_exposure) >= ?', number.weeks.ago).where('Date(last_date_of_exposure) <= ?', Date.today)
             when 'months'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(last_date_of_exposure) >= ?',  number.months.ago).where('Date(last_date_of_exposure) <= ?', Date.today)
+              patients = patients.where('Date(last_date_of_exposure) >= ?', number.months.ago).where('Date(last_date_of_exposure) <= ?', Date.today)
             end
           when 'next'
             case filter[:value][:unit]
             when 'days'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(last_date_of_exposure) <= ?',  number.days.from_now).where('Date(last_date_of_exposure) >= ?', Date.today)
+              patients = patients.where('Date(last_date_of_exposure) <= ?', number.days.from_now).where('Date(last_date_of_exposure) >= ?', Date.today)
             when 'weeks'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(last_date_of_exposure) <= ?',  number.weeks.from_now).where('Date(last_date_of_exposure) >= ?', Date.today)
+              patients = patients.where('Date(last_date_of_exposure) <= ?', number.weeks.from_now).where('Date(last_date_of_exposure) >= ?', Date.today)
             when 'months'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(last_date_of_exposure) <= ?',  number.months.from_now).where('Date(last_date_of_exposure) >= ?', Date.today)
+              patients = patients.where('Date(last_date_of_exposure) <= ?', number.months.from_now).where('Date(last_date_of_exposure) >= ?', Date.today)
             end
           end
         end
@@ -487,25 +487,25 @@ class PublicHealthController < ApplicationController
             case filter[:value][:unit]
             when 'days'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(symptom_onset) >= ?',  number.days.ago).where('Date(symptom_onset) <= ?', Date.today)
+              patients = patients.where('Date(symptom_onset) >= ?', number.days.ago).where('Date(symptom_onset) <= ?', Date.today)
             when 'weeks'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(symptom_onset) >= ?',  number.weeks.ago).where('Date(symptom_onset) <= ?', Date.today)
+              patients = patients.where('Date(symptom_onset) >= ?', number.weeks.ago).where('Date(symptom_onset) <= ?', Date.today)
             when 'months'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(symptom_onset) >= ?',  number.months.ago).where('Date(symptom_onset) <= ?', Date.today)
+              patients = patients.where('Date(symptom_onset) >= ?', number.months.ago).where('Date(symptom_onset) <= ?', Date.today)
             end
           when 'next'
             case filter[:value][:unit]
             when 'days'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(symptom_onset) <= ?',  number.days.from_now).where('Date(symptom_onset) >= ?', Date.today)
+              patients = patients.where('Date(symptom_onset) <= ?', number.days.from_now).where('Date(symptom_onset) >= ?', Date.today)
             when 'weeks'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(symptom_onset) <= ?',  number.weeks.from_now).where('Date(symptom_onset) >= ?', Date.today)
+              patients = patients.where('Date(symptom_onset) <= ?', number.weeks.from_now).where('Date(symptom_onset) >= ?', Date.today)
             when 'months'
               number = filter[:value][:number].to_i
-              patients = patients.where('Date(symptom_onset) <= ?',  number.months.from_now).where('Date(symptom_onset) >= ?', Date.today)
+              patients = patients.where('Date(symptom_onset) <= ?', number.months.from_now).where('Date(symptom_onset) >= ?', Date.today)
             end
           end
         end

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -315,41 +315,7 @@ class PublicHealthController < ApplicationController
           patients = patients.where('Date(latest_assessment_at) > ?', compare_date_start).where('Date(latest_assessment_at) < ?', compare_date_end)
         end
       when 'latest-report-relative'
-        case filter[:relativeOption]
-        when 'today'
-          patients = patients.where('Date(latest_assessment_at) = ?', Date.today)
-        when 'tomorrow'
-          patients = patients.where('Date(latest_assessment_at) = ?', Date.tomorrow)
-        when 'yesterday'
-          patients = patients.where('Date(latest_assessment_at) = ?', Date.yesterday)
-        when 'custom'
-          case filter[:value][:when]
-          when 'past'
-            case filter[:value][:unit]
-            when 'days'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(latest_assessment_at) >= ?', number.days.ago).where('Date(latest_assessment_at) <= ?', Date.today)
-            when 'weeks'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(latest_assessment_at) >= ?', number.weeks.ago).where('Date(latest_assessment_at) <= ?', Date.today)
-            when 'months'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(latest_assessment_at) >= ?', number.months.ago).where('Date(latest_assessment_at) <= ?', Date.today)
-            end
-          when 'next'
-            case filter[:value][:unit]
-            when 'days'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(latest_assessment_at) <= ?', number.days.from_now).where('Date(latest_assessment_at) >= ?', Date.today)
-            when 'weeks'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(latest_assessment_at) <= ?', number.weeks.from_now).where('Date(latest_assessment_at) >= ?', Date.today)
-            when 'months'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(latest_assessment_at) <= ?', number.months.from_now).where('Date(latest_assessment_at) >= ?', Date.today)
-            end
-          end
-        end
+        patients = advanced_filter_latest_report_relative(patients, filter)
       when 'hoh'
         patients = if filter[:value]
                      patients.where('patients.id = patients.responder_id')
@@ -376,41 +342,7 @@ class PublicHealthController < ApplicationController
           patients = patients.where('Date(patients.created_at) > ?', compare_date_start).where('Date(patients.created_at) < ?', compare_date_end)
         end
       when 'enrolled-relative'
-        case filter[:relativeOption]
-        when 'today'
-          patients = patients.where('Date(patients.created_at) = ?', Date.today)
-        when 'tomorrow'
-          patients = patients.where('Date(patients.created_at) = ?', Date.tomorrow)
-        when 'yesterday'
-          patients = patients.where('Date(patients.created_at) = ?', Date.yesterday)
-        when 'custom'
-          case filter[:value][:when]
-          when 'past'
-            case filter[:value][:unit]
-            when 'days'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(patients.created_at) >= ?', number.days.ago).where('Date(patients.created_at) <= ?', Date.today)
-            when 'weeks'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(patients.created_at) >= ?', number.weeks.ago).where('Date(patients.created_at) <= ?', Date.today)
-            when 'months'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(patients.created_at) >= ?', number.months.ago).where('Date(patients.created_at) <= ?', Date.today)
-            end
-          when 'next'
-            case filter[:value][:unit]
-            when 'days'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(patients.created_at) <= ?', number.days.from_now).where('Date(patients.created_at) >= ?', Date.today)
-            when 'weeks'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(patients.created_at) <= ?', number.weeks.from_now).where('Date(patients.created_at) >= ?', Date.today)
-            when 'months'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(patients.created_at) <= ?', number.months.from_now).where('Date(patients.created_at) >= ?', Date.today)
-            end
-          end
-        end
+        patients = advanced_filter_enrolled_relative(patients, filter)
       when 'last-date-exposure'
         case filter[:dateOption]
         when 'before'
@@ -425,41 +357,7 @@ class PublicHealthController < ApplicationController
           patients = patients.where('Date(last_date_of_exposure) > ?', compare_date_start).where('Date(last_date_of_exposure) < ?', compare_date_end)
         end
       when 'last-date-exposure-relative'
-        case filter[:relativeOption]
-        when 'today'
-          patients = patients.where('Date(last_date_of_exposure) = ?', Date.today)
-        when 'tomorrow'
-          patients = patients.where('Date(last_date_of_exposure) = ?', Date.tomorrow)
-        when 'yesterday'
-          patients = patients.where('Date(last_date_of_exposure) = ?', Date.yesterday)
-        when 'custom'
-          case filter[:value][:when]
-          when 'past'
-            case filter[:value][:unit]
-            when 'days'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(last_date_of_exposure) >= ?', number.days.ago).where('Date(last_date_of_exposure) <= ?', Date.today)
-            when 'weeks'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(last_date_of_exposure) >= ?', number.weeks.ago).where('Date(last_date_of_exposure) <= ?', Date.today)
-            when 'months'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(last_date_of_exposure) >= ?', number.months.ago).where('Date(last_date_of_exposure) <= ?', Date.today)
-            end
-          when 'next'
-            case filter[:value][:unit]
-            when 'days'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(last_date_of_exposure) <= ?', number.days.from_now).where('Date(last_date_of_exposure) >= ?', Date.today)
-            when 'weeks'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(last_date_of_exposure) <= ?', number.weeks.from_now).where('Date(last_date_of_exposure) >= ?', Date.today)
-            when 'months'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(last_date_of_exposure) <= ?', number.months.from_now).where('Date(last_date_of_exposure) >= ?', Date.today)
-            end
-          end
-        end
+        patients = advanced_filter_lde_relative(patients, filter)
       when 'symptom-onset'
         case filter[:dateOption]
         when 'before'
@@ -474,41 +372,7 @@ class PublicHealthController < ApplicationController
           patients = patients.where('Date(symptom_onset) > ?', compare_date_start).where('Date(symptom_onset) < ?', compare_date_end)
         end
       when 'symptom-onset-relative'
-        case filter[:relativeOption]
-        when 'today'
-          patients = patients.where('Date(symptom_onset) = ?', Date.today)
-        when 'tomorrow'
-          patients = patients.where('Date(symptom_onset) = ?', Date.tomorrow)
-        when 'yesterday'
-          patients = patients.where('Date(symptom_onset) = ?', Date.yesterday)
-        when 'custom'
-          case filter[:value][:when]
-          when 'past'
-            case filter[:value][:unit]
-            when 'days'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(symptom_onset) >= ?', number.days.ago).where('Date(symptom_onset) <= ?', Date.today)
-            when 'weeks'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(symptom_onset) >= ?', number.weeks.ago).where('Date(symptom_onset) <= ?', Date.today)
-            when 'months'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(symptom_onset) >= ?', number.months.ago).where('Date(symptom_onset) <= ?', Date.today)
-            end
-          when 'next'
-            case filter[:value][:unit]
-            when 'days'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(symptom_onset) <= ?', number.days.from_now).where('Date(symptom_onset) >= ?', Date.today)
-            when 'weeks'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(symptom_onset) <= ?', number.weeks.from_now).where('Date(symptom_onset) >= ?', Date.today)
-            when 'months'
-              number = filter[:value][:number].to_i
-              patients = patients.where('Date(symptom_onset) <= ?', number.months.from_now).where('Date(symptom_onset) >= ?', Date.today)
-            end
-          end
-        end
+        patients = advanced_filter_symptom_onset_relative(patients, filter)
       when 'continous-exposure'
         patients = patients.where(continuous_exposure: filter[:value].present? ? true : [nil, false])
       when 'telephone-number'
@@ -628,6 +492,162 @@ class PublicHealthController < ApplicationController
     patients
   end
   # rubocop:enable Metrics/MethodLength
+
+  def advanced_filter_enrolled_relative(patients, filter)
+    case filter[:relativeOption]
+    when 'today'
+      patients = patients.where('Date(patients.created_at) = ?', Date.today)
+    when 'tomorrow'
+      patients = patients.where('Date(patients.created_at) = ?', Date.tomorrow)
+    when 'yesterday'
+      patients = patients.where('Date(patients.created_at) = ?', Date.yesterday)
+    when 'custom'
+      case filter[:value][:when]
+      when 'past'
+        case filter[:value][:unit]
+        when 'days'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(patients.created_at) >= ?', number.days.ago).where('Date(patients.created_at) <= ?', Date.today)
+        when 'weeks'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(patients.created_at) >= ?', number.weeks.ago).where('Date(patients.created_at) <= ?', Date.today)
+        when 'months'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(patients.created_at) >= ?', number.months.ago).where('Date(patients.created_at) <= ?', Date.today)
+        end
+      when 'next'
+        case filter[:value][:unit]
+        when 'days'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(patients.created_at) <= ?', number.days.from_now).where('Date(patients.created_at) >= ?', Date.today)
+        when 'weeks'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(patients.created_at) <= ?', number.weeks.from_now).where('Date(patients.created_at) >= ?', Date.today)
+        when 'months'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(patients.created_at) <= ?', number.months.from_now).where('Date(patients.created_at) >= ?', Date.today)
+        end
+      end
+    end
+    patients
+  end
+
+  def advanced_filter_latest_report_relative(patients, filter)
+    case filter[:relativeOption]
+    when 'today'
+      patients = patients.where('Date(latest_assessment_at) = ?', Date.today)
+    when 'tomorrow'
+      patients = patients.where('Date(latest_assessment_at) = ?', Date.tomorrow)
+    when 'yesterday'
+      patients = patients.where('Date(latest_assessment_at) = ?', Date.yesterday)
+    when 'custom'
+      case filter[:value][:when]
+      when 'past'
+        case filter[:value][:unit]
+        when 'days'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(latest_assessment_at) >= ?', number.days.ago).where('Date(latest_assessment_at) <= ?', Date.today)
+        when 'weeks'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(latest_assessment_at) >= ?', number.weeks.ago).where('Date(latest_assessment_at) <= ?', Date.today)
+        when 'months'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(latest_assessment_at) >= ?', number.months.ago).where('Date(latest_assessment_at) <= ?', Date.today)
+        end
+      when 'next'
+        case filter[:value][:unit]
+        when 'days'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(latest_assessment_at) <= ?', number.days.from_now).where('Date(latest_assessment_at) >= ?', Date.today)
+        when 'weeks'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(latest_assessment_at) <= ?', number.weeks.from_now).where('Date(latest_assessment_at) >= ?', Date.today)
+        when 'months'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(latest_assessment_at) <= ?', number.months.from_now).where('Date(latest_assessment_at) >= ?', Date.today)
+        end
+      end
+    end
+    patients
+  end
+
+  def advanced_filter_lde_relative(patients, filter)
+    case filter[:relativeOption]
+    when 'today'
+      patients = patients.where('Date(last_date_of_exposure) = ?', Date.today)
+    when 'tomorrow'
+      patients = patients.where('Date(last_date_of_exposure) = ?', Date.tomorrow)
+    when 'yesterday'
+      patients = patients.where('Date(last_date_of_exposure) = ?', Date.yesterday)
+    when 'custom'
+      case filter[:value][:when]
+      when 'past'
+        case filter[:value][:unit]
+        when 'days'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(last_date_of_exposure) >= ?', number.days.ago).where('Date(last_date_of_exposure) <= ?', Date.today)
+        when 'weeks'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(last_date_of_exposure) >= ?', number.weeks.ago).where('Date(last_date_of_exposure) <= ?', Date.today)
+        when 'months'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(last_date_of_exposure) >= ?', number.months.ago).where('Date(last_date_of_exposure) <= ?', Date.today)
+        end
+      when 'next'
+        case filter[:value][:unit]
+        when 'days'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(last_date_of_exposure) <= ?', number.days.from_now).where('Date(last_date_of_exposure) >= ?', Date.today)
+        when 'weeks'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(last_date_of_exposure) <= ?', number.weeks.from_now).where('Date(last_date_of_exposure) >= ?', Date.today)
+        when 'months'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(last_date_of_exposure) <= ?', number.months.from_now).where('Date(last_date_of_exposure) >= ?', Date.today)
+        end
+      end
+    end
+    patients
+  end
+
+  def advanced_filter_symptom_onset_relative(patients, filter)
+    case filter[:relativeOption]
+    when 'today'
+      patients = patients.where('Date(symptom_onset) = ?', Date.today)
+    when 'tomorrow'
+      patients = patients.where('Date(symptom_onset) = ?', Date.tomorrow)
+    when 'yesterday'
+      patients = patients.where('Date(symptom_onset) = ?', Date.yesterday)
+    when 'custom'
+      case filter[:value][:when]
+      when 'past'
+        case filter[:value][:unit]
+        when 'days'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(symptom_onset) >= ?', number.days.ago).where('Date(symptom_onset) <= ?', Date.today)
+        when 'weeks'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(symptom_onset) >= ?', number.weeks.ago).where('Date(symptom_onset) <= ?', Date.today)
+        when 'months'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(symptom_onset) >= ?', number.months.ago).where('Date(symptom_onset) <= ?', Date.today)
+        end
+      when 'next'
+        case filter[:value][:unit]
+        when 'days'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(symptom_onset) <= ?', number.days.from_now).where('Date(symptom_onset) >= ?', Date.today)
+        when 'weeks'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(symptom_onset) <= ?', number.weeks.from_now).where('Date(symptom_onset) >= ?', Date.today)
+        when 'months'
+          number = filter[:value][:number].to_i
+          patients = patients.where('Date(symptom_onset) <= ?', number.months.from_now).where('Date(symptom_onset) >= ?', Date.today)
+        end
+      end
+    end
+    patients
+  end
 
   private
 

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -314,6 +314,42 @@ class PublicHealthController < ApplicationController
           compare_date_end = Chronic.parse(filter[:value][:end])
           patients = patients.where('Date(latest_assessment_at) > ?', compare_date_start).where('Date(latest_assessment_at) < ?', compare_date_end)
         end
+      when 'latest-report-relative'
+        case filter[:relativeOption]
+        when 'today'
+          patients = patients.where('Date(latest_assessment_at) = ?', Date.today)
+        when 'tomorrow'
+          patients = patients.where('Date(latest_assessment_at) = ?', Date.tomorrow)
+        when 'yesterday'
+          patients = patients.where('Date(latest_assessment_at) = ?', Date.yesterday)
+        when 'custom'
+          case filter[:value][:when]
+          when 'past'
+            case filter[:value][:unit]
+            when 'days'
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(latest_assessment_at) >= ?',  number.days.ago).where('Date(latest_assessment_at) <= ?', Date.today)
+            when 'weeks' 
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(latest_assessment_at) >= ?',  number.weeks.ago).where('Date(latest_assessment_at) <= ?', Date.today)
+            when 'months'
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(latest_assessment_at) >= ?',  number.months.ago).where('Date(latest_assessment_at) <= ?', Date.today)
+            end
+          when 'next'
+            case filter[:value][:unit]
+            when 'days'
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(latest_assessment_at) <= ?',  number.days.from_now).where('Date(latest_assessment_at) >= ?', Date.today)
+            when 'weeks'
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(latest_assessment_at) <= ?',  number.weeks.from_now).where('Date(latest_assessment_at) >= ?', Date.today)
+            when 'months'
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(latest_assessment_at) <= ?',  number.months.from_now).where('Date(latest_assessment_at) >= ?', Date.today)
+            end
+          end
+        end
       when 'hoh'
         patients = if filter[:value]
                      patients.where('patients.id = patients.responder_id')
@@ -339,6 +375,42 @@ class PublicHealthController < ApplicationController
           compare_date_end = Chronic.parse(filter[:value][:end])
           patients = patients.where('Date(patients.created_at) > ?', compare_date_start).where('Date(patients.created_at) < ?', compare_date_end)
         end
+      when 'enrolled-relative'
+        case filter[:relativeOption]
+        when 'today'
+          patients = patients.where('Date(patients.created_at) = ?', Date.today)
+        when 'tomorrow'
+          patients = patients.where('Date(patients.created_at) = ?', Date.tomorrow)
+        when 'yesterday'
+          patients = patients.where('Date(patients.created_at) = ?', Date.yesterday)
+        when 'custom'
+          case filter[:value][:when]
+          when 'past'
+            case filter[:value][:unit]
+            when 'days'
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(patients.created_at) >= ?',  number.days.ago).where('Date(patients.created_at) <= ?', Date.today)
+            when 'weeks' 
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(patients.created_at) >= ?',  number.weeks.ago).where('Date(patients.created_at) <= ?', Date.today)
+            when 'months'
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(patients.created_at) >= ?',  number.months.ago).where('Date(patients.created_at) <= ?', Date.today)
+            end
+          when 'next'
+            case filter[:value][:unit]
+            when 'days'
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(patients.created_at) <= ?',  number.days.from_now).where('Date(patients.created_at) >= ?', Date.today)
+            when 'weeks'
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(patients.created_at) <= ?',  number.weeks.from_now).where('Date(patients.created_at) >= ?', Date.today)
+            when 'months'
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(patients.created_at) <= ?',  number.months.from_now).where('Date(patients.created_at) >= ?', Date.today)
+            end
+          end
+        end
       when 'last-date-exposure'
         case filter[:dateOption]
         when 'before'
@@ -351,6 +423,42 @@ class PublicHealthController < ApplicationController
           compare_date_start = Chronic.parse(filter[:value][:start])
           compare_date_end = Chronic.parse(filter[:value][:end])
           patients = patients.where('Date(last_date_of_exposure) > ?', compare_date_start).where('Date(last_date_of_exposure) < ?', compare_date_end)
+        end
+      when 'last-date-exposure-relative'
+        case filter[:relativeOption]
+        when 'today'
+          patients = patients.where('Date(last_date_of_exposure) = ?', Date.today)
+        when 'tomorrow'
+          patients = patients.where('Date(last_date_of_exposure) = ?', Date.tomorrow)
+        when 'yesterday'
+          patients = patients.where('Date(last_date_of_exposure) = ?', Date.yesterday)
+        when 'custom'
+          case filter[:value][:when]
+          when 'past'
+            case filter[:value][:unit]
+            when 'days'
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(last_date_of_exposure) >= ?',  number.days.ago).where('Date(last_date_of_exposure) <= ?', Date.today)
+            when 'weeks' 
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(last_date_of_exposure) >= ?',  number.weeks.ago).where('Date(last_date_of_exposure) <= ?', Date.today)
+            when 'months'
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(last_date_of_exposure) >= ?',  number.months.ago).where('Date(last_date_of_exposure) <= ?', Date.today)
+            end
+          when 'next'
+            case filter[:value][:unit]
+            when 'days'
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(last_date_of_exposure) <= ?',  number.days.from_now).where('Date(last_date_of_exposure) >= ?', Date.today)
+            when 'weeks'
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(last_date_of_exposure) <= ?',  number.weeks.from_now).where('Date(last_date_of_exposure) >= ?', Date.today)
+            when 'months'
+              number = filter[:value][:number].to_i
+              patients = patients.where('Date(last_date_of_exposure) <= ?',  number.months.from_now).where('Date(last_date_of_exposure) >= ?', Date.today)
+            end
+          end
         end
       when 'symptom-onset'
         case filter[:dateOption]
@@ -379,25 +487,25 @@ class PublicHealthController < ApplicationController
             case filter[:value][:unit]
             when 'days'
               number = filter[:value][:number].to_i
-              patients = patients.where('symptom_onset >= ?',  number.days.ago).where('symptom_onset <= ?', Date.today)
+              patients = patients.where('Date(symptom_onset) >= ?',  number.days.ago).where('Date(symptom_onset) <= ?', Date.today)
             when 'weeks'
               number = filter[:value][:number].to_i
-              patients = patients.where('symptom_onset >= ?',  number.weeks.ago).where('symptom_onset <= ?', Date.today)
+              patients = patients.where('Date(symptom_onset) >= ?',  number.weeks.ago).where('Date(symptom_onset) <= ?', Date.today)
             when 'months'
               number = filter[:value][:number].to_i
-              patients = patients.where('symptom_onset >= ?',  number.months.ago).where('symptom_onset <= ?', Date.today)
+              patients = patients.where('Date(symptom_onset) >= ?',  number.months.ago).where('Date(symptom_onset) <= ?', Date.today)
             end
           when 'next'
             case filter[:value][:unit]
             when 'days'
               number = filter[:value][:number].to_i
-              patients = patients.where('symptom_onset <= ?',  number.days.from_now).where('symptom_onset >= ?', Date.today)
+              patients = patients.where('Date(symptom_onset) <= ?',  number.days.from_now).where('Date(symptom_onset) >= ?', Date.today)
             when 'weeks'
               number = filter[:value][:number].to_i
-              patients = patients.where('symptom_onset <= ?',  number.weeks.from_now).where('symptom_onset >= ?', Date.today)
+              patients = patients.where('Date(symptom_onset) <= ?',  number.weeks.from_now).where('Date(symptom_onset) >= ?', Date.today)
             when 'months'
               number = filter[:value][:number].to_i
-              patients = patients.where('symptom_onset <= ?',  number.months.from_now).where('symptom_onset >= ?', Date.today)
+              patients = patients.where('Date(symptom_onset) <= ?',  number.months.from_now).where('Date(symptom_onset) >= ?', Date.today)
             end
           end
         end

--- a/app/javascript/components/public_health/AdvancedFilter.js
+++ b/app/javascript/components/public_health/AdvancedFilter.js
@@ -303,6 +303,13 @@ class AdvancedFilter extends React.Component {
     this.setState({ activeFilterOptions });
   };
 
+  // Change the relative filter option for type relative date
+  changeFilterRelativeOption = (index, value, relativeOption) => {
+    let activeFilterOptions = [...this.state.activeFilterOptions];
+    activeFilterOptions[parseInt(index)] = { filterOption: activeFilterOptions[parseInt(index)].filterOption, value: value, relativeOption: relativeOption };
+    this.setState({ activeFilterOptions });
+  };
+
   // Change an index value
   changeValue = (index, value) => {
     let activeFilterOptions = [...this.state.activeFilterOptions];
@@ -447,6 +454,23 @@ class AdvancedFilter extends React.Component {
     );
   };
 
+  // Render relative date specific options
+  renderRelativeOptions = (current, index, value) => {
+    return (
+      <Form.Control
+        as="select"
+        value={current}
+        onChange={event => {
+          this.changeFilterRelativeOption(index, value, event.target.value);
+        }}>
+        <option value="today">today</option>
+        <option value="tomorrow">tomorrow</option>
+        <option value="yesterday">yesterday</option>
+        <option value="custom">more...</option>
+      </Form.Control>
+    );
+  };
+
   // Modal to specify filter name
   renderFilterNameModal = () => {
     return (
@@ -493,7 +517,7 @@ class AdvancedFilter extends React.Component {
   };
 
   // Render a single line "statement"
-  renderStatement = (filterOption, value, index, total, dateOption) => {
+  renderStatement = (filterOption, value, index, total, dateOption, relativeOption) => {
     return (
       <React.Fragment key={'rowkey-filter-p' + index}>
         {index > 0 && index < total && (
@@ -800,7 +824,14 @@ class AdvancedFilter extends React.Component {
               </Col>
             </Row>
             {this.state.activeFilterOptions?.map((statement, index) => {
-              return this.renderStatement(statement.filterOption, statement.value, index, this.state.activeFilterOptions?.length, statement.dateOption);
+              return this.renderStatement(
+                statement.filterOption,
+                statement.value,
+                index,
+                this.state.activeFilterOptions?.length,
+                statement.dateOption,
+                statement.relativeOption
+              );
             })}
             <Row className="pt-2 pb-1">
               <Col>

--- a/app/javascript/components/public_health/AdvancedFilter.js
+++ b/app/javascript/components/public_health/AdvancedFilter.js
@@ -62,7 +62,7 @@ class AdvancedFilter extends React.Component {
         {
           name: 'symptom-onset-relative',
           title: 'Symptom Onset (Relative Date)',
-          description: 'Monitorees who have a symptom onset date during specified date range CHANGE ME',
+          description: 'Monitorees who have a symptom onset date during specified date range (relative to the current date)',
           type: 'relative',
         },
         { name: 'continous-exposure', title: 'Continuous Exposure (Boolean)', description: 'Monitorees who have continuous exposure enabled', type: 'boolean' },

--- a/app/javascript/components/public_health/AdvancedFilter.js
+++ b/app/javascript/components/public_health/AdvancedFilter.js
@@ -259,7 +259,7 @@ class AdvancedFilter extends React.Component {
       // Default to "within" type
       value = { start: moment().add(-72, 'hours'), end: moment() };
     } else if (filterOption.type === 'relative') {
-      value = { days: 1, when: 'past' };
+      value = { number: 1, unit: 'days', when: 'past' };
     } else if (filterOption.type === 'search') {
       value = '';
     }
@@ -661,29 +661,40 @@ class AdvancedFilter extends React.Component {
             {filterOption?.type === 'relative' && relativeOption === 'custom' && (
               <Form.Group className="py-0 my-0">
                 <Row>
-                  <Col className="py-0 px-0 text-center my-auto">
+                  <Col className="py-0 px-0 text-center my-auto" md="auto">
                     <b>IN THE</b>
                   </Col>
-                  <Col>
+                  <Col md="6" className="pr-0">
                     <Form.Control
                       as="select"
                       value={value.when}
                       onChange={event => {
-                        this.changeValue(index, { days: value.days, when: event.target.value });
+                        this.changeValue(index, { number: value.number, unit: value.unit, when: event.target.value });
                       }}>
                       <option value="past">past</option>
                       <option value="next">next</option>
                     </Form.Control>
                   </Col>
-                  <Col>
+                  <Col md="5" className="pr-0">
                     <Form.Control
-                      value={value.days}
+                      value={value.number}
                       type="number"
                       min="1"
-                      onChange={event => this.changeValue(index, { days: event.target.value, when: value.when })}
+                      onChange={event => this.changeValue(index, { number: event.target.value, unit: value.unit, when: value.when })}
                     />
                   </Col>
-                  <Col className="py-0 px-0 ml-2 my-auto">{value.days === 1 ? <b>DAY</b> : <b>DAYS</b>}</Col>
+                  <Col md="8" className="pr-0">
+                    <Form.Control
+                      as="select"
+                      value={value.unit}
+                      onChange={event => {
+                        this.changeValue(index, { number: value.number, unit: event.target.value, when: value.when });
+                      }}>
+                      <option value="days">day(s)</option>
+                      <option value="weeks">week(s)</option>
+                      <option value="months">month(s)</option>
+                    </Form.Control>
+                  </Col>
                 </Row>
               </Form.Group>
             )}

--- a/app/javascript/components/public_health/AdvancedFilter.js
+++ b/app/javascript/components/public_health/AdvancedFilter.js
@@ -39,6 +39,12 @@ class AdvancedFilter extends React.Component {
           options: ['Unknown', 'E-mailed Web Link', 'SMS Texted Weblink', 'Telephone call', 'SMS Text-message', 'Opt-out', ''],
         },
         { name: 'latest-report', title: 'Latest Report (Date)', description: 'Monitorees with latest report during specified date range', type: 'date' },
+        {
+          name: 'latest-report-relative',
+          title: 'Latest Report (Relative Date)',
+          description: 'Monitorees with latest report during specified date range (relative to the current date)',
+          type: 'relative',
+        },
         { name: 'hoh', title: 'Daily Reporters (Boolean)', description: 'Monitorees that are a Head of Household or self-reporter', type: 'boolean' },
         {
           name: 'household-member',
@@ -48,10 +54,22 @@ class AdvancedFilter extends React.Component {
         },
         { name: 'enrolled', title: 'Enrolled (Date)', description: 'Monitorees enrolled in system during specified date range', type: 'date' },
         {
+          name: 'enrolled-relative',
+          title: 'Enrolled (Relative Date)',
+          description: 'Monitorees enrolled in system during specified date range (relative to the current date)',
+          type: 'relative',
+        },
+        {
           name: 'last-date-exposure',
-          title: 'Last date of exposure (Date)',
+          title: 'Last Date of Exposure (Date)',
           description: 'Monitorees who have a last date of exposure during specified date range',
           type: 'date',
+        },
+        {
+          name: 'last-date-exposure-relative',
+          title: 'Last Date of Exposure (Relative Date)',
+          description: 'Monitorees who have a last date of exposure during specified date range (relative to the current date)',
+          type: 'relative',
         },
         {
           name: 'symptom-onset',

--- a/app/javascript/components/public_health/AdvancedFilter.js
+++ b/app/javascript/components/public_health/AdvancedFilter.js
@@ -38,7 +38,7 @@ class AdvancedFilter extends React.Component {
           type: 'option',
           options: ['Unknown', 'E-mailed Web Link', 'SMS Texted Weblink', 'Telephone call', 'SMS Text-message', 'Opt-out', ''],
         },
-        { name: 'latest-report', title: 'Latest Report (Date picker)', description: 'Monitorees with latest report during specified date range', type: 'date' },
+        { name: 'latest-report', title: 'Latest Report (Date)', description: 'Monitorees with latest report during specified date range', type: 'date' },
         { name: 'hoh', title: 'Daily Reporters (Boolean)', description: 'Monitorees that are a Head of Household or self-reporter', type: 'boolean' },
         {
           name: 'household-member',
@@ -46,18 +46,24 @@ class AdvancedFilter extends React.Component {
           description: 'Monitorees that are in a household but not the Head of Household',
           type: 'boolean',
         },
-        { name: 'enrolled', title: 'Enrolled (Date picker)', description: 'Monitorees enrolled in system during specified date range', type: 'date' },
+        { name: 'enrolled', title: 'Enrolled (Date)', description: 'Monitorees enrolled in system during specified date range', type: 'date' },
         {
           name: 'last-date-exposure',
-          title: 'Last date of exposure (Date picker)',
+          title: 'Last date of exposure (Date)',
           description: 'Monitorees who have a last date of exposure during specified date range',
           type: 'date',
         },
         {
           name: 'symptom-onset',
-          title: 'Symptom onset (Date picker)',
+          title: 'Symptom Onset (Date)',
           description: 'Monitorees who have a symptom onset date during specified date range',
           type: 'date',
+        },
+        {
+          name: 'symptom-onset-relative',
+          title: 'Symptom Onset (Relative Date)',
+          description: 'Monitorees who have a symptom onset date during specified date range CHANGE ME',
+          type: 'relative',
         },
         { name: 'continous-exposure', title: 'Continuous Exposure (Boolean)', description: 'Monitorees who have continuous exposure enabled', type: 'boolean' },
         {
@@ -252,6 +258,8 @@ class AdvancedFilter extends React.Component {
     } else if (filterOption.type === 'date') {
       // Default to "within" type
       value = { start: moment().add(-72, 'hours'), end: moment() };
+    } else if (filterOption.type === 'relative') {
+      value = { days: 1, when: 'past' };
     } else if (filterOption.type === 'search') {
       value = '';
     }
@@ -264,7 +272,7 @@ class AdvancedFilter extends React.Component {
     this.setState({ activeFilterOptions });
   };
 
-  // Change an index filter option for date
+  // Change an index filter option for type date
   changeFilterDateOption = (index, value) => {
     let activeFilterOptions = [...this.state.activeFilterOptions];
     let defaultValue = null;
@@ -486,6 +494,11 @@ class AdvancedFilter extends React.Component {
               {this.renderDateOptions(dateOption, index)}
             </Col>
           )}
+          {filterOption?.type === 'relative' && (
+            <Col className="py-0" md="4">
+              {this.renderRelativeOptions(relativeOption, index, value)}
+            </Col>
+          )}
           <Col className="py-0">
             {filterOption?.type === 'boolean' && (
               <ButtonGroup toggle>
@@ -642,6 +655,35 @@ class AdvancedFilter extends React.Component {
                         .format('YYYY-MM-DD')}
                     />
                   </Col>
+                </Row>
+              </Form.Group>
+            )}
+            {filterOption?.type === 'relative' && relativeOption === 'custom' && (
+              <Form.Group className="py-0 my-0">
+                <Row>
+                  <Col className="py-0 px-0 text-center my-auto">
+                    <b>IN THE</b>
+                  </Col>
+                  <Col>
+                    <Form.Control
+                      as="select"
+                      value={value.when}
+                      onChange={event => {
+                        this.changeValue(index, { days: value.days, when: event.target.value });
+                      }}>
+                      <option value="past">past</option>
+                      <option value="next">next</option>
+                    </Form.Control>
+                  </Col>
+                  <Col>
+                    <Form.Control
+                      value={value.days}
+                      type="number"
+                      min="1"
+                      onChange={event => this.changeValue(index, { days: event.target.value, when: value.when })}
+                    />
+                  </Col>
+                  <Col className="py-0 px-0 ml-2 my-auto">{value.days === 1 ? <b>DAY</b> : <b>DAYS</b>}</Col>
                 </Row>
               </Form.Group>
             )}

--- a/app/javascript/components/public_health/AdvancedFilter.js
+++ b/app/javascript/components/public_health/AdvancedFilter.js
@@ -507,16 +507,6 @@ class AdvancedFilter extends React.Component {
           <Col className="py-0" md="9">
             {this.renderOptions(filterOption?.name, index)}
           </Col>
-          {filterOption?.type === 'date' && (
-            <Col className="py-0" md="3">
-              {this.renderDateOptions(dateOption, index)}
-            </Col>
-          )}
-          {filterOption?.type === 'relative' && (
-            <Col className="py-0" md="4">
-              {this.renderRelativeOptions(relativeOption, index, value)}
-            </Col>
-          )}
           <Col className="py-0">
             {filterOption?.type === 'boolean' && (
               <ButtonGroup toggle>
@@ -623,98 +613,114 @@ class AdvancedFilter extends React.Component {
                 </Row>
               </Form.Group>
             )}
-            {filterOption?.type === 'date' && dateOption != 'within' && (
-              <Form.Group className="py-0 my-0">
-                <DateInput
-                  date={value}
-                  onChange={date => {
-                    this.changeValue(index, date);
-                  }}
-                  placement="bottom"
-                  customClass="form-control-md"
-                  minDate={'1900-01-01'}
-                  maxDate={moment()
-                    .add(2, 'years')
-                    .format('YYYY-MM-DD')}
-                />
-              </Form.Group>
+            {filterOption?.type === 'date' && (
+              <Row>
+                <Col className="py-0" md="6">
+                  {this.renderDateOptions(dateOption, index)}
+                </Col>
+                {dateOption != 'within' && (
+                  <Col className="py-0">
+                    <Form.Group className="py-0 my-0">
+                      <DateInput
+                        date={value}
+                        onChange={date => {
+                          this.changeValue(index, date);
+                        }}
+                        placement="bottom"
+                        customClass="form-control-md"
+                        minDate={'1900-01-01'}
+                        maxDate={moment()
+                          .add(2, 'years')
+                          .format('YYYY-MM-DD')}
+                      />
+                    </Form.Group>
+                  </Col>
+                )}
+                {dateOption === 'within' && (
+                  <React.Fragment>
+                    <Col className="pr-0" md="8">
+                      <Form.Group className="py-0 my-0">
+                        <DateInput
+                          date={value.start}
+                          onChange={date => {
+                            this.changeValue(index, { start: date, end: value.end });
+                          }}
+                          placement="bottom"
+                          customClass="form-control-md"
+                          minDate={'1900-01-01'}
+                          maxDate={moment()
+                            .add(2, 'years')
+                            .format('YYYY-MM-DD')}
+                        />
+                      </Form.Group>
+                    </Col>
+                    <Col className="py-0 px-0 text-center my-auto" md="2">
+                      <b>TO</b>
+                    </Col>
+                    <Col className="pl-0" md="8">
+                      <Form.Group className="py-0 my-0">
+                        <DateInput
+                          date={value.end}
+                          onChange={date => {
+                            this.changeValue(index, { start: value.start, end: date });
+                          }}
+                          placement="bottom"
+                          customClass="form-control-md"
+                          minDate={'1900-01-01'}
+                          maxDate={moment()
+                            .add(2, 'years')
+                            .format('YYYY-MM-DD')}
+                        />
+                      </Form.Group>
+                    </Col>
+                  </React.Fragment>
+                )}
+              </Row>
             )}
-            {filterOption?.type === 'date' && dateOption === 'within' && (
-              <Form.Group className="py-0 my-0">
-                <Row>
-                  <Col className="pr-0">
-                    <DateInput
-                      date={value?.start}
-                      onChange={date => {
-                        this.changeValue(index, { start: date, end: value?.end });
-                      }}
-                      placement="bottom"
-                      customClass="form-control-md"
-                      minDate={'1900-01-01'}
-                      maxDate={moment()
-                        .add(2, 'years')
-                        .format('YYYY-MM-DD')}
-                    />
-                  </Col>
-                  <Col className="py-0 px-0 text-center my-auto" md="2">
-                    <b>TO</b>
-                  </Col>
-                  <Col className="pl-0">
-                    <DateInput
-                      date={value?.end}
-                      onChange={date => {
-                        this.changeValue(index, { start: value?.start, end: date });
-                      }}
-                      placement="bottom"
-                      customClass="form-control-md"
-                      minDate={'1900-01-01'}
-                      maxDate={moment()
-                        .add(2, 'years')
-                        .format('YYYY-MM-DD')}
-                    />
-                  </Col>
-                </Row>
-              </Form.Group>
-            )}
-            {filterOption?.type === 'relative' && relativeOption === 'custom' && (
-              <Form.Group className="py-0 my-0">
-                <Row>
-                  <Col className="py-0 px-0 text-center my-auto" md="auto">
-                    <b>IN THE</b>
-                  </Col>
-                  <Col md="6" className="pr-0">
-                    <Form.Control
-                      as="select"
-                      value={value.when}
-                      onChange={event => {
-                        this.changeValue(index, { number: value.number, unit: value.unit, when: event.target.value });
-                      }}>
-                      <option value="past">past</option>
-                      <option value="next">next</option>
-                    </Form.Control>
-                  </Col>
-                  <Col md="5" className="pr-0">
-                    <Form.Control
-                      value={value.number}
-                      type="number"
-                      min="1"
-                      onChange={event => this.changeValue(index, { number: event.target.value, unit: value.unit, when: value.when })}
-                    />
-                  </Col>
-                  <Col md="8" className="pr-0">
-                    <Form.Control
-                      as="select"
-                      value={value.unit}
-                      onChange={event => {
-                        this.changeValue(index, { number: value.number, unit: event.target.value, when: value.when });
-                      }}>
-                      <option value="days">day(s)</option>
-                      <option value="weeks">week(s)</option>
-                      <option value="months">month(s)</option>
-                    </Form.Control>
-                  </Col>
-                </Row>
-              </Form.Group>
+            {filterOption?.type === 'relative' && (
+              <Row>
+                <Col className="py-0" md="7">
+                  {this.renderRelativeOptions(relativeOption, index, value)}
+                </Col>
+                {relativeOption === 'custom' && (
+                  <React.Fragment>
+                    <Col className="py-0 px-0 text-center my-auto" md="auto">
+                      <b>IN THE</b>
+                    </Col>
+                    <Col md="4" className="pr-0">
+                      <Form.Control
+                        as="select"
+                        value={value.when}
+                        onChange={event => {
+                          this.changeValue(index, { number: value.number, unit: value.unit, when: event.target.value });
+                        }}>
+                        <option value="past">past</option>
+                        <option value="next">next</option>
+                      </Form.Control>
+                    </Col>
+                    <Col md="4" className="pr-0">
+                      <Form.Control
+                        value={value.number}
+                        type="number"
+                        min="1"
+                        onChange={event => this.changeValue(index, { number: event.target.value, unit: value.unit, when: value.when })}
+                      />
+                    </Col>
+                    <Col md="6" className="pr-0">
+                      <Form.Control
+                        as="select"
+                        value={value.unit}
+                        onChange={event => {
+                          this.changeValue(index, { number: value.number, unit: event.target.value, when: value.when });
+                        }}>
+                        <option value="days">day(s)</option>
+                        <option value="weeks">week(s)</option>
+                        <option value="months">month(s)</option>
+                      </Form.Control>
+                    </Col>
+                  </React.Fragment>
+                )}
+              </Row>
             )}
             {filterOption?.type === 'search' && (
               <Form.Group className="py-0 my-0">

--- a/app/javascript/components/public_health/AdvancedFilter.js
+++ b/app/javascript/components/public_health/AdvancedFilter.js
@@ -642,7 +642,7 @@ class AdvancedFilter extends React.Component {
                 <Col className="py-0" md="6">
                   {this.renderDateOptions(dateOption, index)}
                 </Col>
-                {dateOption != 'within' && (
+                {dateOption !== 'within' && (
                   <Col className="py-0">
                     <Form.Group className="py-0 my-0">
                       <DateInput

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -7,6 +7,7 @@ require 'redis-queue'
 class ConsumeAssessmentsJob < ApplicationJob
   queue_as :default
 
+  # rubocop:disable Metrics/MethodLength
   def perform
     queue = Redis::Queue.new('q_bridge', 'bp_q_bridge', redis: Rails.application.config.redis)
 
@@ -139,7 +140,7 @@ class ConsumeAssessmentsJob < ApplicationJob
           assessment = Assessment.new(reported_condition: reported_condition, patient: patient, who_reported: 'Monitoree')
           assessment.symptomatic = assessment.symptomatic?
           queue.commit if assessment.save
-        else
+        elsif !message['response_status'].in? %w[opt_out opt_in]
           # If message['reported_symptoms_array'] is not populated then this assessment came in through
           # a generic channel ie: SMS where monitorees are asked YES/NO if they are experiencing symptoms
           patient.active_dependents.each do |dependent|
@@ -173,6 +174,7 @@ class ConsumeAssessmentsJob < ApplicationJob
     sleep(1)
     retry
   end
+  # rubocop:enable Metrics/MethodLength
 
   private
 

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -7,7 +7,6 @@ require 'redis-queue'
 class ConsumeAssessmentsJob < ApplicationJob
   queue_as :default
 
-  # rubocop:disable Metrics/MethodLength
   def perform
     queue = Redis::Queue.new('q_bridge', 'bp_q_bridge', redis: Rails.application.config.redis)
 
@@ -140,7 +139,7 @@ class ConsumeAssessmentsJob < ApplicationJob
           assessment = Assessment.new(reported_condition: reported_condition, patient: patient, who_reported: 'Monitoree')
           assessment.symptomatic = assessment.symptomatic?
           queue.commit if assessment.save
-        elsif !message['response_status'].in? %w[opt_out opt_in]
+        else
           # If message['reported_symptoms_array'] is not populated then this assessment came in through
           # a generic channel ie: SMS where monitorees are asked YES/NO if they are experiencing symptoms
           patient.active_dependents.each do |dependent|
@@ -174,7 +173,6 @@ class ConsumeAssessmentsJob < ApplicationJob
     sleep(1)
     retry
   end
-  # rubocop:enable Metrics/MethodLength
 
   private
 


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1003](SARAALERT-1003)

Add a relative date option to advanced filters.  Example case: users want to see all monitorees with Symptom Onset Date in the past X days

# (Feature) Demo/Screenshots
![Screen Shot 2020-11-10 at 4 49 58 PM](https://user-images.githubusercontent.com/35042815/98737822-cc8e7a00-2374-11eb-823c-3b29d52fe5a1.png)

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`AdvancedFilter.js`
- Added new type `relative` for relative dates that supports filtering by today, tomorrow, yesterday and custom options that include in the `past/next` `number` `days/weeks/months`
- Added a second date advanced filter (in addition to the hardcoded dates) to the following fields: LDE, enrolled, symptom onset and latest report

`public_health_controller.rb`
- Necessary backend changes for supporting all relative date options

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.

**NOTE:** the past/next custom options should include the current day (today) in the filter