### PR TITLE
Case Status Validation Temporary Removal

### DIFF
--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -64,7 +64,7 @@ class ImportController < ApplicationController
               # elsif col_num == 86
               #   patient[field] = validate_workflow_specific_enums(workflow, field, row[col_num], row_ind)
               else
-                 # TODO: Once the above is uncommented, this line can be updated to not have to check the 86 col
+                # TODO: Once the above is uncommented, this line can be updated to not have to check the 86 col
                 patient[field] = validate_field(field, row[col_num], row_ind) unless [85, 86].include?(col_num) && workflow != :isolation
               end
             end

--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -60,11 +60,11 @@ class ImportController < ApplicationController
               elsif col_num == 85 && workflow == :isolation
                 patient[:user_defined_symptom_onset] = row[85].present?
                 patient[field] = validate_field(field, row[col_num], row_ind)
-              # TODO: Commented out temporarily until we're comfortable with this validation
+              # TODO when workflow specific case status validation re-enabled: uncomment
               # elsif col_num == 86
               #   patient[field] = validate_workflow_specific_enums(workflow, field, row[col_num], row_ind)
               else
-                # TODO: Once the above is uncommented, this line can be updated to not have to check the 86 col
+                # TODO when workflow specific case status validation re-enabled: this line can be updated to not have to check the 86 col
                 patient[field] = validate_field(field, row[col_num], row_ind) unless [85, 86].include?(col_num) && workflow != :isolation
               end
             end

--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -60,11 +60,11 @@ class ImportController < ApplicationController
               elsif col_num == 85 && workflow == :isolation
                 patient[:user_defined_symptom_onset] = row[85].present?
                 patient[field] = validate_field(field, row[col_num], row_ind)
-              # TODO when workflow specific case status validation re-enabled: uncomment
+              # TODO: when workflow specific case status validation re-enabled: uncomment
               # elsif col_num == 86
               #   patient[field] = validate_workflow_specific_enums(workflow, field, row[col_num], row_ind)
               else
-                # TODO when workflow specific case status validation re-enabled: this line can be updated to not have to check the 86 col
+                # TODO: when workflow specific case status validation re-enabled: this line can be updated to not have to check the 86 col
                 patient[field] = validate_field(field, row[col_num], row_ind) unless [85, 86].include?(col_num) && workflow != :isolation
               end
             end

--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -60,10 +60,12 @@ class ImportController < ApplicationController
               elsif col_num == 85 && workflow == :isolation
                 patient[:user_defined_symptom_onset] = row[85].present?
                 patient[field] = validate_field(field, row[col_num], row_ind)
-              elsif col_num == 86
-                patient[field] = validate_workflow_specific_enums(workflow, field, row[col_num], row_ind)
+              # TODO: Commented out temporarily until we're comfortable with this validation
+              # elsif col_num == 86
+              #   patient[field] = validate_workflow_specific_enums(workflow, field, row[col_num], row_ind)
               else
-                patient[field] = validate_field(field, row[col_num], row_ind) unless col_num == 85 && workflow != :isolation
+                 # TODO: Once the above is uncommented, this line can be updated to not have to check the 86 col
+                patient[field] = validate_field(field, row[col_num], row_ind) unless [85, 86].include?(col_num) && workflow != :isolation
               end
             end
 

--- a/test/system/roles/public_health/dashboard/import_verifier.rb
+++ b/test/system/roles/public_health/dashboard/import_verifier.rb
@@ -15,13 +15,13 @@ class PublicHealthMonitoringImportVerifier < ApplicationSystemTestCase
                    healthcare_personnel crew_on_passenger_or_cargo_flight member_of_a_common_exposure_cohort].freeze
   STATE_FIELDS = %i[address_state foreign_monitored_address_state additional_planned_travel_destination_state].freeze
   MONITORED_ADDRESS_FIELDS = %i[monitored_address_line_1 monitored_address_city monitored_address_state monitored_address_line_2 monitored_address_zip].freeze
