### PR TITLE
1001 patient digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ bundle exec whenever --update-crontab
       - Purges eligible records
   * `SendPurgeWarningsJob`
       - Send warnings to users of upcoming PurgeJob
+  * `SendPatientDigestJob`
+      - Send hourly reports on recently symptomatic patients to jurisdictions that opt in. 
   * `CacheAnalyticsJob`
       - Caches analytics information for faster retrieval
   * `SendAssessmentsJob`

--- a/app/jobs/send_patient_digest_job.rb
+++ b/app/jobs/send_patient_digest_job.rb
@@ -2,22 +2,20 @@
 
 # SendPatientDigestJob: sends assessment reminder to patients
 class SendPatientDigestJob < ApplicationJob
-    queue_as :mailers
-  
-    def perform(*_args)
-        jurisdiction_ids = []
-        jurisdiction_lists = {}
-        jurisdiction_addressees = {}
-        Jurisdiction.find_each do |jur|
-            if jur.send_digest
-                jurisdiction_ids << jur.id
-                jurisdiction_patients = jur.all_patients.recently_symptomatic
-                jurisdiction_addressees = User.where(jurisdiction_id: jur.id, role: ["super_user", "public_health", "public_health_enroller"])
-                jurisdiction_addressees.each do |user|
-                    eligible = jurisdiction_patients.count
-                    UserMailer.send_patient_digest_job_email(jurisdiction_patients, user, eligible).deliver_now
-                end
-            end
+  queue_as :mailers
+
+  def perform(*_args)
+    jurisdiction_lists = {}
+    jurisdiction_addressees = {}
+    Jurisdiction.find_each do |jur|
+      if jur.send_digest
+        jurisdiction_patients = jur.all_patients.recently_symptomatic
+        jurisdiction_addressees = User.where(jurisdiction_id: jur.id, role: ["super_user", "public_health", "public_health_enroller"])
+        jurisdiction_addressees.each do |user|
+          eligible = jurisdiction_patients.count
+          UserMailer.send_patient_digest_job_email(jurisdiction_patients, user, eligible).deliver_now
         end
+      end
+    end
   end
 end

--- a/app/jobs/send_patient_digest_job.rb
+++ b/app/jobs/send_patient_digest_job.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# SendPatientDigestJob: sends assessment reminder to patients
+class SendPatientDigestJob < ApplicationJob
+    queue_as :mailers
+  
+    def perform(*_args)
+        jurisdiction_ids = []
+        jurisdiction_lists = {}
+        jurisdiction_addressees = {}
+        puts "in here!"
+        Jurisdiction.find_each do |jur|
+            if jur.send_digest
+                puts "in the conditional!"
+                jurisdiction_ids << jur.id
+                jurisdiction_patients = jur.all_patients.recently_symptomatic
+                jurisdiction_addressees = User.where(jurisdiction_id: jur.id)
+                jurisdiction_addressees.each do |user|
+                    eligible = jurisdiction_patients.count
+                    UserMailer.send_patient_digest_job_email(jurisdiction_patients, user, eligible).deliver_now
+                end
+            end
+        end
+  end
+end

--- a/app/jobs/send_patient_digest_job.rb
+++ b/app/jobs/send_patient_digest_job.rb
@@ -10,7 +10,7 @@ class SendPatientDigestJob < ApplicationJob
       if jur.send_digest
         jurisdiction_patients = jur.all_patients.recently_symptomatic
         jurisdiction_addressees = User.where(jurisdiction_id: jur.id, role: %w[super_user public_health public_health_enroller])
-        jurisdiction_addressees.each do |user|
+        jurisdiction_addressees.find_each do |user|
           eligible = jurisdiction_patients.count
           UserMailer.send_patient_digest_job_email(jurisdiction_patients, user, eligible).deliver_now
         end

--- a/app/jobs/send_patient_digest_job.rb
+++ b/app/jobs/send_patient_digest_job.rb
@@ -9,7 +9,7 @@ class SendPatientDigestJob < ApplicationJob
     Jurisdiction.find_each do |jur|
       if jur.send_digest
         jurisdiction_patients = jur.all_patients.recently_symptomatic
-        jurisdiction_addressees = User.where(jurisdiction_id: jur.id, role: ['super_user', 'public_health', 'public_health_enroller'])
+        jurisdiction_addressees = User.where(jurisdiction_id: jur.id, role: %w[super_user, public_health, public_health_enroller])
         jurisdiction_addressees.each do |user|
           eligible = jurisdiction_patients.count
           UserMailer.send_patient_digest_job_email(jurisdiction_patients, user, eligible).deliver_now

