### PR TITLE
(Bugfix) More Batching in Exports to reduce Memory Usage

### DIFF
--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -169,8 +169,7 @@ class ExportController < ApplicationController
       }
     }
 
-    exported_data = get_export_data(patients, config[:data])
-    send_data write_export_data_to_files(config, exported_data, nil)[0][:content]
+    send_data write_export_data_to_files(config, patients, nil, config[:data])[0][:content]
   end
 
   # Single patient NBS export

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -78,7 +78,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     # Filter by assigned jurisdiction
     patients = patients.where(jurisdiction_id: jurisdiction.subtree_ids) if jurisdiction != current_user.jurisdiction && query[:tab] != :transferred_out
 
-    # Fitler by scope
+    # Filter by scope
     patients = patients.where(jurisdiction_id: jurisdiction.id) if query[:scope] == 'exact' && query[:tab] != :transferred_out
 
     # Filter by assigned user

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -27,9 +27,8 @@ class ExportJob < ApplicationJob
 
     # Custom export is already sorted by id, calling order on custom export patients leads to invalid SQL statement because id is not in select list
     patients = patients.order(:id) unless config[:export_type] == :custom
-    patients.find_in_batches(batch_size: RECORD_BATCH_SIZE).with_index do |patients_group, index|
-      exported_data = get_export_data(patients_group, data)
-      files = write_export_data_to_files(config, exported_data, index)
+    patients.in_batches(of: RECORD_BATCH_SIZE).each_with_index do |patients_group, index|
+      files = write_export_data_to_files(config, patients_group, index, data)
       lookups.concat(create_lookups(config, files))
     end
 

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -654,7 +654,8 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
 
   # Gets a hash of the latest transfers of each patient
   def get_patients_transfers(patients)
-    transfers = Transfer.where(patient_id: patients.pluck(:id), created_at: patients.pluck(:latest_transfer_at))
+    transfers = patients.pluck(:id, :latest_transfer_at)
+    transfers = Transfer.where(patient_id: transfers.map { |lt| lt[0] }, created_at: transfers.map { |lt| lt[1] })
     jurisdictions = Jurisdiction.find(transfers.pluck(:from_jurisdiction_id, :to_jurisdiction_id).flatten.uniq)
     jurisdiction_paths = Hash[jurisdictions.pluck(:id, :path).map { |id, path| [id, path] }]
     Hash[transfers.pluck(:patient_id, :created_at, :from_jurisdiction_id, :to_jurisdiction_id)

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -764,7 +764,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
 
     # Get export data in batches to decrease size of export data hash maintained in memory
     patients_group.in_batches(of: 500) do |batch_group|
-      exported_data = get_export_data(batch_group, data)
+      exported_data = get_export_data(batch_group.order(:id), data)
 
       CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
         next unless config.dig(:data, data_type, :checked).present?
@@ -814,14 +814,14 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
 
       # 2) Get export data in batches to decrease size of export data hash maintained in memory
       patients_group.in_batches(of: 500) do |batch_group|
-        exported_data = get_export_data(batch_group, data)
+        exported_data = get_export_data(batch_group.order(:id), data)
 
         #  Write to appropriate sheets (in each file)
         CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
           next unless config.dig(:data, data_type, :checked).present?
 
-          fields = fields[data_type]
-          write_xlsx_rows(config, exported_data, data_type, sheets[data_type], fields)
+          data_type_fields = fields[data_type]
+          write_xlsx_rows(config, exported_data, data_type, sheets[data_type], data_type_fields)
         end
       end
 
@@ -853,7 +853,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
 
         # 2) Get export data in batches to decrease size of export data hash maintained in memory
         patients_group.in_batches(of: 500) do |batch_group|
-          exported_data = get_export_data(batch_group, data)
+          exported_data = get_export_data(batch_group.order(:id), data)
 
           CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
             next unless config.dig(:data, data_type, :checked).present?

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -756,14 +756,14 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
 
       fields[data_type] = config.dig(:data, data_type, :checked)
       package = CSV.generate(headers: true) do |csv|
-        # create CSV with column headers
+        # Create CSV with column headers
         csv << (config.dig(:data, data_type, :headers) || fields[data_type].map { |field| ALL_FIELDS_NAMES.dig(data_type, field) })
         csvs[data_type] = csv
       end
       packages[data_type] = package
     end
 
-    # Get export data in batches to decrease size of export data hash maintained in memory
+    # 2) Get export data in batches to decrease size of export data hash maintained in memory
     patients_group.in_batches(of: 500) do |batch_group|
       exported_data = get_export_data(batch_group.order(:id), data)
 
@@ -776,6 +776,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
       end
     end
 
+    # 3) Write new file for each data type
     CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
       next unless config.dig(:data, data_type, :checked).present?
 
@@ -821,8 +822,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
         CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
           next unless config.dig(:data, data_type, :checked).present?
 
-          data_type_fields = fields[data_type]
-          write_xlsx_rows(config, exported_data, data_type, sheets[data_type], data_type_fields)
+          write_xlsx_rows(config, exported_data, data_type, sheets[data_type], fields[data_type])
         end
       end
 


### PR DESCRIPTION
# Description
We are seeing significant memory issues with custom exports, and have had to temporarily scale up our production resources in the interim. The main issue seems to be the lack of batching when getting all the export data to write to files, as we did previously. This PR adds that additional batching functionality back and makes a few other optimizations.