### PR TITLE
SARAALERT-1157: Saved advanced filter bug

### DIFF
--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -217,9 +217,12 @@ class AdvancedFilter extends React.Component {
       this.add();
     }
 
+    // Set a timestamp to include in url to ensure browser cache is not re-used on page navigation
+    const timestamp = `?t=${new Date().getTime()}`;
+
     // Grab saved filters
     axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
-    axios.get(window.BASE_PATH + '/user_filters').then(response => {
+    axios.get(window.BASE_PATH + '/user_filters' + timestamp).then(response => {
       this.setState({ savedFilters: response.data }, () => {
         // Apply filter if it exists in local storage
         let sessionFilter = localStorage.getItem(`SaraFilter`);


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1157](https://tracker.codev.mitre.org/browse/SARAALERT-1157)

An applied filter will sometimes revert back to its previous saved version upon page navigation.

# (Bugfix) How to Replicate 
Steps: 
-  Open a saved advanced filter
- Choose a different field and set up a completely different filter
- Click Update
- Click Apply
- Open a record
- Click back button
- Click Advanced Filter
- Original filter parameters are shown
- Clicking Cancel, clear all filters, and then opening the saved filter will show the new changes

# (Bugfix) Solution
This ended up being a bug where axios returned a cached response [here](https://github.com/SaraAlert/SaraAlert/blob/1.21.0/app/javascript/components/public_health/query/AdvancedFilter.js#L222) instead of pulling the new data.  Adding a timestamp to the request url makes it unique and thus forces a new response every time.  This appeared to only be an issue when the component was reloaded by page navigation.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.