### PR TITLE
SARAALERT-961: Bugfix for sorting not resetting page count on tables

### DIFF
--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -24,7 +24,7 @@ class CustomTable extends React.Component {
     this.setState(
       state => {
         const sortDirection = state.tableQuery.sortDirection === 'asc' ? 'desc' : 'asc';
-        const tableQuery = { ...state.tableQuery, sortDirection, orderBy: field };
+        const tableQuery = { ...state.tableQuery, sortDirection, orderBy: field, page: 0 };
         return { tableQuery };
       },
       () => {


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-961

Fixes a bug related to not resetting the page when sorting. This affected both the `AdminTable` and `PatientsTable`.

# How to Replicate
1. Go to a page other than page 1 of a line list or admin table.
2. Sort column
3. Notice that the data is for page 1 after sorting but the page number did not update

# Solution
Reset the page in the query passed to the table update callback in CustomTable whenever sorting occurs.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

- [x] Carry out replication steps on both the linelist tables and the admin table and verify page is reset properly.
