### PR TITLE
Monitoring reasons consolidation

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -144,19 +144,27 @@ class AssessmentsController < ApplicationController
       # Determine if a user created this assessment or a monitoree
       @assessment.who_reported = current_user.nil? ? 'Monitoree' : current_user.email
 
-      reported_condition.transaction do
-        reported_condition.save!
+      begin
+        reported_condition.transaction do
+          reported_condition.save!
 
-        @assessment.symptomatic = @assessment.symptomatic?
-        @assessment.save!
+          @assessment.symptomatic = @assessment.symptomatic?
+          @assessment.save!
 
-        # Save a new receipt and clear out any older ones
-        AssessmentReceipt.where(submission_token: submission_token_from_params).delete_all
-        @assessment_receipt = AssessmentReceipt.new(submission_token: submission_token_from_params)
-        @assessment_receipt.save
+          # Save a new receipt and clear out any older ones
+          AssessmentReceipt.where(submission_token: submission_token_from_params).delete_all
+          @assessment_receipt = AssessmentReceipt.new(submission_token: submission_token_from_params)
+          @assessment_receipt.save
 
-        # Create history if assessment was created by user
-        History.report_created(patient: patient, created_by: current_user.email, comment: "User created a new report (ID: #{@assessment.id}).") if current_user
+          # Create history if assessment was created by user
+          if current_user
+            History.report_created(patient: patient, created_by: current_user.email, comment: "User created a new report (ID: #{@assessment.id}).")
+          end
+        end
+      rescue ActiveRecord::RecordInvalid
+        Rails.logger.info(
+          "AssessmentsController: Unable to save assessment due to validation error for patient ID: #{patient.id}"
+        )
       end
     end
   end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -16,11 +16,11 @@ class PatientsController < ApplicationController
 
     @patient = current_user.get_patient(params.permit(:id)[:id])
 
-    @laboratories = @patient.laboratories.order(:created_at)
-    @close_contacts = @patient.close_contacts.order(:created_at)
-
     # If we failed to find a subject given the id, redirect to index
     redirect_to(root_url) && return if @patient.nil?
+
+    @laboratories = @patient.laboratories.order(:created_at)
+    @close_contacts = @patient.close_contacts.order(:created_at)
 
     @possible_jurisdiction_paths = if current_user.can_transfer_patients?
                                      # Allow all jurisdictions as valid transfer options.

--- a/app/helpers/assessment_query_helper.rb
+++ b/app/helpers/assessment_query_helper.rb
@@ -84,7 +84,7 @@ module AssessmentQueryHelper
       }
 
       passes_threshold_data = {}
-      symptoms&.pluck(:name).each do |symptom_name|
+      symptoms&.pluck(:name)&.each do |symptom_name|
         symptom = assessment.get_reported_symptom_by_name(symptom_name)
         value = symptom&.value
         # NOTE: We must check if the value is nil here before making this change.
@@ -98,6 +98,6 @@ module AssessmentQueryHelper
       details[:passes_threshold_data] = passes_threshold_data
       table_data << details
     end
-    { table_data: table_data, symptoms: symptoms ? symptoms : [], total: assessments.total_entries }
+    { table_data: table_data, symptoms: symptoms || [], total: assessments.total_entries }
   end
 end

--- a/app/helpers/assessment_query_helper.rb
+++ b/app/helpers/assessment_query_helper.rb
@@ -35,7 +35,7 @@ module AssessmentQueryHelper
     else
       # Verify this is a sort request for a symptom column.
       symptom_columns = Assessment.get_unique_symptoms_for_assessments(assessments.pluck(:id)).pluck(:name)
-      return assessments unless symptom_columns.include?(order)
+      return assessments unless symptom_columns&.include?(order)
 
       # Find assessment IDs based on the value of the symptom in the specified column
       ordered_values = assessments.map do |a|
@@ -71,6 +71,7 @@ module AssessmentQueryHelper
   def format(assessments)
     table_data = []
     symptoms = Assessment.get_unique_symptoms_for_assessments(assessments.pluck(:id))
