### PR TITLE
SARAALERT-1148: Temporarily Remove Custom Export CSV Option

### DIFF
--- a/app/javascript/components/public_health/CustomExport.js
+++ b/app/javascript/components/public_health/CustomExport.js
@@ -186,6 +186,7 @@ class CustomExport extends React.Component {
           </Modal.Header>
           <Modal.Body className="p-0">
             <div className="p-2">
+              <p className="mx-3 mt-2 mb-3">Files will be exported in the Excel (.xlsx) format.</p>
               <h5 className="mx-3 my-2">Choose which records to export</h5>
               <Row className="mx-3 pb-2">
                 <Col md={24}>
@@ -406,29 +407,7 @@ class CustomExport extends React.Component {
                     onChange={event => this.handlePresetChange('name', event?.target?.value)}
                   />
                 </Col>
-                <Col md={6} className="px-1 pt-2">
-                  <Form.Group className="mb-0">
-                    <Button
-                      id="custom-export-format-csv"
-                      size="sm"
-                      variant={this.state.preset?.config?.format === 'csv' ? 'primary' : 'outline-secondary'}
-                      style={{ outline: 'none', boxShadow: 'none' }}
-                      onClick={() => this.handlePresetChange('config.format', 'csv')}>
-                      <FontAwesomeIcon className="mr-1" icon={['fas', 'file-csv']} />
-                      CSV
-                    </Button>
-                    <Button
-                      id="custom-export-format-xlsx"
-                      size="sm"
-                      variant={this.state.preset?.config?.format === 'xlsx' ? 'primary' : 'outline-secondary'}
-                      style={{ outline: 'none', boxShadow: 'none' }}
-                      onClick={() => this.handlePresetChange('config.format', 'xlsx')}>
-                      <FontAwesomeIcon className="mr-1" icon={['fas', 'file-excel']} />
-                      Excel
-                    </Button>
-                  </Form.Group>
-                </Col>
-                <Col md={6} className="px-1 pt-2">
+                <Col md={12} className="px-1 pt-2">
                   <Form.Group className="mb-0 float-right">
                     {this.state.preset?.id && (
                       <React.Fragment>

--- a/test/system/roles/public_health/dashboard/dashboard.rb
+++ b/test/system/roles/public_health/dashboard/dashboard.rb
@@ -76,9 +76,6 @@ class PublicHealthDashboard < ApplicationSystemTestCase
     # Provide optional custom export format name
     fill_in 'preset', with: settings[:name] if settings[:name].present?
 
-    # Select file format
-    click_on "custom-export-format-#{settings[:format]}" if settings[:format]
-
     # Save, update, or delete preset
     settings[:actions]&.each do |action|
       click_on "custom-export-action-#{action}"

--- a/test/system/roles/public_health/public_health_custom_export_test.rb
+++ b/test/system/roles/public_health/public_health_custom_export_test.rb
@@ -41,35 +41,4 @@ class PublicHealthCustomExportTest < ApplicationSystemTestCase
     }
     @@public_health_test_helper.export_custom('state1_epi', settings)
   end
-
-  test 'export csv format with all monitorees with all data types with all fields' do
-    settings = {
-      records: :all,
-      elements: {
-        patients: {
-          checked: ['Monitoree Details']
-        },
-        assessments: {
-          checked: ['Reports']
-        },
-        laboratories: {
-          checked: ['Lab Results']
-        },
-        close_contacts: {
-          checked: ['Close Contacts']
-        },
-        transfers: {
-          checked: ['Transfers']
-        },
-        histories: {
-          checked: ['History']
-        }
-      },
-      name: 'CSV export all',
-      format: :csv,
-      actions: %i[save export],
-      confirm: :start
-    }
-    @@public_health_test_helper.export_custom('state1_epi', settings)
-  end
 end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1148](https://tracker.codev.mitre.org/browse/SARAALERT-1148)

We have found that the CSV custom exports are getting too large on prod as they are not compressed as Excel files are. As a result, we are temporarily removing the option for CSV custom exports until we have migrated exports to AWS S3.

# Screenshots
Before change:
<img src="https://user-images.githubusercontent.com/11698457/103803344-6e051580-501e-11eb-97cc-583fdc3d37bf.png" width="500" height="500" />

After change:
<img src="https://user-images.githubusercontent.com/11698457/103803355-72313300-501e-11eb-8853-b8a050493031.png" width="500" height="500" />

# Important Changes
`app/javascript/components/public_health/CustomExport.js`
- Removed CSV/Excel button option.
- Added note at the top to state what the file format will be.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.

- [ ] Open the custom export modal and verify the UI changes are present.
- [ ] Test custom export and verify it is the correct format (excel) and unchanged otherwise.
