### PR TITLE
SARAALERT-1089 (continued): Bold "unless" language in the Review Symptom Report pop up

### DIFF
--- a/app/javascript/components/subject/ClearSingleReport.js
+++ b/app/javascript/components/subject/ClearSingleReport.js
@@ -12,23 +12,20 @@ class ClearSingleReport extends React.Component {
       showClearReportModal: false,
       loading: false,
     };
-    this.toggleClearReportModal = this.toggleClearReportModal.bind(this);
-    this.clearReport = this.clearReport.bind(this);
-    this.handleChange = this.handleChange.bind(this);
   }
 
-  toggleClearReportModal() {
+  toggleClearReportModal = () => {
     let current = this.state.showClearReportModal;
     this.setState({
       showClearReportModal: !current,
     });
-  }
+  };
 
-  handleChange(event) {
+  handleChange = event => {
     this.setState({ [event.target.id]: event.target.value });
-  }
+  };
 
-  clearReport() {
+  clearReport = () => {
     this.setState({ loading: true }, () => {
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
       axios
@@ -42,21 +39,21 @@ class ClearSingleReport extends React.Component {
           reportError(error);
         });
     });
-  }
+  };
 
-  createModal(title, toggle, submit) {
+  createModal(toggle, submit) {
     return (
       <Modal size="lg" show centered onHide={toggle}>
         <Modal.Header>
-          <Modal.Title>{title}</Modal.Title>
+          <Modal.Title>Mark as Reviewed</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           {!this.props.patient.isolation && (
             <p>
               You are about to clear the symptomatic report flag (red highlight) on this record. This indicates that the disease of interest is not suspected
               after review of this symptomatic report. The &quot;Needs Review&quot; status will be changed to &quot;No&quot; for this report. The record will
-              move from the symptomatic line list to the asymptomatic or non-reporting line list as appropriate unless another symptomatic report is present in
-              the reports table or a symptom onset date has been entered by a user.
+              move from the symptomatic line list to the asymptomatic or non-reporting line list as appropriate{' '}
+              <b>unless another symptomatic report is present in the reports table or a symptom onset date has been entered by a user.</b>
             </p>
           )}
           {this.props.patient.isolation && (
@@ -94,7 +91,7 @@ class ClearSingleReport extends React.Component {
         <Button variant="link" onClick={this.toggleClearReportModal} className="dropdown-item">
           <i className="fas fa-check fa-fw"></i> Review
         </Button>
-        {this.state.showClearReportModal && this.createModal('Mark As Reviewed', this.toggleClearReportModal, this.clearReport)}
+        {this.state.showClearReportModal && this.createModal(this.toggleClearReportModal, this.clearReport)}
       </React.Fragment>
     );
   }

--- a/app/javascript/tests/subject/ClearSingleReport.test.js
+++ b/app/javascript/tests/subject/ClearSingleReport.test.js
@@ -1,0 +1,82 @@
+import React from 'react'
+import { shallow } from 'enzyme';
+import { Button, Modal } from 'react-bootstrap';
+import ClearSingleReport from '../../components/subject/ClearSingleReport.js'
+import { mockPatient1, mockPatient2 } from '../mocks/mockPatients'
+
+const authyToken = "Q1z4yZXLdN+tZod6dBSIlMbZ3yWAUFdY44U06QWffEP76nx1WGMHIz8rYxEUZsl9sspS3ePF2ZNmSue8wFpJGg==";
+
+function getWrapper(patient) {
+    return shallow(<ClearSingleReport patient={patient} authenticity_token={authyToken} />);
+}
+
+describe('ClearSingleReport', () => {
+  it('Properly renders "Review" button', () => {
+    const wrapper = getWrapper(mockPatient1);
+    expect(wrapper.find(Button).length).toEqual(1);
+    expect(wrapper.find(Button).text().includes('Review')).toBeTruthy();
+    expect(wrapper.find('i').hasClass('fa-check')).toBeTruthy();
+  });
+
+  it('Clicking the "Review" button opens modal', () => {
+    const wrapper = getWrapper(mockPatient1);
+    expect(wrapper.find(Modal).exists()).toBeFalsy();
+    wrapper.find(Button).simulate('click');
+    expect(wrapper.find(Modal).exists()).toBeTruthy();
+  });
+
+  it('Properly renders modal', () => {
+    const wrapper = getWrapper(mockPatient1);
+    wrapper.find(Button).simulate('click');
+    expect(wrapper.find(Modal.Title).exists()).toBeTruthy();
+    expect(wrapper.find(Modal.Title).text()).toEqual('Mark as Reviewed');
+    expect(wrapper.find(Modal.Body).exists()).toBeTruthy();
+    expect(wrapper.find(Modal.Body).find('p').exists()).toBeTruthy();
+    expect(wrapper.find(Modal.Body).find('#reasoning').exists()).toBeTruthy();
+    expect(wrapper.find(Modal.Footer).exists()).toBeTruthy();
+    expect(wrapper.find(Modal.Footer).find(Button).length).toEqual(2);
+    expect(wrapper.find(Modal.Footer).find(Button).at(0).text()).toEqual('Cancel');
+    expect(wrapper.find(Modal.Footer).find(Button).at(1).text()).toEqual('Submit');
+  });
+
+  it('Properly renders modal text if monitoree is in exposure', () => {
+    const wrapper = getWrapper(mockPatient2);
+    wrapper.find(Button).simulate('click');
+    expect(wrapper.find('p').text()).toEqual(`You are about to clear the symptomatic report flag (red highlight) on this record. This indicates that the disease of interest is not suspected after review of this symptomatic report. The \"Needs Review\" status will be changed to \"No\" for this report. The record will move from the symptomatic line list to the asymptomatic or non-reporting line list as appropriate unless another symptomatic report is present in the reports table or a symptom onset date has been entered by a user.`);
+    expect(wrapper.find('b').text()).toEqual('unless another symptomatic report is present in the reports table or a symptom onset date has been entered by a user.');
+  });
+
+  it('Properly renders modal text if monitoree is in isolation', () => {
+    const wrapper = getWrapper(mockPatient1);
+    wrapper.find(Button).simulate('click');
+    expect(wrapper.find('p').text()).toEqual(`This will change the selected report's \"Needs Review\" column from \"Yes\" to \"No\". If this case is currently under the \"Records Requiring Review\" line list, they will be moved to the \"Reporting\" or \"Non-Reporting\" line list as appropriate until a recovery definition is met.`);
+  });
+
+  it('Adding reasoning updates state', () => {
+    const wrapper = getWrapper(mockPatient1);
+    const handleChangeSpy = jest.spyOn(wrapper.instance(), 'handleChange');
+    wrapper.find(Button).simulate('click');
+
+    expect(wrapper.find('#reasoning').exists()).toBeTruthy();
+    wrapper.find('#reasoning').simulate('change', { target: { id: 'reasoning', value: 'insert reasoning text here' } });
+    expect(handleChangeSpy).toHaveBeenCalled();
+    expect(wrapper.state('reasoning')).toEqual('insert reasoning text here');
+  });
+
+  it('Clicking the modal submit button calls submit method', () => {
+    const wrapper = getWrapper(mockPatient1);
+    const handleClearReportSpy = jest.spyOn(wrapper.instance(), 'clearReport');
+    wrapper.find(Button).simulate('click');
+    expect(handleClearReportSpy).toHaveBeenCalledTimes(0);
+    wrapper.find(Button).at(2).simulate('click');
+    expect(handleClearReportSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('Clicking the modal cancel button closes the modal', () => {
+    const wrapper = getWrapper(mockPatient1);
+    wrapper.find(Button).simulate('click');
+    expect(wrapper.find(Modal).exists()).toBeTruthy();
+    wrapper.find(Button).at(1).simulate('click');
+    expect(wrapper.find(Modal).exists()).toBeFalsy();
+  });
+});


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1089](https://tracker.codev.mitre.org/browse/SARAALERT-1089)

Added bolded language to review singular report modal.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`ClearSingleReport.js`
- Updated bolded language
- In line function binding

`ClearSingleReport.test.js`
- Added test suite for singular clear reports modal

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
