### PR TITLE
Bugfix: History comment when changing Assigned Jurisdiction in Enrollment/Edit Wizard

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -917,8 +917,8 @@ class Patient < ApplicationRecord
 
       diffs << {
         attribute: attribute,
-        before: attribute == :jurisdiction_id ? Jurisdiction.find(patient_before[attribute])[:path] : patient_before[attribute],
-        after: attribute == :jurisdiction_id ? Jurisdiction.find(patient_after[attribute])[:path] : patient_after[attribute]
+        before: attribute.to_sym == :jurisdiction_id ? Jurisdiction.find(patient_before[attribute])[:path] : patient_before[attribute],
+        after: attribute.to_sym == :jurisdiction_id ? Jurisdiction.find(patient_after[attribute])[:path] : patient_after[attribute]
       }
     end
     diffs


### PR DESCRIPTION
# Description
The `patient_diff` function is used both by the `patient_controller` and by the `api_controller` and at the moment, they pass the updated attributes differently (as strings or symbols). This functionality will be updated in a future PR that I have been working on for consolidating update logic, but for now this supports both and fixes the issue.

# To Replicate
- Changed Assigned Jurisdiction of existing record in Enrollment/Edit Wizard
- Notice the Record Edit history item uses jurisdiction IDs instead of paths

# To Test Fix

1. Edit Assigned Jurisdiction in Enrollment/Edit Wizard and make sure the Record Edit history item has the full jurisdiction paths.
2. Quickly use Postman to test the API and make a PUT with a jurisdiction change and make sure that History item also shows up correctly.
