### PR TITLE
SARAALERT-1224: Additional order fixes and prep statements for next Rails release 

### DIFF
--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -153,11 +153,11 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     when 'name'
       patients = patients.order(last_name: dir).order(first_name: dir)
     when 'jurisdiction'
-      patients = patients.includes(:jurisdiction).order(Arel.sql('jurisdictions.name ' + dir))
+      patients = patients.includes(:jurisdiction).order('jurisdictions.name ' + dir)
     when 'transferred_from'
-      patients = patients.joins('INNER JOIN jurisdictions ON jurisdictions.id = patients.latest_transfer_from').order(Arel.sql('jurisdictions.path ' + dir))
+      patients = patients.joins('INNER JOIN jurisdictions ON jurisdictions.id = patients.latest_transfer_from').order('jurisdictions.path ' + dir)
     when 'transferred_to'
-      patients = patients.includes(:jurisdiction).order(Arel.sql('jurisdictions.path ' + dir))
+      patients = patients.includes(:jurisdiction).order('jurisdictions.path ' + dir)
     when 'assigned_user'
       patients = patients.order(Arel.sql('CASE WHEN assigned_user IS NULL THEN 1 ELSE 0 END, assigned_user ' + dir))
     when 'state_local_id'

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -502,17 +502,26 @@ class Patient < ApplicationRecord
 
   # Order individuals based on their public health assigned risk assessment
   def self.order_by_risk(asc: true)
-    order_by = ["WHEN exposure_risk_assessment='High' THEN 0",
-                "WHEN exposure_risk_assessment='Medium' THEN 1",
-                "WHEN exposure_risk_assessment='Low' THEN 2",
-                "WHEN exposure_risk_assessment='No Identified Risk' THEN 3",
-                'WHEN exposure_risk_assessment IS NULL THEN 4']
-    order_by_rev = ['WHEN exposure_risk_assessment IS NULL THEN 4',
-                    "WHEN exposure_risk_assessment='High' THEN 3",
-                    "WHEN exposure_risk_assessment='Medium' THEN 2",
-                    "WHEN exposure_risk_assessment='Low' THEN 1",
-                    "WHEN exposure_risk_assessment='No Identified Risk' THEN 0"]
-    order(Arel.sql((['CASE'] + (asc ? order_by : order_by_rev) + ['END']).join(' ')))
+    order_by = <<~SQL
+      CASE
+      WHEN exposure_risk_assessment='High' THEN 0
+      WHEN exposure_risk_assessment='Medium' THEN 1
+      WHEN exposure_risk_assessment='Low' THEN 2
+      WHEN exposure_risk_assessment='No Identified Risk' THEN 3
+      WHEN exposure_risk_assessment IS NULL THEN 4
+      END
+    SQL
+
+    order_by_rev = <<~SQL
+      CASE
+      WHEN exposure_risk_assessment IS NULL THEN 4
+      WHEN exposure_risk_assessment='High' THEN 3
+      WHEN exposure_risk_assessment='Medium' THEN 2
+      WHEN exposure_risk_assessment='Low' THEN 1
+      WHEN exposure_risk_assessment='No Identified Risk' THEN 0
+      END
+    SQL
+    order(Arel.sql(asc ? order_by : order_by_rev))
   end
 
   # Check for potential duplicate records. Duplicate criteria is as follows:

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -146,7 +146,7 @@
 <% end %>
 
 <% if current_user.can_modify_subject_status? %>
-<%= react_component('history/HistoryComponent', { patient_id: @patient.id, histories: @patient.histories.order('created_at DESC'), authenticity_token: form_authenticity_token, history_types: @history_types }) %>
+<%= react_component('history/HistoryComponent', { patient_id: @patient.id, histories: @patient.histories.order(created_at: :desc), authenticity_token: form_authenticity_token, history_types: @history_types }) %>
 <% end %>
 
 <script>


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1224

* Removes unneeded `Arel.sql` statements. 
* Updates existing statements to be compatible with the new internal unsafe query method
* Updates existing statements to be compatible with the future unsafe query method > Rails 6.1.1

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`patient.rb`
- slight refactor of `order_by_risk` which is a bit more lines/verbose but cleans up logic a lot and makes the actual query string frozen.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [x] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.

- [ ] Linelist sort-able
- [ ] Patient page loadable (histories in correct order)
- [ ] Patients order-able by risk in the same fashion as before
