### PR TITLE
SARAALERT-1161: Advance Filter Cancel Clearing Bug

### DIFF
--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -264,7 +264,7 @@ class AdvancedFilter extends React.Component {
   apply = () => {
     this.setState({ show: false, applied: true }, () => {
       this.props.advancedFilterUpdate(this.state.activeFilterOptions);
-      if (this.props.updateStickySettings) {
+      if (this.props.updateStickySettings && this.state.activeFilter) {
         localStorage.setItem(`SaraFilter`, this.state.activeFilter.id);
       }
     });

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -283,12 +283,10 @@ class AdvancedFilter extends React.Component {
   cancel = () => {
     // check if there was a filter applied
     const appliedFilterId = localStorage.getItem(`SaraFilter`);
-    const appliedFilter = this.state.savedFilters.find(filter => {
-      return filter.id === parseInt(appliedFilterId);
-    });
+    const appliedFilter = this.state.savedFilters.find(filter => filter.id === parseInt(appliedFilterId));
 
     // update state accordingly
-    const applied = appliedFilterId;
+    const applied = !!appliedFilterId;
     const activeFilter = applied ? appliedFilter : null;
     const activeFilterOptions = applied ? appliedFilter.contents : [];
     this.setState({ show: false, applied, activeFilter, activeFilterOptions }, () => {

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -7,7 +7,6 @@ import ReactTooltip from 'react-tooltip';
 import { toast } from 'react-toastify';
 import axios from 'axios';
 import moment from 'moment-timezone';
-import _ from 'lodash';
 
 import DateInput from '../../util/DateInput';
 import confirmDialog from '../../util/ConfirmDialog';
@@ -209,6 +208,7 @@ class AdvancedFilter extends React.Component {
       savedFilters: [],
       activeFilter: null,
       applied: false,
+      lastAppliedFilter: null,
     };
   }
 
@@ -262,7 +262,11 @@ class AdvancedFilter extends React.Component {
 
   // Apply the current filter
   apply = () => {
-    this.setState({ show: false, applied: true }, () => {
+    const appliedFilter = {
+      activeFilter: this.state.activeFilter,
+      activeFilterOptions: this.state.activeFilterOptions,
+    };
+    this.setState({ show: false, applied: true, lastAppliedFilter: appliedFilter }, () => {
       this.props.advancedFilterUpdate(this.state.activeFilterOptions);
       if (this.props.updateStickySettings && this.state.activeFilter) {
         localStorage.setItem(`SaraFilter`, this.state.activeFilter.id);
@@ -283,14 +287,9 @@ class AdvancedFilter extends React.Component {
 
   // Reset modal when cancelled
   cancel = () => {
-    // check if there was a filter applied
-    const appliedFilterId = localStorage.getItem(`SaraFilter`);
-    const appliedFilter = this.state.savedFilters.find(filter => filter.id === parseInt(appliedFilterId));
-
-    // update state accordingly
-    const applied = !_.isEmpty(appliedFilter);
-    const activeFilter = applied ? appliedFilter : null;
-    const activeFilterOptions = applied ? appliedFilter.contents : [];
+    const applied = this.state.applied;
+    const activeFilter = applied ? this.state.lastAppliedFilter.activeFilter : null;
+    const activeFilterOptions = applied ? this.state.lastAppliedFilter.activeFilterOptions : [];
     this.setState({ show: false, applied, activeFilter, activeFilterOptions }, () => {
       // if no filter was applied, start again with empty default
       if (!applied) {

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -7,6 +7,7 @@ import ReactTooltip from 'react-tooltip';
 import { toast } from 'react-toastify';
 import axios from 'axios';
 import moment from 'moment-timezone';
+import _ from 'lodash';
 
 import DateInput from '../../util/DateInput';
 import confirmDialog from '../../util/ConfirmDialog';
@@ -286,7 +287,7 @@ class AdvancedFilter extends React.Component {
     const appliedFilter = this.state.savedFilters.find(filter => filter.id === parseInt(appliedFilterId));
 
     // update state accordingly
-    const applied = !!appliedFilterId;
+    const applied = !_.isEmpty(appliedFilter);
     const activeFilter = applied ? appliedFilter : null;
     const activeFilterOptions = applied ? appliedFilter.contents : [];
     this.setState({ show: false, applied, activeFilter, activeFilterOptions }, () => {

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -263,6 +263,9 @@ class AdvancedFilter extends React.Component {
   apply = () => {
     this.setState({ show: false, applied: true }, () => {
       this.props.advancedFilterUpdate(this.state.activeFilterOptions);
+      if (this.props.updateStickySettings) {
+        localStorage.setItem(`SaraFilter`, this.state.activeFilter.id);
+      }
     });
   };
 
@@ -272,6 +275,26 @@ class AdvancedFilter extends React.Component {
       this.props.advancedFilterUpdate(this.state.activeFilter);
       if (this.props.updateStickySettings) {
         localStorage.setItem(`SaraFilter`, null);
+      }
+    });
+  };
+
+  // Reset modal when cancelled
+  cancel = () => {
+    // check if there was a filter applied
+    const appliedFilterId = localStorage.getItem(`SaraFilter`);
+    const appliedFilter = this.state.savedFilters.find(filter => {
+      return filter.id === parseInt(appliedFilterId);
+    });
+
+    // update state accordingly
+    const applied = appliedFilterId;
+    const activeFilter = applied ? appliedFilter : null;
+    const activeFilterOptions = applied ? appliedFilter.contents : [];
+    this.setState({ show: false, applied, activeFilter, activeFilterOptions }, () => {
+      // if no filter was applied, start again with empty default
+      if (!applied) {
+        this.add();
       }
     });
   };
@@ -287,9 +310,6 @@ class AdvancedFilter extends React.Component {
   setFilter = (filter, apply = false) => {
     if (filter) {
       this.setState({ activeFilter: filter, show: true, activeFilterOptions: filter?.contents || [] }, () => {
-        if (this.props.updateStickySettings) {
-          localStorage.setItem(`SaraFilter`, filter.id);
-        }
         if (apply) {
           this.apply();
         }
@@ -1005,11 +1025,7 @@ class AdvancedFilter extends React.Component {
             <p className="lead mr-auto">
               Filter will be applied to the line lists in the <u>{this.props.workflow}</u> workflow until reset.
             </p>
-            <Button
-              variant="secondary btn-square"
-              onClick={() => {
-                this.setState({ show: false });
-              }}>
+            <Button variant="secondary btn-square" onClick={this.cancel}>
               Cancel
             </Button>
           </Modal.Footer>

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -272,7 +272,8 @@ class AdvancedFilter extends React.Component {
 
   // Clear the current filter
   clear = () => {
-    this.setState({ activeFilter: null, applied: false }, () => {
+    this.setState({ activeFilterOptions: [], show: false, activeFilter: null, applied: false }, () => {
+      this.add();
       this.props.advancedFilterUpdate(this.state.activeFilter);
       if (this.props.updateStickySettings) {
         localStorage.setItem(`SaraFilter`, null);


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1161](https://tracker.codev.mitre.org/browse/SARAALERT-1161)

Clicking "Cancel" in Advanced Filter modal does not clear modal or filter name

# (Bugfix) How to Replicate
Currently if you set up a new advanced filter (i.e., choose a field to filter by and set parameters) and click "Cancel":
- The modal closes and you return to the dashboard (the filter you created is not applied)–this is correct behavior
- When you then click "Advanced Filter" it shows the parameters you had previously entered–this is incorrect behavior. The modal should revert to its previous state (the last filter that was applied, or blank if no filter was applied)

Currently if you have a filter applied and then select a saved advanced filter (i.e., from the drop-down) and click "Cancel":
- The modal closes and you return to the dashboard (the filter you created is not applied)–this is correct behavior
- When you then click "Advanced Filter" it shows the parameters you had previously entered–this is incorrect behavior. The modal should revert to its previous state (the last filter that was applied, or blank if no filter was applied)
- The applied filter name (i.e., the name that replaces the drop down arrow in the advanced filter menu) shows up as the named filter you just selected (and cancelled)–this is incorrect behavior. The drop-down name should revert to its previous state)

# (Bugfix) Solution
Add cancel method that properly resets the state depending on if a filter was applied. Also only cache the filter once it is applied, not when it is set.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
