### PR TITLE
SARAALERT-1183: Handle potential overlap in report mailer scheduling

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -698,8 +698,8 @@ class Patient < ApplicationRecord
       end
     end
 
-    # Final last_assessment_reminder_sent check to ensure we cover potential race condition of
-    # multiple mailer jobs being enqueued for the same monitoree.
+    # Check last_assessment_reminder_sent before enqueueing to cover potential race condition of multiple reports
+    # being sent out for the same monitoree.
     return unless last_assessment_reminder_sent <= 12.hours.ago || last_assessment_reminder_sent.nil?
 
     if preferred_contact_method&.downcase == 'sms text-message' && ADMIN_OPTIONS['enable_sms']

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -700,7 +700,7 @@ class Patient < ApplicationRecord
 
     # Check last_assessment_reminder_sent before enqueueing to cover potential race condition of multiple reports
     # being sent out for the same monitoree.
-    return unless last_assessment_reminder_sent <= 12.hours.ago || last_assessment_reminder_sent.nil?
+    return unless last_assessment_reminder_sent_eligible? || send_now
 
     if preferred_contact_method&.downcase == 'sms text-message' && ADMIN_OPTIONS['enable_sms']
       PatientMailer.assessment_sms(self).deliver_later
@@ -873,6 +873,12 @@ class Patient < ApplicationRecord
     else
       timezone_for_state('massachusetts')
     end
+  end
+
+  # Check last_assessment_reminder_sent for eligibility. This is chiefly intended to help cover potential race condition of
+  # multiple reports being sent out for the same monitoree.
+  def last_assessment_reminder_sent_eligible?
+    last_assessment_reminder_sent <= 12.hours.ago || last_assessment_reminder_sent.nil?
   end
 
   # Creates a diff between a patient before and after updates, and creates a detailed record edit History item with the changes.

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -698,6 +698,10 @@ class Patient < ApplicationRecord
       end
     end
 
+    # Final last_assessment_reminder_sent check to ensure we cover potential race condition of
+    # multiple mailer jobs being enqueued for the same monitoree.
+    return unless last_assessment_reminder_sent <= 12.hours.ago || last_assessment_reminder_sent.nil?
+
     if preferred_contact_method&.downcase == 'sms text-message' && ADMIN_OPTIONS['enable_sms']
       PatientMailer.assessment_sms(self).deliver_later
     elsif preferred_contact_method&.downcase == 'sms texted weblink' && ADMIN_OPTIONS['enable_sms']

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -878,7 +878,7 @@ class Patient < ApplicationRecord
   # Check last_assessment_reminder_sent for eligibility. This is chiefly intended to help cover potential race condition of
   # multiple reports being sent out for the same monitoree.
   def last_assessment_reminder_sent_eligible?
-    last_assessment_reminder_sent <= 12.hours.ago || last_assessment_reminder_sent.nil?
+    last_assessment_reminder_sent.nil? || last_assessment_reminder_sent <= 12.hours.ago
   end
 
   # Creates a diff between a patient before and after updates, and creates a detailed record edit History item with the changes.

--- a/test/mailers/patient_mailer_test.rb
+++ b/test/mailers/patient_mailer_test.rb
@@ -111,7 +111,6 @@ class PatientMailerTest < ActionMailer::TestCase
 
       assert_difference '@patient.histories.length', 1 do
         PatientMailer.send(mthd, @patient).deliver_now
-        assert_not_nil @patient.last_assessment_reminder_sent
         @patient.reload
         assert_equal 'Report Reminder', @patient.histories.first.history_type
         comment = "Sara Alert attempted to send an SMS to #{@patient.primary_telephone}, but the message could not be delivered."
@@ -288,7 +287,6 @@ class PatientMailerTest < ActionMailer::TestCase
         PatientMailer.send(mthd, @patient).deliver_now
         @patient.reload
         assert_equal 'Report Reminder', @patient.histories.first.history_type
-        assert_not_nil @patient.last_assessment_reminder_sent
         assert_includes @patient.histories.first.comment, @patient.primary_telephone
       end
     end
@@ -420,6 +418,7 @@ class PatientMailerTest < ActionMailer::TestCase
     assert_includes email_body, @patient.submission_token
     assert_includes email_body, dependent.submission_token
 
+    @patient.update(last_assessment_reminder_sent: nil)
     dependent.update(monitoring: false)
     email = PatientMailer.assessment_email(@patient).deliver_now
     email_body = email.parts.first.body.to_s.gsub("\n", ' ')

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -2131,5 +2131,16 @@ class PatientTest < ActiveSupport::TestCase
     scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
     assert_not scoped_patients.where(id: patient.id).present?
   end
+
+  test 'last assessment reminder sent eligible' do
+    patient = create(:patient)
+    assert patient.last_assessment_reminder_sent_eligible?
+
+    patient.update(last_assessment_reminder_sent: 13.hours.ago)
+    assert patient.last_assessment_reminder_sent_eligible?
+
+    patient.update(last_assessment_reminder_sent: 11.hours.ago)
+    assert_not patient.last_assessment_reminder_sent_eligible?
+  end
 end
 # rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1183

If SendAssessmentJob runs become unwieldy (taking longer than the normal 1 hour), the potential for overlap in eligibility can result in multiple emails (etc.) being sent during the same period. This adds a specific check before anything is sent in the send_assessments method to ensure if this situation arises, multiple messages will not be sent.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/mailers/patient_mailer.rb`
- Do update of last_assessment_reminder_sent upfront (before external call is done to Twilio/SMTP)
- If message failed to send for whatever reason, nil out last_assessment_reminder_sent
- Check last_assessment_reminder_sent in case a duplicate job was already enqueued

`app/models/patient.rb`
- Check last_assessment_reminder_sent right before queueing a new job
