### PR TITLE
Fix date and relative date timezone offset issues

### DIFF
--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -481,8 +481,7 @@ class PublicHealthController < ApplicationController
 
     if timeframe[:after].present?
       # Convert timeframe value to date if field is a date, apply timezone difference if field is a datetime
-      after = timeframe[:after] - tz_diff
-      after = after.to_date if type == :date
+      after = type == :date ? timeframe[:after].to_date : timeframe[:after] + tz_diff
       patients = patients.where('patients.created_at >= ?', after) if field == :created_at
       patients = patients.where('latest_assessment_at >= ?', after) if field == :latest_assessment_at
       patients = patients.where('last_date_of_exposure >= ?', after) if field == :last_date_of_exposure
@@ -491,8 +490,7 @@ class PublicHealthController < ApplicationController
 
     if timeframe[:before].present?
       # Convert timeframe value to date if field is a date, apply timezone difference if field is a datetime
-      before = timeframe[:before] - tz_diff
-      before = before.to_date if type == :date
+      before = type == :date ? timeframe[:before].to_date : timeframe[:before] + tz_diff
       patients = patients.where('patients.created_at <= ?', before) if field == :created_at
       patients = patients.where('latest_assessment_at <= ?', before) if field == :latest_assessment_at
       patients = patients.where('last_date_of_exposure <= ?', before) if field == :last_date_of_exposure

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -481,7 +481,7 @@ class PublicHealthController < ApplicationController
 
     if timeframe[:after].present?
       # Convert timeframe value to date if field is a date, apply timezone difference if field is a datetime
-      after = type == :date ? timeframe[:after].to_date : timeframe[:after] + tz_diff
+      after = type == :date ? (timeframe[:after] - tz_diff).to_date : timeframe[:after] + tz_diff
       patients = patients.where('patients.created_at >= ?', after) if field == :created_at
       patients = patients.where('latest_assessment_at >= ?', after) if field == :latest_assessment_at
       patients = patients.where('last_date_of_exposure >= ?', after) if field == :last_date_of_exposure
@@ -490,7 +490,7 @@ class PublicHealthController < ApplicationController
 
     if timeframe[:before].present?
       # Convert timeframe value to date if field is a date, apply timezone difference if field is a datetime
-      before = type == :date ? timeframe[:before].to_date : timeframe[:before] + tz_diff
+      before = type == :date ? (timeframe[:before] - tz_diff).to_date : timeframe[:before] - tz_diff
       patients = patients.where('patients.created_at <= ?', before) if field == :created_at
       patients = patients.where('latest_assessment_at <= ?', before) if field == :latest_assessment_at
       patients = patients.where('last_date_of_exposure <= ?', before) if field == :last_date_of_exposure


### PR DESCRIPTION
# Description

Date and relative date filters are not working properly in that they are filtering the wrong time

# (Bugfix) How to Replicate
Filter monitorees but date or relative date filters

# (Bugfix) Solution
Only apply the timezone difference for timestamps and add tz_diff instead of subtracting it

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`public_health_controller.rb`
- only apply the timezone difference for timestamps and add tz_diff instead of subtracting it

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
