### PR TITLE
fix close contact phone numbers

### DIFF
--- a/app/javascript/components/close_contact/CloseContact.js
+++ b/app/javascript/components/close_contact/CloseContact.js
@@ -62,7 +62,7 @@ class CloseContact extends React.Component {
               patient_id: this.props.patient.id,
               first_name: this.state.first_name || '',
               last_name: this.state.last_name || '',
-              primary_telephone: this.state.primary_telephone || '',
+              primary_telephone: this.state.primary_telephone ? phoneUtil.format(phoneUtil.parse(this.state.primary_telephone, 'US'), PNF.E164) : '',
               email: this.state.email || '',
               notes: this.state.notes || '',
               enrolled_id: this.state.enrolled_id || null,


### PR DESCRIPTION
# Description

Fix close contact phone numbers

# (Bugfix) How to Replicate
Create close contact with phone number and notice how phone number is not shown after save

# (Bugfix) Solution
Phone number needs to be converted to E164 before being saved in the database in order to be shown properly

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`example_file.js`
- Example change (ex: refactored import function)

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
