### PR TITLE
SARAALERT-938: Check JSON validity in api endpoints

### DIFF
--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -128,7 +128,7 @@ class Fhir::R4::ApiController < ActionController::API
 
     status_ok(resource.as_fhir) && return
   rescue JSON::ParserError
-    status_bad_request(['Failed to parse JSON'])
+    status_bad_request(['Invalid JSON in request body'])
   rescue StandardError
     render json: operation_outcome_fatal.to_json, status: :internal_server_error
   end
@@ -212,7 +212,7 @@ class Fhir::R4::ApiController < ActionController::API
     end
     status_created(resource.as_fhir) && return
   rescue JSON::ParserError
-    status_bad_request(['Failed to parse JSON'])
+    status_bad_request(['Invalid JSON in request body'])
   rescue StandardError
     render json: operation_outcome_fatal.to_json, status: :internal_server_error
   end

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -127,6 +127,8 @@ class Fhir::R4::ApiController < ActionController::API
     end
 
     status_ok(resource.as_fhir) && return
+  rescue JSON::ParserError
+    status_bad_request(['Failed to parse JSON'])
   rescue StandardError
     render json: operation_outcome_fatal.to_json, status: :internal_server_error
   end
@@ -209,6 +211,8 @@ class Fhir::R4::ApiController < ActionController::API
       History.enrollment(patient: resource, created_by: resource.creator&.email, comment: 'Monitoree enrolled via API.')
     end
     status_created(resource.as_fhir) && return
+  rescue JSON::ParserError
+    status_bad_request(['Failed to parse JSON'])
   rescue StandardError
     render json: operation_outcome_fatal.to_json, status: :internal_server_error
   end

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -694,6 +694,17 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_response :unsupported_media_type
   end
 
+  test 'SYSTEM FLOW: should be bad request via create due to invalid JSON' do
+    post(
+      '/fhir/r4/Patient',
+      env: { 'RAW_POST_DATA' => '{ "foo", "bar" }' },
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :bad_request
+    json_response = JSON.parse(response.body)
+    assert_equal 'Failed to parse JSON', json_response['issue'][0]['diagnostics']
+  end
+
   test 'SYSTEM FLOW: should be bad request via create due to non-FHIR' do
     post(
       '/fhir/r4/Patient',
@@ -844,6 +855,17 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
 
     # Closed at date should have been set to today
     assert_equal DateTime.now.to_date, p.closed_at&.to_date
+  end
+
+  test 'SYSTEM FLOW: should be bad request via update due to invalid JSON' do
+    put(
+      '/fhir/r4/Patient/1',
+      env: { 'RAW_POST_DATA' => '{ "foo", "bar" }' },
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :bad_request
+    json_response = JSON.parse(response.body)
+    assert_equal 'Failed to parse JSON', json_response['issue'][0]['diagnostics']
   end
 
   test 'SYSTEM FLOW: should be bad request via update due to bad fhir' do
@@ -1628,6 +1650,17 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_response :unsupported_media_type
   end
 
+  test 'USER FLOW: should be bad request via create due to invalid JSON' do
+    post(
+      '/fhir/r4/Patient',
+      env: { 'RAW_POST_DATA' => '{ "foo", "bar" }' },
+      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :bad_request
+    json_response = JSON.parse(response.body)
+    assert_equal 'Failed to parse JSON', json_response['issue'][0]['diagnostics']
+  end
+
   test 'USER FLOW: should be bad request via create due to non-FHIR' do
     post(
       '/fhir/r4/Patient',
@@ -1787,6 +1820,17 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
 
     # Closed at date should have been set to today
     assert_equal DateTime.now.to_date, p.closed_at&.to_date
+  end
+
+  test 'USER FLOW: should be bad request via update due to invalid JSON' do
+    put(
+      '/fhir/r4/Patient/1',
+      env: { 'RAW_POST_DATA' => '{ "foo", "bar" }' },
+      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :bad_request
+    json_response = JSON.parse(response.body)
+    assert_equal 'Failed to parse JSON', json_response['issue'][0]['diagnostics']
   end
 
   test 'USER FLOW: should be bad request via update due to bad fhir' do

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -702,7 +702,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     )
     assert_response :bad_request
     json_response = JSON.parse(response.body)
-    assert_equal 'Failed to parse JSON', json_response['issue'][0]['diagnostics']
+    assert_equal 'Invalid JSON in request body', json_response['issue'][0]['diagnostics']
   end
 
   test 'SYSTEM FLOW: should be bad request via create due to non-FHIR' do
@@ -865,7 +865,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     )
     assert_response :bad_request
     json_response = JSON.parse(response.body)
-    assert_equal 'Failed to parse JSON', json_response['issue'][0]['diagnostics']
+    assert_equal 'Invalid JSON in request body', json_response['issue'][0]['diagnostics']
   end
 
   test 'SYSTEM FLOW: should be bad request via update due to bad fhir' do
@@ -1658,7 +1658,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     )
     assert_response :bad_request
     json_response = JSON.parse(response.body)
-    assert_equal 'Failed to parse JSON', json_response['issue'][0]['diagnostics']
+    assert_equal 'Invalid JSON in request body', json_response['issue'][0]['diagnostics']
   end
 
   test 'USER FLOW: should be bad request via create due to non-FHIR' do
@@ -1830,7 +1830,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     )
     assert_response :bad_request
     json_response = JSON.parse(response.body)
-    assert_equal 'Failed to parse JSON', json_response['issue'][0]['diagnostics']
+    assert_equal 'Invalid JSON in request body', json_response['issue'][0]['diagnostics']
   end
 
   test 'USER FLOW: should be bad request via update due to bad fhir' do


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-938](https://tracker.codev.mitre.org/browse/SARAALERT-938)

This PR adds error handling for when the body of a POST or PUT is invalid JSON. Previously a 500 was returned, with no indication of what was wrong. Now a 400 is returned, with an error message indicating that parsing JSON failed.


# Important Changes

`api_controller.rb`
- Added rescue blocks to the end of the `update` and `create` methods to catch JSON parse errors specifically, and return a 400 status with an informative error message.

# Testing

To test try making a POST and PUT request to the API with invalid JSON. You can test both workflows, but I can't see how the different flows would make a difference here. 

# Notes

This PR should likely go in after https://github.com/SaraAlert/SaraAlert/pull/522, since #522 adds a PATCH endpoint. I've tested the code added on this PR to ensure it works as expected when an invalid PATCH is sent, so I'm confident it will work, but that order seems the most logical.
