### PR TITLE
(Bugfixes) 1.18.0 Fixes

### DIFF
--- a/app/helpers/assessment_query_helper.rb
+++ b/app/helpers/assessment_query_helper.rb
@@ -84,7 +84,7 @@ module AssessmentQueryHelper
       }
 
       passes_threshold_data = {}
-      symptoms&.pluck(:name).each do |symptom_name|
+      symptoms&.pluck(:name)&.each do |symptom_name|
         symptom = assessment.get_reported_symptom_by_name(symptom_name)
         value = symptom&.value
         # NOTE: We must check if the value is nil here before making this change.
@@ -98,6 +98,6 @@ module AssessmentQueryHelper
       details[:passes_threshold_data] = passes_threshold_data
       table_data << details
     end
-    { table_data: table_data, symptoms: symptoms ? symptoms : [], total: assessments.total_entries }
+    { table_data: table_data, symptoms: symptoms || [], total: assessments.total_entries }
   end
 end

--- a/app/helpers/assessment_query_helper.rb
+++ b/app/helpers/assessment_query_helper.rb
@@ -35,7 +35,7 @@ module AssessmentQueryHelper
     else
       # Verify this is a sort request for a symptom column.
       symptom_columns = Assessment.get_unique_symptoms_for_assessments(assessments.pluck(:id)).pluck(:name)
-      return assessments unless symptom_columns.include?(order)
+      return assessments unless symptom_columns&.include?(order)
 
       # Find assessment IDs based on the value of the symptom in the specified column
       ordered_values = assessments.map do |a|
@@ -71,6 +71,7 @@ module AssessmentQueryHelper
   def format(assessments)
     table_data = []
     symptoms = Assessment.get_unique_symptoms_for_assessments(assessments.pluck(:id))
+
     assessments.each do |assessment|
       reported_condition = assessment.reported_condition
       details = {
@@ -83,7 +84,7 @@ module AssessmentQueryHelper
       }
 
       passes_threshold_data = {}
-      symptoms.pluck(:name).each do |symptom_name|
+      symptoms&.pluck(:name).each do |symptom_name|
         symptom = assessment.get_reported_symptom_by_name(symptom_name)
         value = symptom&.value
         # NOTE: We must check if the value is nil here before making this change.
@@ -97,6 +98,6 @@ module AssessmentQueryHelper
       details[:passes_threshold_data] = passes_threshold_data
       table_data << details
     end
-    { table_data: table_data, symptoms: symptoms, total: assessments.total_entries }
+    { table_data: table_data, symptoms: symptoms ? symptoms : [], total: assessments.total_entries }
   end
 end

