### PR TITLE
SARAALERT-940: Support Patch in API

### DIFF
--- a/API.md
+++ b/API.md
@@ -31,6 +31,7 @@ This API is intended for use by public health organizations using Sara Alert, an
 	  - [POST [base]/Patient](#create-post-pat)
 	- [Updating](#update)
 	  - [PUT [base]/Patient/[:id]](#update-put-pat)
+	  - [PATCH [base]/Patient/[:id]](#update-patch-pat)
 	- [Searching](#search)
 	  - [GET [base]/Patient?parameter(s)](#search-get)
 	  - [GET [base]/QuestionnaireResponse?subject=Patient/[:id]](#search-questionnaire-subj)
@@ -1658,7 +1659,7 @@ On success, the server will return the newly created resource with an id. This i
 ### Updating
 An update request creates a new current version for an existing resource.
 
-**PLEASE NOTE:** This means that if certain attributes of the resource are omitted in the `PUT` requests, they will be replaced with `nil` values, as is expected with `PUT` requests. The Sara Alert team is planning on supporting `PATCH` requests in the future to support updates where only fields that should be changed need to be included.
+**PLEASE NOTE:** The API supports `PUT` and `PATCH` requests, which update an existing resource in different ways. A `PUT` request will replace the entire existing resource. This means that if certain attributes of the resource are omitted in the `PUT` requests, they will be replaced with `nil` values. A `PATCH` request will only modify the attributes indicated in the request, which must follow the [JSON Patch specification](https://tools.ietf.org/html/rfc6902). Omitted attributes are unchanged.
 
 <a name="update-put-pat"/>
 
@@ -2060,6 +2061,142 @@ On success, the server will update the existing resource given the id.
           }
         ]
       }
+    }
+  ],
+  "resourceType": "Patient"
+}
+```
+</details>
+
+<a name="update-patch-pat"/>
+
+#### PATCH `[base]/Patient/[:id]`
+
+#### Request Body
+
+Assume the Patient resource was originally as shown in the example [GET](read-get-pat).
+
+<details>
+  <summary>Click to expand JSON snippet</summary>
+
+```json
+[
+  { "op": "remove", "path": "/communication" },
+  { "op": "replace", "path": "/birthDate", "value": "1985-03-30" }
+]
+```
+</details>
+
+
+#### Response
+
+On success, the server will update the attributes indicated by the request.
+
+<details>
+  <summary>Click to expand JSON snippet</summary>
+
+```json
+{
+  "id": 5,
+  "meta": {
+    "lastUpdated": "2020-05-29T00:19:18+00:00"
+  },
+  "extension": [
+    {
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2054-5",
+            "display": "Black or African American"
+          }
+        },
+        {
+          "url": "text",
+          "valueString": "Black or African American"
+        }
+      ],
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+    },
+    {
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2186-5",
+            "display": "Not Hispanic or Latino"
+          }
+        },
+        {
+          "url": "text",
+          "valueString": "Not Hispanic or Latino"
+        }
+      ],
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+    },
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+      "valueCode": "M"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/preferred-contact-method",
+      "valueString": "E-mailed Web Link"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/symptom-onset-date",
+      "valueDate": "2020-05-23"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/last-exposure-date",
+      "valueDate": "2020-05-18"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/isolation",
+      "valueBoolean": false
+    },
+    {
+        "url": "http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path",
+        "valueString": "USA, State 1"
+    }
+  ],
+  "active": true,
+  "name": [
+    {
+      "family": "O'Kon89",
+      "given": [
+        "Malcolm94",
+        "Bogan39"
+      ]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "(333) 333-3333",
+      "rank": 1
+    },
+    {
+      "system": "phone",
+      "value": "(333) 333-3333",
+      "rank": 2
+    },
+    {
+      "system": "email",
+      "value": "2966977816fake@example.com",
+      "rank": 1
+    }
+  ],
+  "birthDate": "1985-03-30",
+  "address": [
+    {
+      "line": [
+        "22424 Daphne Key"
+      ],
+      "city": "West Gabrielmouth",
+      "state": "Maine",
+      "postalCode": "24683"
     }
   ],
   "resourceType": "Patient"

--- a/API.md
+++ b/API.md
@@ -1659,11 +1659,13 @@ On success, the server will return the newly created resource with an id. This i
 ### Updating
 An update request creates a new current version for an existing resource.
 