--- a/app/jobs/send_patient_digest_job.rb
+++ b/app/jobs/send_patient_digest_job.rb
@@ -8,13 +8,11 @@ class SendPatientDigestJob < ApplicationJob
         jurisdiction_ids = []
         jurisdiction_lists = {}
         jurisdiction_addressees = {}
-        puts "in here!"
         Jurisdiction.find_each do |jur|
             if jur.send_digest
-                puts "in the conditional!"
                 jurisdiction_ids << jur.id
                 jurisdiction_patients = jur.all_patients.recently_symptomatic
-                jurisdiction_addressees = User.where(jurisdiction_id: jur.id)
+                jurisdiction_addressees = User.where(jurisdiction_id: jur.id, role: ["super_user", "public_health", "public_health_enroller"])
                 jurisdiction_addressees.each do |user|
                     eligible = jurisdiction_patients.count
                     UserMailer.send_patient_digest_job_email(jurisdiction_patients, user, eligible).deliver_now

--- a/app/jobs/send_patient_digest_job.rb
+++ b/app/jobs/send_patient_digest_job.rb
@@ -9,7 +9,7 @@ class SendPatientDigestJob < ApplicationJob
     Jurisdiction.find_each do |jur|
       if jur.send_digest
         jurisdiction_patients = jur.all_patients.recently_symptomatic
-        jurisdiction_addressees = User.where(jurisdiction_id: jur.id, role: %w[super_user, public_health, public_health_enroller])
+        jurisdiction_addressees = User.where(jurisdiction_id: jur.id, role: %w[super_user public_health public_health_enroller])
         jurisdiction_addressees.each do |user|
           eligible = jurisdiction_patients.count
           UserMailer.send_patient_digest_job_email(jurisdiction_patients, user, eligible).deliver_now

--- a/app/jobs/send_patient_digest_job.rb
+++ b/app/jobs/send_patient_digest_job.rb
@@ -5,12 +5,11 @@ class SendPatientDigestJob < ApplicationJob
   queue_as :mailers
 
   def perform(*_args)
-    jurisdiction_lists = {}
     jurisdiction_addressees = {}
     Jurisdiction.find_each do |jur|
       if jur.send_digest
         jurisdiction_patients = jur.all_patients.recently_symptomatic
-        jurisdiction_addressees = User.where(jurisdiction_id: jur.id, role: ["super_user", "public_health", "public_health_enroller"])
+        jurisdiction_addressees = User.where(jurisdiction_id: jur.id, role: ['super_user', 'public_health', 'public_health_enroller'])
         jurisdiction_addressees.each do |user|
           eligible = jurisdiction_patients.count
           UserMailer.send_patient_digest_job_email(jurisdiction_patients, user, eligible).deliver_now

--- a/app/jobs/send_purge_warnings_job.rb
+++ b/app/jobs/send_purge_warnings_job.rb
@@ -15,10 +15,11 @@ class SendPurgeWarningsJob < ApplicationJob
     # Loop through and send each admin information about their purge eligible monitorees
     recipients.each do |user|
       # Skip for USA admins
-      next if user.jurisdiction&.name == 'USA'
+      # next if user.jurisdiction&.name == 'USA'
+      # puts "sending"
 
       # Get num purgeable underneath this admin's purview
-      num_purgeable_records = user.viewable_patients.purge_eligible.size
+      num_purgeable_records = user.viewable_patients.purge_eligible.size + 1
 
       # Send email to use with info
       UserMailer.purge_notification(user, num_purgeable_records).deliver_later

--- a/app/jobs/send_purge_warnings_job.rb
+++ b/app/jobs/send_purge_warnings_job.rb
@@ -15,11 +15,10 @@ class SendPurgeWarningsJob < ApplicationJob
     # Loop through and send each admin information about their purge eligible monitorees
     recipients.each do |user|
       # Skip for USA admins
-      # next if user.jurisdiction&.name == 'USA'
-      # puts "sending"
+      next if user.jurisdiction&.name == 'USA'
 
       # Get num purgeable underneath this admin's purview
-      num_purgeable_records = user.viewable_patients.purge_eligible.size + 1
+      num_purgeable_records = user.viewable_patients.purge_eligible.size
 
       # Send email to use with info
       UserMailer.purge_notification(user, num_purgeable_records).deliver_later

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -48,6 +48,12 @@ class UserMailer < ApplicationMailer
     mail(to: ADMIN_OPTIONS['job_run_email'], subject: "Sara Alert Cache Analytics Job Results (#{ActionMailer::Base.default_url_options[:host]})")
   end
 
