### PR TITLE
SARAALERT-765: Update Import Template

### DIFF
--- a/app/javascript/components/public_health/PublicHealthHeader.js
+++ b/app/javascript/components/public_health/PublicHealthHeader.js
@@ -128,7 +128,7 @@ class PublicHealthHeader extends React.Component {
           {this.state.importType === 'saf' && (
             <div className="mb-3">
               <a href="https://github.com/SaraAlert/SaraAlert/blob/master/public/Sara%20Alert%20Import%20Format.xlsx?raw=true">Download formatting guidance</a>{' '}
-              (Updated 12/2/2020)
+              (Updated 12/15/2020)
             </div>
           )}
           <Form inline>

--- a/app/javascript/components/public_health/PublicHealthHeader.js
+++ b/app/javascript/components/public_health/PublicHealthHeader.js
@@ -127,7 +127,8 @@ class PublicHealthHeader extends React.Component {
         <Modal.Body>
           {this.state.importType === 'saf' && (
             <div className="mb-3">
-              <a href="https://github.com/SaraAlert/SaraAlert/blob/master/public/Sara%20Alert%20Import%20Format.xlsx?raw=true">Download formatting guidance</a>
+              <a href="https://github.com/SaraAlert/SaraAlert/blob/master/public/Sara%20Alert%20Import%20Format.xlsx?raw=true">Download formatting guidance</a>{' '}
+              (Updated 12/2/2020)
             </div>
           )}
           <Form inline>

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -127,7 +127,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
           end
         end
       end
-      p.workbook.add_worksheet(name: 'Assessments') do |sheet|
+      p.workbook.add_worksheet(name: 'Reports') do |sheet|
         # headers and all unique symptoms
         symptom_labels = patients.joins(assessments: [{ reported_condition: :symptoms }]).select('symptoms.label').distinct.pluck('symptoms.label').sort
         sheet.add_row ['Patient ID', 'Symptomatic', 'Who Reported', 'Created At', 'Updated At'] + symptom_labels.to_a.sort
@@ -199,7 +199,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
 
   def excel_export_assessments(patients)
     Axlsx::Package.new do |p|
-      p.workbook.add_worksheet(name: 'Assessments') do |sheet|
+      p.workbook.add_worksheet(name: 'Reports') do |sheet|
         # headers and all unique symptoms
         symptom_labels = patients.joins(assessments: [{ reported_condition: :symptoms }]).select('symptoms.label').distinct.pluck('symptoms.label').sort
         sheet.add_row ['Patient ID', 'Symptomatic', 'Who Reported', 'Created At', 'Updated At'] + symptom_labels.to_a.sort

--- a/public/Sara Alert Import Format.xlsx
+++ b/public/Sara Alert Import Format.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0b4c4fad51e09e5cbf8533b1df40536c753bbc5d376dbcda4f43d57adf8e0b2
-size 31141
+oid sha256:a160fc3d075bde2222c5015646ca55b9b1176d40853f0c7a6d0063f18ea71870
+size 36347

--- a/public/Sara Alert Import Format.xlsx
+++ b/public/Sara Alert Import Format.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a160fc3d075bde2222c5015646ca55b9b1176d40853f0c7a6d0063f18ea71870
-size 36347
+oid sha256:abc1c2d87f0bedb00519462f0d0aa1df7b2cb4b00a0843a1b6bc5c1725a39919
+size 36659

--- a/public/Sara Alert Import Format.xlsx
+++ b/public/Sara Alert Import Format.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:01d54c94e6d53f4681c00ea7ca4d6fb07d257d4791df67720fa78d6f61d2f472
-size 26739
+oid sha256:d0b4c4fad51e09e5cbf8533b1df40536c753bbc5d376dbcda4f43d57adf8e0b2
+size 31141

--- a/test/system/roles/public_health/dashboard/export_verifier.rb
+++ b/test/system/roles/public_health/dashboard/export_verifier.rb
@@ -128,7 +128,7 @@ class PublicHealthMonitoringExportVerifier < ApplicationSystemTestCase
 
     patient_ids = patients.pluck(:id)
 
-    assessments = xlsx_assessments.sheet('Assessments')
+    assessments = xlsx_assessments.sheet('Reports')
     symptom_labels = Patient.where(id: patient_ids)
                             .joins(assessments: [{ reported_condition: :symptoms }])
                             .select('symptoms.label')
@@ -137,7 +137,7 @@ class PublicHealthMonitoringExportVerifier < ApplicationSystemTestCase
                             .sort
     assessment_headers = ['Patient ID', 'Symptomatic', 'Who Reported', 'Created At', 'Updated At'] + symptom_labels.to_a.sort
     assessment_headers.each_with_index do |header, col|
-      assert_equal(header, assessments.cell(1, col + 1), "For header: #{header} in Assessments")
+      assert_equal(header, assessments.cell(1, col + 1), "For header: #{header} in Reports")
     end
     assessment_row = 0
     patients.joins(assessments: [{ reported_condition: :symptoms }])
@@ -149,7 +149,7 @@ class PublicHealthMonitoringExportVerifier < ApplicationSystemTestCase
                 symptoms_arr = symptom_labels.map { |symptom_label| symptoms_hash[symptom_label].to_s || '' }
                 assessment_summary_arr.concat(symptoms_arr).each_with_index do |value, col|
                   cell_value = assessments.cell(assessment_row + 2, col + 1)
-                  assert_equal(value.to_s, cell_value || '', "For field: #{assessment_headers[col]} in Assessments")
+                  assert_equal(value.to_s, cell_value || '', "For field: #{assessment_headers[col]} in Reports")
                 end
                 assessment_row += 1
               end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-765](https://tracker.codev.mitre.org/browse/SARAALERT-765)

This ticket updates the Import Format Guidance. 

# (Feature) Demo/Screenshots
Updated the Import Modal to include the last updated date

![image](https://user-images.githubusercontent.com/7842704/100794678-e52a0700-33eb-11eb-9852-658551a4bb29.png)

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [x] Safari
* [ ] IE11

1. Verify that `Sara Alert Import Format.xlsx` has an Updates Tab and that in the Formatting Guidance Rows 4 and 5 are gray and yellow.
2. Verify that selecting `Import` brings up a modal that has the last updated date as shown above.