### PR TITLE
SARAALERT-1111: Refactor Reports Table into React Component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,8 +99,12 @@ gem 'redis-queue'
 
 # JSON Patch and JSON Pointer implementation (using our fork of the gem)
 gem 'hana', '~> 1.3.7'
+
 # Auditing model changes
 gem 'audited'
+
+# Easier ordering for queries
+gem 'order_as_specified'
 
 group :development, :test do
   gem 'brakeman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,6 +226,8 @@ GEM
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    order_as_specified (1.6)
+      activerecord (>= 5.0.0)
     orm_adapter (0.5.0)
     ox (2.13.4)
     parallel (1.20.1)
@@ -429,6 +431,7 @@ DEPENDENCIES
   mocha
   mysql2 (>= 0.4.4)
   newrelic_rpm
+  order_as_specified
   ox
   phonelib
   premailer-rails

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -126,6 +126,8 @@ class AssessmentsController < ApplicationController
       redirect_to(root_url) && return unless patient
 
       threshold_condition_hash = params.permit(:threshold_hash)[:threshold_hash]
+      redirect_to(root_url) && return if threshold_condition_hash.blank?
+
       threshold_condition = ThresholdCondition.find_by(threshold_condition_hash: threshold_condition_hash)
       redirect_to(root_url) && return unless threshold_condition
 

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -2,6 +2,7 @@
 
 # AssessmentsController: for assessment actions
 class AssessmentsController < ApplicationController
+  include AssessmentQueryHelper
   def index; end
 
   def new
@@ -173,6 +174,31 @@ class AssessmentsController < ApplicationController
     comment += ' Symptom updates: ' + delta.join(', ') + '.' unless delta.empty?
     History.report_updated(patient: patient, created_by: current_user.email, comment: comment)
     redirect_to(patient_assessments_url) && return
+  end
+
+  def table
+    redirect_to(root_url) if ADMIN_OPTIONS['report_mode']
+    redirect_to(root_url) && return unless current_user&.can_view_patient_assessments?
+
+    permitted_params = params.permit(:entries, :page, :search, :order, :direction)
+
+    patient_id = params.require(:patient_id)
+    search_text = permitted_params[:search]
+    sort_order = permitted_params[:order]
+    sort_direction = permitted_params[:direction]
+    entries = permitted_params[:entries]
+    page = permitted_params[:page]
+
+    patient = current_user.get_patient(patient_id)
+    assessments = patient&.assessments
+    redirect_to(root_url) && return if patient.nil? || assessments.nil?
+
+    assessments = search(assessments, search_text)
+    assessments = sort(assessments, sort_order, sort_direction)
+    assessments = paginate(assessments, entries, page)
+    assessments = format(assessments)
+
+    render json: assessments
   end
 
   # For report mode instances, this is the default landing

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -156,7 +156,6 @@ class AssessmentsController < ApplicationController
         # Create history if assessment was created by user
         History.report_created(patient: patient, created_by: current_user.email, comment: "User created a new report (ID: #{@assessment.id}).") if current_user
       end
-      redirect_to(patient_assessments_url)
     end
   end
 
@@ -197,7 +196,6 @@ class AssessmentsController < ApplicationController
     comment = 'User updated an existing report (ID: ' + assessment.id.to_s + ').'
     comment += ' Symptom updates: ' + delta.join(', ') + '.' unless delta.empty?
     History.report_updated(patient: patient, created_by: current_user.email, comment: comment)
-    redirect_to(patient_assessments_url) && return
   end
 
   # For report mode instances, this is the default landing

--- a/app/helpers/assessment_query_helper.rb
+++ b/app/helpers/assessment_query_helper.rb
@@ -86,8 +86,12 @@ module AssessmentQueryHelper
       symptoms.pluck(:name).each do |symptom_name|
         symptom = assessment.get_reported_symptom_by_name(symptom_name)
         value = symptom&.value
-        value = value == true ? 'Yes' : 'No' if symptom&.type == 'BoolSymptom'
-        details[symptom_name] = value.blank? ? '' : value
+        # NOTE: We must check if the value is nil here before making this change.
+        # Otherwise, text responses of "Yes" will show "No" in each row because the value for each symptom is still empty, for example.
+        if symptom&.type == 'BoolSymptom' && !value.nil?
+          value = value == true ? 'Yes' : 'No'
+        end
+        details[symptom_name] = value.nil? ? '' : value
         passes_threshold_data[symptom_name] = assessment.symptom_passes_threshold(symptom_name)
       end
       details[:passes_threshold_data] = passes_threshold_data

--- a/app/helpers/assessment_query_helper.rb
+++ b/app/helpers/assessment_query_helper.rb
@@ -6,6 +6,7 @@ module AssessmentQueryHelper
     Assessment.where(patient_id: patient_ids).order(:patient_id)
   end
 
+  # Queries assessments by ID or reporter based on search text.
   def search(assessments, search)
     return assessments if search.blank?
 
@@ -14,6 +15,7 @@ module AssessmentQueryHelper
     )
   end
 
+  # Sorts assessments based on given column and direction.
   def sort(assessments, order, direction)
     # Order by created_at date by default
     return assessments.order(created_at: 'desc') if order.blank? || direction.blank?
@@ -58,12 +60,14 @@ module AssessmentQueryHelper
     assessments
   end
 
+  # Paginates assessments data.
   def paginate(assessments, entries, page)
     return assessments if entries.blank? || entries <= 0 || page.blank? || page.negative?
 
     assessments.paginate(per_page: entries, page: page + 1)
   end
 
+  # Formats assessments to be displayed on the frontend.
   def format(assessments)
     table_data = []
     columns = Assessment.get_symptom_names_for_assessments(assessments.pluck(:id))
@@ -80,9 +84,9 @@ module AssessmentQueryHelper
 
       passes_threshold_data = {}
       columns.each do |symptom_name|
-        reported_condition = assessment.get_reported_symptom_by_name(symptom_name)
-        value = reported_condition&.value
-        value = value == true ? 'Yes' : 'No' if reported_condition&.type == 'BoolSymptom'
+        symptom = assessment.get_reported_symptom_by_name(symptom_name)
+        value = symptom&.value
+        value = value == true ? 'Yes' : 'No' if symptom&.type == 'BoolSymptom'
         details[symptom_name] = value.blank? ? '' : value
         passes_threshold_data[symptom_name] = assessment.symptom_passes_threshold(symptom_name)
       end

--- a/app/helpers/assessment_query_helper.rb
+++ b/app/helpers/assessment_query_helper.rb
@@ -79,7 +79,7 @@ module AssessmentQueryHelper
         who_reported: assessment.who_reported,
         created_at: assessment.created_at,
         threshold_condition_hash: reported_condition&.threshold_condition&.threshold_condition_hash,
-        symptoms: reported_condition&.symptoms
+        symptoms: reported_condition&.symptoms.uniq(&:name)
       }
 
       passes_threshold_data = {}

--- a/app/helpers/assessment_query_helper.rb
+++ b/app/helpers/assessment_query_helper.rb
@@ -7,7 +7,7 @@ module AssessmentQueryHelper
   end
 
   def search(assessments, search)
