### PR TITLE
SARAALERT-944: Consolidate field update logic in application so it can be used in API updates

### DIFF
--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -153,7 +153,7 @@ class Fhir::R4::ApiController < ActionController::API
     created_by_label = "#{@m2m_workflow ? current_client_application&.name : current_resource_owner&.email} (API)"
 
     # Handle History for monitoree details information updates
-    info_updates = updates.filter { |attr, value| PatientHelper.info_fields.include?(attr)}
+    info_updates = updates.filter { |attr, _value| PatientHelper.info_fields.include?(attr) }
     Patient.detailed_history_edit(patient_before, patient, info_updates&.keys, created_by_label)
 
     # Handle History for monitoree monitoring information updates
@@ -165,8 +165,8 @@ class Fhir::R4::ApiController < ActionController::API
       household_status: :patient,
       propagation: :none
     }
-
-    patient.update_patient_monitoring_history(updates, patient_before, history_data)  end
+    patient.update_patient_monitoring_history(updates, patient_before, history_data)
+  end
 
   # Create a resource given a type.
   #
@@ -490,7 +490,7 @@ class Fhir::R4::ApiController < ActionController::API
       if current_resource_owner.can_use_api?
         @user_workflow = true
         @current_actor = current_resource_owner
-        return
+        nil
       else
         head :unauthorized
       end

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -123,17 +123,16 @@ class Fhir::R4::ApiController < ActionController::API
       status_unprocessable_entity && return if request_updates.nil?
 
       # Get any additional updates that may need to occur based on initial changes
-      all_updates = patient.get_updates_from_monitoring_changes(request_updates)
 
       # Assign any remaining updates to the patient
       # NOTE: The patient.update method does not allow a context to be passed, so first we assign the updates, then save
-      patient.assign_attributes(all_updates)
+      patient.assign_attributes(request_updates)
       # Verify that the updated jurisdiction and other updates are valid
       unless jurisdiction_valid_for_client?(patient) && patient.save(context: :api)
         status_unprocessable_entity(format_model_validation_errors(patient)) && return
       end
       # If the jurisdiction was changed, create a Transfer
-      if all_updates&.keys&.include?(:jurisdiction_id) && !all_updates[:jurisdiction_id].nil?
+      if request_updates&.keys&.include?(:jurisdiction_id) && !request_updates[:jurisdiction_id].nil?
         Transfer.create(patient: patient, from_jurisdiction: patient_before[:jurisdiction], to_jurisdiction: patient.jurisdiction, who: @current_actor)
       end
 

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -148,6 +148,11 @@ class Fhir::R4::ApiController < ActionController::API
     render json: operation_outcome_fatal.to_json, status: :internal_server_error
   end
 
+  # Create History items corresponding to Patient changes from an update.
+  #
+  # updates - A hash that contains attributes corresponding to the Patient.
+  # patient_before - The Patient before updates were applied.
+  # patient - The Patient after the updates have been applied.
   def update_all_patient_history(updates, patient_before, patient)
     created_by_label = "#{@m2m_workflow ? current_client_application&.name : current_resource_owner&.email} (API)"
 
@@ -538,6 +543,11 @@ class Fhir::R4::ApiController < ActionController::API
     false
   end
 
+  # Determine if a Patient's jurisdiction can be updated by the requesting application.
+  #
+  # patient - The Patient to check (patient.jurisdiction_id should be set to the updated value).
+  #
+  # Returns true if the jurisdiction is valid, otherwise false.
   def jurisdiction_valid_for_update?(patient)
     allowed_jurisdiction_ids = @current_actor.jurisdictions_for_transfer
     return true if !patient.jurisdiction_id.nil? && allowed_jurisdiction_ids.keys.include?(patient.jurisdiction_id)

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -197,8 +197,7 @@ class PatientsController < ApplicationController
       if current_user.jurisdiction.subtree_ids.include?(content[:jurisdiction_id].to_i)
         old_jurisdiction = patient.jurisdiction[:path]
         new_jurisdiction = Jurisdiction.find(content[:jurisdiction_id])[:path]
-        patient.transfer_jurisdiction(content[:jurisdiction_id], current_user)
-        content.delete[:jurisdiction_id] = patient.jurisdiction_id
+        transfer = Transfer.create(patient: patient, from_jurisdiction: patient.jurisdiction, to_jurisdiction_id: content[:jurisdiction_id], who: current_user)
         comment = "User changed Jurisdiction from \"#{old_jurisdiction}\" to \"#{new_jurisdiction}\"."
         history = History.monitoring_change(patient: patient, created_by: current_user.email, comment: comment)
         if propagated_fields.include?('jurisdiction_id')
@@ -240,6 +239,7 @@ class PatientsController < ApplicationController
     end
 
     # Reset symptom onset date if moving from isolation to exposure
+    # TODO: handle this method not existing anymore
     patient.reset_symptom_onset if !content[:isolation].nil? && !content[:isolation]
 
     # Update patient history with detailed edit diff
@@ -368,12 +368,12 @@ class PatientsController < ApplicationController
     # Figure out what exactly changed, and limit update to only those fields
     diff_state = params[:diffState]&.map(&:to_sym)
     permitted_params = if diff_state.nil?
-                        PatientHelper.monitoring_fields
+                         PatientHelper.monitoring_fields
                        else
-                        PatientHelper.monitoring_fields & diff_state # Set intersection between what the front end is saying changed, and status fields
+                         PatientHelper.monitoring_fields & diff_state # Set intersection between what the front end is saying changed, and status fields
                        end
     updates = params.require(:patient).permit(permitted_params).to_h.deep_symbolize_keys
-    
+
     patient_before = patient.dup
 
     # Get any additional updates that may need to occur based on initial changes
@@ -401,7 +401,6 @@ class PatientsController < ApplicationController
     # NOTE: We use updates rather than all updates here because we want to determine what History
     # messages are needed based on the original changes
     patient.update_patient_monitoring_history(updates, patient_before, history_data)
-    
   end
 
   def clear_assessments

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -24,13 +24,7 @@ class PatientsController < ApplicationController
     @laboratories = @patient.laboratories.order(:created_at)
     @close_contacts = @patient.close_contacts.order(:created_at)
 
-    @possible_jurisdiction_paths = if current_user.can_transfer_patients?
-                                     # Allow all jurisdictions as valid transfer options.
-                                     Hash[Jurisdiction.all.where.not(name: 'USA').pluck(:id, :path).map { |id, path| [id, path] }]
-                                   else
-                                     # Otherwise, only show jurisdictions within hierarchy.
-                                     Hash[current_user.jurisdiction.subtree.pluck(:id, :path).map { |id, path| [id, path] }]
-                                   end
+    @possible_jurisdiction_paths = current_user.get_jurisdictions_for_transfer
 
     # Household members (dependents) for the HOH excluding HOH
     @dependents_exclude_hoh = @patient.dependents_exclude_self.where(purged: false)

--- a/app/helpers/fhir_helper.rb
+++ b/app/helpers/fhir_helper.rb
@@ -103,6 +103,7 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
   # Create a hash of atttributes that corresponds to a Sara Alert Patient (and can be used to
   # create new ones, or update existing ones), using the given FHIR::Patient.
   def patient_from_fhir(patient, default_jurisdiction_id)
+    symptom_onset = from_date_extension(patient, ['symptom-onset-date'])
     {
       monitoring: patient&.active.nil? ? false : patient.active,
       first_name: patient&.name&.first&.given&.first,
@@ -136,7 +137,8 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
       sex: from_us_core_birthsex(patient),
       preferred_contact_method: from_string_extension(patient, 'preferred-contact-method'),
       preferred_contact_time: from_string_extension(patient, 'preferred-contact-time'),
-      symptom_onset: from_date_extension(patient, ['symptom-onset-date']),
+      symptom_onset: symptom_onset,
+      user_defined_symptom_onset: !symptom_onset.nil?,
       last_date_of_exposure: from_date_extension(patient, %w[last-date-of-exposure last-exposure-date]),
       isolation: from_isolation_extension(patient),
       jurisdiction_id: from_full_assigned_jurisdiction_path_extension(patient, default_jurisdiction_id),

--- a/app/helpers/patient_helper.rb
+++ b/app/helpers/patient_helper.rb
@@ -219,6 +219,7 @@ module PatientHelper # rubocop:todo Metrics/ModuleLength
       continuous_exposure
       user_defined_symptom_onset
       extended_isolation
+      jurisdiction_id
     ]
   end
 

--- a/app/helpers/patient_helper.rb
+++ b/app/helpers/patient_helper.rb
@@ -225,6 +225,7 @@ module PatientHelper # rubocop:todo Metrics/ModuleLength
 
   def self.info_fields
     %i[
+      isolation
       first_name
       middle_name
       last_name

--- a/app/helpers/patient_helper.rb
+++ b/app/helpers/patient_helper.rb
@@ -197,4 +197,60 @@ module PatientHelper # rubocop:todo Metrics/ModuleLength
     }
     languages[language&.downcase&.to_sym].present? ? languages[language&.downcase&.to_sym] : nil
   end
+
+  # Calculated symptom onset date is based on latest symptomatic assessment.
+  def calculated_symptom_onset
+    assessments.where(symptomatic: true).minimum(:created_at)&.to_date
+  end
+
+  def self.monitoring_fields
+    return %i[
+      monitoring
+      monitoring_reason
+      monitoring_plan
+      exposure_risk_assessment
+      public_health_action
+      isolation
+      pause_notifications
+      symptom_onset
+      case_status
+      assigned_user
+      last_date_of_exposure
+      continuous_exposure
+      user_defined_symptom_onset
+      extended_isolation
+    ]
+  end
+
+  def self.info_fields
+    return [
+      :first_name,
+      :middle_name,
+      :last_name,  
+      :secondary_telephone, 
+      :email, 
+      :date_of_birth,
+      :address_line_1, 
+      :address_line_2, 
+      :address_city,     
+      :address_state, 
+      :address_zip,
+      :monitored_address_line_1,
+      :monitored_address_line_2, 
+      :monitored_address_city,     
+      :monitored_address_state, 
+      :monitored_address_zip,
+      :primary_language, 
+      :interpretation_required,
+      :white,
+      :black_or_african_american,
+      :american_indian_or_alaska_native,
+      :asian, 
+      :native_hawaiian_or_other_pacific_islander,
+      :ethnicity,
+      :sex, 
+      :preferred_contact_method,
+      :preferred_contact_time
+    ]
+  end
 end

--- a/app/helpers/patient_helper.rb
+++ b/app/helpers/patient_helper.rb
@@ -204,7 +204,7 @@ module PatientHelper # rubocop:todo Metrics/ModuleLength
   end
 
   def self.monitoring_fields
