### PR TITLE
SA-1101 Assessment update history message fixes

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -192,7 +192,7 @@ class AssessmentsController < ApplicationController
       old_val = assessment.reported_condition&.symptoms&.find_by(name: symptom.name)&.value
       case symptom.type
       when 'BoolSymptom'
-        has_changed = [true, false].include?(new_val) && [true, false].include?(old_val) && new_val != old_val
+        has_changed = old_val != new_val && !old_val.nil? && !new_val.nil?
         delta << "#{symptom.label} (\"#{old_val ? 'Yes' : 'No'}\" to \"#{new_val ? 'Yes' : 'No'}\")" if has_changed
       when 'FloatSymptom', 'IntegerSymptom'
         delta << "#{symptom.label} (\"#{old_val}\" to \"#{new_val}\")" if new_val != old_val

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -178,7 +178,8 @@ class AssessmentsController < ApplicationController
     patient = Patient.find_by(submission_token: submission_token)
     redirect_to(root_url) && return if patient.nil?
 
-    redirect_to(root_url) && return unless current_user&.can_edit_patient_assessments?
+    redirect_to(root_url) && return unless current_user&.can_edit_patient_assessments
+
     assessment = Assessment.find_by(id: params.permit(:id)[:id])
     reported_symptoms_array = params.permit({ symptoms: %i[name value type label notes required] }).to_h['symptoms']
 
@@ -193,7 +194,7 @@ class AssessmentsController < ApplicationController
       when 'BoolSymptom'
         has_changed = [true, false].include?(new_val) && [true, false].include?(old_val) && new_val != old_val
         delta << "#{symptom.label} (\"#{old_val ? 'Yes' : 'No'}\" to \"#{new_val ? 'Yes' : 'No'}\")" if has_changed
-      when 'FloatSymptom','IntegerSymptom'
+      when 'FloatSymptom', 'IntegerSymptom'
         delta << "#{symptom.label} (\"#{old_val}\" to \"#{new_val}\")" if new_val != old_val
       end
     end

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -178,7 +178,7 @@ class AssessmentsController < ApplicationController
     patient = Patient.find_by(submission_token: submission_token)
     redirect_to(root_url) && return if patient.nil?
 
-    redirect_to(root_url) && return unless current_user&.can_edit_patient_assessments
+    redirect_to(root_url) && return unless current_user&.can_edit_patient_assessments?
 
     assessment = Assessment.find_by(id: params.permit(:id)[:id])
     reported_symptoms_array = params.permit({ symptoms: %i[name value type label notes required] }).to_h['symptoms']

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -192,15 +192,15 @@ class AssessmentsController < ApplicationController
         new_val = symptom.bool_value
         old_val = assessment.reported_condition&.symptoms&.find_by(name: symptom.name)&.bool_value
         has_changed = [true, false].include?(new_val) && [true, false].include?(old_val) && new_val != old_val
-        delta << symptom.name + '=' + (new_val ? 'Yes' : 'No') if has_changed
+        delta << "#{symptom.label} (\"#{old_val ? 'Yes' : 'No'}\" to \"#{new_val ? 'Yes' : 'No'}\")" if has_changed
       when 'FloatSymptom'
         new_val = symptom.float_value
         old_val = assessment.reported_condition&.symptoms&.find_by(name: symptom.name)&.float_value
-        delta << "#{symptom.name}=#{new_val}" if new_val != old_val
+        delta << "#{symptom.label} (\"#{old_val}\" to \"#{new_val}\")" if new_val != old_val
       when 'IntegerSymptom'
         new_val = symptom.int_value
         old_val = assessment.reported_condition&.symptoms&.find_by(name: symptom.name)&.int_value
-        delta << "#{symptom.name}=#{new_val}" if new_val != old_val
+        delta << "#{symptom.label} (\"#{old_val}\" to \"#{new_val}\")" if new_val != old_val
       end
     end
 

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -178,7 +178,7 @@ class AssessmentsController < ApplicationController
     patient = Patient.find_by(submission_token: submission_token)
     redirect_to(root_url) && return if patient.nil?
 
-    redirect_to root_url unless current_user&.can_edit_patient_assessments?
+    redirect_to(root_url) && return unless current_user&.can_edit_patient_assessments?
     assessment = Assessment.find_by(id: params.permit(:id)[:id])
     reported_symptoms_array = params.permit({ symptoms: %i[name value type label notes required] }).to_h['symptoms']
 
