### PR TITLE
Bug fix: Properly wait on forks exiting in reports.rake

### DIFF
--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
-
 namespace :reports do
   desc "Receive and Process Reports"
   task receive_and_process_reports: :environment do
+    pids = []
+
     consume_workers = ENV.fetch("CONSUME_WORKERS") { 8 }
     consume_workers.times do
-      Process.fork do
-        ConsumeAssessmentsJob.perform_now
-      end
+      pids << Process.fork { ConsumeAssessmentsJob.perform_now }
     end
-    Process.waitall
+
+    # Process.waitall was not properly exiting for an unknown reason.
+    # Waiting for each PID allows the task to exit properly once all of the forks exit.
+    pids.each{ |pid| Process.wait pid }
   end
 end


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-###

Marked as draft until we find out how the job is exiting in prod.

`Process.waitall` was not properly exiting for an unknown reason. Waiting for each PID individual allows the task to exit properly once all of the forks exit.

# (Feature) Demo/Screenshots
Insert demo video or photos for a new or updated feature or capability.

# (Bugfix) How to Replicate
Add `1 / 0` to the start of the `ConsumeAssessmentsJob` on master and verify that `Process.waitall` gets stuck.

# (Bugfix) Solution
Add `1 / 0` to the start of the `ConsumeAssessmentsJob` on this branch and verify that the task exits.

# Important Changes

`lib/tasks/consume_assessments_job.rb`
- replace `Process.waitall` with a loop that waits for each PID individually

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

