### PR TITLE
SARAALERT-1081: Consolidates the Monitoree Reasons into one place

### DIFF
--- a/app/helpers/validation_helper.rb
+++ b/app/helpers/validation_helper.rb
@@ -72,6 +72,28 @@ module ValidationHelper # rubocop:todo Metrics/ModuleLength
 
   VALID_STATES = STATE_ABBREVIATIONS.values
 
+  USER_SELECTABLE_MONITORING_REASONS = [
+    'Completed Monitoring',
+    'Meets criteria to shorten quarantine',
+    'Does not meet criteria for monitoring',
+    'Meets Case Definition',
+    'Lost to follow-up during monitoring period',
+    'Lost to follow-up (contact never established)',
+    'Transferred to another jurisdiction',
+    'Person Under Investigation (PUI)',
+    'Case confirmed',
+    'Past monitoring period',
+    'Meets criteria to discontinue isolation',
+    'Deceased',
+    'Duplicate',
+    'Other'
+  ].freeze
+
+  SYSTEM_SELECTABLE_MONITORING_REASONS = [
+    'Enrolled more than 14 days after last date of exposure (system)', 'Enrolled more than 10 days after last date of exposure (system)',
+    'Enrolled on last day of monitoring period (system)', 'Completed Monitoring (system)', '', nil
+  ].freeze
+
   VALID_PATIENT_ENUMS = {
     gender_identity: ['Male (Identifies as male)', 'Female (Identifies as female)', 'Transgender Male (Female-to-Male [FTM])',
                       'Transgender Female (Male-to-Female [MTF]', 'Genderqueer / gender nonconforming (neither exclusively male nor female)', 'Another',
@@ -84,12 +106,7 @@ module ValidationHelper # rubocop:todo Metrics/ModuleLength
     preferred_contact_time: %w[Morning Afternoon Evening],
     additional_planned_travel_type: %w[Domestic International],
     exposure_risk_assessment: ['High', 'Medium', 'Low', 'No Identified Risk', '', nil],
-    monitoring_reason: ['Completed Monitoring', 'Meets criteria to shorten quarantine', 'Does not meet criteria for monitoring',
-                        'Enrolled more than 14 days after last date of exposure (system)', 'Enrolled more than 10 days after last date of exposure (system)',
-                        'Enrolled on last day of monitoring period (system)', 'Completed Monitoring (system)', 'Meets Case Definition',
-                        'Lost to follow-up during monitoring period', 'Lost to follow-up (contact never established)', 'Transferred to another jurisdiction',
-                        'Person Under Investigation (PUI)', 'Case confirmed', 'Past monitoring period', 'Meets criteria to discontinue isolation',
-                        'Deceased', 'Duplicate', 'Other', '', nil],
+    monitoring_reason: USER_SELECTABLE_MONITORING_REASONS + SYSTEM_SELECTABLE_MONITORING_REASONS,
     monitoring_plan: ['None', 'Daily active monitoring', 'Self-monitoring with public health supervision', 'Self-monitoring with delegated supervision',
                       'Self-observation', '', nil],
     case_status: ['Confirmed', 'Probable', 'Suspect', 'Unknown', 'Not a Case'],

--- a/app/javascript/components/analytics/PublicHealthAnalytics.js
+++ b/app/javascript/components/analytics/PublicHealthAnalytics.js
@@ -158,7 +158,7 @@ class PublicHealthAnalytics extends React.Component {
               <MonitoreesByEventDate stats={this.props.stats} />
             </Col>
           </Row>
-          <Row className="mb-5 pb-3 mx-1 px-0 pt-4">
+          <Row className="mb-2 pb-3 mx-1 px-0 pt-4">
             <GeographicSummary stats={this.props.stats} />
           </Row>
         </React.Fragment>

--- a/app/javascript/components/analytics/widgets/GeographicSummary.js
+++ b/app/javascript/components/analytics/widgets/GeographicSummary.js
@@ -285,7 +285,7 @@ class GeographicSummary extends React.Component {
       </Button>
     );
     return (
-      <div style={{ width: '100%' }}>
+      <div style={{ width: '96%', marginLeft: '2%' }}>
         <Row className="mb-4 mx-2 px-0">
           <Col md="24">
             <div className="text-center display-5 mb-1 mt-1 pb-4">{moment(this.dateSubset[this.state.selectedDateIndex]).format('MMMM DD, YYYY')}</div>
@@ -303,7 +303,7 @@ class GeographicSummary extends React.Component {
             </div>
           </Col>
         </Row>
-        <div style={{ width: '100%', height: '450px' }}>
+        <div>
           <div className="map-panel-mount-point">
             {this.renderSpinner()}
             <Row>
@@ -350,7 +350,7 @@ class GeographicSummary extends React.Component {
             </Button>
             {backButton}
           </Row>
-          <div className="mb-4">
+          <div>
             <Button
               variant="primary"
               size="md"

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -558,6 +558,7 @@ class PatientsTable extends React.Component {
             <CloseRecords
               authenticity_token={this.props.authenticity_token}
               patients={this.state.table.rowData.filter((_, index) => this.state.selectedPatients.includes(index))}
+              monitoring_reasons={this.props.monitoring_reasons}
               close={() => this.setState({ action: undefined })}
             />
           )}
@@ -594,6 +595,7 @@ PatientsTable.propTypes = {
   tabs: PropTypes.object,
   setQuery: PropTypes.func,
   setFilteredMonitoreesCount: PropTypes.func,
+  monitoring_reasons: PropTypes.array,
 };
 
 export default PatientsTable;

--- a/app/javascript/components/public_health/Workflow.js
+++ b/app/javascript/components/public_health/Workflow.js
@@ -42,6 +42,7 @@ class Workflow extends React.Component {
           workflow={this.props.workflow}
           jurisdiction={this.props.jurisdiction}
           tabs={this.props.tabs}
+          monitoring_reasons={this.props.monitoring_reasons}
           setQuery={query => this.setState({ query })}
           setFilteredMonitoreesCount={current_monitorees_count => this.setState({ current_monitorees_count })}
         />
@@ -57,6 +58,7 @@ Workflow.propTypes = {
   workflow: PropTypes.string,
   tabs: PropTypes.object,
   custom_export_options: PropTypes.object,
+  monitoring_reasons: PropTypes.array,
 };
 
 export default Workflow;

--- a/app/javascript/components/public_health/actions/CloseRecords.js
+++ b/app/javascript/components/public_health/actions/CloseRecords.js
@@ -13,29 +13,12 @@ class CloseRecords extends React.Component {
       apply_to_household: false,
       loading: false,
       monitoring: false,
-      monitoring_reasons: [
-        'Completed Monitoring',
-        'Meets criteria to shorten quarantine',
-        'Does not meet criteria for monitoring',
-        'Meets Case Definition',
-        'Lost to follow-up during monitoring period',
-        'Lost to follow-up (contact never established)',
-        'Transferred to another jurisdiction',
-        'Person Under Investigation (PUI)',
-        'Case confirmed',
-        'Meets criteria to discontinue isolation',
-        'Deceased',
-        'Duplicate',
-        'Other',
-      ],
       monitoring_reason: '',
       reasoning: '',
     };
-    this.handleChange = this.handleChange.bind(this);
-    this.submit = this.submit.bind(this);
   }
 
-  handleChange(event) {
+  handleChange = event => {
     if (event.target.id === 'monitoring_reason') {
       this.setState({ monitoring_reason: event.target.value });
     } else if (event.target.id === 'reasoning') {
@@ -43,9 +26,9 @@ class CloseRecords extends React.Component {
     } else if (event.target.id === 'apply_to_household') {
       this.setState({ apply_to_household: event.target.checked });
     }
-  }
+  };
 
-  submit() {
+  submit = () => {
     let idArray = this.props.patients.map(x => x['id']);
     let diffState = Object.keys(this.state).filter(k => _.get(this.state, k) !== _.get(this.origState, k));
 
@@ -68,7 +51,7 @@ class CloseRecords extends React.Component {
           this.setState({ loading: false });
         });
     });
-  }
+  };
 
   render() {
     return (
@@ -82,9 +65,9 @@ class CloseRecords extends React.Component {
           </p>
           <Form.Group controlId="monitoring_reason">
             <Form.Label>Please select reason for status change:</Form.Label>
-            <Form.Control as="select" size="lg" className="form-square" onChange={this.handleChange} defaultValue={-1}>
-              <option value={''}>--</option>
-              {this.state.monitoring_reasons.map((option, index) => (
+            <Form.Control as="select" size="lg" className="form-square" id="monitoring_reason" onChange={this.handleChange} defaultValue={-1}>
+              <option></option>
+              {this.props.monitoring_reasons.map((option, index) => (
                 <option key={`option-${index}`} value={option}>
                   {option}
                 </option>
@@ -127,6 +110,7 @@ CloseRecords.propTypes = {
   authenticity_token: PropTypes.string,
   patients: PropTypes.array,
   close: PropTypes.func,
+  monitoring_reasons: PropTypes.array,
 };
 
 export default CloseRecords;

--- a/app/javascript/components/subject/monitoring_actions/MonitoringActions.js
+++ b/app/javascript/components/subject/monitoring_actions/MonitoringActions.js
@@ -26,6 +26,7 @@ class MonitoringActions extends React.Component {
                 authenticity_token={this.props.authenticity_token}
                 has_dependents={this.props.has_dependents}
                 in_household_with_member_with_ce_in_exposure={this.props.in_household_with_member_with_ce_in_exposure}
+                monitoring_reasons={this.props.monitoring_reasons}
               />
             </Form.Group>
             <Form.Group as={Col} md="12" lg="8" className="pt-2">
@@ -77,6 +78,7 @@ MonitoringActions.propTypes = {
   assigned_users: PropTypes.array,
   has_dependents: PropTypes.bool,
   in_household_with_member_with_ce_in_exposure: PropTypes.bool,
+  monitoring_reasons: PropTypes.array,
 };
 
 export default MonitoringActions;

--- a/app/javascript/components/subject/monitoring_actions/MonitoringStatus.js
+++ b/app/javascript/components/subject/monitoring_actions/MonitoringStatus.js
@@ -134,22 +134,12 @@ class MonitoringStatus extends React.Component {
             <Form.Group>
               <Form.Label>Please select reason for status change:</Form.Label>
               <Form.Control as="select" size="lg" className="form-square" id="monitoring_reason" onChange={this.handleChange} defaultValue={-1}>
-                <option value={-1} disabled>
-                  --
-                </option>
-                <option>Completed Monitoring</option>
-                <option>Meets criteria to shorten quarantine</option>
-                <option>Does not meet criteria for monitoring</option>
-                <option>Meets Case Definition</option>
-                <option>Lost to follow-up during monitoring period</option>
-                <option>Lost to follow-up (contact never established)</option>
-                <option>Transferred to another jurisdiction</option>
-                <option>Person Under Investigation (PUI)</option>
-                <option>Case confirmed</option>
-                <option>Meets criteria to discontinue isolation</option>
-                <option>Deceased</option>
-                <option>Duplicate</option>
-                <option>Other</option>
+                <option></option>
+                {this.props.monitoring_reasons.map((option, index) => (
+                  <option key={`option-${index}`} value={option}>
+                    {option}
+                  </option>
+                ))}
               </Form.Control>
             </Form.Group>
           )}
@@ -255,6 +245,7 @@ MonitoringStatus.propTypes = {
   authenticity_token: PropTypes.string,
   has_dependents: PropTypes.bool,
   in_household_with_member_with_ce_in_exposure: PropTypes.bool,
+  monitoring_reasons: PropTypes.array,
 };
 
 export default MonitoringStatus;

--- a/app/javascript/tests/mocks/mockMonitoringReasons.js
+++ b/app/javascript/tests/mocks/mockMonitoringReasons.js
@@ -1,0 +1,20 @@
+const mockMonitoringReasons = [
+  'Completed Monitoring',
+  'Meets criteria to shorten quarantine',
+  'Does not meet criteria for monitoring',
+  'Meets Case Definition',
+  'Lost to follow-up during monitoring period',
+  'Lost to follow-up (contact never established)',
+  'Transferred to another jurisdiction',
+  'Person Under Investigation (PUI)',
+  'Case confirmed',
+  'Past monitoring period',
+  'Meets criteria to discontinue isolation',
+  'Deceased',
+  'Duplicate',
+  'Other'
+]
+
+export {
+  mockMonitoringReasons,
+}

--- a/app/javascript/tests/subject/monitoring_actions/MonitoringActions.test.js
+++ b/app/javascript/tests/subject/monitoring_actions/MonitoringActions.test.js
@@ -12,14 +12,16 @@ import PublicHealthAction from '../../../components/subject/monitoring_actions/P
 import { mockPatient1 } from '../../mocks/mockPatients'
 import { mockUser1 } from '../../mocks/mockUsers'
 import { mockJurisdictionPaths } from '../../mocks/mockJurisdiction'
+import { mockMonitoringReasons } from '../../mocks/mockMonitoringReasons'
 
 const authyToken = 'Q1z4yZXLdN+tZod6dBSIlMbZ3yWAUFdY44U06QWffEP76nx1WGMHIz8rYxEUZsl9sspS3ePF2ZNmSue8wFpJGg==';
 const assigned_users = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
 
 describe('MonitoringActions', () => {
   it('Properly renders all main components', () => {
-    const wrapper = shallow(<MonitoringActions patient={mockPatient1} has_dependents={false} in_household_with_member_with_ce_in_exposure={false} isolation={false} 
-      authenticity_token={authyToken} jurisdiction_paths={mockJurisdictionPaths} current_user={mockUser1} assigned_users={assigned_users} user_can_transfer={false} />);
+    const wrapper = shallow(<MonitoringActions patient={mockPatient1} has_dependents={false} in_household_with_member_with_ce_in_exposure={false} isolation={false}
+      authenticity_token={authyToken} jurisdiction_paths={mockJurisdictionPaths} current_user={mockUser1} assigned_users={assigned_users} user_can_transfer={false}
+      monitoring_reasons={mockMonitoringReasons}/>);
 
     expect(wrapper.find(Form).exists()).toBeTruthy();
     expect(wrapper.find(Form.Group).length).toEqual(7);

--- a/app/javascript/tests/subject/monitoring_actions/MonitoringStatus.test.js
+++ b/app/javascript/tests/subject/monitoring_actions/MonitoringStatus.test.js
@@ -6,7 +6,7 @@ import MonitoringStatus from '../../../components/subject/monitoring_actions/Mon
 import InfoTooltip from '../../../components/util/InfoTooltip';
 import DateInput from '../../../components/util/DateInput';
 import { mockPatient1, mockPatient3 } from '../../mocks/mockPatients';
-import mockMonitoringReasons from '../../mocks/mockMonitoringReasons'
+import { mockMonitoringReasons } from '../../mocks/mockMonitoringReasons'
 
 const currentDate = moment(new Date()).format('YYYY-MM-DD');
 const newDate = moment(new Date('9-9-2020')).format('YYYY-MM-DD');

--- a/app/javascript/tests/subject/monitoring_actions/MonitoringStatus.test.js
+++ b/app/javascript/tests/subject/monitoring_actions/MonitoringStatus.test.js
@@ -6,31 +6,16 @@ import MonitoringStatus from '../../../components/subject/monitoring_actions/Mon
 import InfoTooltip from '../../../components/util/InfoTooltip';
 import DateInput from '../../../components/util/DateInput';
 import { mockPatient1, mockPatient3 } from '../../mocks/mockPatients';
+import mockMonitoringReasons from '../../mocks/mockMonitoringReasons'
 
 const currentDate = moment(new Date()).format('YYYY-MM-DD');
 const newDate = moment(new Date('9-9-2020')).format('YYYY-MM-DD');
 const authyToken = 'Q1z4yZXLdN+tZod6dBSIlMbZ3yWAUFdY44U06QWffEP76nx1WGMHIz8rYxEUZsl9sspS3ePF2ZNmSue8wFpJGg==';
 const monitoringStatusValues = [ 'Actively Monitoring', 'Not Monitoring' ];
-const monitoringReasons = [
-  '--',
-  'Completed Monitoring',
-  'Meets criteria to shorten quarantine',
-  'Does not meet criteria for monitoring',
-  'Meets Case Definition',
-  'Lost to follow-up during monitoring period',
-  'Lost to follow-up (contact never established)',
-  'Transferred to another jurisdiction',
-  'Person Under Investigation (PUI)',
-  'Case confirmed',
-  'Meets criteria to discontinue isolation',
-  'Deceased',
-  'Duplicate',
-  'Other'
-];
 
 function getWrapper(patient, hasDependents, inHouseholdWithCeInExposure) {
   return shallow(<MonitoringStatus patient={patient} has_dependents={hasDependents} authenticity_token={authyToken}
-    in_household_with_member_with_ce_in_exposure={inHouseholdWithCeInExposure} />);
+    in_household_with_member_with_ce_in_exposure={inHouseholdWithCeInExposure} monitoring_reasons={mockMonitoringReasons}/>);
 }
 
 describe('MonitoringStatus', () => {
@@ -73,11 +58,10 @@ describe('MonitoringStatus', () => {
     expect(wrapper.find(Modal.Body).find('p').text().includes(`Are you sure you want to change monitoring status to "Not Monitoring"?`)).toBeTruthy();
     expect(wrapper.find(Modal.Body).find('p').find('b').text()).toEqual(' This will move the selected record(s) to the Closed line list and turn Continuous Exposure OFF.');
     expect(wrapper.find('#monitoring_reason').exists()).toBeTruthy();
-    expect(wrapper.find('#monitoring_reason').find('option').length).toEqual(monitoringReasons.length);
-    monitoringReasons.forEach(function(value, index) {
-      expect(wrapper.find('#monitoring_reason').find('option').at(index).text()).toEqual(value);
+    expect(wrapper.find('#monitoring_reason').find('option').length).toEqual(mockMonitoringReasons.length + 1); // the +1 is for the extra blank
+    [''].concat(mockMonitoringReasons).forEach(function(value, index) {
+        expect(wrapper.find('#monitoring_reason').find('option').at(index).text()).toEqual(value);
     });
-    expect(wrapper.find('#monitoring_reason').find('option').at(0).prop('disabled')).toBeTruthy();
     expect(wrapper.find('#reasoning').exists()).toBeTruthy();
 
     // sets state
@@ -170,8 +154,8 @@ describe('MonitoringStatus', () => {
     expect(wrapper.state('monitoring_reason')).toEqual('');
 
     // test changing to each enabled monitoring option
-    monitoringReasons.shift();
-    monitoringReasons.forEach(function(value) {
+    mockMonitoringReasons.shift();
+    mockMonitoringReasons.forEach(function(value) {
       wrapper.find('#monitoring_reason').simulate('change', { target: { id: 'monitoring_reason', value: value } });
       expect(wrapper.state('monitoring_reason')).toEqual(value);
       expect(wrapper.state('monitoring')).toEqual(false);
@@ -215,7 +199,7 @@ describe('MonitoringStatus', () => {
     expect(wrapper.find('#apply_to_household_cm_exp_only_no').prop('checked')).toBeTruthy();
     expect(wrapper.find('#apply_to_household_cm_exp_only_yes').prop('checked')).toBeFalsy();
 
-    // change to 'YES' 
+    // change to 'YES'
     wrapper.find('#apply_to_household_cm_exp_only_yes').simulate('change', { target: { name: 'apply_to_household_cm_exp_only', id: 'apply_to_household_cm_exp_only_yes' } });
     wrapper.update();
     expect(wrapper.state('apply_to_household_cm_exp_only')).toBeTruthy();

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -10,23 +10,6 @@ class Patient < ApplicationRecord
   include ActiveModel::Validations
   include FhirHelper
 
-  MONITORING_REASONS = [
-    'Completed Monitoring',
-    'Meets criteria to shorten quarantine',
-    'Does not meet criteria for monitoring',
-    'Meets Case Definition',
-    'Lost to follow-up during monitoring period',
-    'Lost to follow-up (contact never established)',
-    'Transferred to another jurisdiction',
-    'Person Under Investigation (PUI)',
-    'Case confirmed',
-    'Past monitoring period',
-    'Meets criteria to discontinue isolation',
-    'Deceased',
-    'Duplicate',
-    'Other'
-  ].freeze
-
   columns.each do |column|
     case column.type
     when :text

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -10,6 +10,23 @@ class Patient < ApplicationRecord
   include ActiveModel::Validations
   include FhirHelper
 
+  MONITORING_REASONS = [
+    'Completed Monitoring',
+    'Meets criteria to shorten quarantine',
+    'Does not meet criteria for monitoring',
+    'Meets Case Definition',
+    'Lost to follow-up during monitoring period',
+    'Lost to follow-up (contact never established)',
+    'Transferred to another jurisdiction',
+    'Person Under Investigation (PUI)',
+    'Case confirmed',
+    'Past monitoring period',
+    'Meets criteria to discontinue isolation',
+    'Deceased',
+    'Duplicate',
+    'Other'
+  ].freeze
+
   columns.each do |column|
     case column.type
     when :text

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -31,7 +31,7 @@
                         patient: @patient,
                         jurisdiction_paths: @possible_jurisdiction_paths,
                         assigned_users: @patient.jurisdiction.assigned_users,
-                        monitoring_reasons: Patient::MONITORING_REASONS
+                        monitoring_reasons: ValidationHelper::USER_SELECTABLE_MONITORING_REASONS
                       }) %>
 </div>
 <% end %>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -30,7 +30,8 @@
                         in_household_with_member_with_ce_in_exposure: @household_members_with_ce_in_exposure_excludes_patient.count > 1,
                         patient: @patient,
                         jurisdiction_paths: @possible_jurisdiction_paths,
-                        assigned_users: @patient.jurisdiction.assigned_users
+                        assigned_users: @patient.jurisdiction.assigned_users,
+                        monitoring_reasons: Patient::MONITORING_REASONS
                       }) %>
 </div>
 <% end %>

--- a/app/views/public_health/exposure.html.erb
+++ b/app/views/public_health/exposure.html.erb
@@ -65,5 +65,5 @@
                         }
                       },
                       custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS,
-                      monitoring_reasons: Patient::MONITORING_REASONS
+                      monitoring_reasons: ValidationHelper::USER_SELECTABLE_MONITORING_REASONS
                     }) %>

--- a/app/views/public_health/exposure.html.erb
+++ b/app/views/public_health/exposure.html.erb
@@ -64,5 +64,6 @@
                           description: 'All Monitorees in this jurisdiction, in the Exposure workflow.'
                         }
                       },
-                      custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS
+                      custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS,
+                      monitoring_reasons: Patient::MONITORING_REASONS
                     }) %>

--- a/app/views/public_health/isolation.html.erb
+++ b/app/views/public_health/isolation.html.erb
@@ -59,5 +59,5 @@
                         }
                       },
                       custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS,
-                      monitoring_reasons: Patient::MONITORING_REASONS
+                      monitoring_reasons: ValidationHelper::USER_SELECTABLE_MONITORING_REASONS
                     }) %>

--- a/app/views/public_health/isolation.html.erb
+++ b/app/views/public_health/isolation.html.erb
@@ -58,5 +58,6 @@
                           description: 'All cases in this jurisdiction, in the Isolation workflow.'
                         }
                       },
-                      custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS
+                      custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS,
+                      monitoring_reasons: Patient::MONITORING_REASONS
                     }) %>


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1081

This PR consolidates all of the Monitoree Reasons into one place

# Important Changes
`app/javascript/components/public_health/PatientsTable.js`
- Adds Monitoring Reasons as a prop

`app/javascript/components/public_health/Workflow.js`
- Adds Monitoring Reasons as a prop

`app/javascript/components/public_health/actions/CloseRecords.js`
- Iterates over new Monitoring_Reaons for `Select` Dropdown

`app/javascript/components/subject/monitoring_actions/MonitoringActions.js`
- Adds Monitoring Reasons as a prop

`app/javascript/components/subject/monitoring_actions/MonitoringStatus.js`
- Iterates over new Monitoring_Reaons for `Select` Dropdown

`app/views/patients/show.html.erb`
- Adds Monitoring Reasons as a prop

`app/views/public_health/exposure.html.erb`
- Adds Monitoring Reasons as a prop

`app/views/public_health/isolation.html.erb`
- Adds Monitoring Reasons as a prop

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11
