### PR TITLE
Relative date advanced filter bugfix

### DIFF
--- a/app/javascript/components/public_health/AdvancedFilter.js
+++ b/app/javascript/components/public_health/AdvancedFilter.js
@@ -286,6 +286,7 @@ class AdvancedFilter extends React.Component {
       filterOption,
       value,
       dateOption: filterOption.type === 'date' ? 'within' : null,
+      relativeOption: filterOption.type === 'relative' ? 'today' : null,
     };
     this.setState({ activeFilterOptions });
   };


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1003](https://tracker.codev.mitre.org/browse/SARAALERT-1003)

# (Bugfix) How to Replicate
Select one of the relative date options in the advance filter and hit apply without changing anything, the today filter will not work

# (Bugfix) Solution
Adding missing line to set the relativeOption at the beginning