-  # TODO when workflow specific case status validation re-enabled: take out 'case_status'
-  ISOLATION_FIELDS = %i[symptom_onset extended_isolation, case_status].freeze
+  # TODO: when workflow specific case status validation re-enabled: take out 'case_status'
+  ISOLATION_FIELDS = %i[symptom_onset extended_isolation case_status].freeze
   ENUM_FIELDS = %i[ethnicity preferred_contact_method primary_telephone_type secondary_telephone_type preferred_contact_time additional_planned_travel_type
                    exposure_risk_assessment monitoring_plan case_status].freeze
   RISK_FACTOR_FIELDS = %i[contact_of_known_case was_in_health_care_facility_with_known_cases].freeze
-  # TODO when workflow specific case status validation re-enabled: uncomment
-  #WORKFLOW_SPECIFIC_FIELDS = %i[case_status].freeze
+  # TODO: when workflow specific case status validation re-enabled: uncomment
+  # WORKFLOW_SPECIFIC_FIELDS = %i[case_status].freeze
 
   def verify_epi_x_field_validation(jurisdiction_id, workflow, file_name)
     sheet = get_xslx(file_name).sheet(0)
@@ -173,11 +173,11 @@ class PublicHealthMonitoringImportVerifier < ApplicationSystemTestCase
             assert_equal(row[index - 13].to_s, patient[field].to_s, "#{field} mismatch in row #{row_num}")
           elsif field == :symptom_onset # isolation workflow specific field
             assert_equal(workflow == :isolation ? row[index].to_s : '', patient[field].to_s, "#{field} mismatch in row #{row_num}")
-          # TODO when workflow specific case status validation re-enabled: remove the next 3 lines
+          # TODO: when workflow specific case status validation re-enabled: remove the next 3 lines
           elsif field == :case_status # isolation workflow specific enum field
             normalized_cell_value = NORMALIZED_ENUMS[field][unformat_enum_field(row[index])].to_s
             assert_equal(workflow == :isolation ? normalized_cell_value : '', patient[field].to_s, "#{field} mismatch in row #{row_num}")
-          # TODO when workflow specific case status validation re-enabled: uncomment
+          # TODO: when workflow specific case status validation re-enabled: uncomment
           # elsif field == :case_status
           #   normalized_cell_value = if workflow == :isolation
           #                             NORMALIZED_ISOLATION_ENUMS[field][unformat_enum_field(row[index])].to_s
@@ -211,7 +211,7 @@ class PublicHealthMonitoringImportVerifier < ApplicationSystemTestCase
       if value && !value.blank? && VALIDATION[field][:checks].include?(:enum) && !NORMALIZED_ENUMS[field].keys.include?(unformat_enum_field(value))
         assert page.has_content?("'#{value}' is not an acceptable value for '#{VALIDATION[field][:label]}'"), "Error message for #{field} missing"
       end
-      # TODO when workflow specific case status validation re-enabled: uncomment
+      # TODO: when workflow specific case status validation re-enabled: uncomment
       # if value && !value.blank? && WORKFLOW_SPECIFIC_FIELDS.include?(field)
       #   if workflow == :exposure && !NORMALIZED_EXPOSURE_ENUMS[field].keys.include?(unformat_enum_field(value))
       #     assert page.has_content?('for monitorees imported into the Exposure workflow'), "Error message for #{field} incorrect"

--- a/test/system/roles/public_health/dashboard/import_verifier.rb
+++ b/test/system/roles/public_health/dashboard/import_verifier.rb
@@ -15,11 +15,13 @@ class PublicHealthMonitoringImportVerifier < ApplicationSystemTestCase
                    healthcare_personnel crew_on_passenger_or_cargo_flight member_of_a_common_exposure_cohort].freeze
   STATE_FIELDS = %i[address_state foreign_monitored_address_state additional_planned_travel_destination_state].freeze
   MONITORED_ADDRESS_FIELDS = %i[monitored_address_line_1 monitored_address_city monitored_address_state monitored_address_line_2 monitored_address_zip].freeze
-  ISOLATION_FIELDS = %i[symptom_onset extended_isolation].freeze
+  # TODO when workflow specific case status validation re-enabled: take out 'case_status'
+  ISOLATION_FIELDS = %i[symptom_onset extended_isolation, case_status].freeze
   ENUM_FIELDS = %i[ethnicity preferred_contact_method primary_telephone_type secondary_telephone_type preferred_contact_time additional_planned_travel_type
                    exposure_risk_assessment monitoring_plan case_status].freeze
   RISK_FACTOR_FIELDS = %i[contact_of_known_case was_in_health_care_facility_with_known_cases].freeze
