### PR TITLE
SARAALERT-1118: Should not be able to click "Export" button multiple times

### DIFF
--- a/app/javascript/components/public_health/ConfirmExport.js
+++ b/app/javascript/components/public_health/ConfirmExport.js
@@ -10,9 +10,22 @@ class ConfirmExport extends React.Component {
     };
   }
 
+  getUrl = () => {
+    switch (this.props.exportType) {
+      case 'Line list CSV':
+        return `/export/csv_linelist/${this.props.workflow}`;
+      case 'Sara Alert Format':
+        return `/export/sara_alert_format/${this.props.workflow}`;
+      case 'Excel Export For Purge-Eligible Monitorees':
+        return '/export/full_history_patients/purgeable';
+      case 'Excel Export For All Monitorees':
+        return '/export/full_history_patients/all';
+    }
+  };
+
   submit = () => {
     this.setState({ loading: true }, () => {
-      this.props.onStartExport();
+      this.props.onStartExport(this.getUrl());
     });
   };
 
@@ -20,7 +33,9 @@ class ConfirmExport extends React.Component {
     return (
       <Modal size="lg" className="confirm-export-modal-container" show={this.props.show} onHide={this.props.onCancel} centered>
         <Modal.Header>
-          <Modal.Title>{this.props.title}</Modal.Title>
+          <Modal.Title>
+            {`${this.props.exportType}${this.props.workflow ? ` (${this.props.workflow})` : ''}${this.props.presetName ? ` (${this.props.presetName})` : ''}`}
+          </Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <p>
@@ -53,7 +68,9 @@ class ConfirmExport extends React.Component {
 
 ConfirmExport.propTypes = {
   show: PropTypes.bool,
-  title: PropTypes.string,
+  exportType: PropTypes.string,
+  presetName: PropTypes.string,
+  workflow: PropTypes.string,
   onCancel: PropTypes.func,
   onStartExport: PropTypes.func,
 };

--- a/app/javascript/components/public_health/ConfirmExport.js
+++ b/app/javascript/components/public_health/ConfirmExport.js
@@ -3,9 +3,21 @@ import { PropTypes } from 'prop-types';
 import { Button, Modal } from 'react-bootstrap';
 
 class ConfirmExport extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loading: false,
+    };
+  }
+
+  submit = () => {
+    this.setState({ loading: true });
+    this.props.onStartExport();
+  };
+
   render() {
     return (
-      <Modal size="lg" className="confirm-export-modal-container" show={this.props.show} centered>
+      <Modal size="lg" className="confirm-export-modal-container" show={this.props.show} onHide={this.props.onCancel} centered>
         <Modal.Header>
           <Modal.Title>{this.props.title}</Modal.Title>
         </Modal.Header>
@@ -24,7 +36,12 @@ class ConfirmExport extends React.Component {
           <Button variant="secondary btn-square" onClick={this.props.onCancel}>
             Cancel
           </Button>
-          <Button variant="primary btn-square" onClick={this.props.onStartExport}>
+          <Button variant="primary btn-square" disabled={this.state.loading} onClick={this.submit}>
+            {this.state.loading && (
+              <React.Fragment>
+                <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
+              </React.Fragment>
+            )}
             Start Export
           </Button>
         </Modal.Footer>

--- a/app/javascript/components/public_health/ConfirmExport.js
+++ b/app/javascript/components/public_health/ConfirmExport.js
@@ -11,8 +11,9 @@ class ConfirmExport extends React.Component {
   }
 
   submit = () => {
-    this.setState({ loading: true });
-    this.props.onStartExport();
+    this.setState({ loading: true }, () => {
+      this.props.onStartExport();
+    });
   };
 
   render() {

--- a/app/javascript/components/public_health/CustomExport.js
+++ b/app/javascript/components/public_health/CustomExport.js
@@ -502,7 +502,6 @@ class CustomExport extends React.Component {
           show={this.state.show_confirm_export_modal}
           exportType={'Custom Export Format'}
           presetName={this.state.preset?.name}
-          // title={`Custom Export Format ${this.state.preset?.name ? `(${this.state.preset.name})` : ''}`}
           onCancel={() => this.setState({ show_confirm_export_modal: false })}
           onStartExport={this.export}
         />

--- a/app/javascript/components/public_health/CustomExport.js
+++ b/app/javascript/components/public_health/CustomExport.js
@@ -500,7 +500,9 @@ class CustomExport extends React.Component {
         </Modal>
         <ConfirmExport
           show={this.state.show_confirm_export_modal}
-          title={`Custom Export Format ${this.state.preset?.name ? `(${this.state.preset.name})` : ''}`}
+          exportType={'Custom Export Format'}
+          presetName={this.state.preset?.name}
+          // title={`Custom Export Format ${this.state.preset?.name ? `(${this.state.preset.name})` : ''}`}
           onCancel={() => this.setState({ show_confirm_export_modal: false })}
           onStartExport={this.export}
         />

--- a/app/javascript/components/public_health/CustomExport.js
+++ b/app/javascript/components/public_health/CustomExport.js
@@ -498,13 +498,15 @@ class CustomExport extends React.Component {
             )}
           </Modal.Footer>
         </Modal>
-        <ConfirmExport
-          show={this.state.show_confirm_export_modal}
-          exportType={'Custom Export Format'}
-          presetName={this.state.preset?.name}
-          onCancel={() => this.setState({ show_confirm_export_modal: false })}
-          onStartExport={this.export}
-        />
+        {this.state.show_confirm_export_modal && (
+          <ConfirmExport
+            show={this.state.show_confirm_export_modal}
+            exportType={'Custom Export Format'}
+            presetName={this.state.preset?.name}
+            onCancel={() => this.setState({ show_confirm_export_modal: false })}
+            onStartExport={this.export}
+          />
+        )}
       </React.Fragment>
     );
   }

--- a/app/javascript/components/public_health/Export.js
+++ b/app/javascript/components/public_health/Export.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
-import { Button, ButtonGroup, Modal, DropdownButton, Dropdown } from 'react-bootstrap';
+import { ButtonGroup, DropdownButton, Dropdown } from 'react-bootstrap';
 
 import { ToastContainer, toast } from 'react-toastify';
 import axios from 'axios';
@@ -59,39 +59,6 @@ class Export extends React.Component {
         });
       });
   };
