### PR TITLE
SARAALERT-943: Remove duplication in API controller tests

### DIFF
--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -441,6 +441,8 @@ class Fhir::R4::ApiController < ActionController::API
   end
 
   # Return a well known statement
+  #
+  # GET /fhir/r4/.well-known/smart-configuration
   def well_known
     render json: {
       authorization_endpoint: "#{root_url}oauth/authorize",


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-943](https://tracker.codev.mitre.org/browse/SARAALERT-943)

Most tests in the `api_controller_test.rb` file were duplicated, once for the `USER` workflow, and once for the `SYSTEM` (machine to machine) workflow. In most cases, this duplication wasn't really necessary, because the test was not testing any workflow specific logic. This PR removes the `USER` workflow version of tests that were duplicated unnecessarily.

# Important Changes
`api_controller_test.rb`
- Removed duplicate `USER FLOW` tests.
- Re-organized tests to be grouped by function. Now if there is a function that requires both `USER` and `SYSTEM` tests, those tests are alongside each other, not split into two sections.
- Add a few small tests for some lines that were not being covered before.

# Testing
The diff is not an easy read, but I checked this by looking through each test I removed, and ensuring it's "duplicate" is still present, and ensuring that I felt good that the two flows didn't need to be tested in this case. Another method for testing this is checking out the coverage report. If you compare the coverage on this branch vs `1.18.0`, you should see that in removing the `USER FLOW` tests, the coverage was not lessened. It should actually be slightly larger on this branch than `1.18.0`, because of some of the new tests added in this PR.