-**PLEASE NOTE:** The API supports `PUT` and `PATCH` requests, which update an existing resource in different ways. A `PUT` request will replace the entire existing resource. This means that if certain attributes of the resource are omitted in the `PUT` requests, they will be replaced with `nil` values. A `PATCH` request will only modify the attributes indicated in the request, which must follow the [JSON Patch specification](https://tools.ietf.org/html/rfc6902). Omitted attributes are unchanged.
+**PLEASE NOTE:** The API supports `PUT` and `PATCH` requests, which update an existing resource in different ways. A `PUT` request will replace the entire existing resource. This means that if certain attributes of the resource are omitted in the `PUT` requests, they will be replaced with null values. A `PATCH` request will only modify the attributes indicated in the request, which must follow the [JSON Patch specification](https://tools.ietf.org/html/rfc6902). Omitted attributes are unchanged. For further details on the contents of a `PATCH` request, see the [JSON Patch documentation](http://jsonpatch.com/).
 
 <a name="update-put-pat"/>
 
 #### PUT `[base]/Patient/[:id]`
+
+**NOTE:** This is a `PUT` operation, it will replace the entire resource. If you intend to modify specific attributes instead, see [PATCH](#update-patch-pat).
 
 #### Request Body
 
@@ -2071,6 +2073,8 @@ On success, the server will update the existing resource given the id.
 <a name="update-patch-pat"/>
 
 #### PATCH `[base]/Patient/[:id]`
+
+**NOTE:** This is a `PATCH` operation, it will only modify specified attributes. If you intend to replace the entire resource instead, see [PUT](#update-put-pat).
 
 #### Request Body
 

--- a/API.md
+++ b/API.md
@@ -402,6 +402,9 @@ A capability statement is available at `[base]/metadata`:
               "code": "update"
             },
             {
+              "code": "patch"
+            },
+            {
               "code": "create"
             },
             {

--- a/API.md
+++ b/API.md
@@ -2074,7 +2074,7 @@ On success, the server will update the existing resource given the id.
 
 #### Request Body
 
-Assume the Patient resource was originally as shown in the example [GET](read-get-pat).
+Assume the Patient resource was originally as shown in the example Patient [GET](#read-get-pat), and the patch is specified as below.
 
 <details>
   <summary>Click to expand JSON snippet</summary>

--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,9 @@ gem 'fhir_models'
 # Split-arch queue support
 gem 'redis-queue'
 
+# JSON Patch and JSON Pointer implementation
+gem 'hana'
+
 group :development, :test do
   gem 'brakeman'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -91,8 +91,8 @@ gem 'fhir_models'
 # Split-arch queue support
 gem 'redis-queue'
 
-# JSON Patch and JSON Pointer implementation
-gem 'hana'
+# JSON Patch and JSON Pointer implementation (using our fork of the gem)
+gem 'hana', '1.3.6', github: 'SaraAlert/hana', branch: 'master'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/SaraAlert/hana.git
+  revision: 85feb253a8b7e2e7b0b54a691c0734798f280dfe
+  branch: master
+  specs:
+    hana (1.3.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -175,7 +182,6 @@ GEM
       rchardet (~> 1.8)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    hana (1.3.6)
     html_tokenizer (0.0.7)
     htmlentities (4.3.4)
     httpclient (2.8.3)
@@ -416,7 +422,7 @@ DEPENDENCIES
   ffi-hunspell
   fhir_models
   gemsurance
-  hana
+  hana (= 1.3.6)!
   jbuilder (~> 2.7)
   letter_opener
   listen (>= 3.0.5, < 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,6 +416,7 @@ DEPENDENCIES
   ffi-hunspell
   fhir_models
   gemsurance
+  hana
   jbuilder (~> 2.7)
   letter_opener
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -78,12 +78,19 @@ class Fhir::R4::ApiController < ActionController::API
   #
   # PUT /fhir/r4/[:resource_type]/[:id]
   def update
-    status_unsupported_media_type && return unless content_type_header?
+    if request.patch?
+      status_unsupported_media_type && return unless content_type_header?('application/json-patch+json')
 
-    # Parse in the FHIR::Patient
-    contents = FHIR.from_contents(request.body.string)
-    errors = contents&.validate
-    status_bad_request(format_fhir_validation_errors(errors)) && return if contents.nil? || !errors.empty?
+      # Parse in the JSON patch
+      patch = Hana::Patch.new(JSON.parse(request.body.string))
+    else
+      status_unsupported_media_type && return unless content_type_header?('application/fhir+json')
+
+      # Parse in the FHIR::Patient
+      contents = FHIR.from_contents(request.body.string)
+      errors = contents&.validate
+      status_bad_request(format_fhir_validation_errors(errors)) && return if contents.nil? || !errors.empty?
+    end
 
     resource_type = params.permit(:resource_type)[:resource_type]&.downcase
     case resource_type
@@ -95,9 +102,17 @@ class Fhir::R4::ApiController < ActionController::API
         :'system/Patient.*'
       )
 
-      updates = patient_from_fhir(contents, default_patient_jurisdiction_id)
-
       resource = get_patient(params.permit(:id)[:id])
+
+      if request.patch? && !resource.nil?
+        begin
+          contents = apply_patch(resource, patch)
+        rescue StandardError => e
+          status_bad_request([['Unable to apply patch', e&.message].compact.join(': ')]) && return
+        end
+      end
+
+      updates = patient_from_fhir(contents, default_patient_jurisdiction_id)
 
       # Grab patient before changes to construct diff
       patient_before = resource.dup
@@ -140,7 +155,7 @@ class Fhir::R4::ApiController < ActionController::API
   #
   # POST /fhir/r4/[:resource_type]
   def create
-    status_unsupported_media_type && return unless content_type_header?
+    status_unsupported_media_type && return unless content_type_header?('application/fhir+json')
 
     # Parse in the FHIR::Patient
     contents = FHIR.from_contents(request.body.string)
@@ -531,6 +546,11 @@ class Fhir::R4::ApiController < ActionController::API
     end
   end
 
+  # Apply a patch to a resource that can be represented as FHIR
+  def apply_patch(resource, patch)
+    FHIR.from_contents(patch.apply(resource.as_fhir.to_hash).to_json)
+  end
+
   # Check accept header for correct mime type (or allow fhir _format)
   def accept_header?
     return request.headers['Accept']&.include?('application/fhir+json') if params.permit(:_format)[:_format].nil?
@@ -539,8 +559,8 @@ class Fhir::R4::ApiController < ActionController::API
   end
 
   # Check content type header for correct mime type
-  def content_type_header?
-    request.headers['Content-Type']&.include?('application/fhir+json')
+  def content_type_header?(header)
+    request.headers['Content-Type']&.include?(header)
   end
 
   # Generic 406 not acceptable

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -394,6 +394,7 @@ class Fhir::R4::ApiController < ActionController::API
             interaction: [
               FHIR::CapabilityStatement::Rest::Resource::Interaction.new(code: 'read'),
               FHIR::CapabilityStatement::Rest::Resource::Interaction.new(code: 'update'),
+              FHIR::CapabilityStatement::Rest::Resource::Interaction.new(code: 'patch'),
               FHIR::CapabilityStatement::Rest::Resource::Interaction.new(code: 'create'),
               FHIR::CapabilityStatement::Rest::Resource::Interaction.new(code: 'search-type')
             ],

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -560,7 +560,7 @@ class Fhir::R4::ApiController < ActionController::API
 
   # Check content type header for correct mime type
   def content_type_header?(header)
-    request.headers['Content-Type']&.include?(header)
+    request.content_type == header
   end
 
   # Generic 406 not acceptable

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
       get '/.well-known/smart-configuration', to: 'api#well_known'
       get '/:resource_type/:id', to: 'api#show'
       put '/:resource_type/:id', to: 'api#update'
+      patch '/:resource_type/:id', to: 'api#update'
       post '/:resource_type', to: 'api#create'
       get '/:resource_type', to: 'api#search'
       post '/:resource_type/_search', to: 'api#search'


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-940](https://tracker.codev.mitre.org/browse/SARAALERT-940)

This adds support for PATCH in the API. The body of the PATCH request should follow the [JSON Patch](https://tools.ietf.org/html/rfc6902) specification.

# Important Changes
`api_controller.rb`
- Add support for processing PATCH requests on a Patient. A PATCH proceeds by getting the existing resource, converting it to FHIR, and then applying the patch to get updated FHIR. That updated FHIR then follows the same flow as when an updated FHIR Patient is directly specified in a PUT.

`routes.rb`
- Adds a PATCH endpoint for Patient that routes to `update`.

`API.md`
- Documentation on PATCH
# Testing
Test sending PATCH updates to existing Patient resources. Here is an example PATCH:
```
[
  { "op": "remove", "path": "/communication" },
  { "op": "replace", "path": "/birthDate", "value": "1985-03-30" }
]
```
The possible patch operations are `add`, `remove`, `replace`, `move`, `copy`, `test`, so those operations can all be tested. Try testing patches that are invalid and should result in error messages indicating that the patch failed. You can also try testing patches that are themselves valid, but create an invalid Patient when applied. These patches should fail with the same type of validation messages you would expect on a `PUT` or `POST`.