### PR TITLE
SARAALERT-1045: Bug fix - Case Status Bulk Action Modal default value

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -550,6 +550,15 @@ class PatientsController < ApplicationController
     diffs
   end
 
+  # Returns case status value(s) of the selected patient(s) so bulk update modal displays correct default value
+  def current_case_status
+    redirect_to(root_url) && return unless current_user.can_edit_patient?
+
+    patient_ids = params[:patient_ids]
+    patients = current_user.viewable_patients.where(id: patient_ids)
+    render json: { case_status: patients.pluck(:case_status), isolation: patients.pluck(:isolation), monitoring: patients.pluck(:monitoring) }
+  end
+
   # Parameters allowed for saving to database
   def allowed_params
     params.require(:patient).permit(

--- a/app/javascript/components/public_health/actions/UpdateCaseStatus.js
+++ b/app/javascript/components/public_health/actions/UpdateCaseStatus.js
@@ -26,27 +26,36 @@ class UpdateCaseStatus extends React.Component {
   }
 
   componentDidMount() {
-    const distinctCaseStatus = [...new Set(this.props.patients.map(x => x.case_status))];
-    const distinctIsolation = [...new Set(this.props.patients.map(x => x.isolation))];
-    const distinctMonitoring = [...new Set(this.props.patients.map(x => x.monitoring))];
+    axios
+      .post('/patients/current_case_status/', {
+        patient_ids: this.props.patients.map(x => x.id),
+      })
+      .then(response => {
+        const distinctCaseStatus = [...new Set(response.data.case_status)];
+        const distinctIsolation = [...new Set(response.data.isolation)];
+        const distinctMonitoring = [...new Set(response.data.monitoring)];
 
-    var state_updates = {};
-    if (distinctCaseStatus.length === 1 && distinctCaseStatus[0] !== null) {
-      state_updates.initialCaseStatus = distinctCaseStatus[0];
-      state_updates.caseStatus = distinctCaseStatus[0];
-    }
-    if (distinctIsolation.length === 1 && distinctIsolation[0] !== null) {
-      state_updates.initialIsolation = distinctIsolation[0];
-      state_updates.isolation = distinctIsolation[0];
-    }
-    if (distinctMonitoring.length === 1 && distinctMonitoring[0] !== null) {
-      state_updates.initialMonitoring = distinctMonitoring[0];
-      state_updates.monitoring = distinctMonitoring[0];
-    }
+        var state_updates = {};
+        if (distinctCaseStatus.length === 1 && distinctCaseStatus[0] !== null) {
+          state_updates.initialCaseStatus = distinctCaseStatus[0];
+          state_updates.case_status = distinctCaseStatus[0];
+        }
+        if (distinctIsolation.length === 1 && distinctIsolation[0] !== null) {
+          state_updates.initialIsolation = distinctIsolation[0];
+          state_updates.isolation = distinctIsolation[0];
+        }
+        if (distinctMonitoring.length === 1 && distinctMonitoring[0] !== null) {
+          state_updates.initialMonitoring = distinctMonitoring[0];
+          state_updates.monitoring = distinctMonitoring[0];
+        }
 
-    if (Object.keys(state_updates).length) {
-      this.setState(state_updates);
-    }
+        if (Object.keys(state_updates).length) {
+          this.setState(state_updates);
+        }
+      })
+      .catch(error => {
+        reportError(error);
+      });
   }
 
   handleChange(event) {

--- a/app/javascript/components/public_health/actions/UpdateCaseStatus.js
+++ b/app/javascript/components/public_health/actions/UpdateCaseStatus.js
@@ -35,7 +35,7 @@ class UpdateCaseStatus extends React.Component {
         const distinctIsolation = [...new Set(response.data.isolation)];
         const distinctMonitoring = [...new Set(response.data.monitoring)];
 
-        var state_updates = {};
+        const state_updates = {};
         if (distinctCaseStatus.length === 1 && distinctCaseStatus[0] !== null) {
           state_updates.initialCaseStatus = distinctCaseStatus[0];
           state_updates.case_status = distinctCaseStatus[0];

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,7 @@ Rails.application.routes.draw do
   post '/patients/:id/status/clear', to: 'patients#clear_assessments'
   post '/patients/:id/status/clear/:assessment_id', to: 'patients#clear_assessment'
   post '/patients/:id/update_hoh', to: 'patients#update_hoh'
+  post '/patients/current_case_status', to: 'patients#current_case_status'
 
   resources :patients, param: :submission_token do
     resources :assessments, only: [:create, :new, :index]


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1045](https://tracker.codev.mitre.org/browse/SARAALERT-1045)

If one or more monitorees are selected for bulk actions and the Case Status bulk action is selected, the resulting modal was not displaying the currently selected value for the monitoree(s). Expected behavior is that a default value should be displayed if (1) a single monitoree is selected or (2) multiple moniotrees are selected and they all hold the same case status value. This PR addresses this issue so a default value is correctly displayed in these situations

![image](https://user-images.githubusercontent.com/42656458/105089521-3f019180-5a6b-11eb-8f86-9b56d35906c9.png)

# (Bugfix) How to Replicate

1. In the Patient Table view, select a monitoree for bulk actions that is known to have a Cases Status value that is not blank.
2. In the Bulk Actions drop down, select Case Status.
3. In the resulting modal, observe that the default value is blank and doesn't display the monitorees current case status value.

# (Bugfix) Solution
Monitoree case status information was not readily available from the data in the Patient Table as the modal was expecting. A new route was created to query the backend for the case status information for the selected monitorees so the modal is able to correctly determine which default value to display. 

# Important Changes

`app/controllers/patients_controller.rb`
- Function that grabs and returns the following data elements for certain selected monitorees: `case_status`, `isolation`, and `monitoring`

`app/javascript/components/public_health/actions/UpdateCaseStatus.js`
- Included a call to the backend to retrieve the case status information so the modal can determine which default value to display.

`config/routes.rb`
- New route to retrieve case status data so the bulk action modal can display the correct default value

# Testing
This fix was tested on the following browsers:
* [x] Chrome
* [x] Firefox
* [ ] Safari
* [ ] IE11

* [ ] Select one monitoree on the dashboard, open the Bulk Actions Case Status modal & confirm the correct default value is displayed --> Test this for a few monitorees each with a different case status.
* [ ] Select 2 or more monitorees that you know have the same case status, open the Bulk Actions Case Status modal & confirm the correct default value is displayed --> Test this for a few monitorees each with a different case status.
* [ ] Select 2 or more monitorees that you know have different case statuses, open the Bulk Actions Case Status modal & confirm the modal displays the blank Case Status option by default & the "Submit" button is enabled. 
