### PR TITLE
Speeding up show.html.erb.

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -93,7 +93,7 @@ class Assessment < ApplicationRecord
 
   # Gets all symptom names for a given array of assessment IDs.
   def self.get_symptom_names_for_assessments(assessment_ids)
-    reported_condition_ids = ReportedCondition.where(type: "ReportedCondition", assessment_id: assessment_ids).pluck(:id)
+    reported_condition_ids = ReportedCondition.where(type: 'ReportedCondition', assessment_id: assessment_ids).pluck(:id)
     Symptom.where(condition_id: reported_condition_ids).pluck(:name)
   end
 

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -91,6 +91,12 @@ class Assessment < ApplicationRecord
     reported_condition&.symptoms&.find_by(name: symptom_name)
   end
 
+  # Gets all symptom names for a given array of assessment IDs.
+  def self.get_symptom_names_for_assessments(assessment_ids)
+    reported_condition_ids = ReportedCondition.where(type: "ReportedCondition", assessment_id: assessment_ids).pluck(:id)
+    Symptom.where(condition_id: reported_condition_ids).pluck(:name)
+  end
+
   def translations
     I18n.backend.send(:init_translations) unless I18n.backend.initialized?
     {

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -79,8 +79,7 @@
         <%= react_component('subject/ContactAttempt', { authenticity_token: form_authenticity_token, patient: @patient }) %>
       </div>
     </div>
-    <% columns = [] %>
-    <% @patient.assessments.includes([:reported_condition]).each { |assessment| columns.concat(assessment.all_symptom_names) } %>
+    <% columns = Assessment.get_symptom_names_for_assessments(@patient.assessments.pluck(:id)) %>
     <% columns = columns.uniq.sort %>
     <table class="assessment_table table table-sm table-striped table-bordered table-hover table-smaller-font">
       <thead>
@@ -111,12 +110,13 @@
           <td><%= assessment.who_reported %></td>
           <td><%= local_time(assessment.created_at, '%Y-%m-%d %H:%M %Z') %></td>
           <% columns.each do |column| -%>
-          <% if assessment.get_reported_symptom_by_name(column) == nil %>
+          <% reported_condition = assessment.get_reported_symptom_by_name(column)%>
+          <% if reported_condition == nil %>
           <td></td>
           <% end %>
-          <%passes_threshold = assessment.symptom_passes_threshold(column)%>
-          <%symptom_value = assessment.get_reported_symptom_value(column)%>
-          <% if assessment.get_reported_symptom_by_name(column)&.type == "BoolSymptom"%>
+          <% passes_threshold = assessment.symptom_passes_threshold(column) %>
+          <% symptom_value = reported_condition&.value %>
+          <% if reported_condition&.type == "BoolSymptom"%>
           <% if symptom_value == true %>
           <% symptom_value = 'Yes' %>
           <% elsif symptom_value == false %>
@@ -124,7 +124,7 @@
           <%end%>
           <td><% if passes_threshold==true -%><span class="concern"><%=symptom_value%></span><% elsif passes_threshold==false -%><%=symptom_value%><%else -%><% end -%></td>
           <% end %>
-          <% if assessment.get_reported_symptom_by_name(column)&.type == "FloatSymptom" || assessment.get_reported_symptom_by_name(column)&.type == "IntegerSymptom"%>
+          <% if reported_condition&.type == "FloatSymptom" || reported_condition&.type == "IntegerSymptom"%>
           <td><% if passes_threshold==true -%><span class="concern"><%=symptom_value%></span><% elsif passes_threshold==false -%><%=symptom_value%><%else -%><% end -%></td>
           <% end %>
           <% end -%>


### PR DESCRIPTION
# Description
Speedups for Patient show page, specifically for the Reports table.

- We were calling `get_reported_symptom_by_name` a ton and get a huge speedup by just storing that in a variable. We were doing that query like 5 times per assessment.
- We were populating the columns using a lot of expensive operations. This change gets us a speedup from ~2.379 s -> ~0.022 seconds for a record with 500 assessments.