### PR TITLE
SARAALERT-1089: Bold "unless" language in the Review Symptom Report pop up

### DIFF
--- a/app/javascript/components/subject/ClearReports.js
+++ b/app/javascript/components/subject/ClearReports.js
@@ -41,11 +41,11 @@ class ClearReports extends React.Component {
     });
   };
 
-  createModal(title, toggle, submit) {
+  createModal(toggle, submit) {
     return (
       <Modal size="lg" show centered onHide={toggle}>
         <Modal.Header>
-          <Modal.Title>{title}</Modal.Title>
+          <Modal.Title>Mark All As Reviewed</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           {!this.props.patient.isolation && (
@@ -91,7 +91,7 @@ class ClearReports extends React.Component {
         <Button onClick={this.toggleClearReportsModal} className="mr-2">
           <i className="fas fa-check"></i> Mark All As Reviewed
         </Button>
-        {this.state.showClearReportsModal && this.createModal('Mark All As Reviewed', this.toggleClearReportsModal, this.clearReports)}
+        {this.state.showClearReportsModal && this.createModal(this.toggleClearReportsModal, this.clearReports)}
       </React.Fragment>
     );
   }

--- a/app/javascript/components/subject/ClearReports.js
+++ b/app/javascript/components/subject/ClearReports.js
@@ -12,23 +12,20 @@ class ClearReports extends React.Component {
       showClearReportsModal: false,
       loading: false,
     };
-    this.toggleClearReportsModal = this.toggleClearReportsModal.bind(this);
-    this.clearReports = this.clearReports.bind(this);
-    this.handleChange = this.handleChange.bind(this);
   }
 
-  toggleClearReportsModal() {
+  toggleClearReportsModal = () => {
     let current = this.state.showClearReportsModal;
     this.setState({
       showClearReportsModal: !current,
     });
-  }
+  };
 
-  handleChange(event) {
+  handleChange = event => {
     this.setState({ [event.target.id]: event.target.value });
-  }
+  };
 
-  clearReports() {
+  clearReports = () => {
     this.setState({ loading: true }, () => {
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
       axios
@@ -42,7 +39,7 @@ class ClearReports extends React.Component {
           reportError(error);
         });
     });
-  }
+  };
 
   createModal(title, toggle, submit) {
     return (
@@ -55,8 +52,8 @@ class ClearReports extends React.Component {
             <p>
               You are about to clear all symptomatic report flags (red highlight) on this record. This indicates that the disease of interest is not suspected
               after review of all of the monitoree&apos;s symptomatic reports. The &quot;Needs Review&quot; status will be changed to &quot;No&quot; for all
-              reports. The record will move from the symptomatic line list to the asymptomatic or non-reporting line list as appropriate unless a symptom onset
-              date has been entered by a user.
+              reports. The record will move from the symptomatic line list to the asymptomatic or non-reporting line list as appropriate
+              <b> unless a symptom onset date has been entered by a user.</b>
             </p>
           )}
           {this.props.patient.isolation && (

--- a/app/javascript/tests/subject/ClearReports.test.js
+++ b/app/javascript/tests/subject/ClearReports.test.js
@@ -1,0 +1,82 @@
+import React from 'react'
+import { shallow } from 'enzyme';
+import { Button, Modal } from 'react-bootstrap';
+import ClearReports from '../../components/subject/ClearReports.js'
+import { mockPatient1, mockPatient2 } from '../mocks/mockPatients'
+
+const authyToken = "Q1z4yZXLdN+tZod6dBSIlMbZ3yWAUFdY44U06QWffEP76nx1WGMHIz8rYxEUZsl9sspS3ePF2ZNmSue8wFpJGg==";
+
+function getWrapper(patient) {
+    return shallow(<ClearReports patient={patient} authenticity_token={authyToken} />);
+}
+
+describe('ClearReports', () => {
+  it('Properly renders "Mark All As Reviewed" button', () => {
+    const wrapper = getWrapper(mockPatient1);
+    expect(wrapper.find(Button).length).toEqual(1);
+    expect(wrapper.find(Button).text().includes('Mark All As Reviewed')).toBeTruthy();
+    expect(wrapper.find('i').hasClass('fa-check')).toBeTruthy();
+  });
+
+  it('Clicking the "Mark All As Reviewed" button opens modal', () => {
+    const wrapper = getWrapper(mockPatient1);
+    expect(wrapper.find(Modal).exists()).toBeFalsy();
+    wrapper.find(Button).simulate('click');
+    expect(wrapper.find(Modal).exists()).toBeTruthy();
+  });
+
+  it('Properly renders modal', () => {
+    const wrapper = getWrapper(mockPatient1);
+    wrapper.find(Button).simulate('click');
+    expect(wrapper.find(Modal.Title).exists()).toBeTruthy();
+    expect(wrapper.find(Modal.Title).text()).toEqual('Mark All As Reviewed');
+    expect(wrapper.find(Modal.Body).exists()).toBeTruthy();
+    expect(wrapper.find(Modal.Body).find('p').exists()).toBeTruthy();
+    expect(wrapper.find(Modal.Body).find('#reasoning').exists()).toBeTruthy();
+    expect(wrapper.find(Modal.Footer).exists()).toBeTruthy();
+    expect(wrapper.find(Modal.Footer).find(Button).length).toEqual(2);
+    expect(wrapper.find(Modal.Footer).find(Button).at(0).text()).toEqual('Cancel');
+    expect(wrapper.find(Modal.Footer).find(Button).at(1).text()).toEqual('Submit');
+  });
+
+  it('Properly renders modal text if monitoree is in exposure', () => {
+    const wrapper = getWrapper(mockPatient2);
+    wrapper.find(Button).simulate('click');
+    expect(wrapper.find('p').text()).toEqual(`You are about to clear all symptomatic report flags (red highlight) on this record. This indicates that the disease of interest is not suspected after review of all of the monitoree's symptomatic reports. The \"Needs Review\" status will be changed to \"No\" for all reports. The record will move from the symptomatic line list to the asymptomatic or non-reporting line list as appropriate unless a symptom onset date has been entered by a user.`);
+    expect(wrapper.find('b').text()).toEqual(' unless a symptom onset date has been entered by a user.');
+  });
+
+  it('Properly renders modal text if monitoree is in isolation', () => {
+    const wrapper = getWrapper(mockPatient1);
+    wrapper.find(Button).simulate('click');
+    expect(wrapper.find('p').text()).toEqual(`This will change any reports where the \"Needs Review\" column is \"Yes\" to \"No\". If this case is currently under the \"Records Requiring Review\" line list, they will be moved to the \"Reporting\" or \"Non-Reporting\" line list as appropriate until a recovery definition is met.`);
+  });
+
+  it('Adding reasoning updates state', () => {
+    const wrapper = getWrapper(mockPatient1);
+    const handleChangeSpy = jest.spyOn(wrapper.instance(), 'handleChange');
+    wrapper.find(Button).simulate('click');
+
+    expect(wrapper.find('#reasoning').exists()).toBeTruthy();
+    wrapper.find('#reasoning').simulate('change', { target: { id: 'reasoning', value: 'insert reasoning text here' } });
+    expect(handleChangeSpy).toHaveBeenCalled();
+    expect(wrapper.state('reasoning')).toEqual('insert reasoning text here');
+  });
+
+  it('Clicking the modal submit button calls the clearReports function', () => {
+    const wrapper = getWrapper(mockPatient1);
+    const handleClearReportsSpy = jest.spyOn(wrapper.instance(), 'clearReports');
+    wrapper.find(Button).simulate('click');
+    expect(handleClearReportsSpy).toHaveBeenCalledTimes(0);
+    wrapper.find(Button).at(2).simulate('click');
+    expect(handleClearReportsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('Clicking the modal cancel button closes the modal', () => {
+    const wrapper = getWrapper(mockPatient1);
+    wrapper.find(Button).simulate('click');
+    expect(wrapper.find(Modal).exists()).toBeTruthy();
+    wrapper.find(Button).at(1).simulate('click');
+    expect(wrapper.find(Modal).exists()).toBeFalsy();
+  });
+});


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1089](https://tracker.codev.mitre.org/browse/SARAALERT-1089)

See JIRA for suggested bold text in `Mark All As Reviewed` reports modal

# (Feature) Demo/Screenshots
![Screen Shot 2020-12-18 at 11 38 23 AM](https://user-images.githubusercontent.com/35042815/102638503-94254d00-4125-11eb-94bc-aa44d46a49b5.png)

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`ClearReports.js`
- Added specified bold text
- Swapped to inline binding

`ClearReports.test.js`
- Added full test suite for this component

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
