### PR TITLE
SARAALERT-1153: Update Transfer Linelist Logic

### DIFF
--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -105,8 +105,8 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
       return current_user.viewable_patients.exposure_asymptomatic if tab == :asymptomatic
       return current_user.viewable_patients.exposure_under_investigation if tab == :pui
       return current_user.viewable_patients.monitoring_closed_without_purged.where(isolation: false) if tab == :closed
-      return jurisdiction.transferred_in_patients.monitoring_open.where(isolation: false) if tab == :transferred_in
-      return jurisdiction.transferred_out_patients.monitoring_open.where(isolation: false) if tab == :transferred_out
+      return jurisdiction.transferred_in_patients.where(isolation: false) if tab == :transferred_in
+      return jurisdiction.transferred_out_patients.where(isolation: false) if tab == :transferred_out
 
       current_user.viewable_patients.where(isolation: false, purged: false)
     when :isolation
@@ -114,14 +114,14 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
       return current_user.viewable_patients.isolation_non_reporting if tab == :non_reporting
       return current_user.viewable_patients.isolation_reporting if tab == :reporting
       return current_user.viewable_patients.monitoring_closed_without_purged.where(isolation: true) if tab == :closed
-      return jurisdiction.transferred_in_patients.monitoring_open.where(isolation: true) if tab == :transferred_in
-      return jurisdiction.transferred_out_patients.monitoring_open.where(isolation: true) if tab == :transferred_out
+      return jurisdiction.transferred_in_patients.where(isolation: true) if tab == :transferred_in
+      return jurisdiction.transferred_out_patients.where(isolation: true) if tab == :transferred_out
 
       current_user.viewable_patients.where(isolation: true, purged: false)
     else
       return current_user.viewable_patients.monitoring_closed_without_purged if tab == :closed
-      return jurisdiction.transferred_in_patients.monitoring_open if tab == :transferred_in
-      return jurisdiction.transferred_out_patients.monitoring_open if tab == :transferred_out
+      return jurisdiction.transferred_in_patients if tab == :transferred_in
+      return jurisdiction.transferred_out_patients if tab == :transferred_out
 
       current_user.viewable_patients.where(purged: false)
     end

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -33,12 +33,12 @@ class Jurisdiction < ApplicationRecord
 
   # All patients that were in the jurisdiction before (but were transferred), and are not currently in the subtree
   def transferred_out_patients
-    Patient.where(id: Transfer.where(from_jurisdiction_id: subtree_ids).pluck(:patient_id)).where.not(jurisdiction_id: subtree_ids + [id])
+    Patient.where(purged: false, id: Transfer.where(from_jurisdiction_id: subtree_ids).pluck(:patient_id)).where.not(jurisdiction_id: subtree_ids + [id])
   end
 
   # All patients that were transferred into the jurisdiction in the last 24 hours
   def transferred_in_patients
