### PR TITLE
(Bugfix) Moving queries until after check for nil Patient.

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -16,11 +16,11 @@ class PatientsController < ApplicationController
 
     @patient = current_user.get_patient(params.permit(:id)[:id])
 
-    @laboratories = @patient.laboratories.order(:created_at)
-    @close_contacts = @patient.close_contacts.order(:created_at)
-
     # If we failed to find a subject given the id, redirect to index
     redirect_to(root_url) && return if @patient.nil?
+
+    @laboratories = @patient.laboratories.order(:created_at)
+    @close_contacts = @patient.close_contacts.order(:created_at)
 
     @possible_jurisdiction_paths = if current_user.can_transfer_patients?
                                      # Allow all jurisdictions as valid transfer options.


### PR DESCRIPTION
# Description
After 1.19.0, we are seeing users hit an error when trying to access `laboratories` on a nil `Patient`. This happens if they try to navigate to a Patient record they do not have access to, so it's not a big issue. Previously, they would just be redirected to the home page (which is also something we already have a ticket to improve actually: [SARAALERT-876](https://tracker.codev.mitre.org/browse/SARAALERT-876)).

Here's the related Sentry error:
![Screen Shot 2020-12-23 at 11 59 05 AM](https://user-images.githubusercontent.com/11698457/103020394-4be79f80-4516-11eb-9892-2bbc66868724.png)


This PR just properly grabs the `@laboratories` and `@close_contacts` _after_ the check for a nil record and redirect.

# (Bugfix) How to Replicate
Try and navigate to a record that you don't have access to (make sure you're not logged in as a USA level user) (maybe a dependent in a household that is out of your jurisdiction).

# (Bugfix) Solution
Make sure to check for nil patient before anything else in the `show` action.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

To Test:
- [ ] Replicate the above and verify it redirects properly instead of throwing an error.
