### PR TITLE
SARAALERT-1038: Improve API Logging

### DIFF
--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# TokensController: add logging to TokensController defined by Doorkeeper
+class TokensController < Doorkeeper::TokensController
+  after_action do
+    Rails.logger.info("Response: #{response.body}") if response.status >= 400 && !response.body.blank?
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  use_doorkeeper
+  use_doorkeeper do
+    controllers tokens: 'tokens'
+  end
 
   if ADMIN_OPTIONS['report_mode']
     root to: 'assessments#landing'


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1038](https://tracker.codev.mitre.org/browse/SARAALERT-1038)

This adds additional logging to the API, so that when investigating issues we may have an easier time figuring out what is going wrong for an API user.

# Important Changes
`tokens_controller.rb`
- This file contains a definition of a new `TokensController` class which inherits from `Doorkeeper::TokensController`, and adds some additional logging. This is the only change, so that in all other ways the class will works as defined originally by the Doorkeeper gem. When the response is 4xx or 5xx, we now log the body of the response, to hopefully help with debugging.

# Note
I looked into adding more logging to the `APIController`, but I wasn't sure it made a ton of sense. In many of the cases, the status code is descriptive enough (aka if the status code is 403 we know that means they were trying to access a resource they didn't have access to, I could log a message saying that, but it didn't seem like it would be particularly helpful). The one case that I saw that it may be helpful to log extra info was in the case of a 400 error, since those happen if the user is doing something like POSTing an invalid patient, and there are many things that could be going wrong. However, I'm not sure if logging those responses would be appropriate, since they could contain personal information. For example, if someone tries to add a patient with `"birthDate": "12/28/2020"`, this will be an error because we expect the `birthDate` to be formatted as `YYYY-MM-DD`. But the error message detailing the issue contains the `12/28/2020` value, and I wasn't sure if that was something we'd want to log. If I'm wrong on that, happy to add it to this PR.