### PR TITLE
1056: makes map resizable to make DC visible

### DIFF
--- a/app/javascript/components/analytics/widgets/CountyLevelMaps.js
+++ b/app/javascript/components/analytics/widgets/CountyLevelMaps.js
@@ -286,7 +286,7 @@ class CountyLevelMaps extends React.Component {
           this.chart.maxZoomLevel = 32;
           this.chart.goHome();
           setTimeout(() => {
-            this.chart.maxZoomLevel = 1;
+            this.chart.maxZoomLevel = 10;
             this.updateJurisdictionData();
             this.props.decrementSpinnerCount();
           }, 1050);

--- a/app/javascript/components/analytics/widgets/CountyLevelMaps.js
+++ b/app/javascript/components/analytics/widgets/CountyLevelMaps.js
@@ -50,7 +50,7 @@ class CountyLevelMaps extends React.Component {
     this.chart.seriesContainer.draggable = true;
     this.chart.seriesContainer.resizable = true;
     this.chart.seriesContainer.wheelable = true;
-    this.chart.maxZoomLevel = 1;
+    this.chart.maxZoomLevel = 10;
     this.heatLegend = this.chart.createChild(am4maps.HeatLegend);
 
     this.usaSeries = this.chart.series.push(new am4maps.MapPolygonSeries());
@@ -119,7 +119,7 @@ class CountyLevelMaps extends React.Component {
     this.territoryChart.seriesContainer.draggable = true;
     this.territoryChart.seriesContainer.resizable = true;
     this.territoryChart.seriesContainer.wheelable = true;
-    this.territoryChart.maxZoomLevel = 1;
+    this.territoryChart.maxZoomLevel = 10;
 
     // It appears the separatorLines must be mounted on the chart instance (as opposed to a Series)
     this.territoryChart.geodata = separatorLines;

--- a/app/javascript/components/analytics/widgets/CountyLevelMaps.js
+++ b/app/javascript/components/analytics/widgets/CountyLevelMaps.js
@@ -47,9 +47,9 @@ class CountyLevelMaps extends React.Component {
   componentDidMount = () => {
     this.chart = am4core.create(`chartdiv-${this.props.id}`, am4maps.MapChart);
     this.chart.projection = new am4maps.projections.AlbersUsa();
-    this.chart.seriesContainer.draggable = false;
-    this.chart.seriesContainer.resizable = false;
-    this.chart.seriesContainer.wheelable = false;
+    this.chart.seriesContainer.draggable = true;
+    this.chart.seriesContainer.resizable = true;
+    this.chart.seriesContainer.wheelable = true;
     this.chart.maxZoomLevel = 1;
     this.heatLegend = this.chart.createChild(am4maps.HeatLegend);
 
@@ -116,9 +116,9 @@ class CountyLevelMaps extends React.Component {
 
     this.territoryChart = am4core.create(`territorydiv-${this.props.id}`, am4maps.MapChart);
     this.territoryChart.projection = new am4maps.projections.Miller();
-    this.territoryChart.seriesContainer.draggable = false;
-    this.territoryChart.seriesContainer.resizable = false;
-    this.territoryChart.seriesContainer.wheelable = false;
+    this.territoryChart.seriesContainer.draggable = true;
+    this.territoryChart.seriesContainer.resizable = true;
+    this.territoryChart.seriesContainer.wheelable = true;
     this.territoryChart.maxZoomLevel = 1;
 
     // It appears the separatorLines must be mounted on the chart instance (as opposed to a Series)


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1056

Changes the county level maps settings to be resizable to DC is visible. The original code changes are not mine: David had a fix ready when I was assigned the task, and I've used his solution here. 

# (Feature) Demo/Screenshots
Screenshots pending

# Important Changes
-  app/javascript/components/analytics/widgets/CountyLevelMaps.js - The only file changed, makes the user able to resize, drag, and wheel the map chart. 

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [x] Firefox
* [ ] Safari
* [ ] IE11

