### PR TITLE
SARAALERT-1052: Support for new CDC Quarantine Guidance in Advanced Filter

### DIFF
--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -441,7 +441,7 @@ class PublicHealthController < ApplicationController
         end
       when 'ten-day-quarantine'
         patients = advanced_filter_quarantine_option(patients, filter, tz_offset, :ten_day)
-      when `seven-day-quarantine`
+      when 'seven-day-quarantine'
         patients = advanced_filter_quarantine_option(patients, filter, tz_offset, :seven_day)
       end
     end

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -440,9 +440,9 @@ class PublicHealthController < ApplicationController
           patients = patients.where_assoc_count(filter[:value][:number], operator, :contact_attempts)
         end
       when 'ten-day-quarantine'
-        patients = advanced_filter_quarantine_option(patients, tz_offset, :ten_day)
+        patients = advanced_filter_quarantine_option(patients, filter, tz_offset, :ten_day)
       when `seven-day-quarantine`
-        patients = advanced_filter_quarantine_option(patients, tz_offset, :seven_day)
+        patients = advanced_filter_quarantine_option(patients, filter, tz_offset, :seven_day)
       end
     end
     patients
@@ -450,7 +450,7 @@ class PublicHealthController < ApplicationController
   # rubocop:enable Metrics/MethodLength
 
   # Handles a given quarantine option from the advanced filter.
-  def advanced_filter_quarantine_option(patients, tz_offset, option_type)
+  def advanced_filter_quarantine_option(patients, filter, tz_offset, option_type)
     # Adjust for difference between client and server timezones.
     # NOTE: Adding server timezone offset in cases where the server may not be running in UTC time.
     # NOTE: + because js and ruby offsets are flipped. Both of these values are in seconds.

--- a/app/javascript/components/public_health/AdvancedFilter.js
+++ b/app/javascript/components/public_health/AdvancedFilter.js
@@ -510,10 +510,14 @@ class AdvancedFilter extends React.Component {
     );
   };
 
-  renderRelativeTooltip = (filter, value, index) => {
-    const tooltipId = `${filter.name}-${index}`;
+  /**
+   * Gets the string inside the tooltip for relative date filter options.
+   * @param {Object} filter - Filter currently selected
+   * @param {*} value - Filter value
+   */
+  getRelativeTooltipString(filter, value) {
     const filterName = filter.title.replace(' (Relative Date)', '');
-    let rangeString, start, end;
+    let statement, rangeString, start, end;
 
     // set variables for date options including a time stamp
     if (filter.hasTimestamp) {
@@ -549,17 +553,55 @@ class AdvancedFilter extends React.Component {
       }
     }
 
-    const statement = `${filterName} “${value.when}” relative date periods include records ${rangeString}.  The current setting of "${value.when}  ${value.number} ${value.unit}" will return records with ${filterName} date from ${start} through ${end}.`;
-    return (
-      <div style={{ display: 'inline' }}>
-        <span data-for={tooltipId} data-tip="" className="ml-1 tooltip-af">
-          <i className="fas fa-question-circle px-0"></i>
-        </span>
-        <ReactTooltip id={tooltipId} multiline={true} place="bottom" type="dark" effect="solid" className="tooltip-container">
-          <span>{statement}</span>
-        </ReactTooltip>
-      </div>
-    );
+    statement = `${filterName} “${value.when}” relative date periods include records ${rangeString}.
+                 The current setting of "${value.when}  ${value.number} ${value.unit}" will return records with ${filterName} date from ${start} through ${end}.`;
+    return statement;
+  }
+
+  /**
+   * Renders a tooltip for the specific filter option/type.
+   * @param {Object} filter - Filter currently selected
+   * @param {*} value - Filter value
+   * @param {Number} index  - Filter index
+   */
+  renderOptionTooltip = (filter, value, index) => {
+    const tooltipId = `${filter.name}-${index}`;
+    let statement;
+
+    // Relative dates all get a specific tooltip
+    if (filter.title.includes('(Relative Date)')) {
+      statement = this.getRelativeTooltipString(filter, value);
+    } else {
+      // Otherwise base it on specific filter option
+      switch (filter.name) {
+        case 'ten-day-quarantine':
+          statement =
+            'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom ' +
+            'Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.';
+          break;
+        case 'seven-day-quarantine':
+          statement =
+            'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom ' +
+            'Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.';
+          break;
+        default:
+          statement = '';
+      }
+    }
+
+    // Only render if there is a valid statement for this filter option.
+    if (statement) {
+      return (
+        <div style={{ display: 'inline' }}>
+          <span data-for={tooltipId} data-tip="" className="ml-1 tooltip-af">
+            <i className="fas fa-question-circle px-0"></i>
+          </span>
+          <ReactTooltip id={tooltipId} multiline={true} place="bottom" type="dark" effect="solid" className="tooltip-container">
+            <span>{statement}</span>
+          </ReactTooltip>
+        </div>
+      );
+    }
   };
 
   // Modal to specify filter name
@@ -831,11 +873,14 @@ class AdvancedFilter extends React.Component {
                       </Form.Control>
                     </Col>
                     <Col md="2" className="text-center my-auto">
-                      {this.renderRelativeTooltip(filterOption, value, index)}
+                      {this.renderOptionTooltip(filterOption, value, index)}
                     </Col>
                   </React.Fragment>
                 )}
               </Row>
