### PR TITLE
Added new scope for Monitorees by Event Date component for isolation …

### DIFF
--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -286,7 +286,7 @@ class CacheAnalyticsJob < ApplicationJob
 
     monitorees.where(isolation: true)
               .monitoring_active(true)
-              .exposed_in_time_frame(NUM_PAST_DAYS.days.ago.to_date.to_datetime)
+              .symptom_onset_in_time_frame(NUM_PAST_DAYS.days.ago.to_date.to_datetime)
               .group(:symptom_onset)
               .order(:symptom_onset)
               .size
@@ -316,7 +316,7 @@ class CacheAnalyticsJob < ApplicationJob
               end
     monitorees.where(isolation: true)
               .monitoring_active(true)
-              .exposed_in_time_frame(NUM_PAST_WEEKS.weeks.ago.to_date.to_datetime)
+              .symptom_onset_in_time_frame(NUM_PAST_WEEKS.weeks.ago.to_date.to_datetime)
               .group(symptom_onset_weeks)
               .order(Arel.sql(symptom_onset_weeks))
               .size
@@ -347,7 +347,7 @@ class CacheAnalyticsJob < ApplicationJob
               end
     monitorees.where(isolation: true)
               .monitoring_active(true)
-              .exposed_in_time_frame(NUM_PAST_MONTHS.months.ago.to_date.to_datetime)
+              .symptom_onset_in_time_frame(NUM_PAST_MONTHS.months.ago.to_date.to_datetime)
               .group(symptom_onset_months)
               .order(Arel.sql(symptom_onset_months))
               .size

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -410,6 +410,11 @@ class Patient < ApplicationRecord
     where('last_date_of_exposure >= ?', time_frame)
   }
 
+  # All individuals with a last date of exposure within the given time frame
+  scope :symptom_onset_in_time_frame, lambda { |time_frame|
+    where('symptom_onset >= ?', time_frame)
+  }
+
   # All individuals enrolled within the given time frame
   scope :enrolled_in_time_frame, lambda { |time_frame|
     case time_frame

--- a/test/jobs/analytics_job_test.rb
+++ b/test/jobs/analytics_job_test.rb
@@ -101,7 +101,7 @@ class AnalyticsJobTest < ActiveSupport::TestCase
     verify_monitoree_count(active_counts, 4, true, 'Last Exposure Date', days_ago(5), 6)
     verify_monitoree_count(active_counts, 5, true, 'Last Exposure Date', days_ago(3), 1)
     verify_monitoree_count(active_counts, 6, true, 'Last Exposure Date', days_ago(1), 1)
-    assert_equal(9, active_counts.length)
+    assert_equal(8, active_counts.length)
   end
 
   test 'monitoree counts by last exposure week' do


### PR DESCRIPTION
There had been a bug where the queries for the isolation workflow were incorrect in the `Monitorees by Event Date` component. This small PR adds a new scope to properly query for those values.