### PR TITLE
SARAALERT-1205: Format dates in custom export consistently

### DIFF
--- a/app/helpers/patient_details_helper.rb
+++ b/app/helpers/patient_details_helper.rb
@@ -49,7 +49,7 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
       closed_at: closed_at || '',
       transferred_from: latest_transfer&.from_path || '',
       transferred_to: latest_transfer&.to_path || '',
-      expected_purge_date: expected_purge_date_exp || '',
+      expected_purge_ts: expected_purge_date_exp || '',
       symptom_onset: symptom_onset&.strftime('%F') || '',
       extended_isolation: extended_isolation || ''
     }

--- a/app/helpers/patient_details_helper.rb
+++ b/app/helpers/patient_details_helper.rb
@@ -41,12 +41,12 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
       end_of_monitoring: (continuous_exposure ? 'Continuous Exposure' : end_of_monitoring) || '',
       risk_level: exposure_risk_assessment || '',
       monitoring_plan: monitoring_plan || '',
-      latest_report: latest_assessment_at&.rfc2822 || '',
-      transferred_at: latest_transfer_at&.rfc2822 || '',
+      latest_report: latest_assessment_at || '',
+      transferred_at: latest_transfer_at || '',
       reason_for_closure: monitoring_reason || '',
       public_health_action: public_health_action || '',
       status: status&.to_s&.humanize&.downcase&.gsub('exposure ', '')&.gsub('isolation ', '') || '',
-      closed_at: closed_at&.rfc2822 || '',
+      closed_at: closed_at || '',
       transferred_from: latest_transfer&.from_path || '',
       transferred_to: latest_transfer&.to_path || '',
       expected_purge_date: expected_purge_date,
@@ -177,7 +177,10 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
       head_of_household: head_of_household || false,
       pause_notifications: pause_notifications || false,
       expected_purge_ts: expected_purge_ts || '',
-      monitoring_reason: monitoring_reason || ''
+      monitoring_reason: monitoring_reason || '',
+      closed_at: closed_at || '',
+      created_at: created_at || '',
+      updated_at: updated_at || ''
     }
 
     full_history_details.merge(additional_custom_export_details)

--- a/app/helpers/patient_details_helper.rb
+++ b/app/helpers/patient_details_helper.rb
@@ -49,7 +49,7 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
       closed_at: closed_at || '',
       transferred_from: latest_transfer&.from_path || '',
       transferred_to: latest_transfer&.to_path || '',
-      expected_purge_date: expected_purge_date,
+      expected_purge_date: expected_purge_date_exp || '',
       symptom_onset: symptom_onset&.strftime('%F') || '',
       extended_isolation: extended_isolation || ''
     }
@@ -176,7 +176,7 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
       responder_id: responder_id || '',
       head_of_household: head_of_household || false,
       pause_notifications: pause_notifications || false,
-      expected_purge_ts: expected_purge_ts || '',
+      expected_purge_ts: expected_purge_date_exp || '',
       monitoring_reason: monitoring_reason || '',
       closed_at: closed_at || '',
       created_at: created_at || '',

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -629,8 +629,8 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
     patient_details[:symptom_onset_defined_by] = patient[:user_defined_symptom_onset] ? 'User' : 'System'
     patient_details[:monitoring_status] = patient[:monitoring] ? 'Actively Monitoring' : 'Not Monitoring'
     patient_details[:end_of_monitoring] = patient.end_of_monitoring || '' if fields.include?(:end_of_monitoring)
