### PR TITLE
SARAALERT-1075: added null option to preferred contact method dropdown

### DIFF
--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -236,6 +236,7 @@ class Contact extends React.Component {
                     className="form-square"
                     value={this.state.current.patient.preferred_contact_method || ''}
                     onChange={this.handleChange}>
+                    <option></option>
                     <option>Unknown</option>
                     <option>E-mailed Web Link</option>
                     <option>SMS Texted Weblink</option>


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1075](https://tracker.codev.mitre.org/browse/SARAALERT-1075)

If you enroll a new monitoree with a preferred contact method of Unknown, it shows up as null in the monitoree details and when you use the advanced filter on preferred contact method.

# (Bugfix) How to Replicate
Steps to recreate [here](https://teams.microsoft.com/l/file/1C336B99-88E0-4AC8-AE31-33BA1D20EF2E?tenantId=c620dc48-1d50-4952-8b39-df4d54d74d82&fileType=pptx&objectUrl=https%3A%2F%2Fmitre.sharepoint.com%2Fsites%2FCoVDT%2FShared%20Documents%2FGeneral%2FProduct%20Owner%20Materials%2FTesting%2FBug%20Reports%2Fpreferred%20reporting%20field%20bug.pptx&baseUrl=https%3A%2F%2Fmitre.sharepoint.com%2Fsites%2FCoVDT&serviceName=teams&threadId=19:00d3d45c64ca457795d58c2764d517cd@thread.skype&groupId=7de0f318-3170-4f1c-82eb-95bfe132bfe9)

# (Bugfix) Solution
Issue ended up being that the set value of the dropdown was null even though the shown option was unknown.  This is because there is no null option in the preferred contact method dropdown.  Decided to add a null option to the dropdown since we allow null on import.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