--- a/app/javascript/components/patient/Patient.js
+++ b/app/javascript/components/patient/Patient.js
@@ -69,14 +69,14 @@ class Patient extends React.Component {
       <React.Fragment>
         <Row id="monitoree-details-header">
           <Col className="mt-1">
-            <h3>
+            <div className="h3">
               <span className="pr-2">
                 {`${this.props.details.first_name ? this.props.details.first_name : ''}${
                   this.props.details.middle_name ? ' ' + this.props.details.middle_name : ''
                 }${this.props.details.last_name ? ' ' + this.props.details.last_name : ''}`}
               </span>
               {this.props?.dependents && this.props?.dependents?.length > 0 && <BadgeHOH patientId={String(this.props.details.id)} location={'right'} />}
-            </h3>
+            </div>
           </Col>
           <Col md="auto" className="jurisdiction-user-box mr-3">
             <Row id="jurisdiction-path">
@@ -626,7 +626,7 @@ class Patient extends React.Component {
                     <div>
                       {this.props.goto && (
                         <Button variant="link" className="pt-0" onClick={() => this.props.goto(5)}>
-                          <h5>(Edit)</h5>
+                          <div className="h5">(Edit)</div>
                         </Button>
                       )}
                     </div>
@@ -682,7 +682,7 @@ class Patient extends React.Component {
                       <div>
                         {this.props.goto && (
                           <Button variant="link" className="pt-0" onClick={() => this.props.goto(5)}>
-                            <h5>(Edit)</h5>
+                            <div className="h5">(Edit)</div>
                           </Button>
                         )}
                       </div>

--- a/app/javascript/tests/patient/Patient.test.js
+++ b/app/javascript/tests/patient/Patient.test.js
@@ -33,7 +33,7 @@ describe('Patient', () => {
             jurisdiction_path="USA, State 1, County 2" authenticity_token={authyToken} />);
 
         expect(wrapper.find('#monitoree-details-header').exists()).toBeTruthy();
-        expect(wrapper.find('#monitoree-details-header').find('h3').text().includes(nameFormatter(mockPatient1))).toBeTruthy();
+        expect(wrapper.find('#monitoree-details-header').find('.h3').text().includes(nameFormatter(mockPatient1))).toBeTruthy();
         expect(wrapper.find('#monitoree-details-header').find(BadgeHOH).exists()).toBeTruthy();
         expect(wrapper.find('.jurisdiction-user-box').exists()).toBeTruthy();
         expect(wrapper.find('#jurisdiction-path').text()).toEqual('Assigned Jurisdiction: USA, State 1, County 2');

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -22,7 +22,13 @@ class ConsumeAssessmentsJob < ApplicationJob
         end
 
         if message['response_status'].in? %w[opt_out opt_in]
-          handle_opt_in_opt_out(message)
+          begin
+            handle_opt_in_opt_out(message)
+          rescue StandardError => e
+            Rails.logger.info(
+              "ConsumeAssessmentsJob: failure handling opt-in/opt-out message (message response status: #{message['response_status']}), (error: #{e})"
+            )
+          end
           queue.commit
           next
         end

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -710,9 +710,11 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
 
     assessments_details = []
     assessments.each do |assessment|
-      assessment_details = assessment.custom_details(fields, patients_identifiers[assessment.patient_id])
+      assessment_details = assessment.custom_details(fields, patients_identifiers[assessment.patient_id]) || {}
       if fields.include?(:symptoms)
         symptom_names_and_labels&.map(&:first)&.each do |symptom_name|
+          next if assessments_hash[assessment[:id]].nil?
+
           assessment_details[symptom_name.to_sym] = assessments_hash[assessment[:id]][symptom_name]
         end
       end

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -713,6 +713,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
       assessment_details = assessment.custom_details(fields, patients_identifiers[assessment.patient_id]) || {}
       if fields.include?(:symptoms)
         symptom_names_and_labels&.map(&:first)&.each do |symptom_name|
+          # Nil check in case for some reason there were assessments with nil ReportedCondition
           next if assessments_hash[assessment[:id]].nil?
 
           assessment_details[symptom_name.to_sym] = assessments_hash[assessment[:id]][symptom_name]

--- a/app/mailers/twilio_sender.rb
+++ b/app/mailers/twilio_sender.rb
@@ -46,10 +46,11 @@ class TwilioSender
       Rails.logger.warn e.error_message
       return
     end
-    return if execution.nil? || execution.context.nil? || execution.context['trigger'].nil? || execution.context['trigger']['message'].nil?
 
-    phone_number_from = execution.context['trigger']['message']['From'] || nil
-    phone_number_to = execution.context['trigger']['message']['To'] || nil
+    trigger_message = execution&.context&.[]('trigger')&.[]('message')
+    phone_number_from = trigger_message&.[]('From')
+    phone_number_to = trigger_message&.[]('To')
+
     return { monitoree_number: phone_number_from, sara_number: phone_number_to } if !phone_number_from.nil? && !phone_number_to.nil?
 
     nil

--- a/app/mailers/twilio_sender.rb
+++ b/app/mailers/twilio_sender.rb
@@ -46,6 +46,8 @@ class TwilioSender
       Rails.logger.warn e.error_message
       return
     end
+    return if execution.nil? || execution.context.nil? || execution.context['trigger'].nil? || execution.context['trigger']['message'].nil?
+
     phone_number_from = execution.context['trigger']['message']['From'] || nil
     phone_number_to = execution.context['trigger']['message']['To'] || nil
     return { monitoree_number: phone_number_from, sara_number: phone_number_to } if !phone_number_from.nil? && !phone_number_to.nil?

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -97,7 +97,7 @@ class Assessment < ApplicationRecord
   def self.get_unique_symptoms_for_assessments(assessment_ids)
     threshold_cond_hashes = ReportedCondition.where(type: 'ReportedCondition', assessment_id: assessment_ids).pluck(:threshold_condition_hash)
     condition_ids = ThresholdCondition.where(type: 'ThresholdCondition', threshold_condition_hash: threshold_cond_hashes)
-    Symptom.where(condition_id: condition_ids).uniq(&:name)
+    Symptom.where(condition_id: condition_ids)&.uniq(&:name)
   end
 
   def translations


### PR DESCRIPTION
# Description
We are seeing a few failures on prod after 1.18.0 that seem to stem from unexpected prod data and needed nil checks. 

1. For some reason, the fetch for phone number when getting an opt-in/opt-out message appears to be failing/have unexpected data on prod. This requires further investigation, but for now, it needs to be caught to avoid causing an error in ConsumeAssessments.
![Screen Shot 2020-12-22 at 10 16 30 AM](https://user-images.githubusercontent.com/11698457/102904047-2b98e180-443f-11eb-947a-3a7cfcfdeb25.png)


2. Nil check needed on export when extracting assessment details. Looks like something related to a nil condition (still investigating).
![Screen Shot 2020-12-22 at 10 16 42 AM](https://user-images.githubusercontent.com/11698457/102903942-0906c880-443f-11eb-898f-19b1a17197fd.png)


# Testing
Please test these changes locally and on demo and verify that exporting assessments still works as expected, and that the consume assessments job runs and can handle an error in the Twilio Sender helper method as expected.