### PR TITLE
1051: Add support for State/Local ID in the API

### DIFF
--- a/app/helpers/fhir_helper.rb
+++ b/app/helpers/fhir_helper.rb
@@ -42,6 +42,7 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
         }
       )],
       id: patient.id,
+      identifier: [to_statelocal_identifier(patient.user_defined_id_statelocal)],
       active: patient.monitoring,
       name: [FHIR::HumanName.new(given: [patient.first_name, patient.middle_name].reject(&:blank?), family: patient.last_name)],
       telecom: [
@@ -151,7 +152,8 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
       travel_related_notes: from_string_extension(patient, 'travel-related-notes'),
       additional_planned_travel_related_notes: from_string_extension(patient, 'additional-planned-travel-notes'),
       primary_telephone_type: from_primary_phone_type_extension(patient),
-      secondary_telephone_type: from_secondary_phone_type_extension(patient)
+      secondary_telephone_type: from_secondary_phone_type_extension(patient),
+      user_defined_id_statelocal: from_statelocal_id_extension(patient)
     }
   end
 
@@ -327,5 +329,14 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
 
   def from_fhir_phone_number(value)
     Phonelib.parse(value, 'US').full_e164.presence || value
+  end
+
+  def to_statelocal_identifier(statelocal_identifier)
+    FHIR::Identifier.new(value: statelocal_identifier, system: 'http://saraalert.org/SaraAlert/state-local-id') unless statelocal_identifier.blank?
+  end
+
+  def from_statelocal_id_extension(patient)
+    statelocal_id = patient&.identifier&.find { |i| i&.system == 'http://saraalert.org/SaraAlert/state-local-id' }
+    statelocal_id&.value
   end
 end

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -638,6 +638,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal patient.exposure_notes, fhir_ext_str(json_response, 'exposure-notes')
     assert_equal patient.travel_related_notes, fhir_ext_str(json_response, 'travel-related-notes')
     assert_equal patient.additional_planned_travel_related_notes, fhir_ext_str(json_response, 'additional-planned-travel-notes')
+    assert_equal patient.user_defined_id_statelocal, json_response['identifier'].find { |i| i['system'].include? 'state-local-id' }['value']
   end
 
   test 'SYSTEM FLOW: should get observation via show' do
@@ -726,6 +727,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal patient.exposure_notes, fhir_ext_str(json_response, 'exposure-notes')
     assert_equal patient.travel_related_notes, fhir_ext_str(json_response, 'travel-related-notes')
     assert_equal patient.additional_planned_travel_related_notes, fhir_ext_str(json_response, 'additional-planned-travel-notes')
+    assert_equal patient.user_defined_id_statelocal, json_response['identifier'].find { |i| i['system'].include? 'state-local-id' }['value']
   end
 
   test 'SYSTEM FLOW: should calculate Patient age via create' do
@@ -873,6 +875,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal patient.exposure_notes, fhir_ext_str(json_response, 'exposure-notes')
     assert_equal patient.travel_related_notes, fhir_ext_str(json_response, 'travel-related-notes')
     assert_equal patient.additional_planned_travel_related_notes, fhir_ext_str(json_response, 'additional-planned-travel-notes')
+    assert_equal patient.user_defined_id_statelocal, json_response['identifier'].find { |i| i['system'].include? 'state-local-id' }['value']
   end
 
   test 'SYSTEM FLOW: should update Patient via update and set omitted fields to nil ' do


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1051](https://tracker.codev.mitre.org/browse/SARAALERT-1051)

This adds support for reading and writing the State/Local ID in the API. See the Jira ticket for full context if interested, but we decided to implement this in FHIR as a `Patient.identifier`, with an `Identifier.system` that we define (`http://saraalert.org/SaraAlert/state-local-id`). There is no validation. A corresponding PR for the IG will be coming soon, but should not block this review. Also, I will update the docs for this when we have a final decision for how we're tracking our Wiki pages.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`fhir_helper.rb`
- Simple mapping between the Sara Alert model and FHIR

# Testing

Sent POST, PUT, and GET Patient requests to test the new identifier. It should look like this:
```javascript
{
  "identifier": [
    {
      "system": "http://saraalert.org/SaraAlert/state-local-id",
      "value": "ABC-123"
    }
  ]
}
```