### PR TITLE
SARAALERT-1154: Analytics Transfer Data is inconsistent

### DIFF
--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -381,6 +381,7 @@ class CacheAnalyticsJob < ApplicationJob
                                                    .enrolled_in_time_frame(time_frame)
                                                    .size,
                         transferred_in: Transfer.where(to_jurisdiction_id: subjur_ids)
+                                                .where.not(from_jurisdiction_id: subjur_ids)
                                                 .where_assoc_exists(:patient, isolation: workflow == 'Isolation')
                                                 .in_time_frame(time_frame)
                                                 .size,
@@ -389,6 +390,7 @@ class CacheAnalyticsJob < ApplicationJob
                                           .closed_in_time_frame(time_frame)
                                           .size,
                         transferred_out: Transfer.where(from_jurisdiction_id: subjur_ids)
+                                                 .where.not(to_jurisdiction_id: subjur_ids)
                                                  .where_assoc_exists(:patient, isolation: workflow == 'Isolation')
                                                  .in_time_frame(time_frame)
                                                  .size,

--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -380,6 +380,7 @@ class CacheAnalyticsJob < ApplicationJob
                         new_enrollments: monitorees.where(isolation: workflow == 'Isolation')
                                                    .enrolled_in_time_frame(time_frame)
                                                    .size,
+                        # only transfers from outside this jurisdiction's hierarchy to a jurisdiction within this jurisdiction's hierarchy are included
                         transferred_in: Transfer.where(to_jurisdiction_id: subjur_ids)
                                                 .where.not(from_jurisdiction_id: subjur_ids)
                                                 .where_assoc_exists(:patient, isolation: workflow == 'Isolation')
@@ -389,6 +390,7 @@ class CacheAnalyticsJob < ApplicationJob
                                           .monitoring_closed
                                           .closed_in_time_frame(time_frame)
                                           .size,
+                        # only transfers from within this jurisdiction's hierarchy to a jurisdiction outside this jurisdiction's hierarchy are included
                         transferred_out: Transfer.where(from_jurisdiction_id: subjur_ids)
                                                  .where.not(to_jurisdiction_id: subjur_ids)
                                                  .where_assoc_exists(:patient, isolation: workflow == 'Isolation')

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -22,16 +22,6 @@ class Transfer < ApplicationRecord
     to_jurisdiction[:path] || to_jurisdiction.jurisdiction_path_string
   end
 
-  # All incoming transfers with the given jurisdiction id
-  scope :with_incoming_jurisdiction_id, lambda { |jurisdiction_id|
-    where('to_jurisdiction_id = ?', jurisdiction_id)
-  }
-
-  # All outgoing transfers with the given jurisdiction id
-  scope :with_outgoing_jurisdiction_id, lambda { |jurisdiction_id|
-    where('from_jurisdiction_id = ?', jurisdiction_id)
-  }
-
   # All transfers within the given time frame
   scope :in_time_frame, lambda { |time_frame|
     case time_frame

--- a/test/models/transfer_test.rb
+++ b/test/models/transfer_test.rb
@@ -150,32 +150,6 @@ class TransferTest < ActiveSupport::TestCase
     assert_equal(transfer.to_path, to_jurisdiction.jurisdiction_path_string)
   end
 
-  test 'with incoming jurisdiction id' do
-    to_jurisdiction = create(:jurisdiction)
-
-    assert_difference("Transfer.with_incoming_jurisdiction_id(#{to_jurisdiction.id}).size", 1) do
-      create(:transfer, to_jurisdiction: to_jurisdiction)
-    end
-
-    assert_no_difference("Transfer.with_incoming_jurisdiction_id(#{to_jurisdiction.id}).size") do
-      create(:transfer)
-    end
-  end
-
-  test 'with outgoing jurisdiction id' do
-    from_jurisdiction = create(:jurisdiction)
-
-    assert_difference("Transfer.with_outgoing_jurisdiction_id(#{from_jurisdiction.id}).size", 1) do
-      transfer = build(:transfer)
-      transfer.from_jurisdiction = from_jurisdiction
-      transfer.save!
-    end
-
-    assert_no_difference("Transfer.with_outgoing_jurisdiction_id(#{from_jurisdiction.id}).size") do
-      create(:transfer)
-    end
-  end
-
   test 'transfer in time frame' do
     assert_no_difference("Transfer.in_time_frame('Invalid').size") do
       create(:transfer)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1154](https://tracker.codev.mitre.org/browse/SARAALERT-1154)

Transfer columns do not include sub-jurisdictions which needs to be changed to include them.

# (Bugfix) How to Replicate
Transfer a monitoree from `USA, State 1, County 1` to `USA, State 1, County 2`, view analytics before and after running analytics and notice that the transfer numbers do not change.

# (Bugfix) Solution
- query transfers from jurisdiction subtree instead of only the immediate jurisdiction

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