-  WORKFLOW_SPECIFIC_FIELDS = %i[case_status].freeze
+  # TODO when workflow specific case status validation re-enabled: uncomment
+  #WORKFLOW_SPECIFIC_FIELDS = %i[case_status].freeze
 
   def verify_epi_x_field_validation(jurisdiction_id, workflow, file_name)
     sheet = get_xslx(file_name).sheet(0)
@@ -171,13 +173,18 @@ class PublicHealthMonitoringImportVerifier < ApplicationSystemTestCase
             assert_equal(row[index - 13].to_s, patient[field].to_s, "#{field} mismatch in row #{row_num}")
           elsif field == :symptom_onset # isolation workflow specific field
             assert_equal(workflow == :isolation ? row[index].to_s : '', patient[field].to_s, "#{field} mismatch in row #{row_num}")
-          elsif field == :case_status
-            normalized_cell_value = if workflow == :isolation
-                                      NORMALIZED_ISOLATION_ENUMS[field][unformat_enum_field(row[index])].to_s
-                                    else
-                                      NORMALIZED_EXPOSURE_ENUMS[field][unformat_enum_field(row[index])].to_s
-                                    end
-            assert_equal(normalized_cell_value, patient[field].to_s, "#{field} mismatch in row #{row_num}")
+          # TODO when workflow specific case status validation re-enabled: remove the next 3 lines
+          elsif field == :case_status # isolation workflow specific enum field
+            normalized_cell_value = NORMALIZED_ENUMS[field][unformat_enum_field(row[index])].to_s
+            assert_equal(workflow == :isolation ? normalized_cell_value : '', patient[field].to_s, "#{field} mismatch in row #{row_num}")
+          # TODO when workflow specific case status validation re-enabled: uncomment
+          # elsif field == :case_status
+          #   normalized_cell_value = if workflow == :isolation
+          #                             NORMALIZED_ISOLATION_ENUMS[field][unformat_enum_field(row[index])].to_s
+          #                           else
+          #                             NORMALIZED_EXPOSURE_ENUMS[field][unformat_enum_field(row[index])].to_s
+          #                           end
+          #   assert_equal(normalized_cell_value, patient[field].to_s, "#{field} mismatch in row #{row_num}")
           elsif field == :jurisdiction_path
             assert_equal(row[index] ? row[index].to_s : user_jurisdiction[:path].to_s, patient.jurisdiction[:path].to_s, "#{field} mismatch in row #{row_num}")
           elsif ENUM_FIELDS.include?(field)
@@ -204,13 +211,14 @@ class PublicHealthMonitoringImportVerifier < ApplicationSystemTestCase
       if value && !value.blank? && VALIDATION[field][:checks].include?(:enum) && !NORMALIZED_ENUMS[field].keys.include?(unformat_enum_field(value))
         assert page.has_content?("'#{value}' is not an acceptable value for '#{VALIDATION[field][:label]}'"), "Error message for #{field} missing"
       end
-      if value && !value.blank? && WORKFLOW_SPECIFIC_FIELDS.include?(field)
-        if workflow == :exposure && !NORMALIZED_EXPOSURE_ENUMS[field].keys.include?(unformat_enum_field(value))
-          assert page.has_content?('for monitorees imported into the Exposure workflow'), "Error message for #{field} incorrect"
-        elsif workflow == :isolation && !NORMALIZED_ISOLATION_ENUMS[field].keys.include?(unformat_enum_field(value))
-          assert page.has_content?('for cases imported into the Isolation workflow'), "Error message for #{field} incorrect"
-        end
-      end
+      # TODO when workflow specific case status validation re-enabled: uncomment
+      # if value && !value.blank? && WORKFLOW_SPECIFIC_FIELDS.include?(field)
+      #   if workflow == :exposure && !NORMALIZED_EXPOSURE_ENUMS[field].keys.include?(unformat_enum_field(value))
+      #     assert page.has_content?('for monitorees imported into the Exposure workflow'), "Error message for #{field} incorrect"
+      #   elsif workflow == :isolation && !NORMALIZED_ISOLATION_ENUMS[field].keys.include?(unformat_enum_field(value))
+      #     assert page.has_content?('for cases imported into the Isolation workflow'), "Error message for #{field} incorrect"
+      #   end
+      # end
       if value && !value.blank? && VALIDATION[field][:checks].include?(:bool) && !%w[true false].include?(value.to_s.downcase)
         assert page.has_content?("'#{value}' is not an acceptable value for '#{VALIDATION[field][:label]}'"), "Error message for #{field} missing"
       end