@@ -187,19 +187,13 @@ class AssessmentsController < ApplicationController
     # Figure out the change
     delta = []
     typed_reported_symptoms.each do |symptom|
+      new_val = symptom.value
+      old_val = assessment.reported_condition&.symptoms&.find_by(name: symptom.name)&.value
       case symptom.type
       when 'BoolSymptom'
-        new_val = symptom.bool_value
-        old_val = assessment.reported_condition&.symptoms&.find_by(name: symptom.name)&.bool_value
         has_changed = [true, false].include?(new_val) && [true, false].include?(old_val) && new_val != old_val
         delta << "#{symptom.label} (\"#{old_val ? 'Yes' : 'No'}\" to \"#{new_val ? 'Yes' : 'No'}\")" if has_changed
-      when 'FloatSymptom'
-        new_val = symptom.float_value
-        old_val = assessment.reported_condition&.symptoms&.find_by(name: symptom.name)&.float_value
-        delta << "#{symptom.label} (\"#{old_val}\" to \"#{new_val}\")" if new_val != old_val
-      when 'IntegerSymptom'
-        new_val = symptom.int_value
-        old_val = assessment.reported_condition&.symptoms&.find_by(name: symptom.name)&.int_value
+      when 'FloatSymptom','IntegerSymptom'
         delta << "#{symptom.label} (\"#{old_val}\" to \"#{new_val}\")" if new_val != old_val
       end
     end

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -179,7 +179,6 @@ class AssessmentsController < ApplicationController
     redirect_to(root_url) && return if patient.nil?
 
     redirect_to root_url unless current_user&.can_edit_patient_assessments?
-    patient = Patient.find_by(submission_token: params.permit(:patient_submission_token)[:patient_submission_token])
     assessment = Assessment.find_by(id: params.permit(:id)[:id])
     reported_symptoms_array = params.permit({ symptoms: %i[name value type label notes required] }).to_h['symptoms']
 
@@ -188,10 +187,20 @@ class AssessmentsController < ApplicationController
     # Figure out the change
     delta = []
     typed_reported_symptoms.each do |symptom|
-      new_val = symptom.bool_value
-      old_val = assessment.reported_condition&.symptoms&.find_by(name: symptom.name)&.bool_value
-      if new_val.present? && old_val.present? && new_val != old_val
-        delta << symptom.name + '=' + (new_val ? 'Yes' : 'No')
+      case symptom.type
+      when 'BoolSymptom'
+        new_val = symptom.bool_value
+        old_val = assessment.reported_condition&.symptoms&.find_by(name: symptom.name)&.bool_value
+        has_changed = [true, false].include?(new_val) && [true, false].include?(old_val) && new_val != old_val
+        delta << symptom.name + '=' + (new_val ? 'Yes' : 'No') if has_changed
+      when 'FloatSymptom'
+        new_val = symptom.float_value
+        old_val = assessment.reported_condition&.symptoms&.find_by(name: symptom.name)&.float_value
+        delta << "#{symptom.name}=#{new_val}" if new_val != old_val
+      when 'IntegerSymptom'
+        new_val = symptom.int_value
+        old_val = assessment.reported_condition&.symptoms&.find_by(name: symptom.name)&.int_value
+        delta << "#{symptom.name}=#{new_val}" if new_val != old_val
       end
     end
 

--- a/test/controllers/assessments_controller_test.rb
+++ b/test/controllers/assessments_controller_test.rb
@@ -207,7 +207,7 @@ class AssessmentsControllerTest < ActionController::TestCase
           }
           assert_redirected_to :patient_assessments
           assert_match(/Symptom updates/, History.last.comment)
-          assert_match(/fever=Yes/, History.last.comment)
+          assert_match(/Fever \("No" to "Yes"\)/, History.last.comment)
         end
       end
     end
@@ -261,7 +261,7 @@ class AssessmentsControllerTest < ActionController::TestCase
           }
           assert_redirected_to :patient_assessments
           assert_match(/Symptom updates/, History.last.comment)
-          assert_match(/temperature=100.4/, History.last.comment)
+          assert_match(/Temperature \("99.8" to "100.4"\)/, History.last.comment)
         end
       end
     end
@@ -316,7 +316,7 @@ class AssessmentsControllerTest < ActionController::TestCase
           }
           assert_redirected_to :patient_assessments
           assert_match(/Symptom updates/, History.last.comment)
