### PR TITLE
Bugfix for updating multiple races with FHIR

### DIFF
--- a/app/helpers/fhir_helper.rb
+++ b/app/helpers/fhir_helper.rb
@@ -198,7 +198,7 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
   # Return a boolean indicating if the given race code is present on the given FHIR::Patient.
   def race_code?(patient, code)
     url = 'us-core-race'
-    patient&.extension&.select { |e| e.url.include?(url) }&.first&.extension&.select { |e| e.url == 'ombCategory' }&.first&.valueCoding&.code == code
+    patient&.extension&.select { |e| e.url.include?(url) }&.first&.extension&.select { |e| e.url == 'ombCategory' }&.any?{ |e| e&.valueCoding&.code == code }
   end
 
   # Build a FHIR US Core Ethnicity Extension given Sara Alert ethnicity information.

--- a/app/helpers/fhir_helper.rb
+++ b/app/helpers/fhir_helper.rb
@@ -198,7 +198,7 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
   # Return a boolean indicating if the given race code is present on the given FHIR::Patient.
   def race_code?(patient, code)
     url = 'us-core-race'
-    patient&.extension&.select { |e| e.url.include?(url) }&.first&.extension&.select { |e| e.url == 'ombCategory' }&.any?{ |e| e&.valueCoding&.code == code }
+    patient&.extension&.select { |e| e.url.include?(url) }&.first&.extension&.select { |e| e.url == 'ombCategory' }&.any? { |e| e&.valueCoding&.code == code }
   end
 
   # Build a FHIR US Core Ethnicity Extension given Sara Alert ethnicity information.

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -195,7 +195,9 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       travel_related_notes: 'travel related notes',
       additional_planned_travel_related_notes: 'additional travel related notes',
       primary_telephone_type: 'Plain Cell',
-      secondary_telephone_type: 'Landline'
+      secondary_telephone_type: 'Landline',
+      black_or_african_american: true,
+      asian: true
     )
     @patient_2 = Patient.find_by(id: 2).as_fhir
 
@@ -916,6 +918,8 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal 1, json_response['id']
     p = Patient.find_by(id: 1)
     assert_not p.nil?
+    assert p.black_or_african_american
+    assert p.asian
     assert_equal 'Patient', json_response['resourceType']
     assert_equal 'Kirlin44', json_response['name'].first['family']
     assert_equal 'SMS Texted Weblink', json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-method' }.first['valueString']


### PR DESCRIPTION
# (Bugfix) How to Replicate
When updating a patient with the FHIR api, only the first race matching race was being set to true

# (Bugfix) Solution
The selector was changed to match any instead of only the first.  The update test checks this condition, and if any additional tests should be updated let me know.