### PR TITLE
Update integer for condition_id to not be above max int

### DIFF
--- a/test/factories/symptom.rb
+++ b/test/factories/symptom.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     end
     label { Faker::Alphanumeric.alphanumeric(number: 10) }
     notes { Faker::Alphanumeric.alphanumeric(number: 10) }
-    condition_id { Faker::Alphanumeric.alphanumeric(number: 10) }
+    condition_id { Faker::Alphanumeric.alphanumeric(number: 9) }
 
     initialize_with { type.constantize.new }
 


### PR DESCRIPTION
Fixes a small issue in the `Symptom` factory generating an ID above max integer.

Can be seen in [this test run](https://github.com/SaraAlert/SaraAlert/runs/1444866354?check_suite_focus=true)