+  def send_patient_digest_job_email(patients, user, eligible)
+    @patients = patients
+    @eligible = eligible
+    mail(to: user.email.strip, subject: "Sara Alert Recently Symptomatic Patients (#{ActionMailer::Base.default_url_options[:host]})")
+  end
+
   def download_email(user, export_type, lookups, batch_size)
     @user = user
     @export_type = export_type

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -343,6 +343,8 @@ class Patient < ApplicationRecord
     where(monitoring: true)
       .where(purged: false)
       .where('latest_assessment_at >= ?', 60.minutes.ago)
+      .where(public_health_action: 'None')
+      .where.not(symptom_onset: nil)
       .distinct
   }
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -339,6 +339,13 @@ class Patient < ApplicationRecord
       .distinct
   }
 
+  scope :recently_symptomatic, lambda {
+    where(monitoring: true)
+      .where(purged: false)
+      .where('latest_assessment_at >= ?', 60.minutes.ago)
+      .distinct
+  }
+
   # Individuals not meeting review but are reporting (isolation workflow only)
   scope :isolation_reporting, lambda {
     where.not(id: Patient.unscoped.isolation_requiring_review)

--- a/app/views/user_mailer/send_patient_digest_job_email.html.erb
+++ b/app/views/user_mailer/send_patient_digest_job_email.html.erb
@@ -1,0 +1,14 @@
+<h1>
+  Sara Alert Recently Symptomatic Patients  (<%= ActionMailer::Base.default_url_options[:host] %>)
+</h1>
+<h2>
+  <%= DateTime.now.in_time_zone('Eastern Time (US & Canada)') %>
+</h2>
+<br />
+Total patients reported symptomatic in the last hour: <%= @eligible %>
+<br />
+Links to symptomatic patients in the last hour:
+<% @patients.each do |patient| %>
+    <%= link_to patient.first_name + ' ' + patient.last_name, patient %>
+    <br>
+<% end %>

--- a/app/views/user_mailer/send_patient_digest_job_email.html.erb
+++ b/app/views/user_mailer/send_patient_digest_job_email.html.erb
@@ -8,6 +8,7 @@
 Total patients reported symptomatic in the last hour: <%= @eligible %>
 <br />
 Links to symptomatic patients in the last hour:
+<br />
 <% @patients.each do |patient| %>
     <%= link_to patient.first_name + ' ' + patient.last_name, patient %>
     <br>

--- a/app/views/user_mailer/send_patient_digest_job_email.html.erb
+++ b/app/views/user_mailer/send_patient_digest_job_email.html.erb
@@ -11,5 +11,4 @@ Links to symptomatic patients in the last hour:
 <br />
 <% @patients.each do |patient| %>
     <%= link_to patient.first_name + ' ' + patient.last_name, patient %>
-    <br>
 <% end %>

--- a/app/views/user_mailer/send_patient_digest_job_email.html.erb
+++ b/app/views/user_mailer/send_patient_digest_job_email.html.erb
@@ -10,5 +10,5 @@ Total patients reported symptomatic in the last hour: <%= @eligible %>
 Links to symptomatic patients in the last hour:
 <br />
 <% @patients.each do |patient| %>
-    <%= link_to patient.first_name + ' ' + patient.last_name, patient %>
+    <%= link_to url_for(patient), patient %>
 <% end %>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -30,3 +30,7 @@ end
 every 1.hours do
   runner "SendAssessmentsJob.perform_later"
 end
+
+# every 1.minutes do
+#   runner "SendPurgeWarningsJob.perform_later"
+# end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -31,6 +31,6 @@ every 1.hours do
   runner "SendAssessmentsJob.perform_later"
 end
 
-# every 1.minutes do
-#   runner "SendPurgeWarningsJob.perform_later"
-# end
+every 1.hours do
+  runner "SendPatientDigestJob.perform_later"
+end

--- a/db/migrate/20201116214553_add_send_digest_to_jurisdictions.rb
+++ b/db/migrate/20201116214553_add_send_digest_to_jurisdictions.rb
@@ -1,5 +1,5 @@
 class AddSendDigestToJurisdictions < ActiveRecord::Migration[6.0]
   def change
-    add_column :jurisdictions, :send_digest, :boolean
+    add_column :jurisdictions, :send_digest, :boolean, default: false
   end
 end

--- a/db/migrate/20201116214553_add_send_digest_to_jurisdictions.rb
+++ b/db/migrate/20201116214553_add_send_digest_to_jurisdictions.rb
@@ -1,0 +1,5 @@
+class AddSendDigestToJurisdictions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :jurisdictions, :send_digest, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_12_173603) do
+ActiveRecord::Schema.define(version: 2020_11_16_214553) do
 
   create_table "analytics", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "jurisdiction_id"
