### PR TITLE
(Bugfix/Error Handling) Additional checks before updating Reports table

### DIFF
--- a/app/javascript/components/patient/PatientReportsTable.js
+++ b/app/javascript/components/patient/PatientReportsTable.js
@@ -98,7 +98,7 @@ class PatientReportsTable extends React.Component {
         }
       })
       .then(response => {
-        if (response && response.data && response.data) {
+        if (response && response.data && response.data.table_data && response.data.symptoms && response.data.total) {
           this.setState(state => {
             let updatedColData = state.table.colData;
             // If first load, populate symptom columns in the table.

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -95,7 +95,9 @@ class Assessment < ApplicationRecord
 
   # Gets all unique symptoms (based on name) for a given array of assessment IDs.
   def self.get_unique_symptoms_for_assessments(assessment_ids)
-    threshold_cond_hashes = ReportedCondition.where(type: 'ReportedCondition', assessment_id: assessment_ids).pluck(:threshold_condition_hash)
+    threshold_cond_hashes = ReportedCondition.where(type: 'ReportedCondition', assessment_id: assessment_ids)&.pluck(:threshold_condition_hash)
+    return if threshold_cond_hashes.nil?
+
     condition_ids = ThresholdCondition.where(type: 'ThresholdCondition', threshold_condition_hash: threshold_cond_hashes)
     Symptom.where(condition_id: condition_ids)&.uniq(&:name)
   end


### PR DESCRIPTION
# Description
As of 1.19.0 with the Patient Reports Table refactor, we have been seeing a small number of occurrences of the following error:
![Screen Shot 2020-12-28 at 12 12 08 PM](https://user-images.githubusercontent.com/11698457/103231506-e9bbdf80-4905-11eb-99b8-65fbcf8ace8e.png)

The `symptoms` returned in `response.data.symptoms` should never be null/undefined as we get them [here](https://github.com/SaraAlert/SaraAlert/blob/master/app/helpers/assessment_query_helper.rb#L73) and send an empty array if somehow nil [here](https://github.com/SaraAlert/SaraAlert/blob/master/app/helpers/assessment_query_helper.rb#L101).

At the moment we believe this error may be occurring when there is an interruption in the request. We specifically investigated the patients we saw this error occur on and found the method returned a number of symptoms properly.

This PR adds correct checks to avoid the error in this case, and also adds a nil check to the `get_unique_symptoms_for_assessments` method.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

I've been unable to replicate the issue shown above, but please test that there is no functionality change when loading and viewing the patient reports table.