-          assert_match(/daysWithoutFever=3/, History.last.comment)
+          assert_match(/Days Without Fever \("2" to "3"\)/, History.last.comment)
         end
       end
     end

--- a/test/controllers/assessments_controller_test.rb
+++ b/test/controllers/assessments_controller_test.rb
@@ -143,7 +143,6 @@ class AssessmentsControllerTest < ActionController::TestCase
     assert_redirected_to :root
   end
 
-
   def update_report_test(role)
     patient_submission_token = patients(:patient_1).submission_token
     assessment = assessments(:patient_1_assessment_2)

--- a/test/controllers/assessments_controller_test.rb
+++ b/test/controllers/assessments_controller_test.rb
@@ -180,8 +180,8 @@ class AssessmentsControllerTest < ActionController::TestCase
             symptoms: symptoms
           }
           assert_redirected_to :patient_assessments
-          assert_match /Symptom updates/, History.last.comment
-          assert_match /fever=Yes/, History.last.comment
+          assert_match(/Symptom updates/, History.last.comment)
+          assert_match(/fever=Yes/, History.last.comment)
         end
       end
     end
@@ -234,8 +234,8 @@ class AssessmentsControllerTest < ActionController::TestCase
             symptoms: symptoms
           }
           assert_redirected_to :patient_assessments
-          assert_match /Symptom updates/, History.last.comment
-          assert_match /temperature=100.4/, History.last.comment
+          assert_match(/Symptom updates/, History.last.comment)
+          assert_match(/temperature=100.4/, History.last.comment)
         end
       end
     end
@@ -289,8 +289,8 @@ class AssessmentsControllerTest < ActionController::TestCase
             symptoms: symptoms
           }
           assert_redirected_to :patient_assessments
-          assert_match /Symptom updates/, History.last.comment
-          assert_match /daysWithoutFever=3/, History.last.comment
+          assert_match(/Symptom updates/, History.last.comment)
+          assert_match(/daysWithoutFever=3/, History.last.comment)
         end
       end
     end

