### PR TITLE
SARAALERT-1144: Latest transfer edge case

### DIFF
--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -639,8 +639,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
 
   # Gets a hash of the latest transfers of each patient
   def get_patients_transfers(patients)
-    transfers = patients.pluck(:id, :latest_transfer_at)
-    transfers = Transfer.where(patient_id: transfers.map { |lt| lt[0] }, created_at: transfers.map { |lt| lt[1] })
+    transfers = Transfer.latest_transfers(patients)
     jurisdictions = Jurisdiction.find(transfers.pluck(:from_jurisdiction_id, :to_jurisdiction_id).flatten.uniq)
     jurisdiction_paths = Hash[jurisdictions.pluck(:id, :path).map { |id, path| [id, path] }]
     Hash[transfers.pluck(:patient_id, :created_at, :from_jurisdiction_id, :to_jurisdiction_id)

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -48,6 +48,11 @@ class Transfer < ApplicationRecord
     end
   }
 
+  def self.latest_transfers(patients)
+    tuples = patients.pluck(:id, :latest_transfer_at)
+    Transfer.where("(patient_id, created_at) IN (#{tuples.collect { '(?, ?)' }.join(', ')})", *tuples.flatten)
+  end
+
   def custom_details(fields, patient_identifiers, user_emails, jurisdiction_paths)
     transfer_details = {}
     transfer_details[:id] = id || '' if fields.include?(:id)

--- a/test/models/transfer_test.rb
+++ b/test/models/transfer_test.rb
@@ -43,6 +43,16 @@ class TransferTest < ActiveSupport::TestCase
     patients.each(&:reload)
 
     assert_equal 3, Transfer.latest_transfers(patients).size
+    assert_includes Transfer.latest_transfers(patients).pluck(:id), transfers[1].id
+    assert_includes Transfer.latest_transfers(patients).pluck(:id), transfers[3].id
+    assert_includes Transfer.latest_transfers(patients).pluck(:id), transfers[4].id
+
+    patient_without_transfer = build(:patient)
+
+    assert_equal 3, Transfer.latest_transfers(patients + [patient_without_transfer]).size
+    assert_includes Transfer.latest_transfers(patients).pluck(:id), transfers[1].id
+    assert_includes Transfer.latest_transfers(patients).pluck(:id), transfers[3].id
+    assert_includes Transfer.latest_transfers(patients).pluck(:id), transfers[4].id
   end
 
   test 'create transfer' do


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1144

Transfer.latest_transfers scope written with test & update import_export.rb to use scope

[PR where bug was originally found](https://github.com/SaraAlert/SaraAlert/pull/625#discussion_r549416079)

# (Bugfix) How to Replicate
There is a rare edge case we believe could crop up for the transfer data in exports if two transfers have the same timestamp. With the example below, all 3 transfers would be returned instead of the expected 2.

| patient_id | created_at                           |
| ---------- | ------------------------------------ |
| 1          | Fri, 25 Dec 2020 19:02:04 UTC +00:00 |
| 2          | Fri, 25 Dec 2020 19:02:04 UTC +00:00 |
| 2          | Sat, 26 Dec 2020 20:17:20 UTC +00:00 |

# (Bugfix) Solution
The solution was to write a new scope in the transfer model that does a proper tuple comparison like `... (id, created_at) IN ((?, ?), (?, ?), (?, ?),)` instead of a `... id IN [...] AND created_at IN [...]`

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`transfer.rb`
- Added new scope for getting the latest transfers for a group of patients

`transfer_test.rb`
- Wrote test for new scope with previously failing edge case

`import_export.rb`
- Edited to now use the added Transfer scope

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

