### PR TITLE
Update API docs for 1.20.0

### DIFF
--- a/docs/api/api-coming-soon.md
+++ b/docs/api/api-coming-soon.md
@@ -6,7 +6,7 @@ nav_order: 2
 ---
 **Below you will find a list of ongoing work that affects the Sara Alert™ API. This page will be updated regularly. If you have any questions on the information here, please email them to our API Help Desk, saraalert-interop@mitre.org. For past release notes, please see [API Release Notes](api-release-notes).**
 
-## Planned for 1.19*:
+## Planned for 1.21*:
 
 Check back soon for an updated list of planned items.
 

--- a/docs/api/api-coming-soon.md
+++ b/docs/api/api-coming-soon.md
@@ -4,13 +4,20 @@ title: Coming Soon
 parent: API
 nav_order: 2
 ---
+
 **Below you will find a list of ongoing work that affects the Sara Alert™ API. This page will be updated regularly. If you have any questions on the information here, please email them to our API Help Desk, saraalert-interop@mitre.org. For past release notes, please see [API Release Notes](api-release-notes).**
 
-## Planned for 1.21*:
+## Planned for 1.21\*:
 
-Check back soon for an updated list of planned items.
+- Add important side effects when certain data is modified via the API
+  - "Closed at" is set to the current time and "Continuous Exposure" is set to `false` when "Monitoring Status" is changed to "Not Monitoring"
+  - "Symptom Onset" is set to the time of the first symptomatic report (if such a report exists) if "Isolation" is set to `false`, or if "Symptom Onset" is deleted
+  - Monitorees are added to the "Transferred In" and "Transferred Out" linelist as appropriate when jurisdiction changes
+  - History items are created to track the side effects detailed above
+- Improved validation error messaging: validation messages will more clearly indicate what value caused the validation error, and where that value is in the JSON document
+- Support for Foreign Address (read/write)
+- Expanded support for languages
 
-***
+---
 
-
-*_This list represents ongoing work. It is subject to change, and the intended release version is not a guarantee_
+\*_This list represents ongoing work. It is subject to change, and the intended release version is not a guarantee_

--- a/docs/api/api-release-notes.md
+++ b/docs/api/api-release-notes.md
@@ -4,6 +4,11 @@ title: Release Notes
 parent: API
 nav_order: 1
 ---
+# 1.20.0
+* Fixed a bug which prevented multiple races from being set at once via the [race](https://www.hl7.org/fhir/us/core/StructureDefinition-us-core-race.html) extension
+  
+***
+
 # 1.18.1
 * Added support for the following attributes on the Patient resource:
   * **Monitoring Plan**


### PR DESCRIPTION
# Description
This PR contains some minor updates to the "Release Notes" and "Coming Soon" pages so that the API docs are ready to deploy once 1.20.0 is out.

# Important Changes

`api-release-notes.md`
- Add release notes for 1.20.0. Note that 1.19.0 is skipped, since nothing user facing was added to the API during that release).

`api-coming-soon.md`
- Change the coming soon version to 1.21.0. As I understand we don't have anything user facing strictly planned for 1.21.0, but I can update this if that's not the case.
