### PR TITLE
SARAALERT-1075 & SARAALERT-1119: Bugs where info is not saved upon enrollment

### DIFF
--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Carousel } from 'react-bootstrap';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import { pickBy, identity } from 'lodash';
+import { debounce, pickBy, identity } from 'lodash';
 import axios from 'axios';
 import libphonenumber from 'google-libphonenumber';
 import _ from 'lodash';
@@ -42,7 +42,7 @@ class Enrollment extends React.Component {
     };
   }
 
-  setEnrollmentState = enrollmentState => {
+  setEnrollmentState = debounce(enrollmentState => {
     let currentEnrollmentState = this.state.enrollmentState;
     this.setState({
       enrollmentState: {
@@ -52,7 +52,7 @@ class Enrollment extends React.Component {
         blocked_sms: enrollmentState.blocked_sms,
       },
     });
-  };
+  }, 1000);
 
   handleConfirmDuplicate = async (data, groupMember, message, reenableSubmit, confirmText) => {
     if (await confirmDialog(confirmText)) {

--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -84,26 +84,10 @@ class Enrollment extends React.Component {
     window.onbeforeunload = null;
     axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
 
-    let diffKeys = Object.keys(this.state.enrollmentState.patient).filter(
-      k => _.get(this.state.enrollmentState.patient, k) !== _.get(this.props.patient, k) || k === 'id'
-    );
-
-    // Manually add preferred contact method for new enrollment if it is not changed
-    if (!this.editMode && !diffKeys.includes('preferred_contact_method')) {
-      diffKeys.push('preferred_contact_method');
-    }
-
-    // Manually add close contact keys to diffKeys if enrolling from a close contact
-    // They are passed in as props and thus are not added by triggering the onChange
-    if (!this.editMode && this.props.cc_id) {
-      const closeContactKeys = ['first_name', 'last_name', 'primary_telephone', 'email', 'contact_of_known_case', 'contact_of_known_case_id', 'exposure_notes'];
-      closeContactKeys.forEach(key => {
-        // only add the key if it is not already there
-        if (!diffKeys.includes(key)) {
-          diffKeys.push(key);
-        }
-      });
-    }
+    // If enrolling, include ALL fields in diff keys. If editing, only include the ones that have changed
+    let diffKeys = this.props.editMode
+      ? Object.keys(this.state.enrollmentState.patient).filter(k => _.get(this.state.enrollmentState.patient, k) !== _.get(this.props.patient, k) || k === 'id')
+      : Object.keys(this.state.enrollmentState.patient);
 
     let data = new Object({
       patient: this.props.parent_id ? this.state.enrollmentState.patient : _.pick(this.state.enrollmentState.patient, diffKeys),

--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -88,6 +88,11 @@ class Enrollment extends React.Component {
       k => _.get(this.state.enrollmentState.patient, k) !== _.get(this.props.patient, k) || k === 'id'
     );
 
+    // Manually add preferred contact method for new enrollment if it is not changed
+    if (!this.editMode && !diffKeys.includes('preferred_contact_method')) {
+      diffKeys.push('preferred_contact_method');
+    }
+
     // Manually add close contact keys to diffKeys if enrolling from a close contact
     // They are passed in as props and thus are not added by triggering the onChange
     if (!this.editMode && this.props.cc_id) {
@@ -203,7 +208,6 @@ class Enrollment extends React.Component {
   };
 
   render() {
-    console.log(this.props.propagated_fields);
     return (
       <React.Fragment>
         <Carousel


### PR DESCRIPTION
# Description
Jira Tickets:

[SARAALERT-1075](https://tracker.codev.mitre.org/browse/SARAALERT-1075): When enrolling, the default `preferred_contact_method` of `Unknown` is not stored and is set as null when you finish enrollment.

[SARAALERT-1119](https://tracker.codev.mitre.org/browse/SARAALERT-1119): When enrolling a close contact, all the fields ('first_name', 'last_name', 'primary_telephone', 'email', 'contact_of_known_case', 'contact_of_known_case_id', 'exposure_notes') all are not set when submit.

# (Bugfix) How to Replicate
Enroll a close contact, only fill out the required fields and don't touch the preferred contact method dropdown.  Once you submit, you'll see none of these fields were saved.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`Enrollment.js`
- Manually update diffKeys in both of these specific cases to ensure they are updated upon submit. It's wonky but it works.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
