### PR TITLE
(Bugfix) Bug with allowed_params was preventing dup detection.

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -102,11 +102,11 @@ class PatientsController < ApplicationController
 
     # Check for potential duplicate
     unless params[:bypass_duplicate]
-      duplicate_data = current_user.viewable_patients.duplicate_data(params[:patient].permit(*allowed_params)[:first_name],
-                                                                     params[:patient].permit(*allowed_params)[:last_name],
-                                                                     params[:patient].permit(*allowed_params)[:sex],
-                                                                     params[:patient].permit(*allowed_params)[:date_of_birth],
-                                                                     params[:patient].permit(*allowed_params)[:user_defined_id_statelocal])
+      duplicate_data = current_user.viewable_patients.duplicate_data(allowed_params[:first_name],
+                                                                     allowed_params[:last_name],
+                                                                     allowed_params[:sex],
+                                                                     allowed_params[:date_of_birth],
+                                                                     allowed_params[:user_defined_id_statelocal])
 
       render(json: duplicate_data) && return if duplicate_data[:is_duplicate]
     end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1119](https://tracker.codev.mitre.org/browse/SARAALERT-1131)

Duplicate detection was unknowingly not working when the `allowed_params` method was changed.

# (Bugfix) How to Replicate
Try and enroll a duplicate and notice it is not detected. Duplicates are either:
- matching first name, last name, sex, and DoB
   OR
- matching state/local id

# (Bugfix) Solution
Fixing use of `allowed_params` method since it has been updated to already permit the params.