-    return assessments if search.nil? || search.blank?
+    return assessments if search.blank?
 
     assessments.where('id like ?', "#{search&.downcase}%").or(
       assessments.where('who_reported like ?', "#{search&.downcase}%")

--- a/app/helpers/assessment_query_helper.rb
+++ b/app/helpers/assessment_query_helper.rb
@@ -34,7 +34,7 @@ module AssessmentQueryHelper
       assessments = assessments.order(created_at: dir)
     else
       # Verify this is a sort request for a symptom column.
-      symptom_columns = Assessment.get_symptom_names_for_assessments(assessments.pluck(:id))
+      symptom_columns = Assessment.get_unique_symptoms_for_assessments(assessments.pluck(:id)).pluck(:name)
       return assessments unless symptom_columns.include?(order)
 
       # Find assessment IDs based on the value of the symptom in the specified column
@@ -70,7 +70,7 @@ module AssessmentQueryHelper
   # Formats assessments to be displayed on the frontend.
   def format(assessments)
     table_data = []
-    columns = Assessment.get_symptom_names_for_assessments(assessments.pluck(:id))
+    symptoms = Assessment.get_unique_symptoms_for_assessments(assessments.pluck(:id))
     assessments.each do |assessment|
       reported_condition = assessment.reported_condition
       details = {
@@ -83,7 +83,7 @@ module AssessmentQueryHelper
       }
 
       passes_threshold_data = {}
-      columns.each do |symptom_name|
+      symptoms.pluck(:name).each do |symptom_name|
         symptom = assessment.get_reported_symptom_by_name(symptom_name)
         value = symptom&.value
         value = value == true ? 'Yes' : 'No' if symptom&.type == 'BoolSymptom'
@@ -93,6 +93,6 @@ module AssessmentQueryHelper
       details[:passes_threshold_data] = passes_threshold_data
       table_data << details
     end
-    { table_data: table_data, total: assessments.total_entries }
+    { table_data: table_data, symptoms: symptoms, total: assessments.total_entries }
   end
 end

--- a/app/helpers/assessment_query_helper.rb
+++ b/app/helpers/assessment_query_helper.rb
@@ -5,4 +5,67 @@ module AssessmentQueryHelper
   def assessments_by_patient_ids(patient_ids)
     Assessment.where(patient_id: patient_ids).order(:patient_id)
   end
+
+  def search(assessments, search)
+    return assessments if search.nil? || search.blank?
+
+    assessments.where('id like ?', "#{search&.downcase}%").or(
+      assessments.where('who_reported like ?', "#{search&.downcase}%")
+    )
+  end
+
+  def sort(assessments, order, direction)
+    # Order by created_at date by default
+    return assessments.order(created_at: 'desc') if order.blank? || direction.blank?
+
+    # Satisfy brakeman with additional sanitation logic
+    dir = direction == 'asc' ? 'asc' : 'desc'
+
+    # TODO: order assessments by their value for each symptom
+    case order
+    when 'id'
+      assessments = assessments.order(id: dir)
+    when 'symptomatic'
+      assessments = assessments.order(symptomatic: dir)
+    when 'who_reported'
+      assessments = assessments.order(who_reported: dir)
+    when 'created_at'
+      assessments = assessments.order(created_at: dir)
+    end
+    assessments
+  end
+
+  def paginate(assessments, entries, page)
+    return assessments if entries.blank? || entries <= 0 || page.blank? || page.negative?
+
+    assessments.paginate(per_page: entries, page: page + 1)
+  end
+
+  def format(assessments)
+    table_data = []
+    columns = Assessment.get_symptom_names_for_assessments(assessments.pluck(:id))
+    assessments.each do |assessment|
+      reported_condition = assessment.reported_condition
+      details = {
+        id: assessment[:id],
+        symptomatic: assessment.symptomatic ? 'Yes' : 'No',
+        who_reported: assessment.who_reported,
+        created_at: assessment.created_at,
+        threshold_condition_hash: reported_condition&.threshold_condition&.threshold_condition_hash,
+        symptoms: reported_condition&.symptoms
+      }
+
+      passes_threshold_data = {}
+      columns.each do |symptom_name|
+        reported_condition = assessment.get_reported_symptom_by_name(symptom_name)
+        value = reported_condition&.value
+        value = value == true ? 'Yes' : 'No' if reported_condition&.type == 'BoolSymptom'
+        details[symptom_name] = value.blank? ? '' : value
+        passes_threshold_data[symptom_name] = assessment.symptom_passes_threshold(symptom_name)
+      end
+      details[:passes_threshold_data] = passes_threshold_data
+      table_data << details
+    end
+    { table_data: table_data, total: assessments.total_entries }
+  end
 end

--- a/app/helpers/assessment_query_helper.rb
+++ b/app/helpers/assessment_query_helper.rb
@@ -79,7 +79,7 @@ module AssessmentQueryHelper
         who_reported: assessment.who_reported,
         created_at: assessment.created_at,
         threshold_condition_hash: reported_condition&.threshold_condition&.threshold_condition_hash,
-        symptoms: reported_condition&.symptoms.uniq(&:name)
+        symptoms: reported_condition&.symptoms&.uniq(&:name)
       }
 
       passes_threshold_data = {}