--- a/test/controllers/assessments_controller_test.rb
+++ b/test/controllers/assessments_controller_test.rb
@@ -1,0 +1,301 @@
+# frozen_string_literal: true
+
+require 'test_case'
+
+class AssessmentsControllerTest < ActionController::TestCase
+  def setup; end
+
+  def teardown; end
+
+  def symptoms_param(model_symptoms)
+    model_symptoms.map do |s|
+      {
+        name: s.name,
+        value: s.value,
+        type: s.type,
+        label: s.label,
+        notes: s.notes,
+        required: s.required
+      }
+    end
+  end
+
+  test 'successful get new report as patient' do
+    ADMIN_OPTIONS['report_mode'] = true
+    patient_submission_token = patients(:patient_1).submission_token
+    unique_identifier = patients(:patient_1).jurisdiction.unique_identifier
+    get :new, params: {
+      patient_submission_token: patient_submission_token,
+      unique_identifier: unique_identifier
+    }
+    assert_response :success
+  end
+
+  test 'successful get using old_unique_identifier as patient' do
+    ADMIN_OPTIONS['report_mode'] = true
+    patient_submission_token = patients(:patient_1).submission_token
+    unique_identifier = JurisdictionLookup.find_by(
+      new_unique_identifier: patients(:patient_1).jurisdiction.unique_identifier
+    ).old_unique_identifier
+    get :new, params: {
+      patient_submission_token: patient_submission_token,
+      unique_identifier: unique_identifier
+    }
+    assert_response :success
+  end
+
+  test 'successful get new report as user' do
+    ADMIN_OPTIONS['report_mode'] = false
+    user = create(:public_health_enroller_user)
+    sign_in user
+    patient_submission_token = patients(:patient_1).submission_token
+    unique_identifier = patients(:patient_1).jurisdiction.unique_identifier
+    get :new, params: {
+      patient_submission_token: patient_submission_token,
+      unique_identifier: unique_identifier
+    }
+    assert_response :success
+  end
+
+  test 'successful create report as patient' do
+    ADMIN_OPTIONS['report_mode'] = true
+    patient_submission_token = patients(:patient_1).submission_token
+    unique_identifier = patients(:patient_1).jurisdiction.unique_identifier
+    assert_difference ['AssessmentReceipt.count'], 1 do
+      post :create, params: {
+        patient_submission_token: patient_submission_token,
+        unique_identifier: unique_identifier,
+        experiencing_symptoms: 'yes'
+      }
+    end
+    assert_response :success
+  end
+
+  test 'hit limit number of reports per time period as patient' do
+    ADMIN_OPTIONS['report_mode'] = true
+    patient_submission_token = patients(:patient_1).submission_token
+    unique_identifier = patients(:patient_1).jurisdiction.unique_identifier
+    assert_difference ['AssessmentReceipt.count'], 1 do
+      post :create, params: {
+        patient_submission_token: patient_submission_token,
+        unique_identifier: unique_identifier,
+        experiencing_symptoms: 'yes'
+      }
+    end
+    assert_response :success
+    get :new, params: {
+      patient_submission_token: patient_submission_token,
+      unique_identifier: unique_identifier
+    }
+    assert_redirected_to :already_reported_report
+  end
+
+  test 'successful create report as user' do
+    ADMIN_OPTIONS['report_mode'] = false
+    patient_submission_token = patients(:patient_1).submission_token
+    unique_identifier = patients(:patient_1).jurisdiction.unique_identifier
+    AssessmentReceipt.create(submission_token: patient_submission_token)
+    %i[public_health_enroller_user public_health_user contact_tracer_user super_user].each do |role|
+      user = create(role)
+      sign_in user
+      assert_no_difference 'AssessmentReceipt.count' do
+        assert_difference 'Assessment.count', 1 do
+          post :create, params: {
+            patient_submission_token: patient_submission_token,
+            unique_identifier: unique_identifier,
+            experiencing_symptoms: 'yes',
+            symptoms: [
+              {
+                name: 'Cough',
+                value: false,
+                type: 'BoolSymptom',
+                label: 'Cough',
+                notes: 'Have you coughed today?'
+              }
+            ]
+          }
+        end
+      end
+      assert_redirected_to :patient_assessments
+      sign_out user
+    end
+  end
+
+  test 'redirected on bad update params' do
+    post :update, params: {
+      patient_submission_token: '',
+      id: ''
+    }
+    assert_redirected_to :root
+  end
+
+  test 'redirected on ' do
+  end
+
+  test 'successfuly update report as user' do
+    patient_submission_token = patients(:patient_1).submission_token
+    assessment = assessments(:patient_1_assessment_2)
+
+    # edit the assessment
+    %i[public_health_user public_health_enroller_user contact_tracer_user super_user].each do |role|
+      user = create(role)
+      symptoms = symptoms_param(assessment.reported_condition.symptoms)
+      expected_change = !symptoms.first[:value]
+      symptoms.first[:value] = expected_change
+      sign_in user
+      assert_changes 'History.count' do
+        assert_no_difference 'AssessmentReceipt.count' do
+          assert_no_difference 'Assessment.count' do
+            post :update, params: {
+              patient_submission_token: patient_submission_token,
+              id: assessment.id,
+              experiencing_symptoms: 'yes',
+              symptoms: symptoms
+            }
+            assert_redirected_to :patient_assessments
+          end
+        end
+      end
+      assessment.reload
+      assert_equal expected_change, assessment.reported_condition.symptoms.first.bool_value
+    end
+  end
+
+  test 'successfuly update with old_submission_token' do
+    submission_token = patients(:patient_1).submission_token
+    old_submission_token = PatientLookup.find_by(new_submission_token: submission_token).old_submission_token
+    assessment = assessments(:patient_1_assessment_2)
+    user = create(:public_health_user)
+    symptoms = symptoms_param(assessment.reported_condition.symptoms)
+    expected_change = !symptoms.first[:value]
+    symptoms.first[:value] = expected_change
+    sign_in user
+    assert_changes 'History.count' do
+      assert_no_difference 'AssessmentReceipt.count' do
+        assert_no_difference 'Assessment.count' do
+          post :update, params: {
+            patient_submission_token: old_submission_token,
+            id: assessment.id,
+            experiencing_symptoms: 'yes',
+            symptoms: symptoms
+          }
+          assert_redirected_to :patient_assessments
+          assert_match /Symptom updates/, History.last.comment
+          assert_match /fever=Yes/, History.last.comment
+        end
+      end
+    end
+    assessment.reload
+    assert_equal expected_change, assessment.reported_condition.symptoms.first.bool_value
+  end
+
+  test 'updating with a new arbitrary float symptom' do
+    submission_token = patients(:patient_1).submission_token
+    assessment = assessments(:patient_1_assessment_2)
+    user = create(:public_health_user)
+    symptoms = symptoms_param(assessment.reported_condition.symptoms)
+    symptoms << {
+      name: 'temperature',
+      value: 99.8,
+      type: 'FloatSymptom',
+      label: 'Temperature',
+      notes: nil,
+      required: false
+    }
+    sign_in user
+
+    # create the new symptom
+    assert_changes 'History.count' do
+      assert_no_difference 'AssessmentReceipt.count' do
+        assert_no_difference 'Assessment.count' do
+          post :update, params: {
+            patient_submission_token: submission_token,
+            id: assessment.id,
+            experiencing_symptoms: 'yes',
+            symptoms: symptoms
+          }
+          assert_redirected_to :patient_assessments
+        end
+      end
+    end
+    assessment.reload
+
+    assert_equal 99.8, symptoms.find { |d| d[:name] == 'temperature' }[:value]
+
+    # update the new symptom
+    symptoms.find { |d| d[:name] == 'temperature' }[:value] = 100.4
+    assert_changes 'History.count' do
+      assert_no_difference 'AssessmentReceipt.count' do
+        assert_no_difference 'Assessment.count' do
+          post :update, params: {
+            patient_submission_token: submission_token,
+            id: assessment.id,
+            experiencing_symptoms: 'yes',
+            symptoms: symptoms
+          }
+          assert_redirected_to :patient_assessments
+          assert_match /Symptom updates/, History.last.comment
+          assert_match /temperature=100.4/, History.last.comment
+        end
+      end
+    end
+    assessment.reload
+    symptoms = symptoms_param(assessment.reported_condition.symptoms)
+    assert_equal 100.4, symptoms.find { |d| d[:name] == 'temperature' }[:value]
+  end
+
+  test 'updating with a new arbitrary integer symptom' do
+    submission_token = patients(:patient_1).submission_token
+    assessment = assessments(:patient_1_assessment_2)
+    user = create(:public_health_user)
+    symptoms = symptoms_param(assessment.reported_condition.symptoms)
+    symptoms << {
+      name: 'daysWithoutFever',
+      value: 2,
+      type: 'IntegerSymptom',
+      label: 'Days Without Fever',
+      notes: nil,
+      required: false
+    }
+    sign_in user
+
+    # create the new symptom
+    assert_changes 'History.count' do
+      assert_no_difference 'AssessmentReceipt.count' do
+        assert_no_difference 'Assessment.count' do
+          post :update, params: {
+            patient_submission_token: submission_token,
+            id: assessment.id,
+            experiencing_symptoms: 'yes',
+            symptoms: symptoms
+          }
+          assert_redirected_to :patient_assessments
+        end
+      end
+    end
+    assessment.reload
+
+    assert_equal 2, symptoms.find { |d| d[:name] == 'daysWithoutFever' }[:value]
+
+    # update the new symptom
+    symptoms.find { |d| d[:name] == 'daysWithoutFever' }[:value] = 3
+    assert_changes 'History.count' do
+      assert_no_difference 'AssessmentReceipt.count' do
+        assert_no_difference 'Assessment.count' do
+          post :update, params: {
+            patient_submission_token: submission_token,
+            id: assessment.id,
+            experiencing_symptoms: 'yes',
+            symptoms: symptoms
+          }
+          assert_redirected_to :patient_assessments
+          assert_match /Symptom updates/, History.last.comment
+          assert_match /daysWithoutFever=3/, History.last.comment
+        end
+      end
+    end
+    assessment.reload
+    symptoms = symptoms_param(assessment.reported_condition.symptoms)
+    assert_equal 3, symptoms.find { |d| d[:name] == 'daysWithoutFever' }[:value]
+  end
+end


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1101

Write assessment controller tests & track float/integer/bool symptoms in history properly
# (Feature) Demo/Screenshots
Insert demo video or photos for a new or updated feature or capability.

# (Bugfix) How to Replicate
- checkout master
- change a symptom in a test or on local server
- verify that the created history message does NOT contain a `Symptom updates: _____` sentence.

# (Bugfix) Solution
The original state of the change tracking was not properly saving boolean symptoms and not attempting to track float or integer symptoms. This PR addresses both issues.

# Important Changes

`app/controllers/assessments_controller.rb`
- bug fix for patient find using an old key
- fix bug with history tracking on boolean symptom update
- add history tracking for updates on float and integer symptoms
`test/controllers/assessments_controller_test.rb`
- New test file for assessments controller

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11
