### PR TITLE
Duplicate responders blocked

### DIFF
--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -214,7 +214,8 @@ class ConsumeAssessmentsJob < ApplicationJob
 
         unless dependents.blank?
           create_contact_attempt_history_for_dependents(dependents, "The system will now be able to send an SMS to this monitoree's head of household
-            #{patient.primary_telephone}, because the head of household re-enabled communications with Sara Alert by sending a START keyword to #{sara_number}.")
+            #{patient.primary_telephone}, because the head of household re-enabled communications with Sara Alert by sending a START
+            keyword to #{sara_number}.")
         end
       end
     end

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -89,7 +89,7 @@ class PatientMailer < ApplicationMailer
     params = { prompt: contents, patient_submission_token: patient.submission_token,
                threshold_hash: threshold_hash, medium: 'SMS', language: lang.to_s.split('-').first.upcase,
                try_again: I18n.t('assessments.sms.prompt.try-again', locale: lang),
-               max_retries_message: I18n.t('assessments.sms.max_retries_message', locale: lang),
+               max_retries_message: I18n.t('assessments.sms.prompt.max_retries_message', locale: lang),
                thanks: I18n.t('assessments.sms.prompt.thanks', locale: lang) }
 
     if TwilioSender.start_studio_flow(patient, params)

--- a/test/mailers/patient_mailer_test.rb
+++ b/test/mailers/patient_mailer_test.rb
@@ -316,7 +316,7 @@ class PatientMailerTest < ActionMailer::TestCase
       try_again: I18n.t('assessments.sms.prompt.try-again', locale: 'en'),
       thanks: I18n.t('assessments.sms.prompt.thanks', locale: 'en'),
       medium: 'SMS',
-      max_retries_message: I18n.t('assessments.sms.max_retries_message', locale: 'en'),
+      max_retries_message: I18n.t('assessments.sms.prompt.max_retries_message', locale: 'en'),
       patient_submission_token: @patient.submission_token,
       # Don't have any symptoms set up for this jurisdiction.
       threshold_hash: @patient.jurisdiction.jurisdiction_path_threshold_hash,
@@ -346,7 +346,7 @@ class PatientMailerTest < ActionMailer::TestCase
       try_again: I18n.t('assessments.sms.prompt.try-again', locale: 'en'),
       thanks: I18n.t('assessments.sms.prompt.thanks', locale: 'en'),
       medium: 'SMS',
-      max_retries_message: I18n.t('assessments.sms.max_retries_message', locale: 'en'),
+      max_retries_message: I18n.t('assessments.sms.prompt.max_retries_message', locale: 'en'),
       patient_submission_token: @patient.submission_token,
       # Don't have any symptoms set up for this jurisdiction.
       threshold_hash: @patient.jurisdiction.jurisdiction_path_threshold_hash,


### PR DESCRIPTION

Write out a concise summary of this pull request and what it addresses.
If there are multiple responders (id==responder_id) that have the same primary telephone, then ALL of those responders (and their dependents) should get history items indicating that the relevant primary_telephone had replied with STOP (or START).

# (Bugfix) How to Replicate
Create 2 responders with the same phone number, send a STOP message and copy the flow execution ID (retrievable from the studio flow logs) into an opt_out (or opt_in) POST to your report/twilio endpoint with a body such as `{"response_status": "opt_out", 
"patient_submission_token": "FN0a152d1994de69ed7f8d91639bc78e22"}`. You'll notice only the FIRST monitoree with the primary_telephone referenced in the flow execution had history items indicating the number blocking (or unblocking)

# (Bugfix) Solution
Follow the same steps above and see that both monitorees had history items added indicating blocking or unblocking communications with SaraAlert via the primary_telephone number that the START/STOP message was sent from.


# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
