### PR TITLE
Monitoree details updates

### DIFF
--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -516,6 +516,7 @@ class Exposure extends React.Component {
         <Form.Row>
           <Form.Group as={Col} md="auto" className="mb-0 my-auto pb-2">
             <Form.Check
+              className="pt-2 my-auto"
               type="switch"
               id="member_of_a_common_exposure_cohort"
               label="MEMBER OF A COMMON EXPOSURE COHORT"

--- a/app/javascript/components/patient/Patient.js
+++ b/app/javascript/components/patient/Patient.js
@@ -511,7 +511,7 @@ class Patient extends React.Component {
                       </h4>
                     </div>
                     <div>
-                      {this.props.goto && (
+                      {this.props.goto && !this.props.details.isolation && (
                         <Button variant="link" className="pt-0" onClick={() => this.props.goto(5)}>
                           <h5>(Edit)</h5>
                         </Button>

--- a/app/javascript/tests/patient/Patient.test.js
+++ b/app/javascript/tests/patient/Patient.test.js
@@ -279,7 +279,7 @@ describe('Patient', () => {
     it('Renders edit buttons if props.goto is defined', () => {
         const wrapper = shallow(<Patient details={mockPatient1} dependents={[ mockPatient2 ]} goto={goToMock} hideBody={false}
             jurisdiction_path="USA, State 1, County 2" authenticity_token={authyToken} />);
-        expect(wrapper.find(Button).length).toEqual(7);
+        expect(wrapper.find(Button).length).toEqual(6);
         wrapper.find(Button).forEach(function(btn) {
             expect(btn.text()).toEqual('(Edit)');
         });


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-696

- Hide edit button for `Potential Exposure Info` section when in isolation workflow
- Fixed spacing for risk factors list in enrollment

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