-    Patient.where(id: Transfer.where(to_jurisdiction_id: subtree_ids + [id])
+    Patient.where(purged: false, id: Transfer.where(to_jurisdiction_id: subtree_ids + [id])
                               .where.not(from_jurisdiction_id: subtree_ids + [id])
                               .where('created_at > ?', 24.hours.ago).pluck(:patient_id))
            .where(jurisdiction_id: subtree_ids + [id])

--- a/test/models/jurisdiction_test.rb
+++ b/test/models/jurisdiction_test.rb
@@ -10,4 +10,111 @@ class JurisdictionTest < ActiveSupport::TestCase
   test 'create jurisdiction' do
     assert create(:jurisdiction)
   end
+
+  # transferred_out_patients tests
+
+  test 'transferred out patients should not include purged' do
+    # Create not purged patient that is then transferred and verify it IS included in transferred_out_patients
+    patient = create(:patient, purged: false)
+    old_jurisdiction = patient.jurisdiction
+    new_jurisdiction = Jurisdiction.find(5)
+    patient.update!(jurisdiction: new_jurisdiction)
+    Transfer.create!(patient: patient, from_jurisdiction: old_jurisdiction, to_jurisdiction_id: new_jurisdiction.id, who: User.first)
+    assert_equal(1, old_jurisdiction.transferred_out_patients.where(id: patient.id).count)
+
+    # Create purged patient that is then transferred and verify it is not included in transferred_out_patients
+    patient = create(:patient, purged: true)
+    old_jurisdiction = patient.jurisdiction
+    new_jurisdiction = Jurisdiction.find(5)
+    patient.update!(jurisdiction: new_jurisdiction)
+    Transfer.create!(patient: patient, from_jurisdiction: old_jurisdiction, to_jurisdiction_id: new_jurisdiction.id, who: User.first)
+    assert_equal(0, old_jurisdiction.transferred_out_patients.where(id: patient.id).count)
+  end
+
+  test 'transferred out patients should not include transfers from jurisdictions outside of its jurisdiction hierarchy' do
+    curr_jur = Jurisdiction.find_by(name: 'State 1')
+
+    # Create patient that is from jurisdiction in hierarchy
+    old_jurisdiction = curr_jur
+    patient = create(:patient, jurisdiction: old_jurisdiction)
+    # Make sure you are not transferring back into the jurisdiction's hierarchy
+    new_jurisdiction = Jurisdiction.find_by(name: 'USA')
+    patient.update!(jurisdiction: new_jurisdiction)
+    Transfer.create!(patient: patient, from_jurisdiction: old_jurisdiction, to_jurisdiction_id: new_jurisdiction.id, who: User.first)
+    assert_equal(1, curr_jur.transferred_out_patients.where(id: patient.id).count)
+
+    # Create patient that is from jurisdiction outside of hierarchy
+    old_jurisdiction = Jurisdiction.find_by(name: 'USA')
+    patient = create(:patient, jurisdiction: old_jurisdiction)
+    new_jurisdiction = Jurisdiction.find(5)
+    patient.update!(jurisdiction: new_jurisdiction)
+    Transfer.create!(patient: patient, from_jurisdiction: old_jurisdiction, to_jurisdiction_id: new_jurisdiction.id, who: User.first)
+    assert_equal(0, curr_jur.transferred_out_patients.where(id: patient.id).count)
+  end
+
+  test 'transferred out patients should include transfers from subjurisdictions' do
+    curr_jur = Jurisdiction.find_by(name: 'State 1')
+
+    # Create patient that is from jurisdiction in hierarchy
+    old_jurisdiction = Jurisdiction.find_by(name: 'County 1')
+    patient = create(:patient, jurisdiction: old_jurisdiction)
+    # Make sure you are not transferring back into the jurisdiction's hierarchy
+    new_jurisdiction = Jurisdiction.find_by(name: 'USA')
+    patient.update!(jurisdiction: new_jurisdiction)
+    Transfer.create!(patient: patient, from_jurisdiction: old_jurisdiction, to_jurisdiction_id: new_jurisdiction.id, who: User.first)
+    assert_equal(1, curr_jur.transferred_out_patients.where(id: patient.id).count)
+  end
+
+  # transferred_in_patients tests
+
+  test 'transferred in patients should not include purged' do
+    # Create not purged patient that is then transferred in and verify it IS included in transferred_in_patients
+    patient = create(:patient, purged: false)
+    old_jurisdiction = patient.jurisdiction
+    new_jurisdiction = Jurisdiction.find(5)
+    patient.update!(jurisdiction: new_jurisdiction)
+    Transfer.create!(patient: patient, from_jurisdiction: old_jurisdiction, to_jurisdiction_id: new_jurisdiction.id, who: User.first)
+    assert_equal(1, new_jurisdiction.transferred_in_patients.where(id: patient.id).count)
+
+    # Create purged patient that is then transferred in and verify it is not included in transferred_in_patients
+    patient = create(:patient, purged: true)
+    old_jurisdiction = patient.jurisdiction
+    new_jurisdiction = Jurisdiction.find(5)
+    patient.update!(jurisdiction: new_jurisdiction)
+    Transfer.create!(patient: patient, from_jurisdiction: old_jurisdiction, to_jurisdiction_id: new_jurisdiction.id, who: User.first)
+    assert_equal(0, new_jurisdiction.transferred_in_patients.where(id: patient.id).count)
+  end
+
+  test 'transferred in patients should not include transfers into jurisdictions outside of its jurisdiction hierarchy' do
+    curr_jur = Jurisdiction.find_by(name: 'State 1')
+
+    # Create patient that is transferred to jurisdiction in hierarchy
+    old_jurisdiction = Jurisdiction.find_by(name: 'USA')
+    patient = create(:patient, jurisdiction: old_jurisdiction)
+    new_jurisdiction = curr_jur
+    patient.update!(jurisdiction: new_jurisdiction)
+    Transfer.create!(patient: patient, from_jurisdiction: old_jurisdiction, to_jurisdiction_id: new_jurisdiction.id, who: User.first)
+    assert_equal(1, curr_jur.transferred_in_patients.where(id: patient.id).count)
+
+    # Create patient that is transferred to jurisdiction outside of hierarchy
+    old_jurisdiction = Jurisdiction.find_by(name: 'USA')
+    patient = create(:patient, jurisdiction: old_jurisdiction)
+    new_jurisdiction = Jurisdiction.find_by(name: 'State 2')
+    patient.update!(jurisdiction: new_jurisdiction)
+    Transfer.create!(patient: patient, from_jurisdiction: old_jurisdiction, to_jurisdiction_id: new_jurisdiction.id, who: User.first)
+    assert_equal(0, curr_jur.transferred_in_patients.where(id: patient.id).count)
+  end
+
+  test 'transferred in patients should include transfers into subjurisdictions' do
+    curr_jur = Jurisdiction.find_by(name: 'State 1')
+
+    # Create patient that is from jurisdiction in hierarchy
+    # Make sure you are not transferring from the jurisdiction's hierarchy
+    old_jurisdiction = Jurisdiction.find_by(name: 'USA')
+    patient = create(:patient, jurisdiction: old_jurisdiction)
+    new_jurisdiction = Jurisdiction.find_by(name: 'County 1')
+    patient.update!(jurisdiction: new_jurisdiction)
+    Transfer.create!(patient: patient, from_jurisdiction: old_jurisdiction, to_jurisdiction_id: new_jurisdiction.id, who: User.first)
+    assert_equal(1, curr_jur.transferred_in_patients.where(id: patient.id).count)
+  end
 end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1153](https://tracker.codev.mitre.org/browse/SARAALERT-1153)

This PR updates what patients can be shown in the transferred in/out linelists with the following changes:
- Closed records should show up on both linelists.
- Purged records should NOT show up on either of the transfer linelists.

It also adds tests for these methods on the Jurisdiction model.

# Important Changes
`app/helpers/patient_query_helper.rb`
- Allow closed records to show up on these linelists.

`app/models/jurisdiction.rb`
- Don't allow purged records to show up on these linelists.

`test/models/jurisdiction_test.rb`
- Added tests for the `transferred_out_patients` and `transferred_in_patients` methods.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.

- [ ] Verify closed records can show up on both linelists.
- [ ] Verify purged records do not show up on either linelist.
