### PR TITLE
Analytics tweaks

### DIFF
--- a/app/javascript/components/analytics/PublicHealthAnalytics.js
+++ b/app/javascript/components/analytics/PublicHealthAnalytics.js
@@ -5,6 +5,7 @@ import moment from 'moment-timezone';
 import domtoimage from 'dom-to-image';
 import Switch from 'react-switch';
 import 'rc-slider/assets/index.css';
+import ReactTooltip from 'react-tooltip';
 
 import MonitoreeFlow from './widgets/MonitoreeFlow';
 import Demographics from './widgets/Demographics';
@@ -63,23 +64,32 @@ class PublicHealthAnalytics extends React.Component {
     } else {
       return (
         <React.Fragment>
-          <Row className="mb-2 mx-0 px-0 pt-2">
-            <Col md="24" className="mx-2 px-0">
-              <Button variant="primary" className="btn-square export-png" onClick={this.exportAsPNG}>
-                <i className="fas fa-download"></i>&nbsp;&nbsp;EXPORT ANALYSIS AS PNG
-              </Button>
-            </Col>
-          </Row>
-          <Row className="mb-2 mx-0 px-0 pt-4 pb-2">
-            <Col md="24" className="mx-2 px-0">
-              <p className="display-6">
-                <i className="fas fa-info-circle mr-1"></i> Analytics are generated using data from both exposure and isolation workflows. Last Updated At{' '}
+          <Row className="mx-0 px-0 mt-1 mb-4 ">
+            <Col className="mx-2 px-0">
+              <div className="display-6">
+                <div style={{ display: 'inline' }}>
+                  <span data-for="analytics-refresh" data-tip="" className="ml-1">
+                    <i className="fas fa-info-circle mr-1 px-0"></i>
+                  </span>
+                  <ReactTooltip id="analytics-refresh" multiline={true} place="right" effect="solid" className="tooltip-container">
+                    <div className="font-weight-bold p-2">
+                      The data on this page refreshes once a day. Therefore, any changes to records throughout the day will not be reflected on this page until
+                      it is refreshed around 11:30 PM EST.
+                    </div>
+                  </ReactTooltip>
+                </div>
+                Last Updated At{' '}
                 {moment
                   .tz(this.props.stats.last_updated_at, 'UTC')
                   .tz(moment.tz.guess())
                   .format('YYYY-MM-DD HH:mm z')}
                 .
-              </p>
+              </div>
+            </Col>
+            <Col className="mx-2 px-0 text-right">
+              <Button variant="primary" className="btn-square export-png" onClick={this.exportAsPNG}>
+                <i className="fas fa-download"></i>&nbsp;&nbsp;EXPORT ANALYSIS AS PNG
+              </Button>
             </Col>
           </Row>
           <Row className="mb-4 mx-2 px-0">

--- a/app/javascript/components/analytics/PublicHealthAnalytics.js
+++ b/app/javascript/components/analytics/PublicHealthAnalytics.js
@@ -74,7 +74,7 @@ class PublicHealthAnalytics extends React.Component {
                   <ReactTooltip id="analytics-refresh" multiline={true} place="right" effect="solid" className="tooltip-container">
                     <div className="font-weight-bold p-2">
                       The data on this page refreshes once a day. Therefore, any changes to records throughout the day will not be reflected on this page until
-                      it is refreshed around 11:30 PM EST.
+                      it is refreshed around 12:00 midnight EST.
                     </div>
                   </ReactTooltip>
                 </div>

--- a/app/javascript/components/analytics/widgets/CustomizedAxisTick.js
+++ b/app/javascript/components/analytics/widgets/CustomizedAxisTick.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Text } from 'recharts';
-
+// The purpose of this file is to provide a customized axis for the recharts bar-graphs.
+// By default, the library selects x-axis values for each bar. If they are too long,
+// the library seemingly randomly selects to show some and not others. This can make it
+// look like certain values are missing (when they are just hidden).
+// Obviously, that's not desirable behavior. This component can be used as a tick
+// for the XAxis. It essentially text-wraps all bar-values so they are all shown, and none
+// are hidden.
 class CustomizedAxisTick extends React.Component {
   constructor(props) {
     super(props);

--- a/app/javascript/components/analytics/widgets/CustomizedAxisTick.js
+++ b/app/javascript/components/analytics/widgets/CustomizedAxisTick.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { PropTypes } from 'prop-types';
+import { Text } from 'recharts';
+
+class CustomizedAxisTick extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+  render() {
+    const { x, y, payload } = this.props;
+    return (
+      <Text x={x} y={y} width={65} textAnchor="middle" verticalAnchor="start" style={{ fontSize: '.8rem' }}>
+        {payload.value}
+      </Text>
+    );
+  }
+}
+CustomizedAxisTick.propTypes = {
+  x: PropTypes.number,
+  y: PropTypes.number,
+  payload: PropTypes.object, // top, right, bottom, left
+};
+export default CustomizedAxisTick;

--- a/app/javascript/components/analytics/widgets/CustomizedAxisTick.js
+++ b/app/javascript/components/analytics/widgets/CustomizedAxisTick.js
@@ -15,7 +15,7 @@ class CustomizedAxisTick extends React.Component {
   render() {
     const { x, y, payload } = this.props;
     return (
-      <Text x={x} y={y} width={65} textAnchor="middle" verticalAnchor="start" style={{ fontSize: '.8rem' }}>
+      <Text x={x} y={y} width={65} textAnchor="middle" verticalAnchor="start" className="recharts-custom-tick">
         {payload.value}
       </Text>
     );

--- a/app/javascript/components/analytics/widgets/Demographics.js
+++ b/app/javascript/components/analytics/widgets/Demographics.js
@@ -92,7 +92,7 @@ class Demographics extends React.Component {
     <Card.Body className="mt-5">
       <Row>
         {this.barGraphData.map((graphData, i) => (
-          <Col md="12" key={i}>
+          <Col xl="12" key={i}>
             <div className="mx-2 mt-3 analytics-chart-borders">
               <h4 className="text-center">{graphData.title}</h4>
               <ResponsiveContainer width="100%" height={400}>

--- a/app/javascript/components/analytics/widgets/Demographics.js
+++ b/app/javascript/components/analytics/widgets/Demographics.js
@@ -5,9 +5,9 @@ import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Toolti
 import _ from 'lodash';
 
 const WORKFLOWS = ['Exposure', 'Isolation'];
-const AGEGROUPS = ['0-19', '20-29', '30-39', '40-49', '50-59', '60-69', '70-79', '>=80', 'FAKE_BIRTHDATE'];
-const SEXES = ['Male', 'Female', 'Unknown'];
-const ETHNICITIES = ['Hispanic or Latino', 'Not Hispanic or Latino'];
+const AGEGROUPS = ['0-19', '20-29', '30-39', '40-49', '50-59', '60-69', '70-79', '>=80', 'Missing', 'FAKE_BIRTHDATE'];
+const SEXES = ['Male', 'Female', 'Unknown', 'Missing'];
+const ETHNICITIES = ['Hispanic or Latino', 'Not Hispanic or Latino', 'Missing'];
 const RACES = [
   'White',
   'Black or African American',
@@ -15,9 +15,18 @@ const RACES = [
   'American Indian or Alaska Native',
   'Native Hawaiian or Other Pacific Islander',
   'More Than One Race',
+  'Missing',
   'Unknown',
 ];
-const SEXUAL_ORIENTATIONS = ['Straight or Heterosexual', 'Lesbian, Gay, or Homosexual', 'Bisexual', 'Another', 'Choose not to disclose', 'Don’t know'];
+const SEXUAL_ORIENTATIONS = [
+  'Straight or Heterosexual',
+  'Lesbian, Gay, or Homosexual',
+  'Bisexual',
+  'Another',
+  'Choose not to disclose',
+  'Missing',
+  'Don’t know',
+];
 
 class Demographics extends React.Component {
   constructor(props) {

--- a/app/javascript/components/analytics/widgets/Demographics.js
+++ b/app/javascript/components/analytics/widgets/Demographics.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Card, Col, Row } from 'react-bootstrap';
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
+import CustomizedAxisTick from './CustomizedAxisTick';
 import _ from 'lodash';
 
 const WORKFLOWS = ['Exposure', 'Isolation'];
@@ -106,7 +107,7 @@ class Demographics extends React.Component {
                     bottom: 5,
                   }}>
                   <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="name" />
+                  <XAxis dataKey="name" interval={0} tick={<CustomizedAxisTick />} height={100} />
                   <YAxis />
                   <Tooltip />
                   <Legend />

--- a/app/javascript/components/analytics/widgets/Demographics.js
+++ b/app/javascript/components/analytics/widgets/Demographics.js
@@ -3,6 +3,7 @@ import { PropTypes } from 'prop-types';
 import { Card, Col, Row } from 'react-bootstrap';
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
 import CustomizedAxisTick from './CustomizedAxisTick';
+import InfoTooltip from '../../util/InfoTooltip';
 import _ from 'lodash';
 
 const WORKFLOWS = ['Exposure', 'Isolation'];
@@ -61,7 +62,7 @@ class Demographics extends React.Component {
     this.raceChartData = this.mapToChartFormat(RACES, this.raceData);
     this.soChartData = this.mapToChartFormat(SEXUAL_ORIENTATIONS, this.soData);
     this.barGraphData = [
-      { title: 'Age (Years)', data: this.ageChartData },
+      { title: 'Current Age (Years)', data: this.ageChartData },
       { title: 'Sex', data: this.sexChartData },
       { title: 'Ethnicity', data: this.ethnicityChartData },
       { title: 'Race', data: this.raceChartData },
@@ -94,7 +95,16 @@ class Demographics extends React.Component {
         {this.barGraphData.map((graphData, i) => (
           <Col xl="12" key={i}>
             <div className="mx-2 mt-3 analytics-chart-borders">
-              <h4 className="text-center">{graphData.title}</h4>
+              <h4 className="text-center">
+                {graphData.title}
+                {graphData.title === 'Current Age (Years)' ? (
+                  <span className="h6">
+                    <InfoTooltip tooltipTextKey="analyticsAgeTip" location="right"></InfoTooltip>
+                  </span>
+                ) : (
+                  ''
+                )}
+              </h4>
               <ResponsiveContainer width="100%" height={400}>
                 <BarChart
                   width={500}
@@ -126,7 +136,12 @@ class Demographics extends React.Component {
     <Card.Body className="mt-4">
       <Row>
         <Col md="12">
-          <h4 className="text-left mt-2 mb-n1">Age (Years)</h4>
+          <div className="text-left mt-2 mb-n1">
+            <span className="h4">Current Age (Years)</span>
+            <span className="h6">
+              <InfoTooltip tooltipTextKey="analyticsAgeTip" location="right"></InfoTooltip>
+            </span>
+          </div>
           <table className="analytics-table">
             <thead>
               <tr>

--- a/app/javascript/components/analytics/widgets/Demographics.js
+++ b/app/javascript/components/analytics/widgets/Demographics.js
@@ -53,8 +53,8 @@ class Demographics extends React.Component {
     this.barGraphData = [
       { title: 'Age (Years)', data: this.ageChartData },
       { title: 'Sex', data: this.sexChartData },
-      { title: 'Race', data: this.ethnicityChartData },
-      { title: 'Ethnicity', data: this.raceChartData },
+      { title: 'Ethnicity', data: this.ethnicityChartData },
+      { title: 'Race', data: this.raceChartData },
       { title: 'Sexual Orientation', data: this.soChartData },
     ];
   }

--- a/app/javascript/components/analytics/widgets/Demographics.js
+++ b/app/javascript/components/analytics/widgets/Demographics.js
@@ -15,8 +15,8 @@ const RACES = [
   'American Indian or Alaska Native',
   'Native Hawaiian or Other Pacific Islander',
   'More Than One Race',
-  'Missing',
   'Unknown',
+  'Missing',
 ];
 const SEXUAL_ORIENTATIONS = [
   'Straight or Heterosexual',
@@ -24,8 +24,8 @@ const SEXUAL_ORIENTATIONS = [
   'Bisexual',
   'Another',
   'Choose not to disclose',
-  'Missing',
   'Don’t know',
+  'Missing',
 ];
 
 class Demographics extends React.Component {

--- a/app/javascript/components/analytics/widgets/Demographics.js
+++ b/app/javascript/components/analytics/widgets/Demographics.js
@@ -266,7 +266,7 @@ class Demographics extends React.Component {
     return (
       <React.Fragment>
         <Card className="card-square text-center">
-          <div className="analytics-card-header font-weight-bold h5"> Demographics ​</div>
+          <div className="analytics-card-header font-weight-bold h5"> Demographics (Active Records Only) ​ ​</div>
           {this.props.showGraphs ? this.renderBarGraphs() : this.renderTables()}
         </Card>
       </React.Fragment>

--- a/app/javascript/components/analytics/widgets/ExposureSummary.js
+++ b/app/javascript/components/analytics/widgets/ExposureSummary.js
@@ -81,7 +81,7 @@ class ExposureSummary extends React.Component {
     <Card.Body className="mt-5">
       <Row>
         {this.barGraphData.map((graphData, i) => (
-          <Col md="12" key={i}>
+          <Col xl="12" key={i}>
             <div className="mx-2 mt-3 analytics-chart-borders">
               <h4 className="text-center">{graphData.title}</h4>
               <ResponsiveContainer width="100%" height={400}>

--- a/app/javascript/components/analytics/widgets/ExposureSummary.js
+++ b/app/javascript/components/analytics/widgets/ExposureSummary.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Card, Button, Row, Col } from 'react-bootstrap';
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
+import CustomizedAxisTick from './CustomizedAxisTick';
 import _ from 'lodash';
 
 const WORKFLOWS = ['Exposure', 'Isolation'];
@@ -95,7 +96,7 @@ class ExposureSummary extends React.Component {
                     bottom: 5,
                   }}>
                   <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="name" />
+                  <XAxis dataKey="name" interval={0} tick={<CustomizedAxisTick />} height={100} />
                   <YAxis />
                   <Tooltip />
                   <Legend />

--- a/app/javascript/components/analytics/widgets/ExposureSummary.js
+++ b/app/javascript/components/analytics/widgets/ExposureSummary.js
@@ -181,7 +181,7 @@ class ExposureSummary extends React.Component {
     return (
       <React.Fragment>
         <Card className="card-square text-center">
-          <div className="analytics-card-header font-weight-bold h5"> Exposure Summary ​</div>
+          <div className="analytics-card-header font-weight-bold h5"> Exposure Summary (Active Records Only) ​</div>
           {this.props.showGraphs ? this.renderBarGraphs() : this.renderTables()}
         </Card>
       </React.Fragment>

--- a/app/javascript/components/analytics/widgets/MonitoreeFlow.js
+++ b/app/javascript/components/analytics/widgets/MonitoreeFlow.js
@@ -31,7 +31,7 @@ class MonitoreeFlow extends React.Component {
     return (
       <React.Fragment>
         <Card className="card-square text-center">
-          <div className="analytics-card-header font-weight-bold h5"> Monitoree Flow Over Time ​</div>
+          <div className="analytics-card-header font-weight-bold h5"> Monitoree Flow Over Time (All Records) ​</div>
           <Card.Body className="mt-4">
             <table className="analytics-table">
               <thead>
@@ -86,6 +86,10 @@ class MonitoreeFlow extends React.Component {
                 </tbody>
               ))}
             </table>
+            <div className="text-secondary fake-demographic-text mb-1">
+              <i className="fas fa-info-circle mr-3 mt-2"></i>
+              Total includes all incoming and outgoing counts ever recorded for this jurisdiction
+            </div>
           </Card.Body>
         </Card>
       </React.Fragment>

--- a/app/javascript/components/analytics/widgets/MonitoreesByEventDate.js
+++ b/app/javascript/components/analytics/widgets/MonitoreesByEventDate.js
@@ -51,9 +51,9 @@ class MonitoreesByEventDate extends React.Component {
     } else if (timeRes === 'Month') {
       dateRangeInQuestion = 'Last Exposure Month';
     }
-    DATES_OF_INTEREST = _.uniq(this.props.stats.monitoree_counts.filter(x => x.category_type === dateRangeInQuestion).map(x => x.category))
-      .sort()
-      .slice(0, 14);
+    DATES_OF_INTEREST = _.uniq(
+      this.props.stats.monitoree_counts.filter(x => x.category_type === dateRangeInQuestion && x.category).map(x => x.category)
+    ).sort();
     this.setState({
       graphData: WORKFLOWS.map(workflow => this.mapToChartFormat(DATES_OF_INTEREST, this.parseOutFields(DATES_OF_INTEREST, dateRangeInQuestion), workflow)),
       lastDateInQuestion: _.last(DATES_OF_INTEREST),
@@ -64,7 +64,7 @@ class MonitoreesByEventDate extends React.Component {
     return (
       <React.Fragment>
         <Card className="card-square text-center">
-          <div className="analytics-card-header font-weight-bold h5"> Monitorees by Event Date ​</div>
+          <div className="analytics-card-header font-weight-bold h5"> Monitorees by Event Date ​(Active Records Only) ​</div>
           <Card.Body className="mt-4">
             <Form.Row className="justify-content-md-center">
               <Form.Group as={Col} md="8" onChange={val => this.setTimeResolution(val.target.value)}>

--- a/app/javascript/components/analytics/widgets/PreferredReportingMethod.js
+++ b/app/javascript/components/analytics/widgets/PreferredReportingMethod.js
@@ -102,7 +102,7 @@ class RiskStratification extends React.Component {
     return (
       <React.Fragment>
         <Card className="card-square text-center">
-          <div className="analytics-card-header font-weight-bold h5">Actively Monitored Individuals by Reporting Method</div>
+          <div className="analytics-card-header font-weight-bold h5">Monitorees by Reporting Method (Active Records Only)</div>
           <Card.Body className="mt-4">
             <table className="analytics-table">
               <thead>

--- a/app/javascript/components/analytics/widgets/PreferredReportingMethod.js
+++ b/app/javascript/components/analytics/widgets/PreferredReportingMethod.js
@@ -6,7 +6,7 @@ import { Card } from 'react-bootstrap';
 const WORKFLOWS = ['Exposure', 'Isolation'];
 
 // Provide a separate array, as object-iteration order is not guaranteed in JS
-const CONTACT_METHOD_HEADERS = ['Email', 'SMS Weblink', 'SMS Text', 'Phone Call', 'Opt-Out', 'Unknown', 'Total'];
+const CONTACT_METHOD_HEADERS = ['Email', 'SMS Weblink', 'SMS Text', 'Phone Call', 'Opt-Out', 'Unknown', 'Missing', 'Total'];
 
 // Maps the difference between what we have server-side and what we want to display to the client
 const CONTACT_METHOD_MAPPINGS = {
@@ -16,6 +16,7 @@ const CONTACT_METHOD_MAPPINGS = {
   'Telephone call': 'Phone Call',
   'Opt-out': 'Opt-Out',
   Unknown: 'Unknown',
+  Missing: 'Missing',
 };
 
 // The goal was to have as few hard-coded options as possisble.

--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -320,6 +320,12 @@ const TOOLTIP_TEXT = {
       See User Guide for list of fields that are not purged for use in the analytics summary.{' '}
     </div>
   ),
+  analyticsAgeTip: (
+    <div>
+      Current Age is calculated as:
+      <div>Current Date - Date of Birth</div>
+    </div>
+  ),
 };
 
 class InfoTooltip extends React.Component {

--- a/app/javascript/packs/stylesheets/analytics.scss
+++ b/app/javascript/packs/stylesheets/analytics.scss
@@ -142,3 +142,7 @@
     border-radius: 4px !important;
   }
 }
+
+.recharts-custom-tick {
+  font-size: .9rem;
+}

--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -298,7 +298,7 @@ class CacheAnalyticsJob < ApplicationJob
       DATE_ADD(last_date_of_exposure, INTERVAL(1 - DAYOFWEEK(last_date_of_exposure)) DAY)
     SQL
     symptom_onset_weeks = <<-SQL
-      DATE_ADD(last_date_of_exposure, INTERVAL(1 - DAYOFWEEK(symptom_onset)) DAY)
+      DATE_ADD(symptom_onset, INTERVAL(1 - DAYOFWEEK(symptom_onset)) DAY)
     SQL
     monitorees.where(isolation: false)
               .monitoring_active(true)

--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -99,7 +99,12 @@ class CacheAnalyticsJob < ApplicationJob
               .order(Arel.sql(age_groups), :isolation)
               .size
               .map do |(age_group, isolation), total|
-                counts.append(monitoree_count(analytic_id, true, 'Age Group', age_group.nil? ? 'Missing' : age_group, total, isolation ? 'Isolation' : 'Exposure'))
+                counts.append(monitoree_count(analytic_id,
+                                              true,
+                                              'Age Group',
+                                              age_group.nil? ? 'Missing' : age_group,
+                                              total,
+                                              isolation ? 'Isolation' : 'Exposure'))
               end
     counts
   end

--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -99,7 +99,7 @@ class CacheAnalyticsJob < ApplicationJob
               .order(Arel.sql(age_groups), :isolation)
               .size
               .map do |(age_group, isolation), total|
-                counts.append(monitoree_count(analytic_id, true, 'Age Group', age_group, total, isolation ? 'Isolation' : 'Exposure'))
+                counts.append(monitoree_count(analytic_id, true, 'Age Group', age_group.nil? ? 'Missing' : age_group, total, isolation ? 'Isolation' : 'Exposure'))
               end
     counts
   end

--- a/test/system/roles/analyst/dashboard/monitoree_counts_verifier.rb
+++ b/test/system/roles/analyst/dashboard/monitoree_counts_verifier.rb
@@ -17,7 +17,7 @@ class AnalystDashboardMonitoreeCountsVerifier < ApplicationSystemTestCase
   end
 
   def verify_monitoree_counts_by_age_group(analytic_id, active_monitoring)
-    element = find('h4', text: 'Age (Years)').first(:xpath, './/..//table/tbody')
+    element = find('span', text: 'Current Age (Years)').first(:xpath, './/..//..//table/tbody')
     verify_monitoree_counts_for_category_type(element, analytic_id, active_monitoring, 'Age Group')
   end
 


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-951
This is a followup commit to address some feedback received from the Analytics Overhaul page.

In summary this PR:
1. Fixes a SQL query bug that was selecting incorrect values for the Monitorees by Event Date component
2. Clears up confusion about whether Analytics Data was coming from All Records or Active Records
3. Clears up confusion about any discrepancies in the Analytics data and the linelists (explains the cached nature of the analytics in the UI).
4. Fixes a bug where two labels had been accidentally swapped

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