--- a/test/system/roles/public_health/public_health_import_export_test.rb
+++ b/test/system/roles/public_health/public_health_import_export_test.rb
@@ -174,12 +174,12 @@ class PublicHealthTest < ApplicationSystemTestCase
     @@public_health_test_helper.import_and_cancel('locals2c4_epi', :exposure, 'Sara-Alert-Format-Exposure-Workflow.xlsx', 'Sara Alert Format')
   end
 
-  # TODO when workflow specific case status validation re-enabled: uncomment
+  # TODO: when workflow specific case status validation re-enabled: uncomment
   # test 'import sara alert format to exposure and validate workflow specific fields' do
   #   @@public_health_test_helper.import_sara_alert_format('state1_epi_enroller', :exposure, 'Sara-Alert-Format-Isolation-Workflow.xlsx', :invalid_fields, [])
   # end
 
-  # TODO when workflow specific case status validation re-enabled: uncomment
+  # TODO: when workflow specific case status validation re-enabled: uncomment
   # test 'import sara alert format to isolation and validate workflow specific fields' do
   #   @@public_health_test_helper.import_sara_alert_format('state1_epi_enroller', :isolation, 'Sara-Alert-Format-Exposure-Workflow.xlsx', :invalid_fields, [])
   # end

--- a/test/system/roles/public_health/public_health_import_export_test.rb
+++ b/test/system/roles/public_health/public_health_import_export_test.rb
@@ -174,13 +174,15 @@ class PublicHealthTest < ApplicationSystemTestCase
     @@public_health_test_helper.import_and_cancel('locals2c4_epi', :exposure, 'Sara-Alert-Format-Exposure-Workflow.xlsx', 'Sara Alert Format')
   end
 
-  test 'import sara alert format to exposure and validate workflow specific fields' do
-    @@public_health_test_helper.import_sara_alert_format('state1_epi_enroller', :exposure, 'Sara-Alert-Format-Isolation-Workflow.xlsx', :invalid_fields, [])
-  end
+  # TODO when workflow specific case status validation re-enabled: uncomment
+  # test 'import sara alert format to exposure and validate workflow specific fields' do
+  #   @@public_health_test_helper.import_sara_alert_format('state1_epi_enroller', :exposure, 'Sara-Alert-Format-Isolation-Workflow.xlsx', :invalid_fields, [])
+  # end
 
-  test 'import sara alert format to isolation and validate workflow specific fields' do
-    @@public_health_test_helper.import_sara_alert_format('state1_epi_enroller', :isolation, 'Sara-Alert-Format-Exposure-Workflow.xlsx', :invalid_fields, [])
-  end
+  # TODO when workflow specific case status validation re-enabled: uncomment
+  # test 'import sara alert format to isolation and validate workflow specific fields' do
+  #   @@public_health_test_helper.import_sara_alert_format('state1_epi_enroller', :isolation, 'Sara-Alert-Format-Exposure-Workflow.xlsx', :invalid_fields, [])
+  # end
 
   # TODO: Re-enable when migrating away from GitHub LFS
   # test 'download sara alert format guidance from exposure workflow' do


### PR DESCRIPTION
# Description
Until we get more confirmation from our jurisdictions, we want to avoid deploying anymore import validation. This PR comments out the case status validation introduced in [this PR.](https://github.com/SaraAlert/SaraAlert/pull/485) There doesn't appear to be anything broken/wrong, but this is a safety precaution to make sure we don't disrupt workflows right before Thanksgiving break.

@hackrm Let me know if anything else needs to be updated to temporarily remove those changes.

To be clear, this reverts to previous functionality which was that case status was NOT imported at all in the Exposure workflow, and in the isolation workflow it checks that it is ANY of the possible strings. 