### PR TITLE
Update hana to 1.3.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ gem 'fhir_models'
 gem 'redis-queue'
 
 # JSON Patch and JSON Pointer implementation (using our fork of the gem)
-gem 'hana', '1.3.6', github: 'SaraAlert/hana', branch: 'master'
+gem 'hana', '~> 1.3.7'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/SaraAlert/hana.git
-  revision: 85feb253a8b7e2e7b0b54a691c0734798f280dfe
-  branch: master
-  specs:
-    hana (1.3.6)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -182,6 +175,7 @@ GEM
       rchardet (~> 1.8)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hana (1.3.7)
     html_tokenizer (0.0.7)
     htmlentities (4.3.4)
     httpclient (2.8.3)
@@ -422,7 +416,7 @@ DEPENDENCIES
   ffi-hunspell
   fhir_models
   gemsurance
-  hana (= 1.3.6)!
+  hana (~> 1.3.7)
   jbuilder (~> 2.7)
   letter_opener
   listen (>= 3.0.5, < 3.2)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-940](https://tracker.codev.mitre.org/browse/SARAALERT-940)

This PR updates the `Gemfile` to point to version `1.3.7` of the `hana` gem. We had been pointing to our fork of the gem, but the changes we made got merged and released into `1.3.7`, so we no longer need to point at our local fork.

# Important Changes
`Gemfile`
- Require `1.3.7` or higher for `hana`.

# Testing
You can do a quick test to ensure the code we added is in version `1.3.7` by testing out a JSON Patch that triggers some of the error handling we added. One example would be doing a `replace` on a field that doesn't exist:
```
[
    { "op": "replace", "path": "/foo", "value": "1" }
]
```
In previous versions of `hana`, this would not cause any errors, but in version `1.3.7`, you should see an error like 
```
"Unable to apply patch: key 'foo' not found"
```