+
     assessments.each do |assessment|
       reported_condition = assessment.reported_condition
       details = {
@@ -83,7 +84,7 @@ module AssessmentQueryHelper
       }
 
       passes_threshold_data = {}
-      symptoms.pluck(:name).each do |symptom_name|
+      symptoms&.pluck(:name).each do |symptom_name|
         symptom = assessment.get_reported_symptom_by_name(symptom_name)
         value = symptom&.value
         # NOTE: We must check if the value is nil here before making this change.
@@ -97,6 +98,6 @@ module AssessmentQueryHelper
       details[:passes_threshold_data] = passes_threshold_data
       table_data << details
     end
-    { table_data: table_data, symptoms: symptoms, total: assessments.total_entries }
+    { table_data: table_data, symptoms: symptoms ? symptoms : [], total: assessments.total_entries }
   end
 end

--- a/app/javascript/components/patient/Patient.js
+++ b/app/javascript/components/patient/Patient.js
@@ -69,14 +69,14 @@ class Patient extends React.Component {
       <React.Fragment>
         <Row id="monitoree-details-header">
           <Col className="mt-1">
-            <h3>
+            <div className="h3">
               <span className="pr-2">
                 {`${this.props.details.first_name ? this.props.details.first_name : ''}${
                   this.props.details.middle_name ? ' ' + this.props.details.middle_name : ''
                 }${this.props.details.last_name ? ' ' + this.props.details.last_name : ''}`}
               </span>
               {this.props?.dependents && this.props?.dependents?.length > 0 && <BadgeHOH patientId={String(this.props.details.id)} location={'right'} />}
-            </h3>
+            </div>
           </Col>
           <Col md="auto" className="jurisdiction-user-box mr-3">
             <Row id="jurisdiction-path">
@@ -626,7 +626,7 @@ class Patient extends React.Component {
                     <div>
                       {this.props.goto && (
                         <Button variant="link" className="pt-0" onClick={() => this.props.goto(5)}>
-                          <h5>(Edit)</h5>
+                          <div className="h5">(Edit)</div>
                         </Button>
                       )}
                     </div>
@@ -682,7 +682,7 @@ class Patient extends React.Component {
                       <div>
                         {this.props.goto && (
                           <Button variant="link" className="pt-0" onClick={() => this.props.goto(5)}>
-                            <h5>(Edit)</h5>
+                            <div className="h5">(Edit)</div>
                           </Button>
                         )}
                       </div>

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -554,6 +554,7 @@ class PatientsTable extends React.Component {
             <CloseRecords
               authenticity_token={this.props.authenticity_token}
               patients={this.state.table.rowData.filter((_, index) => this.state.selectedPatients.includes(index))}
+              monitoring_reasons={this.props.monitoring_reasons}
               close={() => this.setState({ action: undefined })}
             />
           )}
@@ -589,6 +590,7 @@ PatientsTable.propTypes = {
   tabs: PropTypes.object,
   setQuery: PropTypes.func,
   setFilteredMonitoreesCount: PropTypes.func,
+  monitoring_reasons: PropTypes.array,
 };
 
 export default PatientsTable;

--- a/app/javascript/components/public_health/Workflow.js
+++ b/app/javascript/components/public_health/Workflow.js
@@ -42,6 +42,7 @@ class Workflow extends React.Component {
           workflow={this.props.workflow}
           jurisdiction={this.props.jurisdiction}
           tabs={this.props.tabs}
+          monitoring_reasons={this.props.monitoring_reasons}
           setQuery={query => this.setState({ query })}
           setFilteredMonitoreesCount={current_monitorees_count => this.setState({ current_monitorees_count })}
         />
@@ -57,6 +58,7 @@ Workflow.propTypes = {
   workflow: PropTypes.string,
   tabs: PropTypes.object,
   custom_export_options: PropTypes.object,
+  monitoring_reasons: PropTypes.array,
 };
 
 export default Workflow;

--- a/app/javascript/components/public_health/actions/CloseRecords.js
+++ b/app/javascript/components/public_health/actions/CloseRecords.js
@@ -13,29 +13,13 @@ class CloseRecords extends React.Component {
       apply_to_household: false,
       loading: false,
       monitoring: false,
-      monitoring_reasons: [
-        'Completed Monitoring',
-        'Meets criteria to shorten quarantine',
-        'Does not meet criteria for monitoring',
-        'Meets Case Definition',
-        'Lost to follow-up during monitoring period',
-        'Lost to follow-up (contact never established)',
-        'Transferred to another jurisdiction',
-        'Person Under Investigation (PUI)',
-        'Case confirmed',
-        'Meets criteria to discontinue isolation',
-        'Deceased',
-        'Duplicate',
-        'Other',
-      ],
       monitoring_reason: '',
       reasoning: '',
     };
-    this.handleChange = this.handleChange.bind(this);
-    this.submit = this.submit.bind(this);
+    this.monitoring_reasons = this.props.monitoring_reasons.filter(x => x);
   }
 
-  handleChange(event) {
+  handleChange = event => {
     if (event.target.id === 'monitoring_reason') {
       this.setState({ monitoring_reason: event.target.value });
     } else if (event.target.id === 'reasoning') {
@@ -43,9 +27,9 @@ class CloseRecords extends React.Component {
     } else if (event.target.id === 'apply_to_household') {
       this.setState({ apply_to_household: event.target.checked });
     }
-  }
+  };
 
-  submit() {
+  submit = () => {
     let idArray = this.props.patients.map(x => x['id']);
     let diffState = Object.keys(this.state).filter(k => _.get(this.state, k) !== _.get(this.origState, k));
 
@@ -68,7 +52,7 @@ class CloseRecords extends React.Component {
           this.setState({ loading: false });
         });
     });
-  }
+  };
 
   render() {
     return (
@@ -83,8 +67,10 @@ class CloseRecords extends React.Component {
           <Form.Group>
             <Form.Label>Please select reason for status change:</Form.Label>
             <Form.Control as="select" size="lg" className="form-square" id="monitoring_reason" onChange={this.handleChange} defaultValue={-1}>
-              <option value={''}>--</option>
-              {this.state.monitoring_reasons.map((option, index) => (
+              <option value={-1} disabled>
+                --
+              </option>
+              {this.monitoring_reasons.map((option, index) => (
                 <option key={`option-${index}`} value={option}>
                   {option}
                 </option>
@@ -127,6 +113,7 @@ CloseRecords.propTypes = {
   authenticity_token: PropTypes.string,
   patients: PropTypes.array,
   close: PropTypes.func,
+  monitoring_reasons: PropTypes.array,
 };
 
 export default CloseRecords;

--- a/app/javascript/components/subject/monitoring_actions/MonitoringActions.js
+++ b/app/javascript/components/subject/monitoring_actions/MonitoringActions.js
@@ -26,6 +26,7 @@ class MonitoringActions extends React.Component {
                 authenticity_token={this.props.authenticity_token}
                 has_dependents={this.props.has_dependents}
                 in_household_with_member_with_ce_in_exposure={this.props.in_household_with_member_with_ce_in_exposure}
+                monitoring_reasons={this.props.monitoring_reasons}
               />
             </Form.Group>
             <Form.Group as={Col} md="12" lg="8" className="pt-2">
@@ -77,6 +78,7 @@ MonitoringActions.propTypes = {
   assigned_users: PropTypes.array,
   has_dependents: PropTypes.bool,
   in_household_with_member_with_ce_in_exposure: PropTypes.bool,
+  monitoring_reasons: PropTypes.array,
 };
 
 export default MonitoringActions;

--- a/app/javascript/components/subject/monitoring_actions/MonitoringStatus.js
+++ b/app/javascript/components/subject/monitoring_actions/MonitoringStatus.js
@@ -23,6 +23,7 @@ class MonitoringStatus extends React.Component {
       apply_to_household_cm_exp_only: false,
       apply_to_household_cm_exp_only_date: moment(new Date()).format('YYYY-MM-DD'),
     };
+    this.monitoring_reasons = this.props.monitoring_reasons.filter(x => x);
   }
 
   handleMonitoringStatusChange = event => {
@@ -137,19 +138,11 @@ class MonitoringStatus extends React.Component {
                 <option value={-1} disabled>
                   --
                 </option>
-                <option>Completed Monitoring</option>
-                <option>Meets criteria to shorten quarantine</option>
-                <option>Does not meet criteria for monitoring</option>
-                <option>Meets Case Definition</option>
-                <option>Lost to follow-up during monitoring period</option>
-                <option>Lost to follow-up (contact never established)</option>
-                <option>Transferred to another jurisdiction</option>
-                <option>Person Under Investigation (PUI)</option>
-                <option>Case confirmed</option>
-                <option>Meets criteria to discontinue isolation</option>
-                <option>Deceased</option>
-                <option>Duplicate</option>
-                <option>Other</option>
+                {this.monitoring_reasons.map((option, index) => (
+                  <option key={`option-${index}`} value={option}>
+                    {option}
+                  </option>
+                ))}
               </Form.Control>
             </Form.Group>
           )}
@@ -254,6 +247,7 @@ MonitoringStatus.propTypes = {
   authenticity_token: PropTypes.string,
   has_dependents: PropTypes.bool,
   in_household_with_member_with_ce_in_exposure: PropTypes.bool,
+  monitoring_reasons: PropTypes.array,
 };
 
 export default MonitoringStatus;

--- a/app/javascript/tests/patient/Patient.test.js
+++ b/app/javascript/tests/patient/Patient.test.js
@@ -33,7 +33,7 @@ describe('Patient', () => {
             jurisdiction_path="USA, State 1, County 2" authenticity_token={authyToken} />);
 
         expect(wrapper.find('#monitoree-details-header').exists()).toBeTruthy();
-        expect(wrapper.find('#monitoree-details-header').find('h3').text().includes(nameFormatter(mockPatient1))).toBeTruthy();
+        expect(wrapper.find('#monitoree-details-header').find('.h3').text().includes(nameFormatter(mockPatient1))).toBeTruthy();
         expect(wrapper.find('#monitoree-details-header').find(BadgeHOH).exists()).toBeTruthy();
         expect(wrapper.find('.jurisdiction-user-box').exists()).toBeTruthy();
         expect(wrapper.find('#jurisdiction-path').text()).toEqual('Assigned Jurisdiction: USA, State 1, County 2');

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -22,7 +22,13 @@ class ConsumeAssessmentsJob < ApplicationJob
         end
 
         if message['response_status'].in? %w[opt_out opt_in]
-          handle_opt_in_opt_out(message)
+          begin
+            handle_opt_in_opt_out(message)
+          rescue StandardError => e
+            Rails.logger.info(
+              "ConsumeAssessmentsJob: failure handling opt-in/opt-out message (message response status: #{message['response_status']}), (error: #{e})"
+            )
+          end
           queue.commit
           next
         end

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -143,9 +143,10 @@ class ConsumeAssessmentsJob < ApplicationJob
               assessment.symptomatic = assessment.symptomatic?
               assessment.save!
             end
-          rescue ActiveRecord::RecordInvalid
+          rescue ActiveRecord::RecordInvalid => e
             Rails.logger.info(
-              "ConsumeAssessmentsJob: Unable to save assessment due to validation error for patient ID: #{patient.id}"
+              "AssessmentsController: Unable to save assessment due to validation error for patient ID: #{patient.id}. " \
+              "Error: #{e}"
             )
           end
           queue.commit
@@ -175,8 +176,11 @@ class ConsumeAssessmentsJob < ApplicationJob
                 assessment.symptomatic = assessment.symptomatic? || message['experiencing_symptoms']
                 assessment.save!
               end
-            rescue ActiveRecord::RecordInvalid
-              Rails.logger.info "ConsumeAssessmentsJob: Unable to save assessment due to validation error for patient ID: #{dependent.id}"
+            rescue ActiveRecord::RecordInvalid => e
+              Rails.logger.info(
+                "AssessmentsController: Unable to save assessment due to validation error for patient ID: #{dependent.id}. " \
+                "Error: #{e}"
+              )
             end
             queue.commit
           end

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -710,9 +710,11 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
 
     assessments_details = []
     assessments.each do |assessment|
-      assessment_details = assessment.custom_details(fields, patients_identifiers[assessment.patient_id])
+      assessment_details = assessment.custom_details(fields, patients_identifiers[assessment.patient_id]) || {}
       if fields.include?(:symptoms)
         symptom_names_and_labels&.map(&:first)&.each do |symptom_name|
+          next if assessments_hash[assessment[:id]].nil?
+
           assessment_details[symptom_name.to_sym] = assessments_hash[assessment[:id]][symptom_name]
         end
       end

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -713,6 +713,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
       assessment_details = assessment.custom_details(fields, patients_identifiers[assessment.patient_id]) || {}
       if fields.include?(:symptoms)
         symptom_names_and_labels&.map(&:first)&.each do |symptom_name|
+          # Nil check in case for some reason there were assessments with nil ReportedCondition
           next if assessments_hash[assessment[:id]].nil?
 
           assessment_details[symptom_name.to_sym] = assessments_hash[assessment[:id]][symptom_name]

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -698,7 +698,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
       conditions = ReportedCondition.where(assessment_id: assessments.pluck(:id))
       symptoms = Symptom.where(condition_id: conditions&.pluck(:id)).order(:label)
 
-      conditions_hash = Hash[conditions&.pluck(:id, :assessment_id).map { |id, assessment_id| [id, assessment_id] }]
+      conditions_hash = Hash[conditions&.pluck(:id, :assessment_id)&.map { |id, assessment_id| [id, assessment_id] }]
                         .transform_values { |assessment_id| { assessment_id: assessment_id, symptoms: {} } }
       symptoms&.each do |symptom|
         conditions_hash[symptom[:condition_id]][:symptoms][symptom[:name]] = symptom.value

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -698,7 +698,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
       conditions = ReportedCondition.where(assessment_id: assessments.pluck(:id))
       symptoms = Symptom.where(condition_id: conditions&.pluck(:id)).order(:label)
 
-      conditions_hash = Hash[conditions.pluck(:id, :assessment_id).map { |id, assessment_id| [id, assessment_id] }]
+      conditions_hash = Hash[conditions&.pluck(:id, :assessment_id).map { |id, assessment_id| [id, assessment_id] }]
                         .transform_values { |assessment_id| { assessment_id: assessment_id, symptoms: {} } }
       symptoms&.each do |symptom|
         conditions_hash[symptom[:condition_id]][:symptoms][symptom[:name]] = symptom.value

--- a/app/mailers/twilio_sender.rb
+++ b/app/mailers/twilio_sender.rb
@@ -46,10 +46,11 @@ class TwilioSender
       Rails.logger.warn e.error_message
       return
     end
-    return if execution.nil? || execution.context.nil? || execution.context['trigger'].nil? || execution.context['trigger']['message'].nil?
 
-    phone_number_from = execution.context['trigger']['message']['From'] || nil
-    phone_number_to = execution.context['trigger']['message']['To'] || nil
+    trigger_message = execution&.context&.[]('trigger')&.[]('message')
+    phone_number_from = trigger_message&.[]('From')
+    phone_number_to = trigger_message&.[]('To')
+
     return { monitoree_number: phone_number_from, sara_number: phone_number_to } if !phone_number_from.nil? && !phone_number_to.nil?
 
     nil

--- a/app/mailers/twilio_sender.rb
+++ b/app/mailers/twilio_sender.rb
@@ -46,6 +46,8 @@ class TwilioSender
       Rails.logger.warn e.error_message
       return
     end
+    return if execution.nil? || execution.context.nil? || execution.context['trigger'].nil? || execution.context['trigger']['message'].nil?
+
     phone_number_from = execution.context['trigger']['message']['From'] || nil
     phone_number_to = execution.context['trigger']['message']['To'] || nil
     return { monitoree_number: phone_number_from, sara_number: phone_number_to } if !phone_number_from.nil? && !phone_number_to.nil?

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -97,7 +97,7 @@ class Assessment < ApplicationRecord
   def self.get_unique_symptoms_for_assessments(assessment_ids)
     threshold_cond_hashes = ReportedCondition.where(type: 'ReportedCondition', assessment_id: assessment_ids).pluck(:threshold_condition_hash)
     condition_ids = ThresholdCondition.where(type: 'ThresholdCondition', threshold_condition_hash: threshold_cond_hashes)
-    Symptom.where(condition_id: condition_ids).uniq(&:name)
+    Symptom.where(condition_id: condition_ids)&.uniq(&:name)
   end
 
   def translations

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -10,6 +10,29 @@ class Patient < ApplicationRecord
   include ActiveModel::Validations
   include FhirHelper
 
+  MONITORING_REASONS = [
+    'Not Monitoring',
+    'Completed Monitoring',
+    'Meets criteria to shorten quarantine',
+    'Does not meet criteria for monitoring',
+    'Enrolled more than 14 days after last date of exposure (system)',
+    'Enrolled more than 10 days after last date of exposure (system)',
+    'Enrolled on last day of monitoring period (system)',
+    'Completed Monitoring (system)',
+    'Meets Case Definition',
+    'Lost to follow-up during monitoring period',
+    'Lost to follow-up (contact never established)',
+    'Transferred to another jurisdiction',
+    'Person Under Investigation (PUI)',
+    'Case confirmed',
+    'Past monitoring period',
+    'Meets criteria to discontinue isolation',
+    'Deceased',
+    'Duplicate',
+    'Other',
+    ''
+  ].freeze
+
   columns.each do |column|
     case column.type
     when :text

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -30,7 +30,8 @@
                         in_household_with_member_with_ce_in_exposure: @household_members_with_ce_in_exposure_excludes_patient.count > 1,
                         patient: @patient,
                         jurisdiction_paths: @possible_jurisdiction_paths,
-                        assigned_users: @patient.jurisdiction.assigned_users
+                        assigned_users: @patient.jurisdiction.assigned_users,
+                        monitoring_reasons: Patient::MONITORING_REASONS
                       }) %>
 </div>
 <% end %>

--- a/app/views/public_health/exposure.html.erb
+++ b/app/views/public_health/exposure.html.erb
@@ -64,5 +64,6 @@
                           description: 'All Monitorees in this jurisdiction, in the Exposure workflow.'
                         }
                       },
-                      custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS
+                      custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS,
+                      monitoring_reasons: Patient::MONITORING_REASONS
                     }) %>

--- a/app/views/public_health/isolation.html.erb
+++ b/app/views/public_health/isolation.html.erb
@@ -58,5 +58,6 @@
                           description: 'All cases in this jurisdiction, in the Isolation workflow.'
                         }
                       },
-                      custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS
+                      custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS,
+                      monitoring_reasons: Patient::MONITORING_REASONS
                     }) %>


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1081

This PR consolidates all of the Monitoree Reasons into one place

# Important Changes
`app/javascript/components/public_health/PatientsTable.js`
- Adds Monitoring Reasons as a prop

`app/javascript/components/public_health/Workflow.js`
- Adds Monitoring Reasons as a prop

`app/javascript/components/public_health/actions/CloseRecords.js`
- Iterates over new Monitoring_Reaons for `Select` Dropdown

`app/javascript/components/subject/monitoring_actions/MonitoringActions.js`
- Adds Monitoring Reasons as a prop

`app/javascript/components/subject/monitoring_actions/MonitoringStatus.js`
- Iterates over new Monitoring_Reaons for `Select` Dropdown

`app/models/patient.rb`
- Consolidates Monitoring Reasons in one place 

`app/views/patients/show.html.erb`
- Adds Monitoring Reasons as a prop

`app/views/public_health/exposure.html.erb`
- Adds Monitoring Reasons as a prop

`app/views/public_health/isolation.html.erb`
- Adds Monitoring Reasons as a prop

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11
