### PR TITLE
Get number from existing execution

### DIFF
--- a/app/mailers/twilio_sender.rb
+++ b/app/mailers/twilio_sender.rb
@@ -47,9 +47,14 @@ class TwilioSender
       return
     end
 
-    trigger_message = execution&.context&.[]('trigger')&.[]('message')
-    phone_number_from = trigger_message&.[]('From')
-    phone_number_to = trigger_message&.[]('To')
+    # Get a message out of the studio execution which we can get the To/From numbers out of
+    # The opt-in/out could come from an incoming message trigger OR an existing execution
+    # The message pulled from an existing execution will be the first inbound message found within the execution
+    message = execution&.context&.[]('trigger')&.[]('message') || execution&.context&.[]('widgets')&.values&.select do |x|
+                                                                    x&.[]('inbound')
+                                                                  end&.[](0)&.[]('inbound')
+    phone_number_from = message&.[]('From')
+    phone_number_to = message&.[]('To')
 
     return { monitoree_number: phone_number_from, sara_number: phone_number_to } if !phone_number_from.nil? && !phone_number_to.nil?
 


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1143

This fixes an issue with the TO and FROM phone numbers to be pulled from REST Triggered Studio Flow executions **and** from executions that were triggered via an incoming message.

# (Bugfix) How to Replicate
In the rails console:
```
@client = Twilio::REST::Client.new(ENV['TWILLIO_API_ACCOUNT'], ENV['TWILLIO_API_KEY'])
 execution = @client.studio.v1.flows(ENV['TWILLIO_STUDIO_FLOW']).executions(<opt out execution ID triggered via Twilio REST Trigger>).execution_context.fetch
trigger_message = execution&.context&.[]('trigger')&.[]('message')
# See that the trigger message is unavailable
 execution = @client.studio.v1.flows(ENV['TWILLIO_STUDIO_FLOW']).executions(<opt out execution ID triggered via Incoming message>).execution_context.fetch
trigger_message = execution&.context&.[]('trigger')&.[]('message')
# See that the trigger message is available
```

# (Bugfix) Solution
In the rails console:
```
@client = Twilio::REST::Client.new(ENV['TWILLIO_API_ACCOUNT'], ENV['TWILLIO_API_KEY'])
 execution = @client.studio.v1.flows(ENV['TWILLIO_STUDIO_FLOW']).executions(<opt out execution ID triggered via Twilio REST Trigger>).execution_context.fetch
message = execution&.context&.[]('trigger')&.[]('message') || execution&.context&.[]('widgets')&.values&.select { |x| x&.[]('inbound') }&.[](0)['inbound']
# See that the message is available
 execution = @client.studio.v1.flows(ENV['TWILLIO_STUDIO_FLOW']).executions(<opt out execution ID triggered via Incoming message>).execution_context.fetch
    message = execution&.context&.[]('trigger')&.[]('message') || execution&.context&.[]('widgets')&.values&.select { |x| x&.[]('inbound') }&.[](0)['inbound']
# See that the message is available
```

Message me if you need help getting the relevant execution IDs for test