@@ -110,6 +110,7 @@ ActiveRecord::Schema.define(version: 2020_11_12_173603) do
     t.string "email"
     t.string "webpage"
     t.string "message"
+    t.boolean "send_digest"
     t.index ["ancestry"], name: "index_jurisdictions_on_ancestry"
   end
 
@@ -352,6 +353,9 @@ ActiveRecord::Schema.define(version: 2020_11_12_173603) do
     t.string "sexual_orientation"
     t.boolean "user_defined_symptom_onset"
     t.date "extended_isolation"
+    t.boolean "race_unknown"
+    t.boolean "race_other"
+    t.boolean "race_refused_to_answer"
     t.boolean "head_of_household"
     t.integer "contact_attempts", default: 0
     t.index ["assigned_user"], name: "index_patients_on_assigned_user"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -353,9 +353,6 @@ ActiveRecord::Schema.define(version: 2020_11_16_214553) do
     t.string "sexual_orientation"
     t.boolean "user_defined_symptom_onset"
     t.date "extended_isolation"
-    t.boolean "race_unknown"
-    t.boolean "race_other"
-    t.boolean "race_refused_to_answer"
     t.boolean "head_of_household"
     t.integer "contact_attempts", default: 0
     t.index ["assigned_user"], name: "index_patients_on_assigned_user"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -110,7 +110,7 @@ ActiveRecord::Schema.define(version: 2020_11_16_214553) do
     t.string "email"
     t.string "webpage"
     t.string "message"
-    t.boolean "send_digest"
+    t.boolean "send_digest", default: false
     t.index ["ancestry"], name: "index_jurisdictions_on_ancestry"
   end
 

--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -127,6 +127,7 @@ namespace :admin do
       jurisdiction.phone = jur_values['phone'] || ''
       jurisdiction.webpage = jur_values['webpage'] || ''
       jurisdiction.webpage = jur_values['message'] || ''
+      jurisdiction.send_digest = jur_values['send_digest'] || false
     end
     threshold_condition_symptoms = []
     if jur_symps != nil

--- a/lib/tasks/mailers.rake
+++ b/lib/tasks/mailers.rake
@@ -56,4 +56,9 @@ namespace :mailers do
   task send_purge_warning: :environment do
     SendPurgeWarningsJob.perform_later
   end
+  
+  desc "Sends patient digest to users"
+  task send_patient_digest: :environment do
+    SendPatientDigestJob.perform_later
+  end
 end


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1001
Creates an hourly email digest containing links to all patients reported as symptomatic in the last hour, delivered to superusers, public health users, and public health enrollers. The email is opt-in by jurisdiction: there is a nullable boolean field for the jurisdiction model called "send_digest", which defaults to false and determines whether the digest is sent. 

# (Feature) Demo/Screenshots
<img width="800" alt="Screen Shot 2020-11-18 at 4 49 23 PM" src="https://user-images.githubusercontent.com/16108095/99592736-95484a80-29be-11eb-9bec-2ca943209ed7.png">
<img width="760" alt="Screen Shot 2020-11-18 at 4 49 05 PM" src="https://user-images.githubusercontent.com/16108095/99592740-95e0e100-29be-11eb-9144-ec4bc7f283f3.png">
<img width="826" alt="Screen Shot 2020-11-18 at 4 48 54 PM" src="https://user-images.githubusercontent.com/16108095/99592741-96797780-29be-11eb-82b6-7cc7ab9ac127.png">



# Important Changes
app/jobs/send_patient_digest_job.rb - new file containing the logic for the job. 
app/mailers/user_mailer.rb - has the logic to send the email
app/views/user_mailer/send_patient_digest_job_email.html.erb - format of the email. 


# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [x] Firefox
* [ ] Safari
* [ ] IE11

To verify the email job, run the command: bundle exec rake mailers:send_patient_digest. You will first have to set the send_digest variable of a jurisdiction in the database to true. 

To verify end-to-end: modify the schedule.rb file at line 34 to a shorter timeframe (every 1.minutes, for instance), refresh the crontab, and run the server. 