+            )}
+            {filterOption && filterOption.type !== 'relative' && (
+              <span className="align-middle mx-2">{this.renderOptionTooltip(filterOption, value, index)}</span>
             )}
             {filterOption?.type === 'search' && (
               <Form.Group className="py-0 my-0">

--- a/app/javascript/components/public_health/AdvancedFilter.js
+++ b/app/javascript/components/public_health/AdvancedFilter.js
@@ -575,6 +575,8 @@ class AdvancedFilter extends React.Component {
     let statement;
 
     // Relative dates all get a specific tooltip
+    // NOTE: Right now because of how this is set up, relative dates can't have a tooltip in addition to the one that is shown
+    // here once "more" is selected.
     if (filter.title.includes('(Relative Date)')) {
       statement = this.getRelativeTooltipString(filter, value);
     } else {
@@ -872,9 +874,6 @@ class AdvancedFilter extends React.Component {
                 )}
               </Row>
             )}
-            {filterOption && filterOption.tooltip && filterOption.type !== 'relative' && (
-              <span className="align-middle mx-2">{this.renderOptionTooltip(filterOption, value, index)}</span>
-            )}
             {filterOption?.type === 'search' && (
               <Form.Group className="py-0 my-0">
                 <Form.Control
@@ -888,6 +887,9 @@ class AdvancedFilter extends React.Component {
               </Form.Group>
             )}
           </Col>
+          {filterOption && filterOption.tooltip && filterOption.type !== 'relative' && (
+            <span className="align-middle mx-2">{this.renderOptionTooltip(filterOption, value, index)}</span>
+          )}
           <Col className="py-0" md={2}>
             <div className="float-right">
               <Button variant="danger" onClick={() => this.remove(index)}>

--- a/app/javascript/components/public_health/AdvancedFilter.js
+++ b/app/javascript/components/public_health/AdvancedFilter.js
@@ -188,6 +188,9 @@ class AdvancedFilter extends React.Component {
           title: 'Candidate to Reduce Quarantine after 10 Days (Boolean)',
           description: 'All asymptomatic records that meet CDC criteria to end quarantine after Day 10 (based on last date of exposure)',
           type: 'boolean',
+          tooltip:
+            'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom ' +
+            'Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.',
         },
         {
           name: 'seven-day-quarantine',
@@ -195,6 +198,9 @@ class AdvancedFilter extends React.Component {
           description:
             'All asymptomatic records that meet CDC criteria to end quarantine after Day 7 (based on last date of exposure and most recent lab result)',
           type: 'boolean',
+          tooltip:
+            'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom ' +
+            'Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.',
         },
       ],
       savedFilters: [],
@@ -573,20 +579,7 @@ class AdvancedFilter extends React.Component {
       statement = this.getRelativeTooltipString(filter, value);
     } else {
       // Otherwise base it on specific filter option
-      switch (filter.name) {
-        case 'ten-day-quarantine':
-          statement =
-            'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom ' +
-            'Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.';
-          break;
-        case 'seven-day-quarantine':
-          statement =
-            'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom ' +
-            'Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.';
-          break;
-        default:
-          statement = '';
-      }
+      statement = filter.tooltip;
     }
 
     // Only render if there is a valid statement for this filter option.
@@ -879,7 +872,7 @@ class AdvancedFilter extends React.Component {
                 )}
               </Row>
             )}