-    patient_details[:expected_purge_date] = patient.expected_purge_date || '' if fields.include?(:expected_purge_date)
-    patient_details[:expected_purge_ts] = patient.expected_purge_ts || '' if fields.include?(:expected_purge_ts)
+    patient_details[:expected_purge_date] = patient.expected_purge_date_exp || '' if fields.include?(:expected_purge_date)
+    patient_details[:expected_purge_ts] = patient.expected_purge_date_exp || '' if fields.include?(:expected_purge_ts)
     patient_details[:full_status] = patient.status&.to_s&.humanize&.downcase || '' if fields.include?(:full_status)
     patient_details[:status] = patient.status&.to_s&.humanize&.downcase&.gsub('exposure ', '')&.gsub('isolation ', '') || '' if fields.include?(:status)
 

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -48,7 +48,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
 
   LINELIST_FIELDS = %i[id name jurisdiction_name assigned_user user_defined_id_statelocal sex date_of_birth end_of_monitoring exposure_risk_assessment
                        monitoring_plan latest_assessment_at latest_transfer_at monitoring_reason public_health_action status closed_at transferred_from
-                       transferred_to expected_purge_date symptom_onset extended_isolation].freeze
+                       transferred_to expected_purge_ts symptom_onset extended_isolation].freeze
 
   LINELIST_HEADERS = ['Patient ID', 'Monitoree', 'Jurisdiction', 'Assigned User', 'State/Local ID', 'Sex', 'Date of Birth', 'End of Monitoring', 'Risk Level',
                       'Monitoring Plan', 'Latest Report', 'Transferred At', 'Reason For Closure', 'Latest Public Health Action', 'Status', 'Closed At',
@@ -629,7 +629,6 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
     patient_details[:symptom_onset_defined_by] = patient[:user_defined_symptom_onset] ? 'User' : 'System'
     patient_details[:monitoring_status] = patient[:monitoring] ? 'Actively Monitoring' : 'Not Monitoring'
     patient_details[:end_of_monitoring] = patient.end_of_monitoring || '' if fields.include?(:end_of_monitoring)
-    patient_details[:expected_purge_date] = patient.expected_purge_date_exp || '' if fields.include?(:expected_purge_date)
     patient_details[:expected_purge_ts] = patient.expected_purge_date_exp || '' if fields.include?(:expected_purge_ts)
     patient_details[:full_status] = patient.status&.to_s&.humanize&.downcase || '' if fields.include?(:full_status)
     patient_details[:status] = patient.status&.to_s&.humanize&.downcase&.gsub('exposure ', '')&.gsub('isolation ', '') || '' if fields.include?(:status)

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -610,7 +610,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
     end
 
     PATIENT_FIELD_TYPES[:timestamps].each do |field|
-      patient_details[field] = patient[field]&.rfc2822 || '' if fields.include?(field)
+      patient_details[field] = patient[field] || '' if fields.include?(field)
     end
 
     PATIENT_FIELD_TYPES[:booleans].each do |field|

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -613,15 +613,19 @@ class Patient < ApplicationRecord
     return (created_at.to_date + ADMIN_OPTIONS['monitoring_period_days'].days)&.to_s if created_at.present?
   end
 
-  # Date when patient is expected to be purged (with timezone displayed as 'UTC')
+  # Date when patient is expected to be purged (without any formatting)
   def expected_purge_ts
-    monitoring ? '' : (updated_at + ADMIN_OPTIONS['purgeable_after'].minutes) || ''
+    monitoring ? nil : (updated_at + ADMIN_OPTIONS['purgeable_after'].minutes)
   end
 
   # Date when patient is expected to be purged (with timezone displayed as '+00:00')
   def expected_purge_date
-    exp_purge_ts = expected_purge_ts # avoid calling expected_purge_ts twice
-    exp_purge_ts.blank? ? '' : exp_purge_ts.rfc2822
+    expected_purge_ts&.rfc2822 || ''
+  end
+
+  # Date when patient is expected to be purged (with timezone displayed as 'UTC' for export)
+  def expected_purge_date_exp
+    expected_purge_ts&.strftime('%F %T %Z') || ''
   end
 
   # Determine if this patient's phone number has blocked communication with SaraAlert

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -371,7 +371,7 @@ namespace :demo do
       patient[:case_status] = patient[:isolation] ? ['Confirmed', 'Probable'].sample : ['Suspect', 'Unknown', 'Not a Case', nil].sample
       patient[:monitoring] = rand < 0.95
       patient[:closed_at] = patient[:updated_at] unless patient[:monitoring]
-      patient[:monitoring_reason] = ValidationHelper::VALID_PATIENT_ENUMS[:monitoring_reason].sample unless patient[:monitoring].nil?
+      patient[:monitoring_reason] = ValidationHelper::VALID_PATIENT_ENUMS[:monitoring_reason].sample if patient[:monitoring].nil?
       patient[:public_health_action] = patient[:isolation] || rand < 0.8 ? 'None' : ValidationHelper::VALID_PATIENT_ENUMS[:public_health_action].sample
       patient[:pause_notifications] = rand < 0.1
       patient[:last_assessment_reminder_sent] = today - rand(7).days if rand < 0.3

--- a/test/system/roles/public_health/dashboard/export_verifier.rb
+++ b/test/system/roles/public_health/dashboard/export_verifier.rb
@@ -330,8 +330,6 @@ class PublicHealthMonitoringExportVerifier < ApplicationSystemTestCase
         elsif field == :creator
           responder_email = User.find(patient.creator_id).email
           assert_equal(responder_email, cell_value, "For field: #{field} in Monitorees List (row #{row + 1})")
-        elsif %i[created_at updated_at closed_at].include?(field)
-          assert_equal(patient[field] || '', cell_value || '', "For field: #{field} in Monitorees List (row #{row + 1})")
         else
           assert_equal(patient_details[field].to_s, cell_value || '', "For field: #{field} in Monitorees List (row #{row + 1})")
         end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1205](https://tracker.codev.mitre.org/browse/SARAALERT-1205)

The timestamps for fields in exports are not consistently formatted. The PO team would like them to be consistent and the desired format is `YYYY-MM-DD hh:mm:ss UTC`.

- [x] verify desired format with PO team
- [x] update format of these dates and verify that all others are consistent as well

# (Bugfix) How to Replicate
Perform a custom export, csv export, and comprehensive export and take a look at the timestamps.

# (Bugfix) Solution
Remove the `rfc2822` formatting for timestamps.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