--- a/app/javascript/components/admin/AdminTable.js
+++ b/app/javascript/components/admin/AdminTable.js
@@ -56,11 +56,14 @@ class AdminTable extends React.Component {
 
   /**
    * Creates a "Audit" button for each row of the table.
-   * @param {string} userId
+   * @param {*} value - Value in the given row at the given column.
+   * @param {Object} rowData - Data in the row this button will be created in
+   * @param {Number} colData - Column data for the col this filter is a part of.
    */
-  createAuditButton(_, userId) {
+  // eslint-disable-next-line no-unused-vars
+  createAuditButton(value, rowData, colData, rowIndex, colIndex) {
     return (
-      <div id={userId} className="float-left edit-button">
+      <div id={rowData.id} className="float-left edit-button">
         <i className="fas fa-user-clock"></i>
       </div>
     );
@@ -648,12 +651,10 @@ class AdminTable extends React.Component {
                 }
                 className="ml-3"
                 disabled={!this.state.actionsEnabled}>
-                {this.state.query.tab !== 'closed' && (
-                  <Dropdown.Item className="px-3" onClick={this.handleResetPasswordClick}>
-                    <i className="fas fa-undo"></i>
-                    <span className="ml-2">Reset Password</span>
-                  </Dropdown.Item>
-                )}
+                <Dropdown.Item className="px-3" onClick={this.handleResetPasswordClick}>
+                  <i className="fas fa-undo"></i>
+                  <span className="ml-2">Reset Password</span>
+                </Dropdown.Item>
                 <Dropdown.Item className="px-3" onClick={this.handleReset2FAClick}>
                   <i className="fas fa-key"></i>
                   <span className="ml-2">Reset 2FA</span>

--- a/app/javascript/components/admin/AdminTable.js
+++ b/app/javascript/components/admin/AdminTable.js
@@ -56,12 +56,10 @@ class AdminTable extends React.Component {
 
   /**
    * Creates a "Audit" button for each row of the table.
-   * @param {*} value - Value in the given row at the given column.
-   * @param {Object} rowData - Data in the row this button will be created in
-   * @param {Number} colData - Column data for the col this filter is a part of.
+   * @param {Object} rowData - Data about the cell this filter is called on.
    */
-  // eslint-disable-next-line no-unused-vars
-  createAuditButton(value, rowData, colData, rowIndex, colIndex) {
+  createAuditButton(data) {
+    const rowData = data.rowData;
     return (
       <div id={rowData.id} className="float-left edit-button">
         <i className="fas fa-user-clock"></i>

--- a/app/javascript/components/admin/AdminTable.js
+++ b/app/javascript/components/admin/AdminTable.js
@@ -405,7 +405,7 @@ class AdminTable extends React.Component {
   };
 
   /**
-   * Called when the number of entries to be shown on a page changes.
+   * Called when the number of entries to be shown on a page changes. Resets page to 0.
    * Updates state and then calls table update handler.
    * @param {SyntheticEvent} event - Event when num entries changes
    */
@@ -414,7 +414,7 @@ class AdminTable extends React.Component {
     this.setState(
       state => {
         return {
-          query: { ...state.query, entries: value },
+          query: { ...state.query, entries: value, page: 0 },
         };
       },
       () => {

--- a/app/javascript/components/admin/AuditModal.js
+++ b/app/javascript/components/admin/AuditModal.js
@@ -103,12 +103,10 @@ class AuditModal extends React.Component {
 
   /**
    * Formats values in the timestamp column to be human readable
-   * @param {*} value - Value in the given row at the given column.
-   * @param {Object} rowData - Data in the row this button will be created in
-   * @param {Number} colData - Column data for the col this filter is a part of.
+   * @param {Object} data - Data about the cell this filter is called on.
    */
-  // eslint-disable-next-line no-unused-vars
-  formatTimestamp(timestamp, rowData, colData, rowIndex, colIndex) {
+  formatTimestamp(data) {
+    const timestamp = data.value;
     const ts = moment.tz(timestamp, 'UTC');
     return ts.isValid() ? ts.tz(moment.tz.guess()).format('MM/DD/YYYY HH:mm z') : '';
   }
@@ -129,12 +127,11 @@ class AuditModal extends React.Component {
 
   /**
    * Formatting method for displaying each audit action in the table.
-   * @param {*} change - Audit to display holding the updated element ({String} name) and the before & after values ({Array} details)
-   * @param {Object} rowData - Data in the row this button will be created in
-   * @param {Number} colData - Column data for the col this filter is a part of.
+   * @param {Object} data - Data about the cell this filter is called on.
    */
-  // eslint-disable-next-line no-unused-vars
-  formatChange = (change, rowData, colData, rowIndex, colIndex) => {
+  formatChange = data => {
+    //Audit to display holding the updated element ({String} name) and the before & after values ({Array} details)
+    const change = data.value;
     switch (change.name) {
       case 'locked_at':
         // Generic audit message in case before & after values not provided

--- a/app/javascript/components/admin/AuditModal.js
+++ b/app/javascript/components/admin/AuditModal.js
@@ -267,7 +267,7 @@ class AuditModal extends React.Component {
   };
 
   /**
-   * Called when the number of entries to be shown on a page changes.
+   * Called when the number of entries to be shown on a page changes. Resets page to be 0.
    * Updates state and then calls table update handler.
    * @param {SyntheticEvent} event - Event when num entries changes
    */
@@ -276,7 +276,7 @@ class AuditModal extends React.Component {
     this.setState(
       state => {
         return {
-          query: { ...state.query, entries: value },
+          query: { ...state.query, entries: value, page: 0 },
         };
       },
       () => {

--- a/app/javascript/components/admin/AuditModal.js
+++ b/app/javascript/components/admin/AuditModal.js
@@ -103,9 +103,12 @@ class AuditModal extends React.Component {
 
   /**
    * Formats values in the timestamp column to be human readable
-   * @param {String} timestamp
+   * @param {*} value - Value in the given row at the given column.
+   * @param {Object} rowData - Data in the row this button will be created in
+   * @param {Number} colData - Column data for the col this filter is a part of.
    */
-  formatTimestamp(timestamp) {
+  // eslint-disable-next-line no-unused-vars
+  formatTimestamp(timestamp, rowData, colData, rowIndex, colIndex) {
     const ts = moment.tz(timestamp, 'UTC');
     return ts.isValid() ? ts.tz(moment.tz.guess()).format('MM/DD/YYYY HH:mm z') : '';
   }
@@ -126,9 +129,12 @@ class AuditModal extends React.Component {
 
   /**
    * Formatting method for displaying each audit action in the table.
-   * @param {Object} change - audit to display holding the updated element ({String} name) and the before & after values ({Array} details)
+   * @param {*} change - Audit to display holding the updated element ({String} name) and the before & after values ({Array} details)
+   * @param {Object} rowData - Data in the row this button will be created in
+   * @param {Number} colData - Column data for the col this filter is a part of.
    */
-  formatChange = change => {
+  // eslint-disable-next-line no-unused-vars
+  formatChange = (change, rowData, colData, rowIndex, colIndex) => {
     switch (change.name) {
       case 'locked_at':
         // Generic audit message in case before & after values not provided

--- a/app/javascript/components/assessment/Assessment.js
+++ b/app/javascript/components/assessment/Assessment.js
@@ -62,17 +62,8 @@ class Assessment extends React.Component {
     }
   }
 
-  // TODO: This needs to use generic symptoms lists and not be hard-coded
   hasChanges() {
-    let currentAssessment = _.cloneDeep(this.props.assessment);
-    let symptoms = ['cough', 'difficulty_breathing', 'symptomatic'];
-    // Having falsey values on them causes the comparison to fail.
-    symptoms.forEach(symptom => {
-      if (currentAssessment[parseInt(symptom)] === false) {
-        delete currentAssessment[parseInt(symptom)];
-      }
-    });
-    return !_.isEqual(this.state.assessmentState, currentAssessment);
+    return !_.isEqual(this.state.assessmentState, this.props.assessment);
   }
 
   fieldIsEmptyOrNew(object) {

--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -153,7 +153,7 @@ class CustomTable extends React.Component {
             </tr>
           </thead>
           <tbody>
-            {this.props.rowData.map((rowData, rowIndex) => {
+            {this.props.rowData?.map((rowData, rowIndex) => {
               return (
                 <tr key={rowIndex} id={rowData.id ? rowData.id : rowIndex} className={this.props.getRowClassName ? this.props.getRowClassName(rowData) : ''}>
                   {Object.values(this.props.columnData).map((colData, colIndex) => {
@@ -162,8 +162,9 @@ class CustomTable extends React.Component {
                       // If this column has value options, use the data value as a key to those options
                       value = colData.options[rowData[colData.field]];
                     } else if (colData.filter) {
-                      // If this column has a filter function to be applied, send along data and col index
-                      value = colData.filter(value, rowData, colData, rowIndex, colIndex);
+                      // If this column has a filter function to be applied, send along data for filter to use as it wishes
+                      const filterData = { value: value, rowData: rowData, colData: colData, rowIndex: rowIndex, colIndex: colIndex };
+                      value = colData.filter(filterData);
                     }
                     return (
                       <td key={colIndex} className={colData.className ? colData.className : ''}>
@@ -190,9 +191,15 @@ class CustomTable extends React.Component {
                 </tr>
               );
             })}
+            {!this.props.rowData?.length && (
+              <tr>
+                <td colSpan={this.props.columnData?.length} className="text-center">
+                  No data available in table.
+                </td>
+              </tr>
+            )}
           </tbody>
         </Table>
-        {this.props.rowData.length === 0 && <div className="text-center">No data available in table.</div>}
         <div className="d-flex justify-content-between">
           <Form inline className="align-middle">
             <Row className="fixed-row-size">

--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -138,7 +138,6 @@ class CustomTable extends React.Component {
             <Spinner variant="secondary" animation="border" size="lg" />
           </div>
         )}
-        <div></div>
         <div className={this.props.getCustomTableClassName ? `table-responsive ${this.props.getCustomTableClassName()}` : 'table-responsive'}>
           <Table striped bordered hover size="sm">
             <thead>

--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -138,7 +138,7 @@ class CustomTable extends React.Component {
             <Spinner variant="secondary" animation="border" size="lg" />
           </div>
         )}
-        <Table striped bordered hover size="sm">
+        <Table responsive striped bordered hover size="sm">
           <thead>
             <tr>
               {this.props.columnData.map(data => {
@@ -153,29 +153,28 @@ class CustomTable extends React.Component {
             </tr>
           </thead>
           <tbody>
-            {this.props.rowData.map((data, row) => {
+            {this.props.rowData.map((rowData, rowIndex) => {
               return (
-                <tr key={row} id={data.id ? data.id : row}>
-                  {Object.values(this.props.columnData).map((col, index) => {
-                    let value = data[col.field];
-                    if (col.options) {
+                <tr key={rowIndex} id={rowData.id ? rowData.id : rowIndex} className={this.props.getRowClassName ? this.props.getRowClassName(rowData) : ''}>
+                  {Object.values(this.props.columnData).map((colData, colIndex) => {
+                    let value = rowData[colData.field];
+                    if (colData.options) {
                       // If this column has value options, use the data value as a key to those options
-                      value = col.options[data[col.field]];
-                    } else if (col.filter) {
-                      // If this column has a filter, apply the filter to the value
-                      // Send along string of the ID and HoH bool if needed
-                      value = col.filter(data[col.field], data.id?.toString(), data.is_hoh);
+                      value = colData.options[rowData[colData.field]];
+                    } else if (colData.filter) {
+                      // If this column has a filter function to be applied, send along data and col index
+                      value = colData.filter(value, rowData, colData, rowIndex, colIndex);
                     }
                     return (
-                      <td key={index} className={col.className ? col.className : ''}>
-                        {col.onClick && <span onClick={() => (col.onClick(data.id.toString()) ? col.onClick : null)}>{value}</span>}
-                        {!col.onClick && value}
+                      <td key={colIndex} className={colData.className ? colData.className : ''}>
+                        {colData.onClick && <span onClick={() => (colData.onClick(rowData.id.toString()) ? colData.onClick : null)}>{value}</span>}
+                        {!colData.onClick && value}
                       </td>
                     );
                   })}
                   {this.props.isEditable && (
                     <td>
-                      <div className="float-left edit-button" onClick={() => this.handleEditClick(row)}>
+                      <div className="float-left edit-button" onClick={() => this.handleEditClick(rowIndex)}>
                         <i className="fas fa-edit"></i>
                       </div>
                     </td>
@@ -184,9 +183,8 @@ class CustomTable extends React.Component {
                     <td>
                       <input
                         type="checkbox"
-                        aria-label="Table Select Monitoree Row"
-                        checked={this.props.selectAll || this.props.selectedRows.includes(row)}
-                        onChange={e => this.handleCheckboxChange(e, row)}></input>
+                        checked={this.props.selectAll || this.props.selectedRows.includes(rowIndex)}
+                        onChange={e => this.handleCheckboxChange(e, rowIndex)}></input>
                     </td>
                   )}
                 </tr>
@@ -277,6 +275,7 @@ CustomTable.propTypes = {
   page: PropTypes.number,
   entries: PropTypes.number,
   entryOptions: PropTypes.array,
+  getRowClassName: PropTypes.func,
 };
 
 CustomTable.defaultProps = {

--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -138,68 +138,71 @@ class CustomTable extends React.Component {
             <Spinner variant="secondary" animation="border" size="lg" />
           </div>
         )}
-        <Table responsive striped bordered hover size="sm">
-          <thead>
-            <tr>
-              {this.props.columnData.map(data => {
-                return this.renderTableHeader(data.field, data.label, data.isSortable, data.tooltip, data.icon, data.colWidth);
-              })}
-              {this.props.isEditable && <th>Edit</th>}
-              {this.props.isSelectable && (
-                <th>
-                  <input type="checkbox" onChange={this.toggleSelectAll} checked={this.props.selectAll} aria-label="Table Monitoree Select All"></input>
-                </th>
-              )}
-            </tr>
-          </thead>
-          <tbody>
-            {this.props.rowData?.map((rowData, rowIndex) => {
-              return (
-                <tr key={rowIndex} id={rowData.id ? rowData.id : rowIndex} className={this.props.getRowClassName ? this.props.getRowClassName(rowData) : ''}>
-                  {Object.values(this.props.columnData).map((colData, colIndex) => {
-                    let value = rowData[colData.field];
-                    if (colData.options) {
-                      // If this column has value options, use the data value as a key to those options
-                      value = colData.options[rowData[colData.field]];
-                    } else if (colData.filter) {
-                      // If this column has a filter function to be applied, send along data for filter to use as it wishes
-                      const filterData = { value: value, rowData: rowData, colData: colData, rowIndex: rowIndex, colIndex: colIndex };
-                      value = colData.filter(filterData);
-                    }
-                    return (
-                      <td key={colIndex} className={colData.className ? colData.className : ''}>
-                        {colData.onClick && <span onClick={() => (colData.onClick(rowData.id.toString()) ? colData.onClick : null)}>{value}</span>}
-                        {!colData.onClick && value}
-                      </td>
-                    );
-                  })}
-                  {this.props.isEditable && (
-                    <td>
-                      <div className="float-left edit-button" onClick={() => this.handleEditClick(rowIndex)}>
-                        <i className="fas fa-edit"></i>
-                      </div>
-                    </td>
-                  )}
-                  {this.props.isSelectable && (
-                    <td>
-                      <input
-                        type="checkbox"
-                        checked={this.props.selectAll || this.props.selectedRows.includes(rowIndex)}
-                        onChange={e => this.handleCheckboxChange(e, rowIndex)}></input>
-                    </td>
-                  )}
-                </tr>
-              );
-            })}
-            {!this.props.rowData?.length && (
+        <div></div>
+        <div className={this.props.getCustomTableClassName ? `table-responsive ${this.props.getCustomTableClassName()}` : 'table-responsive'}>
+          <Table striped bordered hover size="sm">
+            <thead>
               <tr>
-                <td colSpan={this.props.columnData?.length} className="text-center">
-                  No data available in table.
-                </td>
+                {this.props.columnData.map(data => {
+                  return this.renderTableHeader(data.field, data.label, data.isSortable, data.tooltip, data.icon, data.colWidth);
+                })}
+                {this.props.isEditable && <th>Edit</th>}
+                {this.props.isSelectable && (
+                  <th>
+                    <input type="checkbox" onChange={this.toggleSelectAll} checked={this.props.selectAll}></input>
+                  </th>
+                )}
               </tr>
-            )}
-          </tbody>
-        </Table>
+            </thead>
+            <tbody>
+              {this.props.rowData?.map((rowData, rowIndex) => {
+                return (
+                  <tr key={rowIndex} id={rowData.id ? rowData.id : rowIndex} className={this.props.getRowClassName ? this.props.getRowClassName(rowData) : ''}>
+                    {Object.values(this.props.columnData).map((colData, colIndex) => {
+                      let value = rowData[colData.field];
+                      if (colData.options) {
+                        // If this column has value options, use the data value as a key to those options
+                        value = colData.options[rowData[colData.field]];
+                      } else if (colData.filter) {
+                        // If this column has a filter function to be applied, send along data for filter to use as it wishes
+                        const filterData = { value: value, rowData: rowData, colData: colData, rowIndex: rowIndex, colIndex: colIndex };
+                        value = colData.filter(filterData);
+                      }
+                      return (
+                        <td key={colIndex} className={colData.className ? colData.className : ''}>
+                          {colData.onClick && <span onClick={() => (colData.onClick(rowData.id.toString()) ? colData.onClick : null)}>{value}</span>}
+                          {!colData.onClick && value}
+                        </td>
+                      );
+                    })}
+                    {this.props.isEditable && (
+                      <td>
+                        <div className="float-left edit-button" onClick={() => this.handleEditClick(rowIndex)}>
+                          <i className="fas fa-edit"></i>
+                        </div>
+                      </td>
+                    )}
+                    {this.props.isSelectable && (
+                      <td>
+                        <input
+                          type="checkbox"
+                          checked={this.props.selectAll || this.props.selectedRows.includes(rowIndex)}
+                          onChange={e => this.handleCheckboxChange(e, rowIndex)}></input>
+                      </td>
+                    )}
+                  </tr>
+                );
+              })}
+              {!this.props.rowData?.length && (
+                <tr>
+                  <td colSpan={this.props.columnData?.length} className="text-center">
+                    No data available in table.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </Table>
+        </div>
         <div className="d-flex justify-content-between">
           <Form inline className="align-middle">
             <Row className="fixed-row-size">
@@ -283,6 +286,7 @@ CustomTable.propTypes = {
   entries: PropTypes.number,
   entryOptions: PropTypes.array,
   getRowClassName: PropTypes.func,
+  getCustomTableClassName: PropTypes.func,
 };
 
 CustomTable.defaultProps = {

--- a/app/javascript/components/patient/PatientReportsTable.js
+++ b/app/javascript/components/patient/PatientReportsTable.js
@@ -1,0 +1,372 @@
+import React from 'react';
+import { Card, DropdownButton, Button, Row, Col, Dropdown, InputGroup, OverlayTrigger, Form, Tooltip } from 'react-bootstrap';
+import { PropTypes } from 'prop-types';
+import CustomTable from '../layout/CustomTable';
+import reportError from '../util/ReportError';
+import LastDateExposure from '../subject/LastDateExposure';
+import CurrentStatus from '../subject/CurrentStatus';
+import ClearReports from '../subject/ClearReports';
+import PauseNotifications from '../subject/PauseNotifications';
+import ContactAttempt from '../subject/ContactAttempt';
+import AddReportNote from '../subject/AddReportNote';
+import ClearSingleReport from '../subject/ClearSingleReport';
+import axios from 'axios';
+import moment from 'moment-timezone';
+import _ from 'lodash';
+import ReportModal from './ReportModal';
+
+class PatientReportsTable extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      table: {
+        colData: [
+          { label: 'Actions', field: '', isSortable: false, filter: this.createActionsButton },
+          { label: 'ID', field: 'id', isSortable: true },
+          { label: 'Needs Review', field: 'symptomatic', isSortable: true },
+          { label: 'Reporter', field: 'who_reported', isSortable: true },
+          { label: 'Created At', field: 'created_at', isSortable: true, filter: this.formatTimestamp },
+        ],
+        rowData: [],
+        totalRows: 0,
+        selectedRows: [],
+        selectAll: false,
+      },
+      query: {
+        page: 0,
+        entries: 10,
+      },
+      entryOptions: [10, 15, 25],
+      cancelToken: axios.CancelToken.source(),
+      isLoading: false,
+      editRow: null,
+      actionsEnabled: false,
+      showReportModal: false,
+    };
+  }
+
+  componentDidMount() {
+    this.populateSymptomCols();
+    this.updateTable(this.state.query);
+  }
+
+  /**
+   * Handles change of input in the search bar. Updates table based on input.
+   * @param {SyntheticEvent} event - Event when the search input changes
+   */
+  handleSearchChange = event => {
+    const value = event.target.value;
+    this.setState(
+      state => {
+        return { query: { ...state.query, search: value } };
+      },
+      () => {
+        this.updateTable(this.state.query);
+      }
+    );
+  };
+
+  populateSymptomCols = () => {
+    for (const symptom of this.props.symptoms) {
+      const symptom_col = { label: symptom.label, field: symptom.name, isSortable: true, filter: this.filterSymptomCell };
+      this.setState(state => {
+        const updated_table_data = { ...state.table };
+        updated_table_data.colData.push(symptom_col);
+        return {
+          table: updated_table_data,
+        };
+      });
+    }
+  };
+
+  // eslint-disable-next-line no-unused-vars
+  filterSymptomCell = (value, rowData, colData, rowIndex, colIndex) => {
+    const symptomName = colData.field;
+    const passesThreshold = rowData.passes_threshold_data[symptomName.toString()];
+    const className = passesThreshold ? 'concern' : '';
+    return <span className={className}>{value}</span>;
+  };
+
+  /**
+   * Called when table data is to be updated because of some change to the table setting.
+   * @param {Object} query - Updated query for table data after change.
+   */
+  updateTable = query => {
+    // cancel any previous unfinished requests to prevent race condition inconsistencies
+    this.state.cancelToken.cancel();
+
+    // generate new cancel token for this request
+    const cancelToken = axios.CancelToken.source();
+
+    this.setState({ query, cancelToken, isLoading: true }, () => {
+      this.queryServer(query);
+    });
+  };
+
+  /**
+   * Returns updated table data via an axios POST request.
+   */
+  queryServer = _.debounce(query => {
+    axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
+    axios
+      .post('/patients/' + this.props.patient.id + '/assessments/table', {
+        patient_id: this.props.patient.id,
+        ...query,
+        cancelToken: this.state.cancelToken.token,
+      })
+      .catch(error => {
+        if (!axios.isCancel(error)) {
+          this.setState(state => {
+            return {
+              table: { ...state.table, rowData: [], totalRows: 0 },
+              isLoading: false,
+            };
+          });
+        } else {
+          reportError(error);
+          this.setState({ isLoading: false });
+        }
+      })
+      .then(response => {
+        if (response && response.data && response.data) {
+          console.log(response.data);
+          this.setState(state => {
+            return {
+              table: { ...state.table, rowData: response.data.table_data, totalRows: response.data.total },
+              isLoading: false,
+            };
+          });
+        } else {
+          this.setState({ isLoading: false });
+        }
+      });
+  }, 500);
+
+  /**
+   * Formats values in the timestamp column to be human readable
+   * @param {String} timestamp
+   */
+  // eslint-disable-next-line no-unused-vars
+  formatTimestamp(timestamp, rowData, colData, rowIndex, colIndex) {
+    const ts = moment.tz(timestamp, 'UTC');
+    return ts.isValid() ? ts.tz(moment.tz.guess()).format('MM/DD/YYYY HH:mm z') : '';
+  }
+
+  /**
+   * Called when table is to be updated because of a sorting change.
+   * @param {Object} query - Updated query for table data after change.
+   */
+  handleTableUpdate = query => {
+    this.setState(
+      state => ({
+        query: { ...state.query, ...query },
+      }),
+      () => {
+        this.updateTable(this.state.query);
+      }
+    );
+  };
+
+  /**
+   * Called when the number of entries to be shown on a page changes.
+   * Updates state and then calls table update handler.
+   * @param {SyntheticEvent} event - Event when num entries changes
+   */
+  handleEntriesChange = event => {
+    const value = event.target.value;
+    this.setState(
+      state => {
+        return {
+          query: { ...state.query, entries: value },
+        };
+      },
+      () => {
+        this.updateTable(this.state.query);
+      }
+    );
+  };
+
+  /**
+   * Called when a page is clicked in the pagination component.
+   * Updates the table based on the selected page.
+   * @param {Object} page - Page object from react-paginate
+   */
+  handlePageUpdate = page => {
+    this.setState(
+      state => {
+        return {
+          query: { ...state.query, page: page.selected },
+        };
+      },
+      () => {
+        this.updateTable(this.state.query);
+      }
+    );
+  };
+
+  /**
+   * Called when the Add User button is clicked.
+   * Updates the state to show the appropriate modal for adding a user.
+   */
+  handleAddReportClick = () => {
+    this.setState({
+      showAddReportModal: true,
+    });
+  };
+
+  /**
+   * Closes the add report modal by updating state.
+   */
+  handleAddReportModalClose = () => {
+    this.setState({
+      showAddReportModal: false,
+    });
+  };
+
+  /**
+   * Called when the Add User button is clicked.
+   * Updates the state to show the appropriate modal for adding a user.
+   */
+  handleEditReportClick = row => {
+    this.setState({
+      showEditReportModal: true,
+      editRow: row,
+    });
+  };
+
+  /**
+   * Closes the edit report modal by updating state.
+   */
+  handleEditReportModalClose = () => {
+    this.setState({
+      showEditReportModal: false,
+      editRow: null,
+    });
+  };
+
+  // eslint-disable-next-line no-unused-vars
+  createActionsButton = (value, rowData, colData, rowIndex, colIndex) => {
+    return (
+      <DropdownButton
+        size="sm"
+        variant="primary"
+        title={
+          <React.Fragment>
+            <i className="fas fa-cogs fw"></i>
+          </React.Fragment>
+        }>
+        <Dropdown.Item className="px-4" onClick={() => this.handleEditReportClick(rowIndex)}>
+          <i className="fas fa-edit fa-fw"></i>
+          <span className="ml-2">Edit</span>
+        </Dropdown.Item>
+        <AddReportNote assessment={rowData} patient={this.props.patient} authenticity_token={this.props.authenticity_token} />
+        <ClearSingleReport assessment_id={rowData.id} patient={this.props.patient} authenticity_token={this.props.authenticity_token} />
+      </DropdownButton>
+    );
+  };
+
+  getRowClassName = rowData => {
+    return rowData.symptomatic === 'Yes' ? 'table-danger' : '';
+  };
+
+  render() {
+    return (
+      <React.Fragment>
+        <Card className="mx-2 mt-3 mb-4 card-square">
+          <Card.Header className="h5">Reports</Card.Header>
+          <Card.Body>
+            <div className="mt-4">
+              <CurrentStatus report_eligibility={this.props.report_eligibility} status={this.props.patient_status} isolation={this.props.patient?.isolation} />
+              <Row className="my-4">
+                <Col>
+                  <Button variant="primary" className="mr-2" onClick={this.handleAddReportClick}>
+                    <i className="fas fa-plus fa-fw"></i>
+                    <span className="ml-2">Add New Report</span>
+                  </Button>
+                  <ClearReports authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
+                  <PauseNotifications authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
+                  <ContactAttempt authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
+                </Col>
+                <Col lg={5}>
+                  <InputGroup size="md">
+                    <InputGroup.Prepend>
+                      <OverlayTrigger overlay={<Tooltip>Search by id or reporter.</Tooltip>}>
+                        <InputGroup.Text className="rounded-0">
+                          <i className="fas fa-search"></i>
+                          <span className="ml-1">Search</span>
+                        </InputGroup.Text>
+                      </OverlayTrigger>
+                    </InputGroup.Prepend>
+                    <Form.Control id="search-input" autoComplete="off" size="md" name="search" onChange={this.handleSearchChange} />
+                  </InputGroup>
+                </Col>
+              </Row>
+              <CustomTable
+                columnData={this.state.table.colData}
+                rowData={this.state.table.rowData}
+                totalRows={this.state.table.totalRows}
+                handleTableUpdate={query => this.updateTable({ ...this.state.query, order: query.orderBy, page: query.page, direction: query.sortDirection })}
+                handleEntriesChange={this.handleEntriesChange}
+                isLoading={this.state.isLoading}
+                page={this.state.query.page}
+                handlePageUpdate={this.handlePageUpdate}
+                entryOptions={this.state.entryOptions}
+                entries={this.state.query.entries}
+                getRowClassName={this.getRowClassName}
+              />
+            </div>
+            <LastDateExposure
+              authenticity_token={this.props.authenticity_token}
+              patient={this.props.patient}
+              is_household_member={this.props.is_household_member}
+              monitoring_period_days={this.props.monitoring_period_days}
+            />
+          </Card.Body>
+        </Card>
+        {this.state.showAddReportModal && (
+          <ReportModal
+            show={this.state.showAddReportModal}
+            onClose={this.handleAddReportModalClose}
+            current_user={this.props.current_user}
+            symptoms={this.props.symptoms}
+            patient={this.props.patient}
+            authenticity_token={this.props.authenticity_token}
+            translations={this.props.translations}
+            calculated_age={this.props.calculated_age}
+            mode="create"
+          />
+        )}
+        {this.state.showEditReportModal && (
+          <ReportModal
+            show={this.state.showEditReportModal}
+            onClose={this.handleEditReportModalClose}
+            current_user={this.props.current_user}
+            assessment={this.state.table.rowData[this.state.editRow]}
+            threshold_condition_hash={this.state.table.rowData[this.state.editRow].threshold_condition_hash}
+            symptoms={this.state.table.rowData[this.state.editRow].symptoms}
+            patient={this.props.patient}
+            authenticity_token={this.props.authenticity_token}
+            translations={this.props.translations}
+            calculated_age={this.props.calculated_age}
+            mode="edit"
+          />
+        )}
+      </React.Fragment>
+    );
+  }
+}
+
+PatientReportsTable.propTypes = {
+  patient: PropTypes.object,
+  symptoms: PropTypes.array,
+  is_household_member: PropTypes.bool,
+  report_eligibility: PropTypes.object,
+  patient_status: PropTypes.string,
+  calculated_age: PropTypes.number,
+  monitoring_period_days: PropTypes.number,
+  current_user: PropTypes.object,
+  translations: PropTypes.object,
+  authenticity_token: PropTypes.string,
+};
+
+export default PatientReportsTable;

--- a/app/javascript/components/patient/PatientReportsTable.js
+++ b/app/javascript/components/patient/PatientReportsTable.js
@@ -383,6 +383,7 @@ class PatientReportsTable extends React.Component {
             threshold_condition_hash={this.props.threshold_condition_hash}
             symptoms={this.props.symptoms}
             patient={this.props.patient}
+            patient_initials={this.props.patient_initials}
             authenticity_token={this.props.authenticity_token}
             translations={this.props.translations}
             calculated_age={this.props.calculated_age}
@@ -398,6 +399,7 @@ class PatientReportsTable extends React.Component {
             threshold_condition_hash={this.state.table.rowData[this.state.editRow].threshold_condition_hash}
             symptoms={this.state.table.rowData[this.state.editRow].symptoms}
             patient={this.props.patient}
+            patient_initials={this.props.patient_initials}
             authenticity_token={this.props.authenticity_token}
             translations={this.props.translations}
             calculated_age={this.props.calculated_age}
@@ -418,6 +420,7 @@ PatientReportsTable.propTypes = {
   report_eligibility: PropTypes.object,
   patient_status: PropTypes.string,
   calculated_age: PropTypes.number,
+  patient_initials: PropTypes.string,
   monitoring_period_days: PropTypes.number,
   current_user: PropTypes.object,
   translations: PropTypes.object,

--- a/app/javascript/components/patient/PatientReportsTable.js
+++ b/app/javascript/components/patient/PatientReportsTable.js
@@ -23,7 +23,9 @@ class PatientReportsTable extends React.Component {
         colData: [
           { label: 'Actions', field: '', isSortable: false, filter: this.createActionsButton },
           { label: 'ID', field: 'id', isSortable: true },
-          { label: 'Needs Review', field: 'symptomatic', isSortable: true },
+          // NOTE: This column is only shown in the Exposure workflow. There is a check when the table data
+          // is initially loaded that removes this column data if the Patient is in the Isolation workflow.
+          { label: 'Needs Review', field: 'symptomatic', isSortable: true, tooltip: 'exposureNeedsReviewColumn' },
           { label: 'Reporter', field: 'who_reported', isSortable: true },
           { label: 'Created At', field: 'created_at', isSortable: true, filter: this.formatTimestamp },
         ],
@@ -103,6 +105,10 @@ class PatientReportsTable extends React.Component {
             if (isInitialLoad) {
               const symptomColData = this.getSymptomCols(response.data.symptoms);
               updatedColData = state.table.colData.concat(symptomColData);
+              // Only show the Needs Review column if the patient is in the Exposure workflow
+              if (this.props.patient.isolation) {
+                delete updatedColData[2];
+              }
             }
             return {
               table: {

--- a/app/javascript/components/patient/PatientReportsTable.js
+++ b/app/javascript/components/patient/PatientReportsTable.js
@@ -40,7 +40,6 @@ class PatientReportsTable extends React.Component {
       cancelToken: axios.CancelToken.source(),
       isLoading: false,
       editRow: null,
-      actionsEnabled: false,
       showReportModal: false,
     };
   }
@@ -333,12 +332,14 @@ class PatientReportsTable extends React.Component {
           <ReportModal
             show={this.state.showAddReportModal}
             onClose={this.handleAddReportModalClose}
+            assessment={{}}
             current_user={this.props.current_user}
             symptoms={this.props.symptoms}
             patient={this.props.patient}
             authenticity_token={this.props.authenticity_token}
             translations={this.props.translations}
             calculated_age={this.props.calculated_age}
+            idPre={'new'}
             mode="create"
           />
         )}
@@ -346,15 +347,16 @@ class PatientReportsTable extends React.Component {
           <ReportModal
             show={this.state.showEditReportModal}
             onClose={this.handleEditReportModalClose}
-            current_user={this.props.current_user}
             assessment={this.state.table.rowData[this.state.editRow]}
+            current_user={this.props.current_user}
             threshold_condition_hash={this.state.table.rowData[this.state.editRow].threshold_condition_hash}
             symptoms={this.state.table.rowData[this.state.editRow].symptoms}
             patient={this.props.patient}
             authenticity_token={this.props.authenticity_token}
             translations={this.props.translations}
             calculated_age={this.props.calculated_age}
-            mode="edit"
+            updateId={this.state.table.rowData[this.state.editRow].id}
+            idPre={this.state.table.rowData[this.state.editRow].id.toString()}
           />
         )}
       </React.Fragment>

--- a/app/javascript/components/patient/PatientReportsTable.js
+++ b/app/javascript/components/patient/PatientReportsTable.js
@@ -192,7 +192,7 @@ class PatientReportsTable extends React.Component {
   };
 
   /**
-   * Called when the number of entries to be shown on a page changes.
+   * Called when the number of entries to be shown on a page changes. Resets page to be 0.
    * Updates state and then calls table update handler.
    * @param {SyntheticEvent} event - Event when num entries changes
    */
@@ -201,7 +201,7 @@ class PatientReportsTable extends React.Component {
     this.setState(
       state => {
         return {
-          query: { ...state.query, entries: value },
+          query: { ...state.query, entries: value, page: 0 },
         };
       },
       () => {

--- a/app/javascript/components/patient/ReportModal.js
+++ b/app/javascript/components/patient/ReportModal.js
@@ -15,16 +15,17 @@ class ReportModal extends React.Component {
         <Modal.Body>
           <Assessment
             current_user={this.props.current_user}
-            assessment={this.props.mode === 'edit' ? this.props.assessment : {}}
+            assessment={this.props.assessment}
             threshold_hash={this.props.threshold_condition_hash}
             symptoms={this.props.symptoms}
-            idPre={this.props.mode === 'edit' ? this.props.assessment.id.toString() : 'new'}
+            idPre={this.props.idPre}
             patient_submission_token={this.props.patient.submission_token}
             patient_initials={this.props.patient.initials}
             patient_age={this.props.calculated_age}
             authenticity_token={this.props.authenticity_token}
             reload={true}
             patient_id={this.props.patient.id}
+            updateId={this.props.updateId}
             translations={this.props.translations}
             lang={'en'}
           />
@@ -41,11 +42,12 @@ ReportModal.propTypes = {
   assessment: PropTypes.object,
   threshold_hash: PropTypes.string,
   symptoms: PropTypes.array,
-  mode: PropTypes.string,
   translations: PropTypes.object,
   patient: PropTypes.object,
   calculated_age: PropTypes.number,
   threshold_condition_hash: PropTypes.string,
+  updateId: PropTypes.number,
+  idPre: PropTypes.string,
   authenticity_token: PropTypes.string,
 };
 

--- a/app/javascript/components/patient/ReportModal.js
+++ b/app/javascript/components/patient/ReportModal.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Modal } from 'react-bootstrap';
+import { PropTypes } from 'prop-types';
+import Assessment from '../assessment/Assessment';
+
+class ReportModal extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <Modal show={this.props.show} onHide={this.props.onClose} backdrop="static" aria-labelledby="contained-modal-title-vcenter" centered>
+        <Modal.Header closeButton></Modal.Header>
+        <Modal.Body>
+          <Assessment
+            current_user={this.props.current_user}
+            assessment={this.props.mode === 'edit' ? this.props.assessment : {}}
+            threshold_hash={this.props.threshold_condition_hash}
+            symptoms={this.props.symptoms}
+            idPre={this.props.mode === 'edit' ? this.props.assessment.id.toString() : 'new'}
+            patient_submission_token={this.props.patient.submission_token}
+            patient_initials={this.props.patient.initials}
+            patient_age={this.props.calculated_age}
+            authenticity_token={this.props.authenticity_token}
+            reload={true}
+            patient_id={this.props.patient.id}
+            translations={this.props.translations}
+            lang={'en'}
+          />
+        </Modal.Body>
+      </Modal>
+    );
+  }
+}
+
+ReportModal.propTypes = {
+  show: PropTypes.bool,
+  onClose: PropTypes.func,
+  current_user: PropTypes.object,
+  assessment: PropTypes.object,
+  threshold_hash: PropTypes.string,
+  symptoms: PropTypes.array,
+  mode: PropTypes.string,
+  translations: PropTypes.object,
+  patient: PropTypes.object,
+  calculated_age: PropTypes.number,
+  threshold_condition_hash: PropTypes.string,
+  authenticity_token: PropTypes.string,
+};
+
+export default ReportModal;

--- a/app/javascript/components/patient/ReportModal.js
+++ b/app/javascript/components/patient/ReportModal.js
@@ -40,7 +40,6 @@ ReportModal.propTypes = {
   onClose: PropTypes.func,
   current_user: PropTypes.object,
   assessment: PropTypes.object,
-  threshold_hash: PropTypes.string,
   symptoms: PropTypes.array,
   translations: PropTypes.object,
   patient: PropTypes.object,

--- a/app/javascript/components/patient/ReportModal.js
+++ b/app/javascript/components/patient/ReportModal.js
@@ -20,7 +20,7 @@ class ReportModal extends React.Component {
             symptoms={this.props.symptoms}
             idPre={this.props.idPre}
             patient_submission_token={this.props.patient.submission_token}
-            patient_initials={this.props.patient.initials}
+            patient_initials={this.props.patient_initials}
             patient_age={this.props.calculated_age}
             authenticity_token={this.props.authenticity_token}
             reload={true}
@@ -44,6 +44,7 @@ ReportModal.propTypes = {
   translations: PropTypes.object,
   patient: PropTypes.object,
   calculated_age: PropTypes.number,
+  patient_initials: PropTypes.string,
   threshold_condition_hash: PropTypes.string,
   updateId: PropTypes.number,
   idPre: PropTypes.string,

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -369,8 +369,9 @@ class PatientsTable extends React.Component {
     }
   }
 
-  // eslint-disable-next-line no-unused-vars
-  linkPatient = (name, rowData, colData) => {
+  linkPatient = data => {
+    const name = data.value;
+    const rowData = data.rowData;
     if (this.state.query.tab === 'transferred_out') {
       return name;
     }
@@ -385,27 +386,28 @@ class PatientsTable extends React.Component {
     return <a href={`/patients/${rowData.id}`}>{name}</a>;
   };
 
-  // eslint-disable-next-line no-unused-vars
-  formatTimestamp(timestamp, rowData, colData, rowIndex, colIndex) {
+  formatTimestamp(data) {
+    const timestamp = data.value;
     const ts = moment.tz(timestamp, 'UTC');
     return ts.isValid() ? ts.tz(moment.tz.guess()).format('MM/DD/YYYY HH:mm z') : '';
   }
 
-  // eslint-disable-next-line no-unused-vars
-  formatDate(date, rowData, colData, rowIndex, colIndex) {
+  formatDate(data) {
+    const date = data.value;
     return date ? moment(date, 'YYYY-MM-DD').format('MM/DD/YYYY') : '';
   }
 
-  // eslint-disable-next-line no-unused-vars
-  formatEndOfMonitoring(endOfMonitoring, rowData, colData, rowIndex, colIndex) {
+  formatEndOfMonitoring(data) {
+    const endOfMonitoring = data.value;
     if (endOfMonitoring === 'Continuous Exposure') {
       return 'Continuous Exposure';
     }
     return moment(endOfMonitoring, 'YYYY-MM-DD').format('MM/DD/YYYY');
   }
 
-  // eslint-disable-next-line no-unused-vars
-  createEligibilityTooltip(reportEligibility, rowData, colData, rowIndex, colIndex) {
+  createEligibilityTooltip(data) {
+    const reportEligibility = data.value;
+    const rowData = data.rowData;
     return <EligibilityTooltip id={rowData.id.toString()} report_eligibility={reportEligibility} inline={false} />;
   }
 

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -369,39 +369,44 @@ class PatientsTable extends React.Component {
     }
   }
 
-  linkPatient = (name, id, isHoH) => {
+  // eslint-disable-next-line no-unused-vars
+  linkPatient = (name, rowData, colData) => {
     if (this.state.query.tab === 'transferred_out') {
       return name;
     }
-    if (isHoH) {
+    if (rowData.is_hoh) {
       return (
         <div>
-          <BadgeHOH patientId={id} customClass={'badge-hoh ml-1'} location={'right'} />
-          <a href={`/patients/${id}`}>{name}</a>
+          <BadgeHOH patientId={rowData.id.toString()} customClass={'badge-hoh ml-1'} location={'right'} />
+          <a href={`/patients/${rowData.id}`}>{name}</a>
         </div>
       );
     }
-    return <a href={`/patients/${id}`}>{name}</a>;
+    return <a href={`/patients/${rowData.id}`}>{name}</a>;
   };
 
-  formatTimestamp(timestamp) {
+  // eslint-disable-next-line no-unused-vars
+  formatTimestamp(timestamp, rowData, colData, rowIndex, colIndex) {
     const ts = moment.tz(timestamp, 'UTC');
     return ts.isValid() ? ts.tz(moment.tz.guess()).format('MM/DD/YYYY HH:mm z') : '';
   }
 
-  formatDate(date) {
+  // eslint-disable-next-line no-unused-vars
+  formatDate(date, rowData, colData, rowIndex, colIndex) {
     return date ? moment(date, 'YYYY-MM-DD').format('MM/DD/YYYY') : '';
   }
 
-  formatEndOfMonitoring(endOfMonitoring) {
+  // eslint-disable-next-line no-unused-vars
+  formatEndOfMonitoring(endOfMonitoring, rowData, colData, rowIndex, colIndex) {
     if (endOfMonitoring === 'Continuous Exposure') {
       return 'Continuous Exposure';
     }
     return moment(endOfMonitoring, 'YYYY-MM-DD').format('MM/DD/YYYY');
   }
 
-  createEligibilityTooltip(reportEligibility, patientId) {
-    return <EligibilityTooltip id={patientId} report_eligibility={reportEligibility} inline={false} />;
+  // eslint-disable-next-line no-unused-vars
+  createEligibilityTooltip(reportEligibility, rowData, colData, rowIndex, colIndex) {
+    return <EligibilityTooltip id={rowData.id.toString()} report_eligibility={reportEligibility} inline={false} />;
   }
 
   render() {

--- a/app/javascript/packs/stylesheets/bootstrap.scss
+++ b/app/javascript/packs/stylesheets/bootstrap.scss
@@ -272,3 +272,10 @@ select.form-control {
   word-break: break-all;
 }
 
+// This is we deal with slight vertical overflow from a dropdown in a table that needs to be horizontal scrollable.
+// See this for the core issue: https://stackoverflow.com/a/6433475
+.reports-table{
+  padding-top: 80px;
+  margin-top: -80px;
+}
+

--- a/app/javascript/packs/stylesheets/bootstrap.scss
+++ b/app/javascript/packs/stylesheets/bootstrap.scss
@@ -271,3 +271,4 @@ select.form-control {
 .wrap {
   word-break: break-all;
 }
+

--- a/app/javascript/packs/stylesheets/bootstrap.scss
+++ b/app/javascript/packs/stylesheets/bootstrap.scss
@@ -272,7 +272,7 @@ select.form-control {
   word-break: break-all;
 }
 
-// This is we deal with slight vertical overflow from a dropdown in a table that needs to be horizontal scrollable.
+// This is how we deal with slight vertical overflow from a dropdown in a table that needs to be horizontal scrollable.
 // See this for the core issue: https://stackoverflow.com/a/6433475
 .reports-table{
   padding-top: 80px;

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -93,11 +93,11 @@ class Assessment < ApplicationRecord
     reported_condition&.symptoms&.find_by(name: symptom_name)
   end
 
-  # Gets all symptom names for a given array of assessment IDs.
-  def self.get_symptom_names_for_assessments(assessment_ids)
+  # Gets all unique symptoms (based on name) for a given array of assessment IDs.
+  def self.get_unique_symptoms_for_assessments(assessment_ids)
     threshold_cond_hashes = ReportedCondition.where(type: 'ReportedCondition', assessment_id: assessment_ids).pluck(:threshold_condition_hash)
     condition_ids = ThresholdCondition.where(type: 'ThresholdCondition', threshold_condition_hash: threshold_cond_hashes)
-    Symptom.where(condition_id: condition_ids).pluck(:name).uniq.sort
+    Symptom.where(condition_id: condition_ids).uniq(&:name)
   end
 
   def translations

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -2,6 +2,8 @@
 
 # Assessment: assessment model
 class Assessment < ApplicationRecord
+  extend OrderAsSpecified
+
   columns.each do |column|
     case column.type
     when :text

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -95,7 +95,7 @@ class Assessment < ApplicationRecord
   def self.get_symptom_names_for_assessments(assessment_ids)
     threshold_cond_hashes = ReportedCondition.where(type: 'ReportedCondition', assessment_id: assessment_ids).pluck(:threshold_condition_hash)
     condition_ids = ThresholdCondition.where(type: 'ThresholdCondition', threshold_condition_hash: threshold_cond_hashes)
-    Symptom.where(condition_id: condition_ids).pluck(:name)
+    Symptom.where(condition_id: condition_ids).pluck(:name).uniq.sort
   end
 
   def translations

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -35,9 +35,11 @@
 </div>
 <% end %>
 
+<%reporting_condition = @patient.jurisdiction.hierarchical_condition_unpopulated_symptoms%>
 <%= react_component('patient/PatientReportsTable', {
                       patient: @patient,
-                      symptoms: @patient.jurisdiction.hierarchical_condition_unpopulated_symptoms.symptoms.uniq,
+                      symptoms: reporting_condition.symptoms,
+                      threshold_condition_hash: reporting_condition.threshold_condition_hash,
                       is_household_member: @household_members.count > 1,
                       report_eligibility: @patient.report_eligibility,
                       patient_status: @patient.status,

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -38,12 +38,13 @@
 <%reporting_condition = @patient.jurisdiction.hierarchical_condition_unpopulated_symptoms%>
 <%= react_component('patient/PatientReportsTable', {
                       patient: @patient,
-                      symptoms: reporting_condition.symptoms,
-                      threshold_condition_hash: reporting_condition.threshold_condition_hash,
                       is_household_member: @household_members.count > 1,
                       report_eligibility: @patient.report_eligibility,
                       patient_status: @patient.status,
                       calculated_age: @patient.calc_current_age,
+                      patient_initials: @patient.initials,
+                      symptoms: reporting_condition.symptoms,
+                      threshold_condition_hash: reporting_condition.threshold_condition_hash,
                       monitoring_period_days: ADMIN_OPTIONS['monitoring_period_days'].to_i,
                       current_user: current_user,
                       translations: Assessment.new.translations,

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -37,7 +37,7 @@
 
 <%= react_component('patient/PatientReportsTable', {
                       patient: @patient,
-                      symptoms: @patient.jurisdiction.hierarchical_condition_unpopulated_symptoms.symptoms,
+                      symptoms: @patient.jurisdiction.hierarchical_condition_unpopulated_symptoms.symptoms.uniq,
                       is_household_member: @household_members.count > 1,
                       report_eligibility: @patient.report_eligibility,
                       patient_status: @patient.status,

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -35,159 +35,18 @@
 </div>
 <% end %>
 
-<% if current_user.can_view_patient_assessments? %>
-<div class="modal fade" tabindex="-1" role="dialog" id="modal-new">
-  <div class="modal-dialog modal-dialog-centered" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
-      <div class="modal-body">
-        <%reporting_condition = @patient.jurisdiction.hierarchical_condition_unpopulated_symptoms%>
-        <%= react_component('assessment/Assessment', {
-                              current_user: current_user,
-                              assessment: {},
-                              threshold_hash: reporting_condition.threshold_condition_hash,
-                              symptoms: reporting_condition.symptoms,
-                              idPre: 'new',
-                              patient_submission_token: @patient.submission_token,
-                              patient_initials: @patient.initials,
-                              patient_age: @patient.calc_current_age,
-                              authenticity_token: form_authenticity_token,
-                              reload: true,
-                              patient_id: @patient.id,
-                              translations: Assessment.new.translations,
-                              lang: 'en'
-                            }) %>
-      </div>
-    </div>
-  </div>
-</div>
-<div class="card mx-2 mt-3 mb-4 card-square">
-  <div class="card-header h5"> Reports</div>
-  <div class="m-4">
-    <%= react_component('subject/CurrentStatus', { report_eligibility: @patient.report_eligibility, status: @patient.status, isolation: @patient.isolation }) %>
-    <div class="pb-4 pt-2">
-      <div class="btn-group" role="group">
-        <button type="button" class="btn btn-primary mr-2" data-toggle="modal" data-target="#modal-new"><i class="fas fa-plus"></i> Add New Report</button>
-        <% unless @patient.isolation %>
-        <%= react_component('subject/ClearReports', { authenticity_token: form_authenticity_token, patient: @patient }) %>
-        <% end %>
-        <%= react_component('subject/PauseNotifications', { authenticity_token: form_authenticity_token, patient: @patient }) %>
-        <%= react_component('subject/ContactAttempt', { authenticity_token: form_authenticity_token, patient: @patient }) %>
-      </div>
-    </div>
-    <% columns = Assessment.get_symptom_names_for_assessments(@patient.assessments.pluck(:id)) %>
-    <% columns = columns.uniq.sort %>
-    <table class="assessment_table table table-sm table-striped table-bordered table-hover table-smaller-font">
-      <thead>
-        <tr>
-          <th class="DataTable-table-header">ID</th>
-          <% unless @patient.isolation %>
-          <th class="DataTable-table-header dt-a-w-50">Needs Review <%= react_component('util/InfoTooltip', { tooltipTextKey: 'exposureNeedsReviewColumn', location: 'right' }, { style: 'display:inline' }) %></th>
-          <% end %>
-          <th class="DataTable-table-header">Reporter</th>
-          <th class="DataTable-table-header">Created</th>
-          <% columns.each do |column| -%>
-          <th class="DataTable-table-header dt-a-w-75"><%= column&.titleize %></th>
-          <% end -%>
-          <th class="DataTable-table-header">Actions</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @assessments.each do |assessment| -%>
-        <% if assessment.symptomatic %>
-          <tr class="table-danger">
-        <% else %>
-          <tr>
-        <% end %>
-        <td><%= assessment.id %></td>
-        <% unless @patient.isolation %>
-        <td><% if assessment.symptomatic %>Yes<% else %>No<% end %></td>
-        <% end %>
-        <td><%= assessment.who_reported %></td>
-        <td><%= local_time(assessment.created_at, '%Y-%m-%d %H:%M %Z') %></td>
-        <% columns.each do |column| -%>
-        <% reported_condition = assessment.get_reported_symptom_by_name(column)%>
-        <% if reported_condition == nil %>
-        <td></td>
-        <% end %>
-        <% passes_threshold = assessment.symptom_passes_threshold(column) %>
-        <% symptom_value = reported_condition&.value %>
-        <% if reported_condition&.type == "BoolSymptom"%>
-        <% if symptom_value == true %>
-        <% symptom_value = 'Yes' %>
-        <% elsif symptom_value == false %>
-        <% symptom_value = 'No'%>
-        <%end%>
-        <td><% if passes_threshold==true -%><span class="concern"><%=symptom_value%></span><% elsif passes_threshold==false -%><%=symptom_value%><%else -%><% end -%></td>
-        <% end %>
-        <% if reported_condition&.type == "FloatSymptom" || reported_condition&.type == "IntegerSymptom"%>
-        <td><% if passes_threshold==true -%><span class="concern"><%=symptom_value%></span><% elsif passes_threshold==false -%><%=symptom_value%><%else -%><% end -%></td>
-        <% end %>
-        <% end -%>
-        <td>
-          <div class="dropdown">
-            <button class="btn btn-sm btn-outline-primary dropdown-toggle btn-block a-dropdown" type="button" id="actionsButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-              <i class="fas fa-cogs fw"></i>
-            </button>
-            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="actionsButton">
-              <button type="button" data-toggle="modal" data-target="#modal-<%= assessment.id %>" class="dropdown-item"><i class="fas fa-edit fa-fw"></i> Edit</button>
-              <%= react_component('subject/AddReportNote', { assessment: assessment, patient: @patient, authenticity_token: form_authenticity_token }) %>
-              <% unless @patient.isolation %>
-              <%= react_component('subject/ClearSingleReport', { assessment_id: assessment.id, patient: @patient, authenticity_token: form_authenticity_token }) %>
-              <% end %>
-            </div>
-          </div>
-        </td>
-      </tr>
-      <% end %>
-      </tbody>
-    </table>
-    <% if @assessments.empty? %>
-      <div class="text-center mb-4">No data available in table.</div>
-    <% end %>
-    <%= react_component('subject/LastDateExposure', {
-                          authenticity_token: form_authenticity_token,
-                          patient: @patient,
-                          is_household_member: @household_members.count > 1,
-                          monitoring_period_days: ADMIN_OPTIONS['monitoring_period_days'].to_i
-                        }) %>
-  </div>
-</div>
-<% @patient.assessments.order('created_at').each do |assessment| -%>
-<div class="modal fade" tabindex="-1" role="dialog" id="<%= 'modal-' + assessment.id.to_s %>" key="<%= 'modal-' + assessment.id.to_s %>">
-  <div class="modal-dialog modal-dialog-centered" role="document">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
-      <div class="modal-body">
-        <%= react_component('assessment/Assessment', {
-                              current_user: current_user,
-                              assessment: assessment,
-                              threshold_hash: assessment&.reported_condition&.threshold_condition_hash,
-                              symptoms: assessment&.reported_condition&.symptoms,
-                              idPre: assessment.id.to_s,
-                              updateId: assessment.id,
-                              patient_submission_token: @patient.submission_token,
-                              patient_initials: @patient.initials,
-                              patient_age: @patient.calc_current_age,
-                              authenticity_token: form_authenticity_token,
-                              reload: true, patient_id: @patient.id,
-                              translations: assessment.translations,
-                              lang: 'en'
-                            }) %>
-      </div>
-    </div>
-  </div>
-</div>
-<% end -%>
-<% end %>
+<%= react_component('patient/PatientReportsTable', {
+                      patient: @patient,
+                      symptoms: @patient.jurisdiction.hierarchical_condition_unpopulated_symptoms.symptoms,
+                      is_household_member: @household_members.count > 1,
+                      report_eligibility: @patient.report_eligibility,
+                      patient_status: @patient.status,
+                      calculated_age: @patient.calc_current_age,
+                      monitoring_period_days: ADMIN_OPTIONS['monitoring_period_days'].to_i,
+                      current_user: current_user,
+                      translations: Assessment.new.translations,
+                      authenticity_token: form_authenticity_token
+                    }) %>
 
 <% if current_user.can_view_patient_laboratories? %>
 <div class="card mx-2 mt-3 mb-4 card-square">
@@ -289,23 +148,6 @@
 
 <script>
   $(document).ready(function() {
-    $('.assessment_table').DataTable({
-      "search": false,
-      "info": false,
-      "lengthMenu": [10, 15, 25, 50],
-      "pageLength": 15,
-      "columnDefs": [{
-        "orderable": false,
-        "targets": -1
-      }],
-      "oLanguage": {
-        "sSearch": "Search Reports:"
-      },
-      "order": [
-        [0, "desc"]
-      ],
-      "dom": "<'row'<'col-sm-24 col-md-12'l><'col-sm-24 col-md-12'f>>" + "<'row'<'table-responsive'<'col-sm-24'tr>>>" + "<'row'<'col-sm-24 col-md-10'i><'col-sm-24 col-md-14'p>>"
-    });
     $('.lab_table').DataTable({
       "search": false,
       "info": false,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,9 +86,7 @@ Rails.application.routes.draw do
   resources :patients, param: :submission_token do
     resources :assessments, only: [:create, :new, :index]
   end
-
-  post '/patients/:patient_id/assessments/table', to: 'assessments#table'
-
+  
   resources :user_filters, only: [:index, :create, :update, :destroy]
 
   resources :user_export_presets, only: [:index, :create, :update, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,8 @@ Rails.application.routes.draw do
     resources :assessments, only: [:create, :new, :index]
   end
 
+  post '/patients/:patient_id/assessments/table', to: 'assessments#table'
+
   resources :user_filters, only: [:index, :create, :update, :destroy]
 
   resources :user_export_presets, only: [:index, :create, :update, :destroy]

--- a/test/system/roles/public_health/patient_page/reports.rb
+++ b/test/system/roles/public_health/patient_page/reports.rb
@@ -23,7 +23,7 @@ class PublicHealthPatientPageReports < ApplicationSystemTestCase
 
   def edit_report(user_label, assessment_id, assessment, submit: true)
     search_for_report(assessment_id)
-    find('button', class: 'a-dropdown').click
+    find("#report-action-button-#{assessment_id}").click
     click_on 'Edit'
     @@assessment_form.submit_assessment(assessment['symptoms'])
     if submit
@@ -40,7 +40,7 @@ class PublicHealthPatientPageReports < ApplicationSystemTestCase
 
   def add_note_to_report(user_label, assessment_id, note, submit: true)
     search_for_report(assessment_id)
-    find('button', class: 'a-dropdown').click
+    find("#report-action-button-#{assessment_id}").click
     click_on 'Add Note'
     fill_in 'comment', with: note
     if submit
@@ -77,6 +77,6 @@ class PublicHealthPatientPageReports < ApplicationSystemTestCase
   end
 
   def search_for_report(query)
-    fill_in 'Search Reports:', with: query
+    fill_in 'reports-search-input', with: query
   end
 end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1111](https://tracker.codev.mitre.org/browse/SARAALERT-1111)

This PR refactors the Patient reports/assessments table from a DataTable to a React component. The purpose for this change is so that we can finally paginate the assessments and gain a huge performance increase as jurisdictions such as GLITC are having trouble loading the Patient page due to many assessments. 

Visual changes:
- Actions button is now the leftmost column for easier access and is in a consistent style with the rest of the application.
- Input for entries per page is now below the table and looks more consistent with other tables in the application.
- Search bar is updated. 

Functional changes:
- Search bar only allows searching by ID or reporter. Before it was sort of a catch all for any text in the table.

NOTE: This also addresses this ticket about table overflow: [SARAALERT-1090](https://tracker.codev.mitre.org/browse/SARAALERT-1090). This was done by adding `responsive` to the `<Table>` element in `CustomTable`. 


# Demo/Screenshots
Before:
![Screen Shot 2020-12-18 at 12 52 14 PM](https://user-images.githubusercontent.com/11698457/102645063-dce20380-412f-11eb-872f-132bf9aab021.png)

After:
![Screen Shot 2020-12-18 at 12 42 10 PM](https://user-images.githubusercontent.com/11698457/102644236-74465700-412e-11eb-8969-32fb5fb3ef72.png)

# Important Changes
`app/views/patients/show.html.erb`
- Removed assessment DataTable and replaced with new React component.

`app/javascript/components/patient/PatientReportsTable.js`
`app/javascript/components/patient/ReportModal.js`
- New React components for table and related modal.

`app/controllers/assessments_controller.rb`
- New action to handle getting data for assessments table. Hit by new route.

`app/helpers/assessment_query_helper.rb`
- Helper methods for filtering/sorting/paginating/formatting assessments table data.

`app/javascript/components/layout/CustomTable.js`
- Clearer variable names
- Passes more params to filter method in colData (if provided)
- Now supports custom row className.

`app/javascript/components/admin/AdminTable.js`
- Updating filter method with new params. 
- Removing unnecessary code about tab,

`app/javascript/components/admin/AuditModal.js`
`app/javascript/components/public_health/PatientsTable.js`
- Updating filter method with new params. 

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

**Please test the following:**
I think I enumerated most of it below, but please review the "Reports" section of the user guide [here](https://saraalert.org/wp-content/uploads/2020/12/Sara-Alert-User-Guide-v1.18.pdf) to understand the expected functionality. I found bugs with this PR by doing so. 
- [ ] All table functionality and buttons is the same as it was before.
    - [ ] Editing reports works
    - [ ] Adding reports works
    - [ ] Marking a report as reviewed works
    - [ ] Adding a note to a report works    
    - [ ] Marking all reports as reviewed works
    - [ ] "Mark All As Reviewed" and "Review" buttons are NOT available in isolation workflow
    - [ ] "Needs Review" column should NOT be shown in isolation workflow
    - [ ] In Exposure workflow, "Needs Review" column should have a tooltip next to it explaining the column
    - [ ] Rows are highlighted red when "needs review" column value is "Yes"
    - [ ] Text of values is highlighted when the value is "Yes" or is a numeric value that passes the threshold provided by the jurisdiction config.
    - [ ] When there is only a single assessment in the table, the actions dropdown should NOT be cut off
    - [ ] When response is received with SMS text and the response is "Yes" the row should be highlighted red by all the symptom col values should be blank
- [ ] Test that functionality is expected when looking a record that has been transferred between jurisdictions with different symptom configurations. Specifically:
    - [ ] Column list of symptoms should be AGGREGATE across all of the record's assessments. So if you transfer a record from USA, State 1 (with pulse ox) to USA, State 2 - it should still show the pulse ox column.
    - [ ] When adding a new record, should only show the current jurisdiction symptom options
    - [ ] When editing an assessment that was created when in a different jurisdiction, should show the options at the time for that assessment (so if it was created when in State 1, should show pulse ox option when editing)
- [ ] The table loads quickly with 500+ legitimate assessments (that have valid symptoms).
- [ ] The table can handle overflow.
- [ ] Admin table was not affected in any way visually/functionally
- [ ] Patient line-lists were not affected in any way visually/functionally