-            {filterOption && filterOption.type !== 'relative' && (
+            {filterOption && filterOption.tooltip && filterOption.type !== 'relative' && (
               <span className="align-middle mx-2">{this.renderOptionTooltip(filterOption, value, index)}</span>
             )}
             {filterOption?.type === 'search' && (

--- a/app/javascript/components/public_health/AdvancedFilter.js
+++ b/app/javascript/components/public_health/AdvancedFilter.js
@@ -183,6 +183,19 @@ class AdvancedFilter extends React.Component {
           type: 'number',
           options: ['Successful', 'Unsuccessful', 'All'],
         },
+        {
+          name: 'ten-day-quarantine',
+          title: 'Candidate to Reduce Quarantine after 10 Days (Boolean)',
+          description: 'All asymptomatic records that meet CDC criteria to end quarantine after Day 10 (based on last date of exposure)',
+          type: 'boolean',
+        },
+        {
+          name: 'seven-day-quarantine',
+          title: 'Candidate to Reduce Quarantine after 7 Days (Boolean)',
+          description:
+            'All asymptomatic records that meet CDC criteria to end quarantine after Day 7 (based on last date of exposure and most recent lab result)',
+          type: 'boolean',
+        },
       ],
       savedFilters: [],
       activeFilter: null,

--- a/app/javascript/components/public_health/actions/CloseRecords.js
+++ b/app/javascript/components/public_health/actions/CloseRecords.js
@@ -15,6 +15,7 @@ class CloseRecords extends React.Component {
       monitoring: false,
       monitoring_reasons: [
         'Completed Monitoring',
+        'Meets criteria to shorten quarantine',
         'Meets Case Definition',
         'Lost to follow-up during monitoring period',
         'Lost to follow-up (contact never established)',

--- a/app/javascript/components/subject/LastDateExposure.js
+++ b/app/javascript/components/subject/LastDateExposure.js
@@ -101,6 +101,17 @@ class LastDateExposure extends React.Component {
     });
   }
 
+  endOfMonitoringTooltipText = () => {
+    return (
+      <div>
+        Calculated by the system as Last Date of Exposure + {this.props.monitoring_period_days} days
+        <div>
+          <i>Only relevant for Exposure Workflow</i>
+        </div>
+      </div>
+    );
+  };
+
   createModal(title, message, close, submit) {
     const update_continuous_exposure = title === 'Continuous Exposure';
     return (
@@ -266,7 +277,7 @@ class LastDateExposure extends React.Component {
               <Row className="reports-actions-title">
                 <Col>
                   <span className="nav-input-label">END OF MONITORING</span>
-                  <InfoTooltip tooltipTextKey="endOfMonitoring" location="right"></InfoTooltip>
+                  <InfoTooltip getCustomText={this.endOfMonitoringTooltipText} location="right"></InfoTooltip>
                 </Col>
               </Row>
               <Row>
@@ -286,6 +297,7 @@ class LastDateExposure extends React.Component {
 LastDateExposure.propTypes = {
   is_household_member: PropTypes.bool,
   authenticity_token: PropTypes.string,
+  monitoring_period_days: PropTypes.number,
   patient: PropTypes.object,
 };
 

--- a/app/javascript/components/subject/monitoring_actions/MonitoringStatus.js
+++ b/app/javascript/components/subject/monitoring_actions/MonitoringStatus.js
@@ -138,6 +138,7 @@ class MonitoringStatus extends React.Component {
                   --
                 </option>
                 <option>Completed Monitoring</option>
+                <option>Meets criteria to shorten quarantine</option>
                 <option>Meets Case Definition</option>
                 <option>Lost to follow-up during monitoring period</option>
                 <option>Lost to follow-up (contact never established)</option>

--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -12,7 +12,14 @@ const TOOLTIP_TEXT = {
     </div>
   ),
 
-  lastDateOfExposure: <div> Used by the system to automatically calculate the monitoring period. </div>,
+  lastDateOfExposure: (
+    <div>
+      Used by the system to automatically calculate the End of Monitoring Date.
+      <div>
+        <i>Only relevant for Exposure Workflow</i>
+      </div>
+    </div>
+  ),
 
   primaryLanguage: (
     <div>
@@ -215,14 +222,6 @@ const TOOLTIP_TEXT = {
     </div>
   ),
 
-  endOfMonitoring: (
-    <div>
-      Calculated by the system as Last Date of Exposure + [14] days
-      <div>
-        <i>Only relevant for Exposure Workflow</i>
-      </div>
-    </div>
-  ),
   extendedIsolation: (
     <div>
       Used by the system to determine eligibility to appear on the <i>Records Requiring Review</i> line list. A case cannot appear on the{' '}
@@ -329,7 +328,7 @@ class InfoTooltip extends React.Component {
     // If multiple instances of the Tooltip Exist on a page, the <ReactTooltip/> cannnot find
     // the correct instance (due to the lack of `data-for`/`id` pairs). Therefore we generate
     // custom string for each instance
-    this.customID = this.makeid(this.props.tooltipTextKey.length || 10).substring(0, 6);
+    this.customID = this.makeid(this.props.tooltipTextKey?.length || 10).substring(0, 6);
   }
 
   makeid = length => {
@@ -348,7 +347,8 @@ class InfoTooltip extends React.Component {
           <i className="fas fa-question-circle px-0"></i>
         </span>
         <ReactTooltip id={this.customID} multiline={true} place={this.props.location} type="dark" effect="solid" className="tooltip-container">
-          <span>{TOOLTIP_TEXT[this.props.tooltipTextKey]}</span>
+          {this.props.tooltipTextKey && <span>{TOOLTIP_TEXT[this.props.tooltipTextKey]}</span>}
+          {!this.props.tooltipTextKey && this.props.getCustomText && <span>{this.props.getCustomText()}</span>}
         </ReactTooltip>
       </div>
     );
@@ -357,6 +357,7 @@ class InfoTooltip extends React.Component {
 
 InfoTooltip.propTypes = {
   tooltipTextKey: PropTypes.string,
+  getCustomText: PropTypes.func,
   location: PropTypes.string, // top, right, bottom, left
 };
 

--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -217,7 +217,7 @@ const TOOLTIP_TEXT = {
 
   endOfMonitoring: (
     <div>
-      Calculated by the system based on Last Date of Exposure
+      Calculated by the system as Last Date of Exposure + [14] days
       <div>
         <i>Only relevant for Exposure Workflow</i>
       </div>

--- a/app/javascript/tests/subject/monitoring_actions/MonitoringStatus.test.js
+++ b/app/javascript/tests/subject/monitoring_actions/MonitoringStatus.test.js
@@ -14,6 +14,7 @@ const monitoringStatusValues = [ 'Actively Monitoring', 'Not Monitoring' ];
 const monitoringReasons = [
   '--',
   'Completed Monitoring',
+  'Meets criteria to shorten quarantine',
   'Meets Case Definition',
   'Lost to follow-up during monitoring period',
   'Lost to follow-up (contact never established)',

--- a/app/javascript/tests/subject/monitoring_actions/MonitoringStatus.test.js
+++ b/app/javascript/tests/subject/monitoring_actions/MonitoringStatus.test.js
@@ -72,7 +72,7 @@ describe('MonitoringStatus', () => {
     expect(wrapper.find(Modal.Body).find('p').text().includes(`Are you sure you want to change monitoring status to "Not Monitoring"?`)).toBeTruthy();
     expect(wrapper.find(Modal.Body).find('p').find('b').text()).toEqual(' This will move the selected record(s) to the Closed line list and turn Continuous Exposure OFF.');
     expect(wrapper.find('#monitoring_reason').exists()).toBeTruthy();
-    expect(wrapper.find('#monitoring_reason').find('option').length).toEqual(12);
+    expect(wrapper.find('#monitoring_reason').find('option').length).toEqual(monitoringReasons.length);
     monitoringReasons.forEach(function(value, index) {
       expect(wrapper.find('#monitoring_reason').find('option').at(index).text()).toEqual(value);
     });

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -465,7 +465,7 @@ class Patient < ApplicationRecord
   # Record must:
   # - be unpurged, open, in exposure workflow, and not in continuous exposure
   # - have reported within 10-13 days after their last date of exposure and has no symptomatic reports
-  # - be between 10-13 days past their last date of exposure
+  # - be 10 or more days past their last date of exposure
   scope :ten_day_quarantine_candidates, lambda { |user_curr_datetime|
     where(purged: false, monitoring: true, isolation: false, continuous_exposure: false)
       .where_assoc_exists(:assessments) do
@@ -474,16 +474,16 @@ class Patient < ApplicationRecord
               'AND DATE_ADD(last_date_of_exposure, INTERVAL 13 DAY)')
           .where('assessments.symptomatic = ?', false)
       end
-      .where('? BETWEEN DATE_ADD(patients.last_date_of_exposure, INTERVAL 10 DAY)'\
-            'AND DATE_ADD(patients.last_date_of_exposure, INTERVAL 13 DAY)', user_curr_datetime.to_date)
+      .where('? >= DATE_ADD(patients.last_date_of_exposure, INTERVAL 10 DAY)', user_curr_datetime.to_date)
   }
+
   # Criteria for this CDC quarantine guidance which can be found here:
   # https://www.cdc.gov/coronavirus/2019-ncov/more/scientific-brief-options-to-reduce-quarantine.html
   #
   # Record must:
   # - be unpurged, open, in exposure workflow, and not in continuous exposure
   # - have reported within 7-9 days after their last date of exposure and has no symptomatic reports
-  # - be between 7-9 days past their last date of exposure
+  # - be 7 or more days past their last date of exposure
   # - have a negative PCR or Antigen test that was collected between 5-9 days after their last date of exposure
   # rubocop:disable Style/MultilineBlockChain
   scope :seven_day_quarantine_candidates, lambda { |user_curr_datetime|
@@ -494,7 +494,7 @@ class Patient < ApplicationRecord
               'AND DATE_ADD(last_date_of_exposure, INTERVAL 9 DAY)')
           .where('assessments.symptomatic = ?', false)
       end
-      .where('? BETWEEN DATE_ADD(last_date_of_exposure, INTERVAL 7 DAY) AND DATE_ADD(last_date_of_exposure, INTERVAL 9 DAY)', user_curr_datetime.to_date)
+      .where('? >= DATE_ADD(last_date_of_exposure, INTERVAL 7 DAY)', user_curr_datetime.to_date)
       .where_assoc_exists(:laboratories) do
         where(result: 'negative', lab_type: %w[PCR ANTIGEN])
           .where('specimen_collection BETWEEN DATE_ADD(last_date_of_exposure, INTERVAL 5 DAY) AND DATE_ADD(last_date_of_exposure, INTERVAL 9 DAY)')

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -20,6 +20,7 @@ class Patient < ApplicationRecord
   end
 
   validates :monitoring_reason, inclusion: { in: ['Completed Monitoring',
+                                                  'Meets criteria to shorten quarantine',
                                                   'Enrolled more than 14 days after last date of exposure (system)',
                                                   'Enrolled more than 10 days after last date of exposure (system)',
                                                   'Enrolled on last day of monitoring period (system)',

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -465,7 +465,7 @@ class Patient < ApplicationRecord
   # Record must:
   # - be unpurged, open, in exposure workflow, and not in continuous exposure
   # - has no symptomatic reports
-  # - have reported within 10-13 days after their last date of exposure 
+  # - have reported within 10-13 days after their last date of exposure
   # - be 10 or more days past their last date of exposure
   scope :ten_day_quarantine_candidates, lambda { |user_curr_datetime|
     where(purged: false, monitoring: true, isolation: false, continuous_exposure: false)

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -146,7 +146,12 @@
         <% end -%>
       </tbody>
     </table>
-    <%= react_component('subject/LastDateExposure', { authenticity_token: form_authenticity_token, patient: @patient, is_household_member: @household_members.count > 1 }) %>
+    <%= react_component('subject/LastDateExposure', {
+      authenticity_token: form_authenticity_token,
+      patient: @patient,
+      is_household_member: @household_members.count > 1,
+      monitoring_period_days: ADMIN_OPTIONS["monitoring_period_days"].to_i
+      }) %>
   </div>
 </div>
 <% @patient.assessments.order('created_at').each do |assessment| -%>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -147,11 +147,11 @@
       </tbody>
     </table>
     <%= react_component('subject/LastDateExposure', {
-      authenticity_token: form_authenticity_token,
-      patient: @patient,
-      is_household_member: @household_members.count > 1,
-      monitoring_period_days: ADMIN_OPTIONS["monitoring_period_days"].to_i
-      }) %>
+                          authenticity_token: form_authenticity_token,
+                          patient: @patient,
+                          is_household_member: @household_members.count > 1,
+                          monitoring_period_days: ADMIN_OPTIONS['monitoring_period_days'].to_i
+                        }) %>
   </div>
 </div>
 <% @patient.assessments.order('created_at').each do |assessment| -%>

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -366,7 +366,7 @@ namespace :demo do
       patient[:case_status] = patient[:isolation] ? ['Confirmed', 'Probable', 'Suspect', 'Unknown', 'Not a Case'].sample : nil
       patient[:monitoring] = rand < 0.95
       patient[:closed_at] = patient[:updated_at] unless patient[:monitoring]
-      patient[:monitoring_reason] = ['Completed Monitoring', 'Meets Case Definition', 'Lost to follow-up during monitoring period',
+      patient[:monitoring_reason] = ['Completed Monitoring', 'Meets criteria to shorten quarantine', 'Meets Case Definition', 'Lost to follow-up during monitoring period',
                                     'Lost to follow-up (contact never established)', 'Transferred to another jurisdiction',
                                     'Person Under Investigation (PUI)', 'Case confirmed', 'Past monitoring period',
                                     'Meets criteria to discontinue isolation', 'Deceased', 'Duplicate', 'Other'].sample unless patient[:monitoring].nil?

--- a/test/controllers/public_health_controller_test.rb
+++ b/test/controllers/public_health_controller_test.rb
@@ -439,7 +439,7 @@ class PublicHealthControllerTest < ActionController::TestCase
       assessment.update(created_at: 1.days.ago) if lde == 14
       assessment.update(created_at: 2.days.ago) if lde == 15
       js_timezone_offsets.each do |offset|
-        patients = @controller.send(:advanced_filter_quarantine_option, user.viewable_patients, {value: true}, offset, :ten_day)
+        patients = @controller.send(:advanced_filter_quarantine_option, user.viewable_patients, { value: true }, offset, :ten_day)
         assert_equal(patients.count, 1)
       end
     end
@@ -458,7 +458,7 @@ class PublicHealthControllerTest < ActionController::TestCase
         laboratory.update(specimen_collection: 3.days.ago)
       end
       js_timezone_offsets.each do |offset|
-        patients = @controller.send(:advanced_filter_quarantine_option, user.viewable_patients, {value: true}, offset, :seven_day)
+        patients = @controller.send(:advanced_filter_quarantine_option, user.viewable_patients, { value: true }, offset, :seven_day)
         assert_equal(patients.count, 1)
       end
     end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -1702,45 +1702,45 @@ class PatientTest < ActiveSupport::TestCase
 
   test 'ten_day_quarantine_candidates scope checks purged, monitoring, isolation, and continuous_exposure' do
     # Monitoring check
-    patient = create(:patient, monitoring: true, last_date_of_exposure: 10.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, monitoring: true, last_date_of_exposure: 10.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    patient = create(:patient, monitoring: false, last_date_of_exposure: 10.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, monitoring: false, last_date_of_exposure: 10.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert_not scoped_patients.where(id: patient.id).present?
 
     # Purged check
-    patient = create(:patient, purged: false, last_date_of_exposure: 10.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, purged: false, last_date_of_exposure: 10.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    patient = create(:patient, purged: true, last_date_of_exposure: 10.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, purged: true, last_date_of_exposure: 10.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert_not scoped_patients.where(id: patient.id).present?
 
     # Isolation check
-    patient = create(:patient, isolation: false, last_date_of_exposure: 10.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, isolation: false, last_date_of_exposure: 10.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    patient = create(:patient, isolation: true, last_date_of_exposure: 10.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, isolation: true, last_date_of_exposure: 10.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert_not scoped_patients.where(id: patient.id).present?
 
     # Continuous exposure check
-    patient = create(:patient, continuous_exposure: false, last_date_of_exposure: 10.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, continuous_exposure: false, last_date_of_exposure: 10.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    patient = create(:patient, continuous_exposure: true, last_date_of_exposure: 10.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, continuous_exposure: true, last_date_of_exposure: 10.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert_not scoped_patients.where(id: patient.id).present?
@@ -1748,40 +1748,46 @@ class PatientTest < ActiveSupport::TestCase
 
   test 'ten_day_quarantine_candidates scope has correct time range based on LDE' do
     # LDE + 9 days: too early
-    patient = create(:patient, last_date_of_exposure: 9.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 9.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert_not scoped_patients.where(id: patient.id).present?
 
     # LDE + 10 days: in range
-    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
     # LDE + 11 days: in range
-    patient = create(:patient, last_date_of_exposure: 11.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 11.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
     # LDE + 12 days: in range
-    patient = create(:patient, last_date_of_exposure: 12.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 12.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
     # LDE + 13 days: in range
-    patient = create(:patient, last_date_of_exposure: 13.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 13.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    # LDE + 14 days: too late
-    patient = create(:patient, last_date_of_exposure: 14.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
-    Assessment.create!(patient_id: patient.id, symptomatic: false)
+    # LDE + 14 days: in range as long as assessments are in range
+    patient = create(:patient, last_date_of_exposure: 14.days.ago.utc.to_date)
+    Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: 1.day.ago)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
-    assert_not scoped_patients.where(id: patient.id).present?
+    assert scoped_patients.where(id: patient.id).present?
+
+    # LDE + 15 days: in range as long as assessments are in range
+    patient = create(:patient, last_date_of_exposure: 15.days.ago.utc.to_date)
+    Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: 2.day.ago)
+    scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
+    assert scoped_patients.where(id: patient.id).present?
   end
 
   test 'ten_day_quarantine_candidates scope asserts no symptomatic assessments' do
@@ -1798,37 +1804,37 @@ class PatientTest < ActiveSupport::TestCase
 
   test 'ten_day_quarantine_candidates scope asserts assessments submitted in time range based on LDE' do
     # LDE + 9 days: too early
-    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: 1.day.ago.utc)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert_not scoped_patients.where(id: patient.id).present?
 
     # LDE + 10 days: in range
-    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
     # LDE + 11 days: in range
-    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 1.day)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
     # LDE + 12 days: in range
-    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 2.day)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
     # LDE + 13 days: in range
-    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 3.day)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    # LDE + 14 days: too late
-    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    # LDE + 1 days: too late
+    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 4.day)
     scoped_patients = Patient.ten_day_quarantine_candidates(DateTime.now.utc)
     assert_not scoped_patients.where(id: patient.id).present?
@@ -1836,52 +1842,52 @@ class PatientTest < ActiveSupport::TestCase
 
   test 'seven_day_quarantine_candidates scope checks purged, monitoring, isolation, and continuous_exposure' do
     # Monitoring check
-    patient = create(:patient, monitoring: true, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, monitoring: true, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    patient = create(:patient, monitoring: false, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, monitoring: false, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert_not scoped_patients.where(id: patient.id).present?
 
     # Purged check
-    patient = create(:patient, purged: false, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, purged: false, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    patient = create(:patient, purged: true, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, purged: true, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert_not scoped_patients.where(id: patient.id).present?
 
     # Isolation check
-    patient = create(:patient, isolation: false, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, isolation: false, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    patient = create(:patient, isolation: true, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, isolation: true, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert_not scoped_patients.where(id: patient.id).present?
 
     # Continuous exposure check
-    patient = create(:patient, continuous_exposure: false, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, continuous_exposure: false, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    patient = create(:patient, continuous_exposure: true, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, continuous_exposure: true, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
@@ -1890,49 +1896,56 @@ class PatientTest < ActiveSupport::TestCase
 
   test 'seven_day_quarantine_candidates scope has correct time range based on LDE' do
     # LDE + 6 days: too early
-    patient = create(:patient, last_date_of_exposure: 6.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 6.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert_not scoped_patients.where(id: patient.id).present?
 
     # LDE + 7 days: in range
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    # # LDE + 8 days: in range
-    patient = create(:patient, last_date_of_exposure: 8.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    # LDE + 8 days: in range
+    patient = create(:patient, last_date_of_exposure: 8.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    # # LDE + 9 days: in range
-    patient = create(:patient, last_date_of_exposure: 9.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    # LDE + 9 days: in range
+    patient = create(:patient, last_date_of_exposure: 9.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    # # LDE + 10 days: too late
-    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
-    Assessment.create!(patient_id: patient.id, symptomatic: false)
-    Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
+    # LDE + 11 days: in range as long as assessments and specimen collection are in range
+    patient = create(:patient, last_date_of_exposure: 11.days.ago.utc.to_date)
+    Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: 3.days.ago)
+    Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: 3.days.ago.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
-    assert_not scoped_patients.where(id: patient.id).present?
+    assert scoped_patients.where(id: patient.id).present?
+
+    # LDE + 12 days: in range as long as assessments and specimen collection are in range
+    patient = create(:patient, last_date_of_exposure: 12.days.ago.utc.to_date)
+    Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: 3.days.ago)
+    Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: 3.days.ago.to_date)
+    scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
+    assert scoped_patients.where(id: patient.id).present?
   end
 
   test 'seven_day_quarantine_candidates scope asserts no symptomatic assessments' do
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: true)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
@@ -1941,35 +1954,35 @@ class PatientTest < ActiveSupport::TestCase
 
   test 'seven_day_quarantine_candidates scope asserts assessments submitted in time range based on LDE' do
     # LDE + 6 days: too early
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: 1.day.ago.utc)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert_not scoped_patients.where(id: patient.id).present?
 
     # LDE + 7 days: in range
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
     # # LDE + 8 days: in range
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 1.day)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
     # # LDE + 9 days: in range
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 2.day)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
     # # LDE + 10 days: too late
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 3.day)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
@@ -1977,13 +1990,13 @@ class PatientTest < ActiveSupport::TestCase
   end
 
   test 'seven_day_quarantine_candidates scope asserts only negative lab tests' do
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'positive', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
@@ -1991,19 +2004,19 @@ class PatientTest < ActiveSupport::TestCase
   end
 
   test 'seven_day_quarantine_candidates scope asserts only PCR or ANTIGEN lab tests' do
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'ANTIGEN', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'test', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
@@ -2012,49 +2025,49 @@ class PatientTest < ActiveSupport::TestCase
 
   test 'seven_day_quarantine_candidates scope asserts lab results specimen_collection within correct range around LDE' do
     # LDE + 4 days: too early
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: 1.day.ago.utc)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: 3.days.ago.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert_not scoped_patients.where(id: patient.id).present?
 
     # LDE + 5 days: in range
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: 2.days.ago)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
     # # LDE + 6 days: in range
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 1.day)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: 1.day.ago)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
     # # LDE + 7 days: in range
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 2.day)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert scoped_patients.where(id: patient.id).present?
 
     # # LDE + 8 days: in range
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 3.day)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date + 1.day)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert_not scoped_patients.where(id: patient.id).present?
 
     # LDE + 9 days: in range
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 3.day)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date + 2.days)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert_not scoped_patients.where(id: patient.id).present?
 
     # LDE + 10 days: too late
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date, latest_assessment_at: DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
     Assessment.create!(patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 3.day)
     Laboratory.create!(patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date + 3.days)
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1052](SARAALERT-1052)

This PR adds support in the Advanced Filter for finding records that meet the new CDC quarantine criteria outlined here: 
https://www.cdc.gov/coronavirus/2019-ncov/more/scientific-brief-options-to-reduce-quarantine.html

It adds the following:
- New 10-day quarantine advanced filter following criteria specified in scope comment
- New 7-day quarantine advanced filter following criteria specified in scope comment
- New reason for closure (monitoring reason)
- Updated end of monitoring tooltip text

# Screenshots
![Screen Shot 2020-12-10 at 1 32 20 PM](https://user-images.githubusercontent.com/11698457/101814431-2907c500-3aec-11eb-9148-fa9a6031f539.png)

# Important Changes
`app/controllers/public_health_controller.rb`
- New advanced filter option support added

`app/javascript/components/public_health/AdvancedFilter.js`
- New advanced filter option support added
- Slight update to tooltip rendering functions

`app/models/patient.rb`
- New scopes for the quarantine options

`test/models/patient_test.rb`
- Tests for new scopes

`misc`
- Everything else is related to the new monitoring reason or tooltip text update.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

I added a fair number of automated tests but those don't cover timezone differences and aren't all-encompassing in general. So please test by doing the following:
- Creating/updating records that should fit criteria and making sure they show up
- Creating/updating records that should NOT fit criteria and making sure they show up

Test around with different assessment submission dates, LDE, lab report specimen_collection dates, etc. 
Also please consider timezone implications.

**I haven't yet tested the performance of these queries yet. Please include that as part of your testing and I will as well.**

# Notes
As result of working on this, I've created to tickets for improvement on code I encountered given that this PR was pressed on time, I wanted to avoid too many changes.
- Consolidating list of monitoring reasons:  [SARAALERT-1081](https://tracker.codev.mitre.org/browse/SARAALERT-1081)
- Improving how we handle tooltips in the Advanced Filter: [SARAALERT-1083](https://tracker.codev.mitre.org/browse/SARAALERT-1083)
