### PR TITLE
added edit button for notes section

### DIFF
--- a/app/javascript/components/patient/Patient.js
+++ b/app/javascript/components/patient/Patient.js
@@ -623,6 +623,13 @@ class Patient extends React.Component {
                         <b>NOTES</b>
                       </h4>
                     </div>
+                    <div>
+                      {this.props.goto && (
+                        <Button variant="link" className="pt-0" onClick={() => this.props.goto(5)}>
+                          <h5>(Edit)</h5>
+                        </Button>
+                      )}
+                    </div>
                     <div className="clearfix"></div>
                   </Col>
                 </Row>

--- a/app/javascript/tests/patient/Patient.test.js
+++ b/app/javascript/tests/patient/Patient.test.js
@@ -279,7 +279,7 @@ describe('Patient', () => {
     it('Renders edit buttons if props.goto is defined', () => {
         const wrapper = shallow(<Patient details={mockPatient1} dependents={[ mockPatient2 ]} goto={goToMock} hideBody={false}
             jurisdiction_path="USA, State 1, County 2" authenticity_token={authyToken} />);
-        expect(wrapper.find(Button).length).toEqual(6);
+        expect(wrapper.find(Button).length).toEqual(7);
         wrapper.find(Button).forEach(function(btn) {
             expect(btn.text()).toEqual('(Edit)');
         });


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-696](https://tracker.codev.mitre.org/browse/SARAALERT-696)

Added edit button for notes section in monitoree details.  when clicked it should open the edit case info page (if in isolation) or the edit exposure info page (if in exposure)

# (Feature) Demo/Screenshots
![Screen Shot 2020-12-14 at 9 29 33 AM](https://user-images.githubusercontent.com/35042815/102093236-e9dcbb00-3dee-11eb-95a1-ab99c9fcbd06.png)

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
