### PR TITLE
SARAALERT-1105: set default preferred_contact_method to 'Unknown'

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -62,7 +62,8 @@ class PatientsController < ApplicationController
                            email: @close_contact.nil? ? '' : @close_contact.email,
                            contact_of_known_case: !@close_contact.nil?,
                            contact_of_known_case_id: @close_contact.nil? ? '' : @close_contact.patient_id,
-                           exposure_notes: @close_contact.nil? ? '' : @close_contact.notes)
+                           exposure_notes: @close_contact.nil? ? '' : @close_contact.notes,
+                           preferred_contact_method: 'Unknown')
   end
 
   # Similar to 'new', except used for creating a new group member


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1105](https://tracker.codev.mitre.org/browse/SARAALERT-1105)

During enrollment, the default value for `preferred_contact_method` is null.  Changed that so it is now `Unknown`.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`patients_controller.rb`
- when creating a new patient, set the `preferred_contact_method` to `Unknown` by default

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
