### PR TITLE
Assessment transaction

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -153,8 +153,8 @@ class AssessmentsController < ApplicationController
     # Figure out the change
     delta = []
     typed_reported_symptoms.each do |symptom|
-      new_val = symptom.value
-      old_val = assessment.reported_condition&.symptoms&.find_by(name: symptom.name)&.value
+      new_val = symptom.bool_value
+      old_val = assessment.reported_condition&.symptoms&.find_by(name: symptom.name)&.bool_value
       if new_val.present? && old_val.present? && new_val != old_val
         delta << symptom.name + '=' + (new_val ? 'Yes' : 'No')
       end


### PR DESCRIPTION
# Description

Move reported_condition and assessment saving into a transaction that explicitly saves the reported_condition and assessment, ensuring that both will not be saved if there were errors saving either.


# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
