### PR TITLE
SARAALERT-983: Update Error Message

### DIFF
--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -269,7 +269,7 @@ class ImportController < ApplicationController
     normalized_sex = SEX_ABBREVIATIONS[value.upcase.to_sym]
     return normalized_sex if normalized_sex
 
-    raise ValidationError.new("'#{value}' is not a valid sex for '#{VALIDATION[field][:label]}'", row_ind)
+    raise ValidationError.new("'#{value}' is not a valid sex for '#{VALIDATION[field][:label]}', acceptable values are Male, Female, and Unknown", row_ind)
   end
 
   def validate_email_field(field, value, row_ind)

--- a/test/system/roles/public_health/dashboard/import_verifier.rb
+++ b/test/system/roles/public_health/dashboard/import_verifier.rb
@@ -245,7 +245,8 @@ class PublicHealthMonitoringImportVerifier < ApplicationSystemTestCase
         assert page.has_content?("'#{value}' is not a valid state for '#{VALIDATION[field][:label]}'"), "Error message for #{field} missing"
       end
       if value && !value.blank? && VALIDATION[field][:checks].include?(:sex) && !%(Male Female Unknown M F).include?(value.capitalize)
-        assert page.has_content?("'#{value}' is not a valid sex for '#{VALIDATION[field][:label]}'"), "Error message for #{field} missing"
+        assert page.has_content?("'#{value}' is not a valid sex for '#{VALIDATION[field][:label]}', acceptable values are Male, Female, and Unknown"),
+               "Error message for #{field} missing"
       end
       if value && !value.blank? && VALIDATION[field][:checks].include?(:email) && !ValidEmail2::Address.new(value).valid?
         assert page.has_content?("'#{value}' is not a valid Email Address for '#{VALIDATION[field][:label]}'"), "Error message for #{field} missing"


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-983](https://tracker.codev.mitre.org/browse/SARAALERT-983)

The validation error for 'Sex' on import does not give the acceptable values.

# (Feature) Demo/Screenshots
![image](https://user-images.githubusercontent.com/7842704/101065841-a4ed9480-3563-11eb-9346-24757a672bee.png)

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Import data with 'Sex' as 'Puppy'. The validation error should specify the acceptable values. The attached Excel file can be used for the import
[SARAALERT-983.xlsx](https://github.com/SaraAlert/SaraAlert/files/5637912/SARAALERT-983.xlsx)

