### PR TITLE
Remove logic for nil experiencing_symptoms parameter

### DIFF
--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -112,7 +112,7 @@ class ConsumeAssessmentsJob < ApplicationJob
           typed_reported_symptoms = Condition.build_symptoms(message['reported_symptoms_array'])
           reported_condition = ReportedCondition.new(symptoms: typed_reported_symptoms, threshold_condition_hash: message['threshold_condition_hash'])
           assessment = Assessment.new(reported_condition: reported_condition, patient: patient, who_reported: 'Monitoree')
-          assessment.symptomatic = assessment.symptomatic? || message['experiencing_symptoms']
+          assessment.symptomatic = assessment.symptomatic?
           queue.commit if assessment.save
         else
           # If message['reported_symptoms_array'] is not populated then this assessment came in through

--- a/test/jobs/consume_assessments_job_test.rb
+++ b/test/jobs/consume_assessments_job_test.rb
@@ -68,7 +68,7 @@ class ConsumeAssessmentsJobTest < ActiveJob::TestCase
     end
   end
 
-  test 'consume assessment with reported symptoms and experiencing symptoms' do
+  test 'consume assessment with experiencing symptoms' do
     assert_difference '@patient.assessments.count', 1 do
       # Force experiencing_symptoms to true
       @redis_queue.push @assessment_generator.reported_symptom_assessment(symptomatic: true)

--- a/test/test_helpers/consume_assessments_job_test_helper.rb
+++ b/test/test_helpers/consume_assessments_job_test_helper.rb
@@ -13,31 +13,26 @@ module ConsumeAssessmentsJobTestHelper
     end
 
     def reported_symptom_assessment(symptomatic: nil)
-      unless symptomatic.nil?
-        return {
-          response_status: nil,
-          threshold_condition_hash: @patient.jurisdiction.hierarchical_symptomatic_condition.threshold_condition_hash,
-          experiencing_symptoms: symptomatic,
-          patient_submission_token: @patient.submission_token
-        }.to_json
-      end
-      # If symptomatic is nil then we will include a reported_symptoms_array
-      # the reported_symptoms_array exists when assessments are completed in the web-form
-      {
+      message = {
         response_status: nil,
         threshold_condition_hash: @patient.jurisdiction.hierarchical_symptomatic_condition.threshold_condition_hash,
-        reported_symptoms_array: [
-          {
-            name: 'Cough',
-            value: false,
-            type: 'BoolSymptom',
-            label: 'Cough',
-            notes: 'Have you coughed today?'
-          }
-        ],
-        patient_submission_token: @patient.submission_token,
-        experiencing_symptoms: nil
-      }.to_json
+        experiencing_symptoms: symptomatic,
+        patient_submission_token: @patient.submission_token
+      }
+
+      reported_symptoms_array = {
+        reported_symptoms_array: [{
+          name: 'Cough',
+          value: false,
+          type: 'BoolSymptom',
+          label: 'Cough',
+          notes: 'Have you coughed today?'
+        }]
+      }
+      # If symptomatic is nil then we will include a reported_symptoms_array
+      # the reported_symptoms_array exists when assessments are completed in the web-form
+      message.merge!(reported_symptoms_array) if symptomatic.nil?
+      message.to_json
     end
 
     def generic_assessment(symptomatic:)

--- a/test/test_helpers/consume_assessments_job_test_helper.rb
+++ b/test/test_helpers/consume_assessments_job_test_helper.rb
@@ -13,7 +13,7 @@ module ConsumeAssessmentsJobTestHelper
     end
 
     def reported_symptom_assessment(symptomatic: nil)
-      if symptomatic
+      unless symptomatic.nil?
         return {
           response_status: nil,
           threshold_condition_hash: @patient.jurisdiction.hierarchical_symptomatic_condition.threshold_condition_hash,
@@ -21,6 +21,8 @@ module ConsumeAssessmentsJobTestHelper
           patient_submission_token: @patient.submission_token
         }.to_json
       end
+      # If symptomatic is nil then we will include a reported_symptoms_array
+      # the reported_symptoms_array exists when assessments are completed in the web-form
       {
         response_status: nil,
         threshold_condition_hash: @patient.jurisdiction.hierarchical_symptomatic_condition.threshold_condition_hash,
@@ -33,7 +35,8 @@ module ConsumeAssessmentsJobTestHelper
             notes: 'Have you coughed today?'
           }
         ],
-        patient_submission_token: @patient.submission_token
+        patient_submission_token: @patient.submission_token,
+        experiencing_symptoms: nil
       }.to_json
     end
 

--- a/test/test_helpers/consume_assessments_job_test_helper.rb
+++ b/test/test_helpers/consume_assessments_job_test_helper.rb
@@ -13,6 +13,14 @@ module ConsumeAssessmentsJobTestHelper
     end
 
     def reported_symptom_assessment(symptomatic: nil)
+      if symptomatic
+        return {
+          response_status: nil,
+          threshold_condition_hash: @patient.jurisdiction.hierarchical_symptomatic_condition.threshold_condition_hash,
+          experiencing_symptoms: symptomatic,
+          patient_submission_token: @patient.submission_token
+        }.to_json
+      end
       {
         response_status: nil,
         threshold_condition_hash: @patient.jurisdiction.hierarchical_symptomatic_condition.threshold_condition_hash,
@@ -25,7 +33,6 @@ module ConsumeAssessmentsJobTestHelper
             notes: 'Have you coughed today?'
           }
         ],
-        experiencing_symptoms: symptomatic,
         patient_submission_token: @patient.submission_token
       }.to_json
     end


### PR DESCRIPTION
# Description

The message sent to ConsumeAssmentsJob, can be sent from the web form with a list of specific reported symptoms (the `reported_symptoms_array`) or in the case of an assessment completed via SMS or Voice will have a `experiencing_symptoms` parameter because the SMS and Voice options do not collect individual symptom information. The reported_symptoms_array and experiencing_symptoms parameters are mutually exclusive in the message sent to the ConsumeAssessmentsJob. The troublesome line of code that was changed `assessment.symptomatic = assessment.symptomatic? || message['experiencing_symptoms']` was changed because `message['experiencing_symptoms']` will be `nil` when that particular line is hit which means that symptomatic will result to `nil` if `assessment.symptomatic?` is false. THIS is because of how the following statements evaluate
`true || nil` -> `true`
`false || nil` -> `false` 


# (Bugfix) How to Replicate
Complete a non-symptomatic assessment -- 
Check how it is saved `Assessment.last.symptomatic` will be nil. 

# (Bugfix) Solution
Complete a non-symptomatic assessment -- 
Check how it is saved `Assessment.last.symptomatic` will be false. 


# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