-
-  createModal(title, toggle, submit, endpoint) {
-    return (
-      <Modal size="lg" show centered onHide={toggle}>
-        <Modal.Header>
-          <Modal.Title>{title}</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <p>
-            After clicking <b>Start Export</b>, Sara Alert will gather all of the monitoree data that comprises your request and generate an export file. Sara
-            Alert will then send your user account an email with a one-time download link. This process may take several minutes to complete, based on the
-            amount of data present.
-          </p>
-          <p>
-            NOTE: The system will store one of each type of export file. If you initiate another export of this file type, any old files will be overwritten and
-            download links that have not been accessed will be invalid. Only one of each export type is allowed per user per hour.
-          </p>
-        </Modal.Body>
-        <Modal.Footer>
-          <Button variant="secondary btn-square" onClick={toggle}>
-            Cancel
-          </Button>
-          <Button
-            variant="primary btn-square"
-            onClick={() => {
-              submit(endpoint);
-            }}>
-            Start Export
-          </Button>
-        </Modal.Footer>
-      </Modal>
-    );
-  }
 
   render() {
     return (

--- a/app/javascript/components/public_health/Export.js
+++ b/app/javascript/components/public_health/Export.js
@@ -87,32 +87,40 @@ class Export extends React.Component {
           <Dropdown.Divider />
           <Dropdown.Item onClick={() => this.setState({ showCustomFormatModal: true })}>Custom Format...</Dropdown.Item>
         </DropdownButton>
-        <ConfirmExport
-          show={this.state.showCSVModal}
-          exportType={'Line list CSV'}
-          workflow={this.props.query.workflow}
-          onCancel={() => this.setState({ showCSVModal: false })}
-          onStartExport={this.submit}
-        />
-        <ConfirmExport
-          show={this.state.showSaraFormatModal}
-          exportType={'Sara Alert Format'}
-          workflow={this.props.query.workflow}
-          onCancel={() => this.setState({ showSaraFormatModal: false })}
-          onStartExport={this.submit}
-        />
-        <ConfirmExport
-          show={this.state.showAllPurgeEligibleModal}
-          exportType={'Excel Export For Purge-Eligible Monitorees'}
-          onCancel={() => this.setState({ showAllPurgeEligibleModal: false })}
-          onStartExport={this.submit}
-        />
-        <ConfirmExport
-          show={this.state.showAllModal}
-          exportType={'Excel Export For All Monitorees'}
-          onCancel={() => this.setState({ showAllModal: false })}
-          onStartExport={this.submit}
-        />
+        {this.state.showCSVModal && (
+          <ConfirmExport
+            show={this.state.showCSVModal}
+            exportType={'Line list CSV'}
+            workflow={this.props.query.workflow}
+            onCancel={() => this.setState({ showCSVModal: false })}
+            onStartExport={this.submit}
+          />
+        )}
+        {this.state.showSaraFormatModal && (
+          <ConfirmExport
+            show={this.state.showSaraFormatModal}
+            exportType={'Sara Alert Format'}
+            workflow={this.props.query.workflow}
+            onCancel={() => this.setState({ showSaraFormatModal: false })}
+            onStartExport={this.submit}
+          />
+        )}
+        {this.state.showAllPurgeEligibleModal && (
+          <ConfirmExport
+            show={this.state.showAllPurgeEligibleModal}
+            exportType={'Excel Export For Purge-Eligible Monitorees'}
+            onCancel={() => this.setState({ showAllPurgeEligibleModal: false })}
+            onStartExport={this.submit}
+          />
+        )}
+        {this.state.showAllModal && (
+          <ConfirmExport
+            show={this.state.showAllModal}
+            exportType={'Excel Export For All Monitorees'}
+            onCancel={() => this.setState({ showAllModal: false })}
+            onStartExport={this.submit}
+          />
+        )}
         <ToastContainer
           position="top-center"
           autoClose={3000}

--- a/app/javascript/components/public_health/Export.js
+++ b/app/javascript/components/public_health/Export.js
@@ -89,27 +89,29 @@ class Export extends React.Component {
         </DropdownButton>
         <ConfirmExport
           show={this.state.showCSVModal}
-          title={`Line list CSV (${this.props.query.workflow})`}
+          exportType={'Line list CSV'}
+          workflow={this.props.query.workflow}
           onCancel={() => this.setState({ showCSVModal: false })}
-          onStartExport={() => this.submit(`/export/csv_linelist/${this.props.query.workflow}`)}
+          onStartExport={this.submit}
         />
         <ConfirmExport
           show={this.state.showSaraFormatModal}
-          title={`Sara Alert Format (${this.props.query.workflow})`}
+          exportType={'Sara Alert Format'}
+          workflow={this.props.query.workflow}
           onCancel={() => this.setState({ showSaraFormatModal: false })}
-          onStartExport={() => this.submit(`/export/sara_alert_format/${this.props.query.workflow}`)}
+          onStartExport={this.submit}
         />
         <ConfirmExport
           show={this.state.showAllPurgeEligibleModal}
-          title={'Excel Export For Purge-Eligible Monitorees'}
+          exportType={'Excel Export For Purge-Eligible Monitorees'}
           onCancel={() => this.setState({ showAllPurgeEligibleModal: false })}
-          onStartExport={() => this.submit('/export/full_history_patients/purgeable')}
+          onStartExport={this.submit}
         />
         <ConfirmExport
           show={this.state.showAllModal}
-          title={'Excel Export For All Monitorees'}
+          exportType={'Excel Export For All Monitorees'}
           onCancel={() => this.setState({ showAllModal: false })}
-          onStartExport={() => this.submit('/export/full_history_patients/all')}
+          onStartExport={this.submit}
         />
         <ToastContainer
           position="top-center"

--- a/app/javascript/tests/mocks/mockExportPresets.js
+++ b/app/javascript/tests/mocks/mockExportPresets.js
@@ -1,0 +1,84 @@
+const mockExportPresets = [
+  { 
+    config: {
+      data: {
+        assessments: {
+          checked: [ 'patient_id', 'user_defined_id_statelocal', 'user_defined_id_cdc', 'user_defined_id_nndss', 'id', 'symptomatic',  'who_reported', 'created_at', 'updated_at', 'symptoms' ],
+          expanded: [],
+          query: {}
+        },
+        close_contacts: {
+          checked: [],
+          expanded: [],
+          query: {}
+        },
+        histories: {
+          checked: [],
+          expanded: [],
+          query: {}
+        },
+        laboratories: {
+          checked: [],
+          expanded: [],
+          query: {}
+        },
+        patients: {
+          checked: [],
+          expanded: [],
+          query: {}
+        },
+        transfers: {
+          checked: [],
+          expanded: [],
+          query: {}
+        },
+        format: 'xlsx'
+      },
+    },
+    id: 1,
+    name: 'custom1'
+  },
+  {
+    config: {
+      data: {
+        assessments: {
+          checked: [ 'patient_id', 'user_defined_id_statelocal', 'symptoms' ],
+          expanded: [],
+          query: {}
+        },
+        close_contacts: {
+          checked: [],
+          expanded: [],
+          query: {}
+        },
+        histories: {
+          checked: [],
+          expanded: [],
+          query: {}
+        },
+        laboratories: {
+          checked: [],
+          expanded: [],
+          query: {}
+        },
+        patients: {
+          checked: [],
+          expanded: [],
+          query: {}
+        },
+        transfers: {
+          checked: [],
+          expanded: [],
+          query: {}
+        },
+        format: 'xlsx'
+      },
+    },
+    id: 2,
+    name: 'custom2'
+  }
+]
+
+export {
+  mockExportPresets
+}

--- a/app/javascript/tests/mocks/mockJurisdiction.js
+++ b/app/javascript/tests/mocks/mockJurisdiction.js
@@ -1,0 +1,18 @@
+const mockJurisdiction1 = {
+  id: 2,
+  path: 'USA, State 1'
+}
+
+const mockJurisdictionPaths = {
+  2: 'USA, State 1',
+  3: 'USA, State 1, County 1',
+  4: 'USA, State 1, County 2',
+  5: 'USA, State 2',
+  6: 'USA, State 2, County 3',
+  7: 'USA, State 2, County 4'
+}
+
+export {
+  mockJurisdiction1,
+  mockJurisdictionPaths
+}

--- a/app/javascript/tests/mocks/mockQueries.js
+++ b/app/javascript/tests/mocks/mockQueries.js
@@ -1,0 +1,28 @@
+const mockQuery1 = {
+  entries: 25,
+  jurisdiction: 2,
+  page: 0,
+  scope: 'all',
+  search: '',
+  tab: 'non_reporting',
+  tz_offset: 300,
+  user: null,
+  workflow: 'exposure'
+}
+
+const mockQuery2 = {
+  entries: 25,
+  jurisdiction: 2,
+  page: 0,
+  scope: 'all',
+  search: '',
+  tab: 'non_reporting',
+  tz_offset: 300,
+  user: null,
+  workflow: 'isolation'
+}
+
+export {
+  mockQuery1,
+  mockQuery2
+}

--- a/app/javascript/tests/mocks/mockTabs.js
+++ b/app/javascript/tests/mocks/mockTabs.js
@@ -1,0 +1,94 @@
+const mockExposureTabs = {
+  all: {
+    description: 'All Monitorees in this jurisdiction, in the Exposure workflow.',
+    label: 'All Monitorees',
+    variant: 'primary'
+  },
+  asymptomatic: {
+    description: 'Monitorees currently reporting no symptoms, who have reported during the last day.',
+    label: 'Asymptomatic',
+    tooltip: 'exposure_asymptomatic',
+    variant: 'success'
+  },
+  closed: {
+    description: 'Monitorees not currently being monitored.',
+    label: 'Closed',
+    tooltip: 'exposure_closed',
+    variant: 'secondary'
+  },
+  non_reporting: {
+    label: 'Non-Reporting',
+    variant: 'warning',
+    tooltip: 'exposure_non_reporting',
+    description: 'Monitorees who have failed to report in the last day, and are not symptomatic.'
+  },
+  pui: {
+    description: 'Monitorees who are currently under investigation.',
+    label: 'PUI',
+    tooltip: 'exposure_under_investigation',
+    variant: 'dark'
+  },
+  symptomatic: {
+    description: 'Monitorees who have reported symptoms, which need to be reviewed.',
+    label: 'Symptomatic',
+    tooltip: 'exposure_symptomatic',
+    variant: 'danger'
+  },
+  transferred_in: {
+    description: 'Monitorees that have been transferred into this jurisdiction during the last 24 hours.',
+    label: 'Transferred In',
+    variant: 'info'
+  },
+  transferred_out: {
+    description: 'Monitorees that have been transferred out of this jurisdiction.',
+    label: 'Transferred Out',
+    variant: 'info'
+  }
+};
+
+const mockIsolationTabs = {
+  all: {
+    description: 'All cases in this jurisdiction, in the Isolation workflow.',
+    label: 'All Cases',
+    variant: 'primary'
+  },
+  closed: {
+    description: 'Cases not currently being monitored.',
+    label: 'Closed',
+    tooltip: 'isolation_closed',
+    variant: 'secondary'
+  },
+  non_reporting: {
+    description: 'Cases who failed to report during the last day and have not yet met recovery definition.',
+    label: 'Non-Reporting',
+    tooltip: 'isolation_non_reporting',
+    variant: 'warning'
+  },
+  reporting: {
+    description: 'Cases who have reported in the last day and have not yet met recovery definition.',
+    label: 'Reporting',
+    tooltip: 'isolation_reporting',
+    variant: 'success'
+  },
+  requiring_review: {
+    description: 'Cases who preliminarily meet the recovery definition and require review.',
+    label: 'Records Requiring Review',
+    tooltip: 'isolation_records_requiring_review',
+    variant: 'danger'
+  },
+  transferred_in: {
+    description: 'Cases that have been transferred into this jurisdiction during the last 24 hours.',
+    label: 'Transferred In',
+    variant: 'info'
+  },
+  transferred_out: {
+    description: 'Cases that have been transferred out of this jurisdiction.',
+    label: 'Transferred Out',
+    variant: 'info'
+  }
+}
+
+export {
+  mockExposureTabs,
+  mockIsolationTabs
+}

--- a/app/javascript/tests/public_health/ConfirmExport.test.js
+++ b/app/javascript/tests/public_health/ConfirmExport.test.js
@@ -3,24 +3,25 @@ import { shallow } from 'enzyme';
 import { Button, Modal } from 'react-bootstrap';
 import ConfirmExport from '../../components/public_health/ConfirmExport.js'
 
+const workflow = 'exposure'
 const onCancelMock = jest.fn();
 const onStartExportMock = jest.fn();
 
-function getWrapper(show) {
-  return shallow(<ConfirmExport show={show} title={'here is a title'} onCancel={onCancelMock} onStartExport={onStartExportMock} />);
+function getWrapper(show, type, workflow) {
+  return shallow(<ConfirmExport show={show} exportType={type} workflow={workflow} onCancel={onCancelMock} onStartExport={onStartExportMock} />);
 }
 
-function getInstance() {
-  return shallow(<ConfirmExport show={true} title={'here is a title'} onCancel={onCancelMock} onStartExport={onStartExportMock} />).instance();
-}
+afterEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('ConfirmExport', () => {
   it('Properly renders all main components', () => {
-    const wrapper = getWrapper(true);
+    const wrapper = getWrapper(true, 'Line list CSV', workflow);
     expect(wrapper.find(Modal).exists()).toBeTruthy();
     expect(wrapper.find(Modal).prop('show')).toBeTruthy();
     expect(wrapper.find(Modal.Header).exists()).toBeTruthy();
-    expect(wrapper.find(Modal.Title).text()).toEqual('here is a title');
+    expect(wrapper.find(Modal.Title).exists()).toBeTruthy();
     expect(wrapper.find(Modal.Body).exists()).toBeTruthy();
     expect(wrapper.find(Modal.Body).find('p').at(0).text()).toEqual('After clicking Start Export, Sara Alert will gather all of the monitoree data that comprises your request and generate an export file. Sara Alert will then send your user account an email with a one-time download link. This process may take several minutes to complete, based on the amount of data present.');
     expect(wrapper.find(Modal.Body).find('p').at(1).text()).toEqual('NOTE: The system will store one of each type of export file. If you initiate another export of this file type, any old files will be overwritten and download links that have not been accessed will be invalid. Only one of each export type is allowed per user per hour.');
@@ -31,28 +32,69 @@ describe('ConfirmExport', () => {
     expect(wrapper.find(Modal.Footer).find(Button).at(1).text()).toEqual('Start Export');
   });
 
+  it('Properly renders modal title (exportType = Line list CSV)', () => {
+    const wrapper = getWrapper(true, 'Line list CSV', workflow);
+    expect(wrapper.find(Modal.Title).text()).toEqual(`Line list CSV (${workflow})`);
+  });
+
+  it('Properly renders modal title for (exportType = Sara Alert Format)', () => {
+    const wrapper = getWrapper(true, 'Sara Alert Format', workflow);
+    expect(wrapper.find(Modal.Title).text()).toEqual(`Sara Alert Format (${workflow})`);
+  });
+
+  it('Properly renders modal title (exportType = Excel Export For Purge-Eligible Monitorees)', () => {
+    const wrapper = getWrapper(true, 'Excel Export For Purge-Eligible Monitorees');
+    expect(wrapper.find(Modal.Title).text()).toEqual('Excel Export For Purge-Eligible Monitorees');
+  });
+
+  it('Properly renders csv modal title (exportType = Excel Export For All Monitorees)', () => {
+    const wrapper = getWrapper(true, 'Excel Export For All Monitorees');
+    expect(wrapper.find(Modal.Title).text()).toEqual('Excel Export For All Monitorees');
+  });
+
   it('Hides modal if props.show is false', () => {
-    const wrapper = getWrapper(false);
+    const wrapper = getWrapper(false, 'Line list CSV', workflow);
     expect(wrapper.find(Modal).exists()).toBeTruthy();
     expect(wrapper.find(Modal).prop('show')).toBeFalsy();
   });
 
   it('Clicking the cancel button calls the onCancel method', () => {
-    const wrapper = getWrapper(true);
+    const wrapper = getWrapper(true, 'Line list CSV', workflow);
     expect(onCancelMock).toHaveBeenCalledTimes(0);
     wrapper.find(Button).at(0).simulate('click');
     expect(onCancelMock).toHaveBeenCalled();
   });
   
-  it('Clicking the submit button calls the submit method', () => {
-    const wrapper = getWrapper(true);
+  it('Clicking the submit button calls the submit method with correct arguments (exportType = Line list CSV)', () => {
+    const wrapper = getWrapper(true, 'Line list CSV', workflow);
     expect(onStartExportMock).toHaveBeenCalledTimes(0);
     wrapper.find(Button).at(1).simulate('click');
-    expect(onStartExportMock).toHaveBeenCalled();
+    expect(onStartExportMock).lastCalledWith(`/export/csv_linelist/${workflow}`);
+  });
+
+  it('Clicking the submit button calls the submit method with correct arguments (exportType = Sara Alert Format)', () => {
+    const wrapper = getWrapper(true, 'Sara Alert Format', workflow);
+    expect(onStartExportMock).toHaveBeenCalledTimes(0);
+    wrapper.find(Button).at(1).simulate('click');
+    expect(onStartExportMock).lastCalledWith(`/export/sara_alert_format/${workflow}`);
+  });
+
+  it('Clicking the submit button calls the submit method with correct arguments (exportType = Excel Export For Purge-Eligible Monitorees)', () => {
+    const wrapper = getWrapper(true, 'Excel Export For Purge-Eligible Monitorees');
+    expect(onStartExportMock).toHaveBeenCalledTimes(0);
+    wrapper.find(Button).at(1).simulate('click');
+    expect(onStartExportMock).lastCalledWith('/export/full_history_patients/purgeable');
+  });
+
+  it('Clicking the submit button calls the submit method with correct arguments (exportType = Excel Export For All Monitorees)', () => {
+    const wrapper = getWrapper(true, 'Excel Export For All Monitorees');
+    expect(onStartExportMock).toHaveBeenCalledTimes(0);
+    wrapper.find(Button).at(1).simulate('click');
+    expect(onStartExportMock).lastCalledWith('/export/full_history_patients/all');
   });
 
   it('Clicking the submit button hides/shows spinner and updates state', () => {
-    const wrapper = getWrapper(true);
+    const wrapper = getWrapper(true, 'Line list CSV', workflow);
     expect(wrapper.state('loading')).toBeFalsy();
     expect(wrapper.find(Button).at(1).find('.spinner-border').exists()).toBeFalsy();
     wrapper.find(Button).at(1).simulate('click');

--- a/app/javascript/tests/public_health/ConfirmExport.test.js
+++ b/app/javascript/tests/public_health/ConfirmExport.test.js
@@ -1,0 +1,62 @@
+import React from 'react'
+import { shallow } from 'enzyme';
+import { Button, Modal } from 'react-bootstrap';
+import ConfirmExport from '../../components/public_health/ConfirmExport.js'
+
+const onCancelMock = jest.fn();
+const onStartExportMock = jest.fn();
+
+function getWrapper(show) {
+  return shallow(<ConfirmExport show={show} title={'here is a title'} onCancel={onCancelMock} onStartExport={onStartExportMock} />);
+}
+
+function getInstance() {
+  return shallow(<ConfirmExport show={true} title={'here is a title'} onCancel={onCancelMock} onStartExport={onStartExportMock} />).instance();
+}
+
+describe('ConfirmExport', () => {
+  it('Properly renders all main components', () => {
+    const wrapper = getWrapper(true);
+    expect(wrapper.find(Modal).exists()).toBeTruthy();
+    expect(wrapper.find(Modal).prop('show')).toBeTruthy();
+    expect(wrapper.find(Modal.Header).exists()).toBeTruthy();
+    expect(wrapper.find(Modal.Title).text()).toEqual('here is a title');
+    expect(wrapper.find(Modal.Body).exists()).toBeTruthy();
+    expect(wrapper.find(Modal.Body).find('p').at(0).text()).toEqual('After clicking Start Export, Sara Alert will gather all of the monitoree data that comprises your request and generate an export file. Sara Alert will then send your user account an email with a one-time download link. This process may take several minutes to complete, based on the amount of data present.');
+    expect(wrapper.find(Modal.Body).find('p').at(1).text()).toEqual('NOTE: The system will store one of each type of export file. If you initiate another export of this file type, any old files will be overwritten and download links that have not been accessed will be invalid. Only one of each export type is allowed per user per hour.');
+    expect(wrapper.find(Modal.Body).find('b').text()).toEqual('Start Export');
+    expect(wrapper.find(Modal.Footer).exists()).toBeTruthy();
+    expect(wrapper.find(Modal.Footer).find(Button).length).toEqual(2);
+    expect(wrapper.find(Modal.Footer).find(Button).at(0).text()).toEqual('Cancel');
+    expect(wrapper.find(Modal.Footer).find(Button).at(1).text()).toEqual('Start Export');
+  });
+
+  it('Hides modal if props.show is false', () => {
+    const wrapper = getWrapper(false);
+    expect(wrapper.find(Modal).exists()).toBeTruthy();
+    expect(wrapper.find(Modal).prop('show')).toBeFalsy();
+  });
+
+  it('Clicking the cancel button calls the onCancel method', () => {
+    const wrapper = getWrapper(true);
+    expect(onCancelMock).toHaveBeenCalledTimes(0);
+    wrapper.find(Button).at(0).simulate('click');
+    expect(onCancelMock).toHaveBeenCalled();
+  });
+  
+  it('Clicking the submit button calls the submit method', () => {
+    const wrapper = getWrapper(true);
+    expect(onStartExportMock).toHaveBeenCalledTimes(0);
+    wrapper.find(Button).at(1).simulate('click');
+    expect(onStartExportMock).toHaveBeenCalled();
+  });
+
+  it('Clicking the submit button hides/shows spinner and updates state', () => {
+    const wrapper = getWrapper(true);
+    expect(wrapper.state('loading')).toBeFalsy();
+    expect(wrapper.find(Button).at(1).find('.spinner-border').exists()).toBeFalsy();
+    wrapper.find(Button).at(1).simulate('click');
+    expect(wrapper.state('loading')).toBeTruthy();
+    expect(wrapper.find(Button).at(1).find('.spinner-border').exists()).toBeTruthy();
+  });
+});

--- a/app/javascript/tests/public_health/Export.test.js
+++ b/app/javascript/tests/public_health/Export.test.js
@@ -1,0 +1,124 @@
+import React from 'react'
+import { shallow } from 'enzyme';
+import { Dropdown, DropdownButton } from 'react-bootstrap';
+import { ToastContainer } from 'react-toastify';
+import Export from '../../components/public_health/Export.js'
+import ConfirmExport from '../../components/public_health/ConfirmExport.js'
+import CustomExport from '../../components/public_health/CustomExport.js'
+import { mockJurisdiction1, mockJurisdictionPaths } from '../mocks/mockJurisdiction'
+import { mockQuery1, mockQuery2 } from '../mocks/mockQueries'
+import { mockExposureTabs, mockIsolationTabs } from '../mocks/mockTabs'
+import { mockExportPresets } from '../mocks/mockExportPresets'
+  
+const authyToken = "Q1z4yZXLdN+tZod6dBSIlMbZ3yWAUFdY44U06QWffEP76nx1WGMHIz8rYxEUZsl9sspS3ePF2ZNmSue8wFpJGg==";
+const dropdownOptions = [ 'Line list CSV', 'Sara Alert Format', 'Excel Export For Purge-Eligible Monitorees', 'Excel Export For All Monitorees', 'Custom Format...' ];
+
+function getExposureWrapper() {
+  return shallow(<Export all_monitorees_count={200} authenticity_token={authyToken} current_monitorees_count={32} custom_export_options={{}}
+    jurisdiction_paths={mockJurisdictionPaths} jurisdiction={mockJurisdiction1} query={mockQuery1} tabs={mockExposureTabs} />);
+}
+
+function getIsolationWrapper() {
+  return shallow(<Export all_monitorees_count={200} authenticity_token={authyToken} current_monitorees_count={32} custom_export_options={{}}
+    jurisdiction_paths={mockJurisdictionPaths} jurisdiction={mockJurisdiction1} query={mockQuery2} tabs={mockIsolationTabs} />);
+}
+
+function getInstance() {
+  return shallow(<Export all_monitorees_count={200} authenticity_token={authyToken} current_monitorees_count={32} custom_export_options={{}}
+    jurisdiction_paths={mockJurisdictionPaths} jurisdiction={mockJurisdiction1} query={mockQuery2} tabs={mockIsolationTabs} />).instance();
+}
+
+describe('Export', () => {
+  it('Properly renders all main components', () => {
+    const wrapper = getExposureWrapper();
+    expect(wrapper.find(DropdownButton).exists()).toBeTruthy();
+    expect(wrapper.find(Dropdown.Item).length).toEqual(5);
+    expect(wrapper.find(Dropdown.Divider).length).toEqual(1);
+    expect(wrapper.find(ConfirmExport).length).toEqual(4);
+    wrapper.find(ConfirmExport).forEach(function(component) {
+      expect(component.prop('show')).toBeFalsy();
+    });
+    expect(wrapper.find(ToastContainer).exists()).toBeTruthy();
+    expect(wrapper.find(CustomExport).exists()).toBeFalsy();
+  });
+
+  it('Properly renders dropdown in exposure workflow', () => {
+    const wrapper = getExposureWrapper();
+    dropdownOptions.forEach(function(option, index) {
+      if (index < 2) {
+        option += ' (exposure)';
+      }
+      expect(wrapper.find(Dropdown.Item).at(index).text()).toEqual(option);
+    });
+  });
+
+  it('Properly renders dropdown in isolation workflow', () => {
+    const wrapper = getIsolationWrapper();
+    dropdownOptions.forEach(function(option, index) {
+      if (index < 2) {
+        option += ' (isolation)';
+      }
+      expect(wrapper.find(Dropdown.Item).at(index).text()).toEqual(option);
+    });
+  });
+
+  it('Clicking "Line list CSV" option displays Confirm Export modal', () => {
+    const wrapper = getExposureWrapper();
+    expect(wrapper.find(Dropdown.Item).at(0).text().includes(dropdownOptions[0])).toBeTruthy();
+    expect(wrapper.find(ConfirmExport).at(0).prop('show')).toBeFalsy();
+    wrapper.find(Dropdown.Item).at(0).simulate('click');
+    expect(wrapper.find(ConfirmExport).at(0).prop('show')).toBeTruthy();
+  });
+
+  it('Clicking "Sara Alert Format" option displays Confirm Export modal', () => {
+    const wrapper = getExposureWrapper();
+    expect(wrapper.find(Dropdown.Item).at(1).text().includes(dropdownOptions[1])).toBeTruthy();
+    expect(wrapper.find(ConfirmExport).at(1).prop('show')).toBeFalsy();
+    wrapper.find(Dropdown.Item).at(1).simulate('click');
+    expect(wrapper.find(ConfirmExport).at(1).prop('show')).toBeTruthy();
+  });
+
+  it('Clicking "Excel Export For Purge-Eligible Monitorees" option displays Confirm Export modal', () => {
+    const wrapper = getExposureWrapper();
+    expect(wrapper.find(Dropdown.Item).at(2).text()).toEqual(dropdownOptions[2]);
+    expect(wrapper.find(ConfirmExport).at(2).prop('show')).toBeFalsy();
+    wrapper.find(Dropdown.Item).at(2).simulate('click');
+    expect(wrapper.find(ConfirmExport).at(2).prop('show')).toBeTruthy();
+  });
+
+  it('Clicking "Excel Export For All Monitorees" option displays Confirm Export modal', () => {
+    const wrapper = getExposureWrapper();
+    expect(wrapper.find(Dropdown.Item).at(3).text()).toEqual(dropdownOptions[3]);
+    expect(wrapper.find(ConfirmExport).at(3).prop('show')).toBeFalsy();
+    wrapper.find(Dropdown.Item).at(3).simulate('click');
+    expect(wrapper.find(ConfirmExport).at(3).prop('show')).toBeTruthy();
+  });
+
+  it('Clicking "Custom Format..." option displays Custom Export modal', () => {
+    const wrapper = getExposureWrapper();
+    expect(wrapper.find(Dropdown.Item).at(4).text()).toEqual(dropdownOptions[4]);
+    expect(wrapper.find(CustomExport).exists()).toBeFalsy();
+    wrapper.find(Dropdown.Item).at(4).simulate('click');
+    expect(wrapper.find(CustomExport).exists()).toBeTruthy();
+  });
+
+  it('Calls reloadExportPresets method when component mounts', () => {
+    const instance  = getInstance();
+    const reloadPresetsSpy = jest.spyOn(instance, 'reloadExportPresets');
+    expect(reloadPresetsSpy).toHaveBeenCalledTimes(0); 
+    instance.componentDidMount();
+    expect(reloadPresetsSpy).toHaveBeenCalledTimes(1); 
+  });
+
+  it('Adds export presets to dropdown list', () => {
+    const wrapper = getExposureWrapper();
+    expect(wrapper.find(Dropdown.Item).length).toEqual(5);
+    expect(wrapper.find(Dropdown.Divider).length).toEqual(1);
+    expect(wrapper.state('savedExportPresets')).toEqual(undefined);
+    wrapper.setState({ savedExportPresets: mockExportPresets });
+    expect(wrapper.find(Dropdown.Item).length).toEqual(7);
+    expect(wrapper.find(Dropdown.Divider).length).toEqual(2);
+    expect(wrapper.find(Dropdown.Item).at(4).text()).toEqual('custom1');
+    expect(wrapper.find(Dropdown.Item).at(5).text()).toEqual('custom2');
+  });
+});

--- a/app/javascript/tests/public_health/Export.test.js
+++ b/app/javascript/tests/public_health/Export.test.js
@@ -34,10 +34,7 @@ describe('Export', () => {
     expect(wrapper.find(DropdownButton).exists()).toBeTruthy();
     expect(wrapper.find(Dropdown.Item).length).toEqual(5);
     expect(wrapper.find(Dropdown.Divider).length).toEqual(1);
-    expect(wrapper.find(ConfirmExport).length).toEqual(4);
-    wrapper.find(ConfirmExport).forEach(function(component) {
-      expect(component.prop('show')).toBeFalsy();
-    });
+    expect(wrapper.find(ConfirmExport).exists()).toBeFalsy();
     expect(wrapper.find(ToastContainer).exists()).toBeTruthy();
     expect(wrapper.find(CustomExport).exists()).toBeFalsy();
   });
@@ -64,42 +61,46 @@ describe('Export', () => {
 
   it('Clicking "Line list CSV" option displays Confirm Export modal', () => {
     const wrapper = getExposureWrapper();
+    expect(wrapper.find(ConfirmExport).exists()).toBeFalsy();
     expect(wrapper.find(Dropdown.Item).at(0).text().includes(dropdownOptions[0])).toBeTruthy();
-    expect(wrapper.find(ConfirmExport).at(0).prop('show')).toBeFalsy();
-    expect(wrapper.find(ConfirmExport).at(0).prop('exportType')).toEqual('Line list CSV');
-    expect(wrapper.find(ConfirmExport).at(0).prop('workflow')).toEqual('exposure');
     wrapper.find(Dropdown.Item).at(0).simulate('click');
-    expect(wrapper.find(ConfirmExport).at(0).prop('show')).toBeTruthy();
+    expect(wrapper.find(ConfirmExport).exists()).toBeTruthy();
+    expect(wrapper.find(ConfirmExport).prop('show')).toBeTruthy();
+    expect(wrapper.find(ConfirmExport).prop('exportType')).toEqual('Line list CSV');
+    expect(wrapper.find(ConfirmExport).prop('workflow')).toEqual('exposure');
   });
 
   it('Clicking "Sara Alert Format" option displays Confirm Export modal', () => {
     const wrapper = getExposureWrapper();
+    expect(wrapper.find(ConfirmExport).exists()).toBeFalsy();
     expect(wrapper.find(Dropdown.Item).at(1).text().includes(dropdownOptions[1])).toBeTruthy();
-    expect(wrapper.find(ConfirmExport).at(1).prop('show')).toBeFalsy();
-    expect(wrapper.find(ConfirmExport).at(1).prop('exportType')).toEqual('Sara Alert Format');
-    expect(wrapper.find(ConfirmExport).at(1).prop('workflow')).toEqual('exposure');
     wrapper.find(Dropdown.Item).at(1).simulate('click');
-    expect(wrapper.find(ConfirmExport).at(1).prop('show')).toBeTruthy();
+    expect(wrapper.find(ConfirmExport).exists()).toBeTruthy();
+    expect(wrapper.find(ConfirmExport).prop('show')).toBeTruthy();
+    expect(wrapper.find(ConfirmExport).prop('exportType')).toEqual('Sara Alert Format');
+    expect(wrapper.find(ConfirmExport).prop('workflow')).toEqual('exposure');
   });
 
   it('Clicking "Excel Export For Purge-Eligible Monitorees" option displays Confirm Export modal', () => {
     const wrapper = getExposureWrapper();
+    expect(wrapper.find(ConfirmExport).exists()).toBeFalsy();
     expect(wrapper.find(Dropdown.Item).at(2).text()).toEqual(dropdownOptions[2]);
-    expect(wrapper.find(ConfirmExport).at(2).prop('show')).toBeFalsy();
-    expect(wrapper.find(ConfirmExport).at(2).prop('exportType')).toEqual('Excel Export For Purge-Eligible Monitorees');
-    expect(wrapper.find(ConfirmExport).at(2).prop('workflow')).toEqual(undefined);
     wrapper.find(Dropdown.Item).at(2).simulate('click');
-    expect(wrapper.find(ConfirmExport).at(2).prop('show')).toBeTruthy();
+    expect(wrapper.find(ConfirmExport).exists()).toBeTruthy();
+    expect(wrapper.find(ConfirmExport).prop('show')).toBeTruthy();
+    expect(wrapper.find(ConfirmExport).prop('exportType')).toEqual('Excel Export For Purge-Eligible Monitorees');
+    expect(wrapper.find(ConfirmExport).prop('workflow')).toEqual(undefined);
   });
 
   it('Clicking "Excel Export For All Monitorees" option displays Confirm Export modal', () => {
     const wrapper = getExposureWrapper();
+    expect(wrapper.find(ConfirmExport).exists()).toBeFalsy();
     expect(wrapper.find(Dropdown.Item).at(3).text()).toEqual(dropdownOptions[3]);
-    expect(wrapper.find(ConfirmExport).at(3).prop('show')).toBeFalsy();
-    expect(wrapper.find(ConfirmExport).at(3).prop('exportType')).toEqual('Excel Export For All Monitorees');
-    expect(wrapper.find(ConfirmExport).at(2).prop('workflow')).toEqual(undefined);
     wrapper.find(Dropdown.Item).at(3).simulate('click');
-    expect(wrapper.find(ConfirmExport).at(3).prop('show')).toBeTruthy();
+    expect(wrapper.find(ConfirmExport).exists()).toBeTruthy();
+    expect(wrapper.find(ConfirmExport).prop('show')).toBeTruthy();
+    expect(wrapper.find(ConfirmExport).prop('exportType')).toEqual('Excel Export For All Monitorees');
+    expect(wrapper.find(ConfirmExport).prop('workflow')).toEqual(undefined);
   });
 
   it('Clicking "Custom Format..." option displays Custom Export modal', () => {

--- a/app/javascript/tests/public_health/Export.test.js
+++ b/app/javascript/tests/public_health/Export.test.js
@@ -66,6 +66,7 @@ describe('Export', () => {
     const wrapper = getExposureWrapper();
     expect(wrapper.find(Dropdown.Item).at(0).text().includes(dropdownOptions[0])).toBeTruthy();
     expect(wrapper.find(ConfirmExport).at(0).prop('show')).toBeFalsy();
+    expect(wrapper.find(ConfirmExport).at(0).prop('title')).toEqual(`Line list CSV (${mockQuery1.workflow})`);
     wrapper.find(Dropdown.Item).at(0).simulate('click');
     expect(wrapper.find(ConfirmExport).at(0).prop('show')).toBeTruthy();
   });
@@ -74,6 +75,7 @@ describe('Export', () => {
     const wrapper = getExposureWrapper();
     expect(wrapper.find(Dropdown.Item).at(1).text().includes(dropdownOptions[1])).toBeTruthy();
     expect(wrapper.find(ConfirmExport).at(1).prop('show')).toBeFalsy();
+    expect(wrapper.find(ConfirmExport).at(1).prop('title')).toEqual(`Sara Alert Format (${mockQuery1.workflow})`);
     wrapper.find(Dropdown.Item).at(1).simulate('click');
     expect(wrapper.find(ConfirmExport).at(1).prop('show')).toBeTruthy();
   });
@@ -82,6 +84,7 @@ describe('Export', () => {
     const wrapper = getExposureWrapper();
     expect(wrapper.find(Dropdown.Item).at(2).text()).toEqual(dropdownOptions[2]);
     expect(wrapper.find(ConfirmExport).at(2).prop('show')).toBeFalsy();
+    expect(wrapper.find(ConfirmExport).at(2).prop('title')).toEqual('Excel Export For Purge-Eligible Monitorees');
     wrapper.find(Dropdown.Item).at(2).simulate('click');
     expect(wrapper.find(ConfirmExport).at(2).prop('show')).toBeTruthy();
   });
@@ -90,6 +93,7 @@ describe('Export', () => {
     const wrapper = getExposureWrapper();
     expect(wrapper.find(Dropdown.Item).at(3).text()).toEqual(dropdownOptions[3]);
     expect(wrapper.find(ConfirmExport).at(3).prop('show')).toBeFalsy();
+    expect(wrapper.find(ConfirmExport).at(3).prop('title')).toEqual('Excel Export For All Monitorees');
     wrapper.find(Dropdown.Item).at(3).simulate('click');
     expect(wrapper.find(ConfirmExport).at(3).prop('show')).toBeTruthy();
   });

--- a/app/javascript/tests/public_health/Export.test.js
+++ b/app/javascript/tests/public_health/Export.test.js
@@ -66,7 +66,8 @@ describe('Export', () => {
     const wrapper = getExposureWrapper();
     expect(wrapper.find(Dropdown.Item).at(0).text().includes(dropdownOptions[0])).toBeTruthy();
     expect(wrapper.find(ConfirmExport).at(0).prop('show')).toBeFalsy();
-    expect(wrapper.find(ConfirmExport).at(0).prop('title')).toEqual(`Line list CSV (${mockQuery1.workflow})`);
+    expect(wrapper.find(ConfirmExport).at(0).prop('exportType')).toEqual('Line list CSV');
+    expect(wrapper.find(ConfirmExport).at(0).prop('workflow')).toEqual('exposure');
     wrapper.find(Dropdown.Item).at(0).simulate('click');
     expect(wrapper.find(ConfirmExport).at(0).prop('show')).toBeTruthy();
   });
@@ -75,7 +76,8 @@ describe('Export', () => {
     const wrapper = getExposureWrapper();
     expect(wrapper.find(Dropdown.Item).at(1).text().includes(dropdownOptions[1])).toBeTruthy();
     expect(wrapper.find(ConfirmExport).at(1).prop('show')).toBeFalsy();
-    expect(wrapper.find(ConfirmExport).at(1).prop('title')).toEqual(`Sara Alert Format (${mockQuery1.workflow})`);
+    expect(wrapper.find(ConfirmExport).at(1).prop('exportType')).toEqual('Sara Alert Format');
+    expect(wrapper.find(ConfirmExport).at(1).prop('workflow')).toEqual('exposure');
     wrapper.find(Dropdown.Item).at(1).simulate('click');
     expect(wrapper.find(ConfirmExport).at(1).prop('show')).toBeTruthy();
   });
@@ -84,7 +86,8 @@ describe('Export', () => {
     const wrapper = getExposureWrapper();
     expect(wrapper.find(Dropdown.Item).at(2).text()).toEqual(dropdownOptions[2]);
     expect(wrapper.find(ConfirmExport).at(2).prop('show')).toBeFalsy();
-    expect(wrapper.find(ConfirmExport).at(2).prop('title')).toEqual('Excel Export For Purge-Eligible Monitorees');
+    expect(wrapper.find(ConfirmExport).at(2).prop('exportType')).toEqual('Excel Export For Purge-Eligible Monitorees');
+    expect(wrapper.find(ConfirmExport).at(2).prop('workflow')).toEqual(undefined);
     wrapper.find(Dropdown.Item).at(2).simulate('click');
     expect(wrapper.find(ConfirmExport).at(2).prop('show')).toBeTruthy();
   });
@@ -93,7 +96,8 @@ describe('Export', () => {
     const wrapper = getExposureWrapper();
     expect(wrapper.find(Dropdown.Item).at(3).text()).toEqual(dropdownOptions[3]);
     expect(wrapper.find(ConfirmExport).at(3).prop('show')).toBeFalsy();
-    expect(wrapper.find(ConfirmExport).at(3).prop('title')).toEqual('Excel Export For All Monitorees');
+    expect(wrapper.find(ConfirmExport).at(3).prop('exportType')).toEqual('Excel Export For All Monitorees');
+    expect(wrapper.find(ConfirmExport).at(2).prop('workflow')).toEqual(undefined);
     wrapper.find(Dropdown.Item).at(3).simulate('click');
     expect(wrapper.find(ConfirmExport).at(3).prop('show')).toBeTruthy();
   });

--- a/app/javascript/tests/subject/monitoring_actions/Jurisdiction.test.js
+++ b/app/javascript/tests/subject/monitoring_actions/Jurisdiction.test.js
@@ -5,20 +5,13 @@ import Jurisdiction from '../../../components/subject/monitoring_actions/Jurisdi
 import InfoTooltip from '../../../components/util/InfoTooltip';
 import { mockPatient1 } from '../../mocks/mockPatients';
 import { mockUser1 } from '../../mocks/mockUsers';
+import { mockJurisdictionPaths } from '../../mocks/mockJurisdiction'
 
 const authyToken = 'Q1z4yZXLdN+tZod6dBSIlMbZ3yWAUFdY44U06QWffEP76nx1WGMHIz8rYxEUZsl9sspS3ePF2ZNmSue8wFpJGg==';
-const jurisdiction_paths = {
-  2: 'USA, State 1',
-  3: 'USA, State 1, County 1',
-  4: 'USA, State 1, County 2',
-  5: 'USA, State 2',
-  6: 'USA, State 2, County 3',
-  7: 'USA, State 2, County 4'
-};
 
 function getWrapper(patient, hasDependents) {
   return shallow(<Jurisdiction patient={patient} current_user={mockUser1} has_dependents={hasDependents}
-    jurisdiction_paths={jurisdiction_paths} authenticity_token={authyToken} user_can_transfer={true} />);
+    jurisdiction_paths={mockJurisdictionPaths} authenticity_token={authyToken} user_can_transfer={true} />);
 }
 
 describe('Jurisdiction', () => {
@@ -29,10 +22,10 @@ describe('Jurisdiction', () => {
     expect(wrapper.find(InfoTooltip).prop('tooltipTextKey')).toEqual('assignedJurisdictionCanTransfer');
     expect(wrapper.find('#jurisdiction_id').exists()).toBeTruthy();
     expect(wrapper.find('option').length).toEqual(6);
-    for (var key of Object.keys(jurisdiction_paths)) {
-      expect(wrapper.find('option').at(key-2).text()).toEqual(jurisdiction_paths[key]);
+    for (var key of Object.keys(mockJurisdictionPaths)) {
+      expect(wrapper.find('option').at(key-2).text()).toEqual(mockJurisdictionPaths[key]);
     }
-    expect(wrapper.find('#jurisdiction_id').prop('value')).toEqual(jurisdiction_paths[mockPatient1.jurisdiction_id]);
+    expect(wrapper.find('#jurisdiction_id').prop('value')).toEqual(mockJurisdictionPaths[mockPatient1.jurisdiction_id]);
     expect(wrapper.find(Button).exists()).toBeTruthy();
     expect(wrapper.find(Button).text().includes('Change Jurisdiction')).toBeTruthy();
     expect(wrapper.find('i').hasClass('fa-map-marked-alt')).toBeTruthy();
@@ -42,7 +35,7 @@ describe('Jurisdiction', () => {
   it('Changing jurisdiction enables change jurisdiction button and sets state correctly', () => {
     const wrapper = getWrapper(mockPatient1, false);
     expect(wrapper.find(Button).prop('disabled')).toBeTruthy();
-    expect(wrapper.state('jurisdiction_path')).toEqual(jurisdiction_paths[mockPatient1.jurisdiction_id]);
+    expect(wrapper.state('jurisdiction_path')).toEqual(mockJurisdictionPaths[mockPatient1.jurisdiction_id]);
     expect(wrapper.state('original_jurisdiction_id')).toEqual(mockPatient1.jurisdiction_id);
 
     wrapper.find('#jurisdiction_id').simulate('change', { target: { id: 'jurisdiction_id', value: 'USA, State 2, County 4' } });
@@ -83,7 +76,7 @@ describe('Jurisdiction', () => {
     expect(wrapper.find(Modal.Title).exists()).toBeTruthy();
     expect(wrapper.find(Modal.Title).text()).toEqual('Jurisdiction');
     expect(modalBody.exists()).toBeTruthy();
-    expect(modalBody.find('p').text().includes(`Are you sure you want to change jurisdiction from "${jurisdiction_paths[mockPatient1.jurisdiction_id]}" to "USA, State 2, County 4"?`)).toBeTruthy();
+    expect(modalBody.find('p').text().includes(`Are you sure you want to change jurisdiction from "${mockJurisdictionPaths[mockPatient1.jurisdiction_id]}" to "USA, State 2, County 4"?`)).toBeTruthy();
     expect(modalBody.find('p').find('b').text()).toEqual(' Please also consider removing or updating the assigned user if it is no longer applicable.');
     expect(modalBody.find(Form.Group).length).toEqual(1);
     expect(modalBody.find(Form.Group).text().includes('Please include any additional details:')).toBeTruthy();
@@ -157,7 +150,7 @@ describe('Jurisdiction', () => {
     // resets state
     expect(wrapper.state('showJurisdictionModal')).toBeFalsy();
     expect(wrapper.state('apply_to_household')).toBeFalsy();
-    expect(wrapper.state('jurisdiction_path')).toEqual(jurisdiction_paths[mockPatient1.jurisdiction_id]);
+    expect(wrapper.state('jurisdiction_path')).toEqual(mockJurisdictionPaths[mockPatient1.jurisdiction_id]);
     expect(wrapper.state('reasoning')).toEqual('');
   });
 

--- a/app/javascript/tests/subject/monitoring_actions/MonitoringActions.test.js
+++ b/app/javascript/tests/subject/monitoring_actions/MonitoringActions.test.js
@@ -11,22 +11,15 @@ import MonitoringStatus from '../../../components/subject/monitoring_actions/Mon
 import PublicHealthAction from '../../../components/subject/monitoring_actions/PublicHealthAction';
 import { mockPatient1 } from '../../mocks/mockPatients'
 import { mockUser1 } from '../../mocks/mockUsers'
+import { mockJurisdictionPaths } from '../../mocks/mockJurisdiction'
 
 const authyToken = 'Q1z4yZXLdN+tZod6dBSIlMbZ3yWAUFdY44U06QWffEP76nx1WGMHIz8rYxEUZsl9sspS3ePF2ZNmSue8wFpJGg==';
 const assigned_users = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
-const jurisdiction_paths = {
-  2: 'USA, State 1',
-  3: 'USA, State 1, County 1',
-  4: 'USA, State 1, County 2',
-  5: 'USA, State 2',
-  6: 'USA, State 2, County 3',
-  7: 'USA, State 2, County 4'
-};
 
 describe('MonitoringActions', () => {
   it('Properly renders all main components', () => {
     const wrapper = shallow(<MonitoringActions patient={mockPatient1} has_dependents={false} in_household_with_member_with_ce_in_exposure={false} isolation={false} 
-      authenticity_token={authyToken} jurisdiction_paths={jurisdiction_paths} current_user={mockUser1} assigned_users={assigned_users} user_can_transfer={false} />);
+      authenticity_token={authyToken} jurisdiction_paths={mockJurisdictionPaths} current_user={mockUser1} assigned_users={assigned_users} user_can_transfer={false} />);
 
     expect(wrapper.find(Form).exists()).toBeTruthy();
     expect(wrapper.find(Form.Group).length).toEqual(7);


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1118](https://tracker.codev.mitre.org/browse/SARAALERT-1118)

When exporting a file, the user is able to click the "Start Export" button multiple times after clicking it once and before the modal closes. Because of the export limitation that we have this doesn't actually cause multiple exports, but it will result in a red message popping up for each extra click telling the user they can't export more. See attached screenshot for the button being referred to.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`ConfirmExport.js`
- Added loading state variable to disable the `StartExport` button when clicked

`ConfirmExport.test.js`
- Added test suite for this component

`Export.test.js`
- Added test suite for this component

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