-    return %i[
+    %i[
       monitoring
       monitoring_reason
       monitoring_plan
@@ -223,34 +223,34 @@ module PatientHelper # rubocop:todo Metrics/ModuleLength
   end
 
   def self.info_fields
-    return [
-      :first_name,
-      :middle_name,
-      :last_name,  
-      :secondary_telephone, 
-      :email, 
-      :date_of_birth,
-      :address_line_1, 
-      :address_line_2, 
-      :address_city,     
-      :address_state, 
-      :address_zip,
-      :monitored_address_line_1,
-      :monitored_address_line_2, 
-      :monitored_address_city,     
-      :monitored_address_state, 
-      :monitored_address_zip,
-      :primary_language, 
-      :interpretation_required,
-      :white,
-      :black_or_african_american,
-      :american_indian_or_alaska_native,
-      :asian, 
-      :native_hawaiian_or_other_pacific_islander,
-      :ethnicity,
-      :sex, 
-      :preferred_contact_method,
-      :preferred_contact_time
+    %i[
+      first_name
+      middle_name
+      last_name
+      secondary_telephone
+      email
+      date_of_birth
+      address_line_1
+      address_line_2
+      address_city
+      address_state
+      address_zip
+      monitored_address_line_1
+      monitored_address_line_2
+      monitored_address_city
+      monitored_address_state
+      monitored_address_zip
+      primary_language
+      interpretation_required
+      white
+      black_or_african_american
+      american_indian_or_alaska_native
+      asian
+      native_hawaiian_or_other_pacific_islander
+      ethnicity
+      sex
+      preferred_contact_method
+      preferred_contact_time
     ]
   end
 end

--- a/app/helpers/patient_helper.rb
+++ b/app/helpers/patient_helper.rb
@@ -199,8 +199,8 @@ module PatientHelper # rubocop:todo Metrics/ModuleLength
   end
 
   # Calculated symptom onset date is based on latest symptomatic assessment.
-  def calculated_symptom_onset
-    assessments.where(symptomatic: true).minimum(:created_at)&.to_date
+  def calculated_symptom_onset(patient)
+    patient.assessments.where(symptomatic: true).minimum(:created_at)&.to_date
   end
 
   def self.monitoring_fields

--- a/app/javascript/components/subject/monitoring_actions/Jurisdiction.js
+++ b/app/javascript/components/subject/monitoring_actions/Jurisdiction.js
@@ -68,7 +68,7 @@ class Jurisdiction extends React.Component {
       axios
         .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/status', {
           patient: this.props.patient,
-          jurisdiction: Object.keys(this.props.jurisdiction_paths).find(id => this.props.jurisdiction_paths[parseInt(id)] === this.state.jurisdiction_path),
+          jurisdiction_id: Object.keys(this.props.jurisdiction_paths).find(id => this.props.jurisdiction_paths[parseInt(id)] === this.state.jurisdiction_path),
           reasoning: this.state.reasoning,
           apply_to_household: this.state.apply_to_household,
           diffState: diffState,

--- a/app/javascript/components/subject/monitoring_actions/Jurisdiction.js
+++ b/app/javascript/components/subject/monitoring_actions/Jurisdiction.js
@@ -63,11 +63,14 @@ class Jurisdiction extends React.Component {
 
   submit = () => {
     const diffState = Object.keys(this.state).filter(k => _.get(this.state, k) !== _.get(this.origState, k));
+    // If the jurisdiction_path changed, this means the underlying id must also have changed
+    if (diffState.indexOf('jurisdiction_path') > -1) {
+      diffState.push('jurisdiction_id');
+    }
     this.setState({ loading: true }, () => {
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
       axios
         .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/status', {
-          patient: this.props.patient,
           jurisdiction_id: Object.keys(this.props.jurisdiction_paths).find(id => this.props.jurisdiction_paths[parseInt(id)] === this.state.jurisdiction_path),
           reasoning: this.state.reasoning,
           apply_to_household: this.state.apply_to_household,

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -3,6 +3,7 @@
 # Assessment: assessment model
 class Assessment < ApplicationRecord
   extend OrderAsSpecified
+  include PatientHelper
 
   columns.each do |column|
     case column.type
@@ -204,7 +205,7 @@ class Assessment < ApplicationRecord
                                                  .maximum(:created_at)
       )
     else
-      new_symptom_onset = patient.assessments.where.not(id: id).where(symptomatic: true).minimum(:created_at)
+      new_symptom_onset = calculated_symptom_onset(patient)
       unless new_symptom_onset == patient[:symptom_onset] || !new_symptom_onset.nil?
         comment = "System cleared symptom onset date from #{patient[:symptom_onset].strftime('%m/%d/%Y')} to blank because a symptomatic report was removed."
         History.monitoring_change(patient: patient, created_by: 'Sara Alert System', comment: comment)

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -16,7 +16,7 @@ class Assessment < ApplicationRecord
   belongs_to :patient
 
   after_save :update_patient_linelist_after_save
-  before_destroy :update_patient_linelist_before_destroy
+  after_destroy :update_patient_linelist_after_destroy
 
   # Assessments created in the last hour that are symptomatic
   scope :symptomatic_last_hour, lambda {
@@ -193,7 +193,7 @@ class Assessment < ApplicationRecord
     end
   end
 
-  def update_patient_linelist_before_destroy
+  def update_patient_linelist_after_destroy
     # latest fever or fever reducer at only needs to be updated upon deletion as it is updated in the symptom model upon symptom creation
     if patient.user_defined_symptom_onset.present? && !patient.symptom_onset.nil?
       patient.update(

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -213,7 +213,7 @@ class History < ApplicationRecord
       # monitoree went from actively monitoring to not monitoring
       history[:note] = ', and chose to "End Monitoring"'
       # monitoree went from exposure to isolation (only applies to when user deliberately selected to continue monitoring in isolation workflow)
-    elsif !history[:patient_before][:isolation].present? && history[:updates][:isolation].present? && diff_state.include?(:isolation)
+    elsif !history[:patient_before][:isolation].present? && history[:updates][:isolation].present? && !diff_state.nil? && diff_state.include?(:isolation)
       history[:note] = ', and chose to "Continue Monitoring in Isolation Workflow"'
     end
 

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -167,39 +167,22 @@ class History < ApplicationRecord
     create_history(patient, created_by, HISTORY_TYPES[:record_automatically_closed], comment)
   end
 
-  def self.monitoring_actions(history, diff_state)
-    return if diff_state.nil?
-
-    History.monitoring_status(history) if diff_state.include?(:monitoring)
-    History.exposure_risk_assessment(history) if diff_state.include?(:exposure_risk_assessment)
-    History.monitoring_plan(history) if diff_state.include?(:monitoring_plan)
-    History.case_status(history, diff_state) if diff_state.include?(:case_status)
-    History.public_health_action(history) if diff_state.include?(:public_health_action)
-    History.jurisdiction(history) if diff_state.include?(:jurisdiction_path)
-    History.assigned_user(history) if diff_state.include?(:assigned_user)
-    History.pause_notifications(history) if diff_state.include?(:pause_notifications)
-    History.symptom_onset(history) if diff_state.include?(:symptom_onset)
-    History.last_date_of_exposure(history) if diff_state.include?(:last_date_of_exposure)
-    History.continuous_exposure(history) if diff_state.include?(:continuous_exposure)
-    History.extended_isolation(history) if diff_state.include?(:extended_isolation)
-  end
-
   def self.monitoring_status(history)
     field = {
       name: 'Monitoring Status',
-      old_value: history[:patient][:monitoring] ? 'Monitoring' : 'Not Monitoring',
-      new_value: history[:params][:monitoring] ? 'Monitoring' : 'Not Monitoring'
+      old_value: history[:patient_before][:monitoring] ? 'Monitoring' : 'Not Monitoring',
+      new_value: history[:updates][:monitoring] ? 'Monitoring' : 'Not Monitoring'
     }
-    return if field[:old_value] == field[:new_value]
 
+    return if field[:old_value] == field[:new_value]
     create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field))
   end
 
   def self.exposure_risk_assessment(history)
     field = {
       name: 'Exposure Risk Assessment',
-      old_value: history[:patient][:exposure_risk_assessment],
-      new_value: history[:params][:exposure_risk_assessment]
+      old_value: history[:patient_before][:exposure_risk_assessment],
+      new_value: history[:updates][:exposure_risk_assessment]
     }
     return if field[:old_value] == field[:new_value]
 
@@ -209,8 +192,8 @@ class History < ApplicationRecord
   def self.monitoring_plan(history)
     field = {
       name: 'Monitoring Plan',
-      old_value: history[:patient][:monitoring_plan],
-      new_value: history[:params][:monitoring_plan]
+      old_value: history[:patient_before][:monitoring_plan],
+      new_value: history[:updates][:monitoring_plan]
     }
     return if field[:old_value] == field[:new_value]
 
@@ -220,16 +203,16 @@ class History < ApplicationRecord
   def self.case_status(history, diff_state)
     field = {
       name: 'Case Status',
-      old_value: history[:patient][:case_status],
-      new_value: history[:params][:case_status]
+      old_value: history[:patient_before][:case_status],
+      new_value: history[:updates][:case_status]
     }
     return if field[:old_value] == field[:new_value]
 
-    if !history[:params][:monitoring].blank? && !history[:params][:monitoring]
+    if !history[:updates][:monitoring].blank? && !history[:updates][:monitoring]
       # monitoree went from actively monitoring to not monitoring
       history[:note] = ', and chose to "End Monitoring"'
       # monitoree went from exposure to isolation (only applies to when user deliberately selected to continue monitoring in isolation workflow)
-    elsif !history[:patient][:isolation].present? && history[:params][:isolation].present? && diff_state.include?(:isolation)
+    elsif !history[:patient_before][:isolation].present? && history[:updates][:isolation].present? && diff_state.include?(:isolation)
       history[:note] = ', and chose to "Continue Monitoring in Isolation Workflow"'
     end
 
@@ -239,8 +222,8 @@ class History < ApplicationRecord
   def self.public_health_action(history)
     field = {
       name: 'Latest Public Health Action',
-      old_value: history[:patient][:public_health_action],
-      new_value: history[:params][:public_health_action]
+      old_value: history[:patient_before][:public_health_action],
+      new_value: history[:updates][:public_health_action]
     }
     return if field[:old_value] == field[:new_value]
 
@@ -250,8 +233,8 @@ class History < ApplicationRecord
   def self.jurisdiction(history)
     field = {
       name: 'Jurisdiction',
-      old_value: Jurisdiction.find(history[:patient][:jurisdiction_id])[:path],
-      new_value: Jurisdiction.find(history[:params][:jurisdiction])[:path]
+      old_value: Jurisdiction.find(history[:patient_before][:jurisdiction_id])[:path],
+      new_value: Jurisdiction.find(history[:updates][:jurisdiction_id])[:path]
     }
     return if field[:old_value] == field[:new_value]
 
@@ -261,8 +244,8 @@ class History < ApplicationRecord
   def self.assigned_user(history)
     field = {
       name: 'Assigned User',
-      old_value: history[:patient][:assigned_user],
-      new_value: history[:params][:assigned_user]
+      old_value: history[:patient_before][:assigned_user],
+      new_value: history[:updates][:assigned_user]
     }
     return if field[:old_value] == field[:new_value]
 
@@ -272,12 +255,12 @@ class History < ApplicationRecord
   def self.pause_notifications(history)
     field = {
       name: 'Notification Status',
-      old_value: history[:patient][:pause_notifications] ? 'paused' : 'resumed',
-      new_value: history[:params][:pause_notifications] ? 'paused' : 'resumed'
+      old_value: history[:patient_before][:pause_notifications] ? 'paused' : 'resumed',
+      new_value: history[:updates][:pause_notifications] ? 'paused' : 'resumed'
     }
     return if field[:old_value] == field[:new_value]
 
-    creator = history[:household] == :patient ? 'User' : 'System'
+    creator = history[:household_status] == :patient ? 'User' : 'System'
     comment = "#{creator} #{field[:new_value]} notifications for this monitoree#{compose_explanation(history, field)}."
     create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment)
   end
@@ -286,8 +269,8 @@ class History < ApplicationRecord
     field = {
       name: 'Symptom Onset Date',
       type: 'date',
-      old_value: history[:patient][:symptom_onset]&.to_date&.strftime('%m/%d/%Y'),
-      new_value: history[:params][:symptom_onset]&.to_date&.strftime('%m/%d/%Y')
+      old_value: history[:patient_before][:symptom_onset]&.to_date&.strftime('%m/%d/%Y'),
+      new_value: history[:updates][:symptom_onset]&.to_date&.strftime('%m/%d/%Y')
     }
     return if field[:old_value] == field[:new_value]
 
@@ -300,8 +283,8 @@ class History < ApplicationRecord
     field = {
       name: 'Last Date of Exposure',
       type: 'date',
-      old_value: history[:patient][:last_date_of_exposure]&.to_date&.strftime('%m/%d/%Y'),
-      new_value: history[:params][:last_date_of_exposure]&.to_date&.strftime('%m/%d/%Y')
+      old_value: history[:patient_before][:last_date_of_exposure]&.to_date&.strftime('%m/%d/%Y'),
+      new_value: history[:updates][:last_date_of_exposure]&.to_date&.strftime('%m/%d/%Y')
     }
     return if field[:old_value] == field[:new_value]
 
@@ -311,12 +294,12 @@ class History < ApplicationRecord
   def self.continuous_exposure(history)
     field = {
       name: 'Continuous Exposure',
-      old_value: history[:patient][:continuous_exposure] ? 'on' : 'off',
-      new_value: history[:params][:continuous_exposure] ? 'on' : 'off'
+      old_value: history[:patient_before][:continuous_exposure] ? 'on' : 'off',
+      new_value: history[:updates][:continuous_exposure] ? 'on' : 'off'
     }
     return if field[:old_value] == field[:new_value]
 
-    creator = history[:household] == :patient ? 'User' : 'System'
+    creator = history[:household_status] == :patient ? 'User' : 'System'
     comment = "#{creator} turned #{field[:new_value]} #{field[:name]}#{compose_explanation(history, field)}."
     create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment)
   end
@@ -325,8 +308,8 @@ class History < ApplicationRecord
     field = {
       name: 'Extended Isolation',
       type: 'date',
-      old_value: history[:patient][:extended_isolation]&.to_date&.strftime('%m/%d/%Y'),
-      new_value: history[:params][:extended_isolation]&.to_date&.strftime('%m/%d/%Y')
+      old_value: history[:patient_before][:extended_isolation]&.to_date&.strftime('%m/%d/%Y'),
+      new_value: history[:updates][:extended_isolation]&.to_date&.strftime('%m/%d/%Y')
     }
     return if field[:old_value] == field[:new_value]
 
@@ -364,12 +347,11 @@ class History < ApplicationRecord
     return if patient.nil?
 
     patient = patient.id if patient.respond_to?(:id)
-
     History.create!(created_by: created_by, comment: comment, patient_id: patient, history_type: type)
   end
 
   private_class_method def self.compose_message(history, field)
-    creator = history[:household] == :patient ? 'User' : 'System'
+    creator = history[:household_status] == :patient ? 'User' : 'System'
     verb = field[:new_value].blank? ? 'cleared' : 'changed'
     from_text = field[:old_value].blank? ? 'blank' : "\"#{field[:old_value]}\""
     to_text = field[:new_value].blank? ? 'blank' : "\"#{field[:new_value]}\""
@@ -383,14 +365,14 @@ class History < ApplicationRecord
   end
 
   private_class_method def self.compose_explanation(history, field)
-    if history[:household] == :patient && history[:propagation] == :group
+    if history[:household_status] == :patient && history[:propagation] == :group
       " and chose to update this #{field[:type]} for all household members"
-    elsif history[:household] == :patient && history[:propagation] == :group_cm
+    elsif history[:household_status] == :patient && history[:propagation] == :group_cm
       " and chose to update this #{field[:type]} for household members under continuous exposure"
-    elsif history[:household] != :patient && history[:propagation] == :group
+    elsif history[:household_status] != :patient && history[:propagation] == :group
       " because User updated #{field[:name]} for another member in this monitoree's household and chose to update this
         #{field[:type].nil? ? 'field' : field[:type]} for all household members"
-    elsif history[:household] != :patient && history[:propagation] == :group_cm
+    elsif history[:household_status] != :patient && history[:propagation] == :group_cm
       " because User updated #{field[:name]} for another member in this monitoree's household and chose to update this
         #{field[:type].nil? ? 'field' : field[:type]} for household members under continuous exposure"
     else

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -175,6 +175,7 @@ class History < ApplicationRecord
     }
 
     return if field[:old_value] == field[:new_value]
+
     create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field))
   end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -945,6 +945,7 @@ class Patient < ApplicationRecord
     token
   end
 
+  # Handle side effect updates to fields that happen whenever certain fields are updated.
   def handle_update
     monitoring_change if monitoring_changed?
     isolation_change if isolation_changed?
@@ -953,6 +954,9 @@ class Patient < ApplicationRecord
     continuous_exposure_change if continuous_exposure_changed?
   end
 
+  # Handle side effects to monitoring being set to false.
+  # * closed_at is set to now, since the record is closed.
+  # * continuous_exposure is not allowed to be true if the Patient is not monitoring.
   def monitoring_change
     return if monitoring
 
@@ -960,32 +964,48 @@ class Patient < ApplicationRecord
     self.continuous_exposure = false
   end
 
+  # Handle side effects to isolation being set to false.
+  # * extended_isolation is set to nil, since the Patient is being moves to exposure workflow.
+  # * symptom_onset is set to a calculated value based on the assessments of the Patient, so they
+  #   may be placed in the proper linelist in exposure workflow.
+  # * user_defined_symptom_onset is set to false, since the calculated value is being used.
   def isolation_change
     return if isolation
 
     self.extended_isolation = nil
     # NOTE: The below will overwrite any new value they may set for symptom onset as they can not be set in the exposure workflow.
     self.user_defined_symptom_onset = false
-    self.symptom_onset = calculated_symptom_onset
+    self.symptom_onset = calculated_symptom_onset(self)
   end
 
+  # Handle side effects to a change in case status.
+  # * public_health_action is set to 'None' when case_status changes to 'Suspect', 'Unknown', or 'Not a Case' so
+  #   that the Patient will be on the appropriate linelist in the exposure workflow.
   def case_status_change
     return unless ['Suspect', 'Unknown', 'Not a Case'].include?(case_status) && public_health_action != 'None'
 
     self.public_health_action = 'None'
   end
 
+  # Handle side effects to symptom_onset being set to nil.
+  # * symptom_onset is set to a calculated value based on the assessments of the Patient.
+  # * user_defined_symptom_onset is set to false, since the calculated value is being used.
   def symptom_onset_change
     return unless symptom_onset.nil?
 
     self.user_defined_symptom_onset = false
-    self.symptom_onset = calculated_symptom_onset
+    self.symptom_onset = calculated_symptom_onset(self)
   end
 
+  # Handle side effects to continuous_exposure being set while not monitoring
+  # * continuous_exposure should alwasy remain false when not monitoring
   def continuous_exposure_change
     self.continuous_exposure = false if continuous_exposure && !monitoring
   end
 
+  # Create History items corresponding to updates to monitoring fields.
+  # The History items detail direct edits, and side effects of those direct edits that are made by the Sara Alert System.
+  # These side effects are handled in the handle_update function
   def monitoring_history_edit(history_data, diff_state)
     patient_before = history_data[:patient_before]
     history_data[:updates]&.keys&.each do |attribute|
@@ -1020,8 +1040,6 @@ class Patient < ApplicationRecord
         History.extended_isolation(history_data)
       when :continuous_exposure
         History.continuous_exposure(history_data)
-      when :isolation
-        update_patient_history_for_isolation(patient_before, updated_value)
       when :symptom_onset
         History.symptom_onset(history_data)
       when :case_status
@@ -1039,6 +1057,12 @@ class Patient < ApplicationRecord
         History.jurisdiction(history_data)
       end
     end
+
+    # NOTE: Changes in case_status may trigger changes in isolation, so add isolation history messages
+    # at the end, so that they will come after any case_status history messages
+    return unless !history_data[:updates][:isolation].nil? && self[:isolation] != patient_before[:isolation]
+
+    update_patient_history_for_isolation(patient_before, self[:isolation])
   end
 
   def update_patient_history_for_isolation(patient_before, new_isolation_value)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -3,6 +3,7 @@
 require 'chronic'
 
 # Patient: patient model
+# rubocop:disable Metrics/ClassLength
 class Patient < ApplicationRecord
   include PatientHelper
   include PatientDetailsHelper
@@ -879,20 +880,22 @@ class Patient < ApplicationRecord
   end
 
   # Creates a diff between a patient before and after updates, and creates a detailed record edit History item with the changes.
-  def self.detailed_history_edit(patient_before, patient_after, user_email, allowed_fields, is_api_edit: false)
-    diffs = patient_diff(patient_before, patient_after, allowed_fields)
+  def self.detailed_history_edit(patient_before, patient_after, attributes, history_creator_label, is_api_edit=false)
+    diffs = patient_diff(patient_before, patient_after, attributes)
     return if diffs.length.zero?
 
     pretty_diff = diffs.collect { |d| "#{d[:attribute].to_s.humanize} (\"#{d[:before]}\" to \"#{d[:after]}\")" }
     comment = is_api_edit ? 'Monitoree record edited via API. ' : 'User edited a monitoree record. '
     comment += "Changes were: #{pretty_diff.join(', ')}."
-    History.record_edit(patient: patient_after, created_by: user_email, comment: comment)
+
+    History.record_edit(patient: patient_after, created_by: history_creator_label, comment: comment)
   end
 
   # Construct a diff for a patient update to keep track of changes
-  def self.patient_diff(patient_before, patient_after, allowed_fields)
+  def self.patient_diff(patient_before, patient_after, attributes)
     diffs = []
-    allowed_fields&.keys&.each do |attribute|
+    attributes&.each do |attribute|
+      # Skip if no value change
       next if patient_before[attribute] == patient_after[attribute]
 
       diffs << {
@@ -920,7 +923,7 @@ class Patient < ApplicationRecord
     return if responder.nil?
 
     # update the initial responder if it changed
-    Patient.where(purged: false).find(initial_responder).refresh_head_of_household if !initial_responder.nil? && initial_responder != responder.id
+    Patient.find(initial_responder).refresh_head_of_household if !initial_responder.nil? && initial_responder != responder.id
     # update the current responder
     responder.refresh_head_of_household
   end
@@ -940,4 +943,132 @@ class Patient < ApplicationRecord
     end
     token
   end
+
+  def get_updates_from_monitoring_changes(monitoring_changes)
+    all_updates = monitoring_changes.deep_dup
+
+    monitoring_changes&.keys&.each do |attribute|
+      new_attribute_value = monitoring_changes[attribute]
+      next if self[attribute] == new_attribute_value
+
+      # Handle reacting to specific attributes as need be
+      case attribute
+      when :monitoring
+        # If record should be closed
+        if !new_attribute_value
+          all_updates[:closed_at] = DateTime.now
+          all_updates[:continuous_exposure] = false
+        end
+      when :isolation
+        # If record is being moved to Exposure workflow from Isolation workflow
+        if !new_attribute_value
+          all_updates[:extended_isolation] = nil
+          # NOTE: The below will overwrite any new value they may set for symptom onset as they can not be set in the exposure workflow.
+          all_updates[:user_defined_symptom_onset] = false
+          all_updates[:symptom_onset] = calculated_symptom_onset
+        end
+      when :case_status
+        # If Case Status has been updated to one of the values meant for the Exposure workflow, reset the Public Health Action.
+        if ['Suspect', 'Unknown', 'Not a Case'].include?(new_attribute_value) && patient[:public_health_action] != 'None'
+          all_updates[:public_health_action] = "None"
+        end
+      when :symptom_onset
+        #If symptom onset is being cleared, reset with calculated value. 
+        if new_attribute_value.nil?
+          all_updates[:user_defined_symptom_onset] = false
+          all_updates[:symptom_onset] = calculated_symptom_onset
+        end
+      when :continuous_exposure
+        # Do not allow continuous exposure to be set for records that are closed
+        if all_updates[:continuous_exposure] && !all_updates[:monitoring].nil? && !all_updates[:monitoring]
+          all_updates.delete(:continuous_exposure)
+        end
+      end
+    end
+
+    all_updates
+  end
+
+
+  def update_patient_monitoring_history(all_updates, patient_before, history_data)
+    all_updates&.keys&.each do |attribute|
+      updated_value = self[attribute]
+      next if patient_before[attribute] == self[attribute]
+
+      case attribute
+      when :monitoring
+        History.monitoring_status(history_data)
+
+        # If the record was in continuous exposure and then it was closed and continuous exposure was turned off
+        if !updated_value && patient_before[:continuous_exposure] && !continuous_exposure
+          History.monitoring_change(
+            patient: self,
+            created_by: 'Sara Alert System',
+            comment: 'System turned off Continuous Exposure because the record was moved to the closed line list.'
+          )
+        end
+      when :exposure_risk_assessment
+        History.exposure_risk_assessment(history_data)
+      when :monitoring_plan
+        History.monitoring_plan(history_data)
+      when :public_health_action
+        History.public_health_action(history_data)
+      when :assigned_user
+        History.assigned_user(history_data)
+      when :pause_notifications
+        History.pause_notifications(history_data)
+      when :last_date_of_exposure
+        History.last_date_of_exposure(history_data)
+      when :extended_isolation
+        History.extended_isolation(history_data)
+      when :continuous_exposure
+        History.continuous_exposure(history_data)
+      when :isolation
+        if !updated_value
+          # If moved from Isolation workflow to Exposure workflow and Extended Isolation was cleared
+          if !patient_before[:extended_isolation].nil? && extended_isolation.nil?
+            History.monitoring_change(
+              patient: self,
+              created_by: 'Sara Alert System',
+              comment: 'System cleared Extended Isolation Date because monitoree was moved from isolation to exposure workflow.'
+            )
+          end
+
+          # If moved from Isolation worklflow to Exposure and symptom onset had to be cleared
+          if !patient_before[:symptom_onset].nil? && symptom_onset.nil?
+            comment = if !patient_before[:symptom_onset].nil? && !new_symptom_onset.nil?
+                        "System changed Symptom Onset Date from #{patient_before[:symptom_onset].strftime('%m/%d/%Y')} to #{new_symptom_onset.strftime('%m/%d/%Y')}
+                        because monitoree was moved from isolation to exposure workflow. This allows the system to show monitoree on appropriate line list based on
+                        daily reports."
+                      elsif patient_before[:symptom_onset].nil? && !new_symptom_onset.nil?
+                        "System changed Symptom Onset Date from blank to #{new_symptom_onset.strftime('%m/%d/%Y')} because monitoree was moved from isolation to
+                        exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
+                      elsif !patient_before[:symptom_onset].nil? && new_symptom_onset.nil?
+                        "System cleared Symptom Onset Date from #{patient_before[:symptom_onset].strftime('%m/%d/%Y')} to blank because monitoree was moved from isolation to
+                        exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
+                      else
+                        'System changed Symptom Onset Date. This allows the system to show monitoree on appropriate line list based on daily reports.'
+                      end
+            History.monitoring_change(patient: self, created_by: 'Sara Alert System', comment: comment)
+          end
+        end
+      when :symptom_onset
+        History.symptom_onset(history_data)
+      when :case_status
+        History.case_status(history, diff_state)
+
+        # If Case Status was updated to one of the values meant for the Exposure workflow and the Public Health Action was reset.
+        if ['Suspect', 'Unknown', 'Not a Case'].include?(new_attribute_value) && patient_before[:public_health_action] != 'None' && public_health_action == "None"
+          message = monitoring ?
+          "System changed Latest Public Health Action from \"#{public_health_action}\" to \"None\" so that the monitoree will appear on
+          the appropriate line list in the exposure workflow to continue monitoring." : "System changed Latest Public Health Action
+          from \"#{public_health_action}\" to \"None\"."
+          History.monitoring_change(patient: self, created_by: 'Sara Alert System', comment: message)
+        end
+      when :jurisdiction_id
+        History.jurisdiction(history_data)
+      end
+    end
+  end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1008,7 +1008,10 @@ class Patient < ApplicationRecord
   # These side effects are handled in the handle_update function
   def monitoring_history_edit(history_data, diff_state)
     patient_before = history_data[:patient_before]
-    history_data[:updates]&.keys&.each do |attribute|
+    # NOTE: Attributes are sorted so that case_status always comes before isolation, since a case_status change may trigger
+    # an isolation change from the front end, and the case_status message should come first
+    attribute_order = %i[case_status isolation]
+    history_data[:updates].keys.sort_by { |key| attribute_order.index(key) || Float::INFINITY }&.each do |attribute|
       updated_value = self[attribute]
       next if patient_before[attribute] == updated_value
 
@@ -1040,6 +1043,8 @@ class Patient < ApplicationRecord
         History.extended_isolation(history_data)
       when :continuous_exposure
         History.continuous_exposure(history_data)
+      when :isolation
+        update_patient_history_for_isolation(patient_before, updated_value)
       when :symptom_onset
         History.symptom_onset(history_data)
       when :case_status
@@ -1057,12 +1062,6 @@ class Patient < ApplicationRecord
         History.jurisdiction(history_data)
       end
     end
-
-    # NOTE: Changes in case_status may trigger changes in isolation, so add isolation history messages
-    # at the end, so that they will come after any case_status history messages
-    return unless !history_data[:updates][:isolation].nil? && self[:isolation] != patient_before[:isolation]
-
-    update_patient_history_for_isolation(patient_before, self[:isolation])
   end
 
   def update_patient_history_for_isolation(patient_before, new_isolation_value)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -960,16 +960,10 @@ class Patient < ApplicationRecord
           all_updates[:continuous_exposure] = false
         end
       when :isolation
-        # If record is being moved to Exposure workflow from Isolation workflow
-        unless new_attribute_value
-          all_updates[:extended_isolation] = nil
-          # NOTE: The below will overwrite any new value they may set for symptom onset as they can not be set in the exposure workflow.
-          all_updates[:user_defined_symptom_onset] = false
-          all_updates[:symptom_onset] = calculated_symptom_onset
-        end
+        add_updates_from_isolation_change(all_updates, new_attribute_value)
       when :case_status
         # If Case Status has been updated to one of the values meant for the Exposure workflow, reset the Public Health Action.
-        if ['Suspect', 'Unknown', 'Not a Case'].include?(new_attribute_value) && patient[:public_health_action] != 'None'
+        if ['Suspect', 'Unknown', 'Not a Case'].include?(new_attribute_value) && public_health_action != 'None'
           all_updates[:public_health_action] = 'None'
         end
       when :symptom_onset
@@ -980,14 +974,28 @@ class Patient < ApplicationRecord
         end
       when :continuous_exposure
         # Do not allow continuous exposure to be set for records that are closed
-        all_updates.delete(:continuous_exposure) if all_updates[:continuous_exposure] && !all_updates[:monitoring].nil? && !all_updates[:monitoring]
+        all_updates.delete(:continuous_exposure) if all_updates[:continuous_exposure] && !monitoring
+      when :jurisdiction_id
+        # Do not allow jurisdiction to be set if it does not exist
+        jur = Jurisdiction.find_by_id(new_attribute_value)
+        all_updates.delete(:jurisdiction_id) if jur.nil?
       end
     end
 
     all_updates
   end
 
-  def update_patient_monitoring_history(all_updates, patient_before, history_data)
+  def add_updates_from_isolation_change(updates, new_isolation_value)
+    # If record is being moved to Exposure workflow from Isolation workflow
+    unless new_isolation_value
+      updates[:extended_isolation] = nil
+      # NOTE: The below will overwrite any new value they may set for symptom onset as they can not be set in the exposure workflow.
+      updates[:user_defined_symptom_onset] = false
+      updates[:symptom_onset] = calculated_symptom_onset
+    end
+  end
+
+  def update_patient_monitoring_history(all_updates, patient_before, history_data, diff_state)
     all_updates&.keys&.each do |attribute|
       updated_value = self[attribute]
       next if patient_before[attribute] == self[attribute]
@@ -1021,49 +1029,53 @@ class Patient < ApplicationRecord
       when :continuous_exposure
         History.continuous_exposure(history_data)
       when :isolation
-        unless updated_value
-          # If moved from Isolation workflow to Exposure workflow and Extended Isolation was cleared
-          if !patient_before[:extended_isolation].nil? && extended_isolation.nil?
-            History.monitoring_change(
-              patient: self,
-              created_by: 'Sara Alert System',
-              comment: 'System cleared Extended Isolation Date because monitoree was moved from isolation to exposure workflow.'
-            )
-          end
-
-          # If moved from Isolation worklflow to Exposure and symptom onset had to be cleared
-          if !patient_before[:symptom_onset].nil? && symptom_onset.nil?
-            comment = if !patient_before[:symptom_onset].nil? && !new_symptom_onset.nil?
-                        "System changed Symptom Onset Date from #{patient_before[:symptom_onset].strftime('%m/%d/%Y')} to #{new_symptom_onset.strftime('%m/%d/%Y')}
-                        because monitoree was moved from isolation to exposure workflow. This allows the system to show monitoree on appropriate line list based on
-                        daily reports."
-                      elsif patient_before[:symptom_onset].nil? && !new_symptom_onset.nil?
-                        "System changed Symptom Onset Date from blank to #{new_symptom_onset.strftime('%m/%d/%Y')} because monitoree was moved from isolation to
-                        exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
-                      elsif !patient_before[:symptom_onset].nil? && new_symptom_onset.nil?
-                        "System cleared Symptom Onset Date from #{patient_before[:symptom_onset].strftime('%m/%d/%Y')} to blank because monitoree was moved from isolation to
-                        exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
-                      else
-                        'System changed Symptom Onset Date. This allows the system to show monitoree on appropriate line list based on daily reports.'
-                      end
-            History.monitoring_change(patient: self, created_by: 'Sara Alert System', comment: comment)
-          end
-        end
+        update_patient_history_for_isolation(patient_before, updated_value)
       when :symptom_onset
         History.symptom_onset(history_data)
       when :case_status
         History.case_status(history_data, diff_state)
 
         # If Case Status was updated to one of the values meant for the Exposure workflow and the Public Health Action was reset.
-        if ['Suspect', 'Unknown', 'Not a Case'].include?(new_attribute_value) && patient_before[:public_health_action] != 'None' && public_health_action == 'None'
+        if ['Suspect', 'Unknown', 'Not a Case'].include?(updated_value) && patient_before[:public_health_action] != 'None' && public_health_action == 'None'
           message = monitoring ?
-          "System changed Latest Public Health Action from \"#{public_health_action}\" to \"None\" so that the monitoree will appear on
+          "System changed Latest Public Health Action from \"#{patient_before[:public_health_action]}\" to \"None\" so that the monitoree will appear on
           the appropriate line list in the exposure workflow to continue monitoring." : "System changed Latest Public Health Action
-          from \"#{public_health_action}\" to \"None\"."
+          from \"#{patient_before[:public_health_action]}\" to \"None\"."
           History.monitoring_change(patient: self, created_by: 'Sara Alert System', comment: message)
         end
       when :jurisdiction_id
         History.jurisdiction(history_data)
+      end
+    end
+  end
+
+  def update_patient_history_for_isolation(patient_before, new_isolation_value)
+    unless new_isolation_value
+      # If moved from Isolation workflow to Exposure workflow and Extended Isolation was cleared
+      if !patient_before[:extended_isolation].nil? && extended_isolation.nil?
+        History.monitoring_change(
+          patient: self,
+          created_by: 'Sara Alert System',
+          comment: 'System cleared Extended Isolation Date because monitoree was moved from isolation to exposure workflow.'
+        )
+      end
+
+      # If moved from Isolation worklflow to Exposure and symptom onset had to be cleared
+      if patient_before[:symptom_onset].nil? != symptom_onset
+        comment = if !patient_before[:symptom_onset].nil? && !symptom_onset.nil?
+                    "System changed Symptom Onset Date from #{patient_before[:symptom_onset].strftime('%m/%d/%Y')} to #{symptom_onset.strftime('%m/%d/%Y')}
+                    because monitoree was moved from isolation to exposure workflow. This allows the system to show monitoree on appropriate line list based on
+                    daily reports."
+                  elsif patient_before[:symptom_onset].nil? && !symptom_onset.nil?
+                    "System changed Symptom Onset Date from blank to #{symptom_onset.strftime('%m/%d/%Y')} because monitoree was moved from isolation to
+                    exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
+                  elsif !patient_before[:symptom_onset].nil? && symptom_onset.nil?
+                    "System cleared Symptom Onset Date from #{patient_before[:symptom_onset].strftime('%m/%d/%Y')} to blank because monitoree was moved from isolation to
+                    exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
+                  else
+                    'System changed Symptom Onset Date. This allows the system to show monitoree on appropriate line list based on daily reports.'
+                  end
+        History.monitoring_change(patient: self, created_by: 'Sara Alert System', comment: comment)
       end
     end
   end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1052,7 +1052,7 @@ class Patient < ApplicationRecord
       when :symptom_onset
         History.symptom_onset(history_data)
       when :case_status
-        History.case_status(history, diff_state)
+        History.case_status(history_data, diff_state)
 
         # If Case Status was updated to one of the values meant for the Exposure workflow and the Public Health Action was reset.
         if ['Suspect', 'Unknown', 'Not a Case'].include?(new_attribute_value) && patient_before[:public_health_action] != 'None' && public_health_action == 'None'

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -954,86 +954,56 @@ class Patient < ApplicationRecord
   end
 
   def monitoring_change
-    unless monitoring
-      self.closed_at = DateTime.now
-      self.continuous_exposure = false
-      History.monitoring_change(
-        patient: self,
-        created_by: 'Sara Alert System',
-        comment: 'System turned off Continuous Exposure because the record was moved to the closed line list.'
-      )
-    end
+    return if monitoring
+
+    self.closed_at = DateTime.now
+    self.continuous_exposure = false
   end
 
   def isolation_change
-    unless isolation
-      isolation_before = self.extended_isolation
-      self.extended_isolation = nil
-      if !isolation_before.nil?
-        History.monitoring_change(
-          patient: self,
-          created_by: 'Sara Alert System',
-          comment: 'System cleared Extended Isolation Date because monitoree was moved from isolation to exposure workflow.'
-        )
-      end
+    return if isolation
 
-      # NOTE: The below will overwrite any new value they may set for symptom onset as they can not be set in the exposure workflow.
-      self.user_defined_symptom_onset = false
-      old_symptom_onset = symptom_onset
-      self.symptom_onset = calculated_symptom_onset
-
-      # If moved from Isolation worklflow to Exposure and symptom onset had to be cleared
-      comment = if !old_symptom_onset.nil? && !symptom_onset.nil?
-                  "System changed Symptom Onset Date from #{old_symptom_onset.strftime('%m/%d/%Y')} to #{symptom_onset.strftime('%m/%d/%Y')}
-                  because monitoree was moved from isolation to exposure workflow. This allows the system to show monitoree on appropriate line list based on
-                  daily reports."
-                elsif old_symptom_onset.nil? && !symptom_onset.nil?
-                  "System changed Symptom Onset Date from blank to #{symptom_onset.strftime('%m/%d/%Y')} because monitoree was moved from isolation to
-                  exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
-                elsif !old_symptom_onset.nil? && symptom_onset.nil?
-                  "System cleared Symptom Onset Date from #{old_symptom_onset.strftime('%m/%d/%Y')} to blank because monitoree was moved from isolation to
-                  exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
-                else
-                  'System changed Symptom Onset Date. This allows the system to show monitoree on appropriate line list based on daily reports.'
-                end
-      History.monitoring_change(patient: self, created_by: 'Sara Alert System', comment: comment)   
-    end
+    self.extended_isolation = nil
+    # NOTE: The below will overwrite any new value they may set for symptom onset as they can not be set in the exposure workflow.
+    self.user_defined_symptom_onset = false
+    self.symptom_onset = calculated_symptom_onset
   end
 
   def case_status_change
-    if ['Suspect', 'Unknown', 'Not a Case'].include?(case_status) && public_health_action != 'None'
-      old_action = public_health_action
-      self.public_health_action = 'None'
+    return unless ['Suspect', 'Unknown', 'Not a Case'].include?(case_status) && public_health_action != 'None'
 
-      message = monitoring ?
-      "System changed Latest Public Health Action from \"#{old_action}\" to \"None\" so that the monitoree will appear on
-      the appropriate line list in the exposure workflow to continue monitoring." : "System changed Latest Public Health Action
-      from \"#{old_action}\" to \"None\"."
-      History.monitoring_change(patient: self, created_by: 'Sara Alert System', comment: message)
-    end
+    self.public_health_action = 'None'
   end
 
   def symptom_onset_change
-    if symptom_onset.nil?
-      self.user_defined_symptom_onset = false
-      self.symptom_onset = calculated_symptom_onset
-    end
+    return unless symptom_onset.nil?
+
+    self.user_defined_symptom_onset = false
+    self.symptom_onset = calculated_symptom_onset
   end
 
   def continuous_exposure_change
-    if continuous_exposure && !monitoring
-      self.continuous_exposure = false
-    end
+    self.continuous_exposure = false if continuous_exposure && !monitoring
   end
 
-  def update_patient_monitoring_history(all_updates, patient_before, history_data, diff_state)
-    all_updates&.keys&.each do |attribute|
+  def monitoring_history_edit(history_data, diff_state)
+    patient_before = history_data[:patient_before]
+    history_data[:updates]&.keys&.each do |attribute|
       updated_value = self[attribute]
-      next if patient_before[attribute] == self[attribute]
+      next if patient_before[attribute] == updated_value
 
       case attribute
       when :monitoring
         History.monitoring_status(history_data)
+
+        # If the record was in continuous exposure and then it was closed and continuous exposure was turned off
+        if !updated_value && patient_before[:continuous_exposure] && !continuous_exposure
+          History.monitoring_change(
+            patient: self,
+            created_by: 'Sara Alert System',
+            comment: 'System turned off Continuous Exposure because the record was moved to the closed line list.'
+          )
+        end
       when :exposure_risk_assessment
         History.exposure_risk_assessment(history_data)
       when :monitoring_plan
@@ -1051,15 +1021,55 @@ class Patient < ApplicationRecord
       when :continuous_exposure
         History.continuous_exposure(history_data)
       when :isolation
-        # Should this have History.isolation()?
+        update_patient_history_for_isolation(patient_before, updated_value)
       when :symptom_onset
         History.symptom_onset(history_data)
       when :case_status
         History.case_status(history_data, diff_state)
+
+        # If Case Status was updated to one of the values meant for the Exposure workflow and the Public Health Action was reset.
+        if ['Suspect', 'Unknown', 'Not a Case'].include?(updated_value) && patient_before[:public_health_action] != 'None' && public_health_action == 'None'
+          message = monitoring ?
+          "System changed Latest Public Health Action from \"#{patient_before[:public_health_action]}\" to \"None\" so that the monitoree will appear on
+          the appropriate line list in the exposure workflow to continue monitoring." : "System changed Latest Public Health Action
+          from \"#{patient_before[:public_health_action]}\" to \"None\"."
+          History.monitoring_change(patient: self, created_by: 'Sara Alert System', comment: message)
+        end
       when :jurisdiction_id
         History.jurisdiction(history_data)
       end
     end
+  end
+
+  def update_patient_history_for_isolation(patient_before, new_isolation_value)
+    return if new_isolation_value
+
+    # If moved from Isolation workflow to Exposure workflow and Extended Isolation was cleared
+    if !patient_before[:extended_isolation].nil? && extended_isolation.nil?
+      History.monitoring_change(
+        patient: self,
+        created_by: 'Sara Alert System',
+        comment: 'System cleared Extended Isolation Date because monitoree was moved from isolation to exposure workflow.'
+      )
+    end
+
+    # If moved from Isolation worklflow to Exposure and symptom onset had to be cleared
+    return unless patient_before[:symptom_onset].nil? != symptom_onset
+
+    comment = if !patient_before[:symptom_onset].nil? && !symptom_onset.nil?
+                "System changed Symptom Onset Date from #{patient_before[:symptom_onset].strftime('%m/%d/%Y')} to #{symptom_onset.strftime('%m/%d/%Y')}
+                because monitoree was moved from isolation to exposure workflow. This allows the system to show monitoree on appropriate line list based on
+                daily reports."
+              elsif patient_before[:symptom_onset].nil? && !symptom_onset.nil?
+                "System changed Symptom Onset Date from blank to #{symptom_onset.strftime('%m/%d/%Y')} because monitoree was moved from isolation to
+                exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
+              elsif !patient_before[:symptom_onset].nil? && symptom_onset.nil?
+                "System cleared Symptom Onset Date from #{patient_before[:symptom_onset].strftime('%m/%d/%Y')} to blank because monitoree was moved from
+                isolation to exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
+              else
+                'System changed Symptom Onset Date. This allows the system to show monitoree on appropriate line list based on daily reports.'
+              end
+    History.monitoring_change(patient: self, created_by: 'Sara Alert System', comment: comment)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -100,6 +100,7 @@ class Patient < ApplicationRecord
 
   around_save :inform_responder, if: :responder_id_changed?
   around_destroy :inform_responder
+  before_update :handle_update
 
   accepts_nested_attributes_for :laboratories
 
@@ -944,54 +945,84 @@ class Patient < ApplicationRecord
     token
   end
 
-  def get_updates_from_monitoring_changes(monitoring_changes)
-    all_updates = monitoring_changes.deep_dup
-
-    monitoring_changes&.keys&.each do |attribute|
-      new_attribute_value = monitoring_changes[attribute]
-      next if self[attribute] == new_attribute_value
-
-      # Handle reacting to specific attributes as need be
-      case attribute
-      when :monitoring
-        # If record should be closed
-        unless new_attribute_value
-          all_updates[:closed_at] = DateTime.now
-          all_updates[:continuous_exposure] = false
-        end
-      when :isolation
-        add_updates_from_isolation_change(all_updates, new_attribute_value)
-      when :case_status
-        # If Case Status has been updated to one of the values meant for the Exposure workflow, reset the Public Health Action.
-        if ['Suspect', 'Unknown', 'Not a Case'].include?(new_attribute_value) && public_health_action != 'None'
-          all_updates[:public_health_action] = 'None'
-        end
-      when :symptom_onset
-        # If symptom onset is being cleared, reset with calculated value.
-        if new_attribute_value.nil?
-          all_updates[:user_defined_symptom_onset] = false
-          all_updates[:symptom_onset] = calculated_symptom_onset
-        end
-      when :continuous_exposure
-        # Do not allow continuous exposure to be set for records that are closed
-        all_updates.delete(:continuous_exposure) if all_updates[:continuous_exposure] && !monitoring
-      when :jurisdiction_id
-        # Do not allow jurisdiction to be set if it does not exist
-        jur = Jurisdiction.find_by_id(new_attribute_value)
-        all_updates.delete(:jurisdiction_id) if jur.nil?
-      end
-    end
-
-    all_updates
+  def handle_update
+    monitoring_change if monitoring_changed?
+    isolation_change if isolation_changed?
+    case_status_change if case_status_changed?
+    symptom_onset_change if symptom_onset_changed?
+    continuous_exposure_change if continuous_exposure_changed?
   end
 
-  def add_updates_from_isolation_change(updates, new_isolation_value)
-    # If record is being moved to Exposure workflow from Isolation workflow
-    unless new_isolation_value
-      updates[:extended_isolation] = nil
+  def monitoring_change
+    unless monitoring
+      self.closed_at = DateTime.now
+      self.continuous_exposure = false
+      History.monitoring_change(
+        patient: self,
+        created_by: 'Sara Alert System',
+        comment: 'System turned off Continuous Exposure because the record was moved to the closed line list.'
+      )
+    end
+  end
+
+  def isolation_change
+    unless isolation
+      isolation_before = self.extended_isolation
+      self.extended_isolation = nil
+      if !isolation_before.nil?
+        History.monitoring_change(
+          patient: self,
+          created_by: 'Sara Alert System',
+          comment: 'System cleared Extended Isolation Date because monitoree was moved from isolation to exposure workflow.'
+        )
+      end
+
       # NOTE: The below will overwrite any new value they may set for symptom onset as they can not be set in the exposure workflow.
-      updates[:user_defined_symptom_onset] = false
-      updates[:symptom_onset] = calculated_symptom_onset
+      self.user_defined_symptom_onset = false
+      old_symptom_onset = symptom_onset
+      self.symptom_onset = calculated_symptom_onset
+
+      # If moved from Isolation worklflow to Exposure and symptom onset had to be cleared
+      comment = if !old_symptom_onset.nil? && !symptom_onset.nil?
+                  "System changed Symptom Onset Date from #{old_symptom_onset.strftime('%m/%d/%Y')} to #{symptom_onset.strftime('%m/%d/%Y')}
+                  because monitoree was moved from isolation to exposure workflow. This allows the system to show monitoree on appropriate line list based on
+                  daily reports."
+                elsif old_symptom_onset.nil? && !symptom_onset.nil?
+                  "System changed Symptom Onset Date from blank to #{symptom_onset.strftime('%m/%d/%Y')} because monitoree was moved from isolation to
+                  exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
+                elsif !old_symptom_onset.nil? && symptom_onset.nil?
+                  "System cleared Symptom Onset Date from #{old_symptom_onset.strftime('%m/%d/%Y')} to blank because monitoree was moved from isolation to
+                  exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
+                else
+                  'System changed Symptom Onset Date. This allows the system to show monitoree on appropriate line list based on daily reports.'
+                end
+      History.monitoring_change(patient: self, created_by: 'Sara Alert System', comment: comment)   
+    end
+  end
+
+  def case_status_change
+    if ['Suspect', 'Unknown', 'Not a Case'].include?(case_status) && public_health_action != 'None'
+      old_action = public_health_action
+      self.public_health_action = 'None'
+
+      message = monitoring ?
+      "System changed Latest Public Health Action from \"#{old_action}\" to \"None\" so that the monitoree will appear on
+      the appropriate line list in the exposure workflow to continue monitoring." : "System changed Latest Public Health Action
+      from \"#{old_action}\" to \"None\"."
+      History.monitoring_change(patient: self, created_by: 'Sara Alert System', comment: message)
+    end
+  end
+
+  def symptom_onset_change
+    if symptom_onset.nil?
+      self.user_defined_symptom_onset = false
+      self.symptom_onset = calculated_symptom_onset
+    end
+  end
+
+  def continuous_exposure_change
+    if continuous_exposure && !monitoring
+      self.continuous_exposure = false
     end
   end
 
@@ -1003,15 +1034,6 @@ class Patient < ApplicationRecord
       case attribute
       when :monitoring
         History.monitoring_status(history_data)
-
-        # If the record was in continuous exposure and then it was closed and continuous exposure was turned off
-        if !updated_value && patient_before[:continuous_exposure] && !continuous_exposure
-          History.monitoring_change(
-            patient: self,
-            created_by: 'Sara Alert System',
-            comment: 'System turned off Continuous Exposure because the record was moved to the closed line list.'
-          )
-        end
       when :exposure_risk_assessment
         History.exposure_risk_assessment(history_data)
       when :monitoring_plan
@@ -1029,53 +1051,13 @@ class Patient < ApplicationRecord
       when :continuous_exposure
         History.continuous_exposure(history_data)
       when :isolation
-        update_patient_history_for_isolation(patient_before, updated_value)
+        # Should this have History.isolation()?
       when :symptom_onset
         History.symptom_onset(history_data)
       when :case_status
         History.case_status(history_data, diff_state)
-
-        # If Case Status was updated to one of the values meant for the Exposure workflow and the Public Health Action was reset.
-        if ['Suspect', 'Unknown', 'Not a Case'].include?(updated_value) && patient_before[:public_health_action] != 'None' && public_health_action == 'None'
-          message = monitoring ?
-          "System changed Latest Public Health Action from \"#{patient_before[:public_health_action]}\" to \"None\" so that the monitoree will appear on
-          the appropriate line list in the exposure workflow to continue monitoring." : "System changed Latest Public Health Action
-          from \"#{patient_before[:public_health_action]}\" to \"None\"."
-          History.monitoring_change(patient: self, created_by: 'Sara Alert System', comment: message)
-        end
       when :jurisdiction_id
         History.jurisdiction(history_data)
-      end
-    end
-  end
-
-  def update_patient_history_for_isolation(patient_before, new_isolation_value)
-    unless new_isolation_value
-      # If moved from Isolation workflow to Exposure workflow and Extended Isolation was cleared
-      if !patient_before[:extended_isolation].nil? && extended_isolation.nil?
-        History.monitoring_change(
-          patient: self,
-          created_by: 'Sara Alert System',
-          comment: 'System cleared Extended Isolation Date because monitoree was moved from isolation to exposure workflow.'
-        )
-      end
-
-      # If moved from Isolation worklflow to Exposure and symptom onset had to be cleared
-      if patient_before[:symptom_onset].nil? != symptom_onset
-        comment = if !patient_before[:symptom_onset].nil? && !symptom_onset.nil?
-                    "System changed Symptom Onset Date from #{patient_before[:symptom_onset].strftime('%m/%d/%Y')} to #{symptom_onset.strftime('%m/%d/%Y')}
-                    because monitoree was moved from isolation to exposure workflow. This allows the system to show monitoree on appropriate line list based on
-                    daily reports."
-                  elsif patient_before[:symptom_onset].nil? && !symptom_onset.nil?
-                    "System changed Symptom Onset Date from blank to #{symptom_onset.strftime('%m/%d/%Y')} because monitoree was moved from isolation to
-                    exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
-                  elsif !patient_before[:symptom_onset].nil? && symptom_onset.nil?
-                    "System cleared Symptom Onset Date from #{patient_before[:symptom_onset].strftime('%m/%d/%Y')} to blank because monitoree was moved from isolation to
-                    exposure workflow. This allows the system to show monitoree on appropriate line list based on daily reports."
-                  else
-                    'System changed Symptom Onset Date. This allows the system to show monitoree on appropriate line list based on daily reports.'
-                  end
-        History.monitoring_change(patient: self, created_by: 'Sara Alert System', comment: comment)
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,11 +84,11 @@ class User < ApplicationRecord
   end
 
   # Get jurisdictions that the user can transfer patients into
-  def get_jurisdictions_for_transfer
+  def jurisdictions_for_transfer
     if can_transfer_patients?
       # Allow all jurisdictions as valid transfer options.
       Hash[Jurisdiction.all.where.not(name: 'USA').pluck(:id, :path).map { |id, path| [id, path] }]
-      else
+    else
       # Otherwise, only show jurisdictions within hierarchy.
       Hash[jurisdiction.subtree.pluck(:id, :path).map { |id, path| [id, path] }]
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,6 +83,17 @@ class User < ApplicationRecord
     end
   end
 
+  # Get jurisdictions that the user can transfer patients into
+  def get_jurisdictions_for_transfer
+    if can_transfer_patients?
+      # Allow all jurisdictions as valid transfer options.
+      Hash[Jurisdiction.all.where.not(name: 'USA').pluck(:id, :path).map { |id, path| [id, path] }]
+      else
+      # Otherwise, only show jurisdictions within hierarchy.
+      Hash[jurisdiction.subtree.pluck(:id, :path).map { |id, path| [id, path] }]
+    end
+  end
+
   # Allow information on the user's jurisdiction to be displayed
   def jurisdiction_path
     jurisdiction&.path&.map(&:name)

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -927,6 +927,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Afternoon', json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-time' }.first['valueString']
     assert_equal 4.days.ago.strftime('%Y-%m-%d'), json_response['extension'].filter { |e| e['url'].include? 'last-date-of-exposure' }.first['valueDate']
     assert_equal 3.days.ago.strftime('%Y-%m-%d'), json_response['extension'].filter { |e| e['url'].include? 'symptom-onset-date' }.first['valueDate']
+    assert p.user_defined_symptom_onset
     assert json_response['extension'].filter { |e| e['url'].include? 'isolation' }.first['valueBoolean']
     assert_equal 'USA, State 1, County 1',
                  json_response['extension'].find { |e| e['url'] == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }['valueString']

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -252,7 +252,8 @@ class PatientsControllerTest < ActionController::TestCase
     assert_not patient.monitoring
     assert_not_nil patient.closed_at
     assert_equal false, patient.continuous_exposure
-    assert_match /"Monitoring" to "Not Monitoring"/, History.find_by(patient: patient).comment
+    assert_match /"Monitoring" to "Not Monitoring"/, History.find_by(patient: patient, created_by: user.email).comment
+    assert_match /System turned off Continuous Exposure/, History.find_by(patient: patient, created_by: 'Sara Alert System').comment
   end
 
   test 'update status for a patient with dependents and apply to household' do 

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -240,7 +240,7 @@ class PatientsControllerTest < ActionController::TestCase
   test 'update status for a patient with no dependents' do
     user = create(:public_health_enroller_user)
     sign_in user
-    patient = create(:patient, creator: user, monitoring: true)
+    patient = create(:patient, creator: user, monitoring: true, continuous_exposure: true)
 
     post :update_status, params: {
       id: patient.id,
@@ -252,11 +252,11 @@ class PatientsControllerTest < ActionController::TestCase
     assert_not patient.monitoring
     assert_not_nil patient.closed_at
     assert_equal false, patient.continuous_exposure
-    assert_match /"Monitoring" to "Not Monitoring"/, History.find_by(patient: patient, created_by: user.email).comment
-    assert_match /System turned off Continuous Exposure/, History.find_by(patient: patient, created_by: 'Sara Alert System').comment
+    assert_match(/"Monitoring" to "Not Monitoring"/, History.find_by(patient: patient, created_by: user.email).comment)
+    assert_match(/System turned off Continuous Exposure/, History.find_by(patient: patient, created_by: 'Sara Alert System').comment)
   end
 
-  test 'update status for a patient with dependents and apply to household' do 
+  test 'update status for a patient with dependents and apply to household' do
     user = create(:public_health_enroller_user)
     sign_in user
     hoh_patient = create(:patient, creator: user, monitoring: true)
@@ -276,7 +276,7 @@ class PatientsControllerTest < ActionController::TestCase
     assert_not dependent_patient.monitoring
   end
 
-  test 'update status for a patient with dependents and apply to continuous exposure household' do 
+  test 'update status for a patient with dependents and apply to continuous exposure household' do
     user = create(:public_health_enroller_user)
     sign_in user
     hoh_patient = create(:patient, creator: user, monitoring: true)
@@ -330,7 +330,7 @@ class PatientsControllerTest < ActionController::TestCase
   test 'update status when jurisdiction changes' do
     user = create(:public_health_enroller_user)
     sign_in user
-    new_jurisdiction = create(:jurisdiction, path: "Bar")
+    new_jurisdiction = create(:jurisdiction, path: 'Bar')
     patient = create(:patient, creator: user, monitoring: true)
     old_jurisdiction = patient.jurisdiction
 
@@ -338,7 +338,7 @@ class PatientsControllerTest < ActionController::TestCase
       id: patient.id,
       patient: { jurisdiction_id: new_jurisdiction.id }
     }, as: :json
-    
+
     assert_response :success
     patient.reload
     assert_equal new_jurisdiction.id, patient.jurisdiction_id
@@ -346,6 +346,6 @@ class PatientsControllerTest < ActionController::TestCase
     assert_equal old_jurisdiction.id, t.from_jurisdiction_id
     assert_equal new_jurisdiction.id, t.to_jurisdiction_id
     assert_equal user.id, t.who_id
-    assert_match /blank to "Bar"/, History.find_by(patient: patient).comment
+    assert_match(/blank to "Bar"/, History.find_by(patient: patient).comment)
   end
 end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -2142,5 +2142,25 @@ class PatientTest < ActiveSupport::TestCase
     patient.update(last_assessment_reminder_sent: 11.hours.ago)
     assert_not patient.last_assessment_reminder_sent_eligible?
   end
+  
+  test 'get_updates_from_monitoring_changes handles monitoring change' do
+    
+  end
+
+  test 'get_updates_from_monitoring_changes handles workflow change' do
+    
+  end
+
+  test 'get_updates_from_monitoring_changes handles symptom_onset change' do
+    
+  end
+
+  test 'get_updates_from_monitoring_changes handles case_status change' do
+    
+  end
+
+  test 'get_updates_from_monitoring_changes handles continuous_exposure change' do
+    
+  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -2144,23 +2144,18 @@ class PatientTest < ActiveSupport::TestCase
   end
   
   test 'get_updates_from_monitoring_changes handles monitoring change' do
-    
   end
 
   test 'get_updates_from_monitoring_changes handles workflow change' do
-    
   end
 
   test 'get_updates_from_monitoring_changes handles symptom_onset change' do
-    
   end
 
   test 'get_updates_from_monitoring_changes handles case_status change' do
-    
   end
 
   test 'get_updates_from_monitoring_changes handles continuous_exposure change' do
-    
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -2143,15 +2143,15 @@ class PatientTest < ActiveSupport::TestCase
     assert_not patient.last_assessment_reminder_sent_eligible?
   end
   
-  test 'get_updates_from_monitoring_changes handles monitoring change' do
+  test 'update handles monitoring change' do
     patient = create(:patient, continuous_exposure: true, monitoring: true, closed_at: nil)
-    updates = patient.get_updates_from_monitoring_changes({monitoring: false})
-    assert_not updates[:monitoring]
-    assert_not updates[:continuous_exposure]
-    assert_not_nil updates[:closed_at]
+    assert patient.update({monitoring: false})
+    assert_not patient.monitoring
+    assert_not patient.continuous_exposure
+    assert_not_nil patient.closed_at
   end
 
-  test 'get_updates_from_monitoring_changes handles workflow change' do
+  test 'update handles workflow change' do
     patient = create(:patient,
                      isolation: true,
                      extended_isolation: DateTime.now + 1.day,
@@ -2159,29 +2159,34 @@ class PatientTest < ActiveSupport::TestCase
                      symptom_onset: DateTime.now - 1.day)
     created_at = DateTime.now.to_date - 1.day
     create(:assessment, patient_id: patient.id, symptomatic: true, created_at: created_at)
-    updates = patient.get_updates_from_monitoring_changes({isolation: false})
-    assert_equal({isolation: false, extended_isolation: nil, user_defined_symptom_onset: false, symptom_onset: created_at}, updates)
+    patient.update({isolation: false})
+    assert_not patient.isolation
+    assert_nil patient.extended_isolation
+    assert_not patient.user_defined_symptom_onset
+    assert_equal created_at, patient.symptom_onset
   end
 
-  test 'get_updates_from_monitoring_changes handles case_status change' do
+  test 'update handles case_status change' do
     patient = create(:patient, public_health_action: 'Recommended medical evaluation of symptoms')
-    updates = patient.get_updates_from_monitoring_changes({case_status: 'Unknown'})
-    assert_equal({case_status: 'Unknown', public_health_action: 'None'}, updates)
+    patient.update({case_status: 'Unknown'})
+    assert_equal 'Unknown', patient.case_status
+    assert_equal 'None', patient.public_health_action
   end
 
-  test 'get_updates_from_monitoring_changes handles symptom_onset change' do
+  test 'update handles symptom_onset change' do
     patient = create(:patient, symptom_onset: DateTime.now - 1.day)
     created_at = DateTime.now.to_date - 2.day
     create(:assessment, patient_id: patient.id, symptomatic: true, created_at: created_at)
-    updates = patient.get_updates_from_monitoring_changes({symptom_onset: nil})
-    assert_equal({symptom_onset: created_at, user_defined_symptom_onset: false}, updates)
+    patient.update({symptom_onset: nil})
+    assert_equal created_at, patient.symptom_onset
+    assert_not patient.user_defined_symptom_onset
   end
 
-  test 'get_updates_from_monitoring_changes handles continuous_exposure change' do
+  test 'update handles continuous_exposure change' do
     patient = create(:patient, monitoring: false, continuous_exposure: false)
-    updates = patient.get_updates_from_monitoring_changes({continuous_exposure: true})
-    # The update to continuous_exposure is removed altogether, since it is not allowed when patient is not monitoring
-    assert_equal({}, updates)
+    patient.update({continuous_exposure: true})
+    # This update is not allowed when monitoring is false
+    assert_not patient.continuous_exposure
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -2142,10 +2142,10 @@ class PatientTest < ActiveSupport::TestCase
     patient.update(last_assessment_reminder_sent: 11.hours.ago)
     assert_not patient.last_assessment_reminder_sent_eligible?
   end
-  
+
   test 'update handles monitoring change' do
     patient = create(:patient, continuous_exposure: true, monitoring: true, closed_at: nil)
-    assert patient.update({monitoring: false})
+    assert patient.update({ monitoring: false })
     assert_not patient.monitoring
     assert_not patient.continuous_exposure
     assert_not_nil patient.closed_at
@@ -2159,7 +2159,7 @@ class PatientTest < ActiveSupport::TestCase
                      symptom_onset: DateTime.now - 1.day)
     created_at = DateTime.now.to_date - 1.day
     create(:assessment, patient_id: patient.id, symptomatic: true, created_at: created_at)
-    patient.update({isolation: false})
+    patient.update({ isolation: false })
     assert_not patient.isolation
     assert_nil patient.extended_isolation
     assert_not patient.user_defined_symptom_onset
@@ -2168,7 +2168,7 @@ class PatientTest < ActiveSupport::TestCase
 
   test 'update handles case_status change' do
     patient = create(:patient, public_health_action: 'Recommended medical evaluation of symptoms')
-    patient.update({case_status: 'Unknown'})
+    patient.update({ case_status: 'Unknown' })
     assert_equal 'Unknown', patient.case_status
     assert_equal 'None', patient.public_health_action
   end
@@ -2177,16 +2177,164 @@ class PatientTest < ActiveSupport::TestCase
     patient = create(:patient, symptom_onset: DateTime.now - 1.day)
     created_at = DateTime.now.to_date - 2.day
     create(:assessment, patient_id: patient.id, symptomatic: true, created_at: created_at)
-    patient.update({symptom_onset: nil})
+    patient.update({ symptom_onset: nil })
     assert_equal created_at, patient.symptom_onset
     assert_not patient.user_defined_symptom_onset
   end
 
   test 'update handles continuous_exposure change' do
     patient = create(:patient, monitoring: false, continuous_exposure: false)
-    patient.update({continuous_exposure: true})
+    patient.update({ continuous_exposure: true })
     # This update is not allowed when monitoring is false
     assert_not patient.continuous_exposure
+  end
+
+  # monitoring_history_edit tests
+  test 'monitoring_history_edit handles monitoring change' do
+    patient = create(:patient, monitoring: false, continuous_exposure: false)
+    history_data = {
+      patient_before: { monitoring: true, continuous_exposure: true },
+      updates: { monitoring: false },
+      patient: patient
+    }
+    patient.monitoring_history_edit(history_data, nil)
+    h = History.where(patient: patient)
+    assert_match(/Continuous Exposure/, h.find_by(created_by: 'Sara Alert System').comment)
+    assert_match(/"Monitoring" to "Not Monitoring"/, h.find_by(history_type: 'Monitoring Change').comment)
+  end
+
+  test 'monitoring_history_edit handles exposure_risk_assessment change' do
+    patient = create(:patient, exposure_risk_assessment: 'Low')
+    history_data = {
+      patient_before: { exposure_risk_assessment: 'High' },
+      updates: { exposure_risk_assessment: 'Low' },
+      patient: patient
+    }
+    patient.monitoring_history_edit(history_data, nil)
+    h = History.where(patient: patient).first
+    assert_match(/Exposure Risk Assessment.*"High".*"Low"/, h.comment)
+  end
+
+  test 'monitoring_history_edit handles monitoring_plan change' do
+    patient = create(:patient, monitoring_plan: 'None')
+    history_data = {
+      patient_before: { monitoring_plan: 'Daily active monitoring' },
+      updates: { monitoring_plan: 'None' },
+      patient: patient
+    }
+    patient.monitoring_history_edit(history_data, nil)
+    h = History.where(patient: patient).first
+    assert_match(/Monitoring Plan.*"Daily active monitoring".*"None"/, h.comment)
+  end
+
+  test 'monitoring_history_edit handles public_health_action change' do
+    patient = create(:patient, public_health_action: 'None')
+    history_data = {
+      patient_before: { public_health_action: 'Recommended laboratory testing' },
+      updates: { public_health_action: 'None' },
+      patient: patient
+    }
+    patient.monitoring_history_edit(history_data, nil)
+    h = History.where(patient: patient).first
+    assert_match(/Latest Public Health Action.*"Recommended laboratory testing".*"None"/, h.comment)
+  end
+
+  test 'monitoring_history_edit handles assigned_user change' do
+    patient = create(:patient, assigned_user: 2)
+    history_data = {
+      patient_before: { assigned_user: 1 },
+      updates: { assigned_user: 2 },
+      patient: patient
+    }
+    patient.monitoring_history_edit(history_data, nil)
+    h = History.where(patient: patient).first
+    assert_match(/Assigned User.*"1".*"2"/, h.comment)
+  end
+
+  test 'monitoring_history_edit handles pause_notifications change' do
+    patient = create(:patient, pause_notifications: false)
+    history_data = {
+      patient_before: { pause_notifications: true },
+      updates: { pause_notifications: false },
+      patient: patient
+    }
+    patient.monitoring_history_edit(history_data, nil)
+    h = History.where(patient: patient).first
+    assert_match(/resumed notifications/, h.comment)
+  end
+
+  test 'monitoring_history_edit handles last_date_of_exposure change' do
+    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
+    history_data = {
+      patient_before: { last_date_of_exposure: 6.days.ago.utc.to_date },
+      updates: { last_date_of_exposure: 7.days.ago.utc.to_date },
+      patient: patient
+    }
+    patient.monitoring_history_edit(history_data, nil)
+    h = History.where(patient: patient).first
+    assert_match(/Last Date of Exposure/, h.comment)
+  end
+
+  test 'monitoring_history_edit handles continuous_exposure change' do
+    patient = create(:patient, continuous_exposure: false)
+    history_data = {
+      patient_before: { continuous_exposure: true },
+      updates: { continuous_exposure: false },
+      patient: patient
+    }
+    patient.monitoring_history_edit(history_data, nil)
+    h = History.where(patient: patient).first
+    assert_match(/Continuous Exposure/, h.comment)
+  end
+
+  test 'monitoring_history_edit handles isolation change' do
+    patient = create(:patient, isolation: false, extended_isolation: nil, symptom_onset: 6.days.ago.utc.to_date)
+    history_data = {
+      patient_before: { isolation: true, extended_isolation: 2.days.from_now.utc.to_date, symptom_onset: 6.days.ago.utc.to_date },
+      updates: { isolation: false },
+      patient: patient
+    }
+    patient.monitoring_history_edit(history_data, nil)
+    h = History.where(patient: patient)
+    assert_match(/cleared Extended Isolation Date/, h.first.comment)
+    assert_match(/changed Symptom Onset Date/, h.second.comment)
+  end
+
+  test 'monitoring_history_edit handles symptom_onset change' do
+    patient = create(:patient, symptom_onset: 6.days.ago.utc.to_date)
+    history_data = {
+      patient_before: { symptom_onset: 7.days.ago.utc.to_date },
+      updates: { symptom_onset: 6.days.ago.utc.to_date },
+      patient: patient
+    }
+    patient.monitoring_history_edit(history_data, nil)
+    h = History.where(patient: patient).first
+    assert_match(/Symptom Onset/, h.comment)
+  end
+
+  test 'monitoring_history_edit handles case_status change' do
+    patient = create(:patient, case_status: 'Unknown', public_health_action: 'None')
+    history_data = {
+      patient_before: { case_status: 'Confirmed', public_health_action: 'Recommended laboratory testing' },
+      updates: { case_status: 'Unknown' },
+      patient: patient
+    }
+    patient.monitoring_history_edit(history_data, nil)
+    h = History.where(patient: patient)
+    assert_match(/Case Status.*"Confirmed".*"Unknown"/, h.first.comment)
+    assert_match(/Latest Public Health Action.*"Recommended laboratory testing".*"None"/, h.second.comment)
+  end
+
+  test 'monitoring_history_edit handles jurisdiction_id change' do
+    patient = create(:patient, jurisdiction_id: 2)
+    history_data = {
+      patient_before: { jurisdiction_id: 1 },
+      updates: { jurisdiction_id: 2 },
+      patient: patient
+    }
+    patient.monitoring_history_edit(history_data, nil)
+    h = History.where(patient: patient).first
+    assert_match(/Jurisdiction/, h.comment)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -2333,7 +2333,7 @@ class PatientTest < ActiveSupport::TestCase
     patient = create(:patient, case_status: 'Unknown', public_health_action: 'None', isolation: false)
     history_data = {
       patient_before: { case_status: 'Confirmed', isolation: true, public_health_action: 'Recommended laboratory testing' },
-      updates: { case_status: 'Unknown', isolation: false },
+      updates: { isolation: false, case_status: 'Unknown' },
       patient: patient
     }
     patient.monitoring_history_edit(history_data, nil)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-944](https://tracker.codev.mitre.org/browse/SARAALERT-944)

This PR consolidates the logic that existed on the `PatientsController` (specifically in the `update_fields` function) onto the `Patient` model, so that the logic can be used via both the `PatientsController`, and the `APIController`. This logic includes side effects that happen when a certain field is updated (ex: If `monitoring` is set to `false`, then `closed_at` is set), and generation of `History` items (ex: Adding a history item that indicates that `monitoring` changed).

# Important Changes
`api_controller.rb`
- Added `update_all_patient_history` function, and called it in `update` so that `History` items are generated when updates are made via the API
- Added a line to create a `Transfer` if a Patient is transferred to a new jurisdiction via the API
- Fixed the jurisdiction validation in `update` to match the logic used in the UI, a user who can transfer Patients is allowed to transfer a Patient to any other jurisdiction (that is not the `USA` root)
- Refactored the `update` function in other minor ways

`patients_controller.rb`
- Replaced the `update_fields` function with `update_monitoring_fields`, and refactored the bulk of the logic out of this function and onto the `Patient` model. The logic to update fields when side effects occur is in the `handle_update` function on the `Patient` model, which is called by the `before_update` hook. The logic to add `History` items is in the `monitoring_history_edit` function on the `Patient` model.

`assessment.rb`
- changed `update_patient_linelist_before_destroy` to `update_patient_linelist_after_destroy` and changed the hook to `after_destroy`. This was needed, because this function triggers `patient.update`, and `patient.update` would calculate `symptom_onset` incorrectly. Since the assessment had not been destroyed, it could be used when finding the most recent symptomatic assessment, which would lead to the calculated `symptom_onset` being based on an `Assessment` that was about to be destroyed.

`patient.rb`
- Added `handle_update` function which handles side effects when certain fields change (ex: if `isolation` is set to `false`, then `extended_isolation` and `user_defined_symptom_onset` are cleared, and `symptom_onset` is set to a calculated value). This function is automatically called whenever `patient.update` is called.
- Added `monitoring_history_edit` function which handles creating a history based on a change to a monitoring field, as defined by the `PatientHelper.monitoring_fields` array. This function is called manually in the `PatientsController` and `APIController`.

`Jurisdiction.js`
- Refactored so that on submission, if `jurisdiction_path` is in the `diffState`, `jurisdiction_id` is included as well.

# Testing
To test the side effects, you can test the following:
- When `monitoring` is set to `false`, `closed_at` is set to the current time, and `continuous_exposure` is set to `false` (UI and API)
- When `isolation` is set to `false`, `extended_isolation` is set to `nil`, `user_defined_symptom_onset` is set to `false`, and `symptom_onset` is set to a calculated value (UI and API)
- When `case_status` is set to `Suspect`, `Unknown` or `Not a Case`, `public_health_action` is set to `None` (UI only)
- When `symptom_onset` is set to `nil`, `user_defined_symptom_onset` is set to `false`, and `symptom_onset` is set a calculated value (UI and API)
- When `continuous_exposure` is set to `true` while `monitoring` is `false`, it should be set back to `false` (UI only)

To test the history item generation, you can test:
- For each of the first three cases above, a history message is generated indicating the update being made by the `Sara Alert System`
- For every field in the `PatientHelper.monitoring_fields` array, if the field is changed via the UI or API, a "Monitoring Change" history item is generated detailing the change