### PR TITLE
Activestorage test fix

### DIFF
--- a/app/views/user_mailer/download_email.html.erb
+++ b/app/views/user_mailer/download_email.html.erb
@@ -23,7 +23,7 @@
       <br />
     </p>
   </p>
-  <%= render partial: 'main_mailer/responsive_button', locals: { link: export_download_url(id: @id), text: "Click here to download" } %>
+  <%= render partial: 'main_mailer/responsive_button', locals: { link: export_download_url(id: @id), text: 'Click here to download' } %>
   <br />
 <% end %>
 

--- a/test/system/lib/system_test_utils.rb
+++ b/test/system/lib/system_test_utils.rb
@@ -12,7 +12,7 @@ class SystemTestUtils < ApplicationSystemTestCase
   USER_PASSWORD = '1234567ab!'
   DOWNLOAD_PATH = Rails.root.join('tmp/downloads')
 
-  ENROLLMENT_SUBMISSION_DELAY = 5 # wait for submission alert animation to finish
+  ENROLLMENT_SUBMISSION_DELAY = 6 # wait for submission alert animation to finish
   ENROLLMENT_PAGE_TRANSITION_DELAY = 1 # wait for carousel animation to finish
   POP_UP_ALERT_ANIMATION_DELAY = 1 # wait for alert to pop up or dismiss
   MODAL_ANIMATION_DELAY = 0.5 # wait for modal to load

--- a/test/system/roles/enroller/enroller_enrollment_test.rb
+++ b/test/system/roles/enroller/enroller_enrollment_test.rb
@@ -6,7 +6,7 @@ SimpleCov.command_name 'SystemTestCaseEnrollerEnrollment'
 
 require_relative 'enroller_test_helper'
 
-class EnrollerTest < ApplicationSystemTestCase
+class EnrollerEnrollmentTest < ApplicationSystemTestCase
   @@enroller_test_helper = EnrollerTestHelper.new(nil)
 
   test 'enroll monitoree with all fields' do


### PR DESCRIPTION
# Description


- When running all tests at once `bundle exec rails test test/system`, then rails would complain that the `EnrollerTest` had duplicate test names. This was because `enroller_enrollment_test.rb` and `enroller_dashboard_test.rb` had the same class name and the same test names. I changed the class name of `enroller_enrollment_test.rb` to `EnrollerEnrollmentTest` to fix this. It REALLY seems like these two test classes contain some of the same exact tests - as in I think we could just delete `enroller_enrollment_test.rb`.
- I noticed a test failing because it would not wait enough time after enrollment, so I increased `ENROLLMENT_SUBMISSION_DELAY` by one second
