### PR TITLE
SARAALERT-1231: Reports Table Component Permissions

### DIFF
--- a/app/javascript/components/assessment/AssessmentTable.js
+++ b/app/javascript/components/assessment/AssessmentTable.js
@@ -321,7 +321,7 @@ class AssessmentTable extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Card className="mx-2 mt-3 mb-4 card-square">
+        <Card id="assessments-table" className="mx-2 mt-3 mb-4 card-square">
           <Card.Header className="h5">Reports</Card.Header>
           <Card.Body>
             <div className="mt-4">

--- a/app/javascript/components/history/HistoryComponent.js
+++ b/app/javascript/components/history/HistoryComponent.js
@@ -116,7 +116,7 @@ class HistoryComponent extends React.Component {
     const historiesArray = this.state.pageOfHistories.map(history => <History key={history.id} history={history} />);
     return (
       <React.Fragment>
-        <Card className="mx-2 mt-3 mb-4 card-square">
+        <Card id="histories" className="mx-2 mt-3 mb-4 card-square">
           <Card.Header>
             <div className="d-flex flex-row align-items-center">
               <div className="float-left flex-grow-1 mb-0 h5">

--- a/app/javascript/components/patient/PatientPage.js
+++ b/app/javascript/components/patient/PatientPage.js
@@ -20,7 +20,7 @@ class PatientPage extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Card className="mx-2 card-square">
+        <Card id="patient-page" className="mx-2 card-square">
           <Card.Header
             className="h5"
             id="patient-info-header"

--- a/app/javascript/components/subject/DownloadMonitoree.js
+++ b/app/javascript/components/subject/DownloadMonitoree.js
@@ -60,7 +60,7 @@ class DownloadMonitoreeExcel extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Button className="mx-2 mt-1 mb-4" onClick={this.downloadExcel} disabled={this.state.loadingExcel}>
+        <Button id="monitoree-excel-export" className="mx-2 mt-1 mb-4" onClick={this.downloadExcel} disabled={this.state.loadingExcel}>
           <i className="fas fa-download"></i> Download Excel Export
           {this.state.loadingExcel && (
             <React.Fragment>
@@ -68,7 +68,7 @@ class DownloadMonitoreeExcel extends React.Component {
             </React.Fragment>
           )}
         </Button>
-        <Button className="mx-1 mt-1 mb-4" onClick={this.downloadNBS} disabled={this.state.loadingNBS}>
+        <Button id="monitoree-nbs-export" className="mx-1 mt-1 mb-4" onClick={this.downloadNBS} disabled={this.state.loadingNBS}>
           <i className="fas fa-download"></i> Download NBS Export
           {this.state.loadingNBS && (
             <React.Fragment>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -20,7 +20,7 @@
                     }) %>
 
 <% if current_user.can_modify_subject_status? %>
-<div class="card mx-2 mt-4 mb-4 card-square">
+<div id="monitoring-actions" class="card mx-2 mt-4 mb-4 card-square">
   <div class="card-header h5">Monitoring Actions</div>
   <%= react_component('subject/monitoring_actions/MonitoringActions', {
                         current_user: current_user,
@@ -36,24 +36,26 @@
 </div>
 <% end %>
 
-<%reporting_condition = @patient.jurisdiction.hierarchical_condition_unpopulated_symptoms%>
-<%= react_component('assessment/AssessmentTable', {
-                      patient: @patient,
-                      is_household_member: @household_members.count > 1,
-                      report_eligibility: @patient.report_eligibility,
-                      patient_status: @patient.status,
-                      calculated_age: @patient.calc_current_age,
-                      patient_initials: @patient.initials,
-                      symptoms: reporting_condition.symptoms,
-                      threshold_condition_hash: reporting_condition.threshold_condition_hash,
-                      monitoring_period_days: ADMIN_OPTIONS['monitoring_period_days'].to_i,
-                      current_user: current_user,
-                      translations: Assessment.new.translations,
-                      authenticity_token: form_authenticity_token
-                    }) %>
+<% if current_user.can_view_patient_assessments? %>
+  <%reporting_condition = @patient.jurisdiction.hierarchical_condition_unpopulated_symptoms%>
+  <%= react_component('assessment/AssessmentTable', {
+                        patient: @patient,
+                        is_household_member: @household_members.count > 1,
+                        report_eligibility: @patient.report_eligibility,
+                        patient_status: @patient.status,
+                        calculated_age: @patient.calc_current_age,
+                        patient_initials: @patient.initials,
+                        symptoms: reporting_condition.symptoms,
+                        threshold_condition_hash: reporting_condition.threshold_condition_hash,
+                        monitoring_period_days: ADMIN_OPTIONS['monitoring_period_days'].to_i,
+                        current_user: current_user,
+                        translations: Assessment.new.translations,
+                        authenticity_token: form_authenticity_token
+                      }) %>
+<% end %>
 
 <% if current_user.can_view_patient_laboratories? %>
-<div class="card mx-2 mt-3 mb-4 card-square">
+<div id="labs-table" class="card mx-2 mt-3 mb-4 card-square">
   <div class="card-header h5">
     Lab Results
     <%= react_component('util/InfoTooltip', { tooltipTextKey: 'labResults', location: 'right' }, { style: 'display:inline' }) %>
@@ -100,7 +102,7 @@
 <% end %>
 
 <% if current_user.can_view_patient_close_contacts? %>
-<div class="card mx-2 mt-3 mb-4 card-square">
+<div id="close-contacts-table" class="card mx-2 mt-3 mb-4 card-square">
   <div class="card-header h5">
     Close Contacts
     <%= react_component('util/InfoTooltip', { tooltipTextKey: 'closeContacts', location: 'right' }, { style: 'display:inline' }) %>

--- a/test/system/roles/enroller/enroller_dashboard_test.rb
+++ b/test/system/roles/enroller/enroller_dashboard_test.rb
@@ -41,4 +41,9 @@ class EnrollerDashboardTest < ApplicationSystemTestCase
   test 'cancel enrollment' do
     @@enroller_test_helper.enroll_monitoree_and_cancel('locals2c3_enroller', 'monitoree_10')
   end
+
+  test 'monitoree page permissions' do
+    @@enroller_test_helper.verify_patient_page_permissions('state1_enroller')
+    @@enroller_test_helper.verify_patient_page_permissions('state1_epi_enroller')
+  end
 end

--- a/test/system/roles/enroller/enroller_test_helper.rb
+++ b/test/system/roles/enroller/enroller_test_helper.rb
@@ -18,6 +18,7 @@ class EnrollerTestHelper < ApplicationSystemTestCase
   @@system_test_utils = SystemTestUtils.new(nil)
 
   MONITOREES = @@system_test_utils.monitorees
+  USERS = @@system_test_utils.users
 
   def view_enrolled_monitorees(user_label)
     @@system_test_utils.login(user_label)
@@ -104,6 +105,19 @@ class EnrollerTestHelper < ApplicationSystemTestCase
     @@system_test_utils.wait_for_pop_up_alert
     page.driver.browser.switch_to.alert.accept
     @@enroller_dashboard_verifier.verify_monitoree_info_not_on_dashboard(monitoree, is_epi: is_epi)
+    @@system_test_utils.logout
+  end
+
+  def verify_patient_page_permissions(user_label)
+    user = User.find_by(email: USERS[user_label]['email'])
+    monitoree = user.patients.first
+
+    # Login and click on a monitoree
+    @@system_test_utils.login(user_label)
+    displayed_name = "#{monitoree.last_name}, #{monitoree.first_name}"
+    click_on displayed_name
+
+    @@enroller_patient_page_verifier.verify_monitoree_displayed_data(user)
     @@system_test_utils.logout
   end
 

--- a/test/system/roles/enroller/patient_page/patient_page_verifier.rb
+++ b/test/system/roles/enroller/patient_page/patient_page_verifier.rb
@@ -48,4 +48,44 @@ class EnrollerPatientPageVerifier < ApplicationSystemTestCase
       end
     end
   end
+
+  # Verifies that only components the user has access to are rendered.
+  def verify_monitoree_displayed_data(user)
+    if user.can_download_monitoree_data?
+      assert_selector('#monitoree-excel-export', count: 1)
+      assert_selector('#monitoree-nbs-export', count: 1)
+    else
+      assert_no_selector('#monitoree-excel-export')
+      assert_no_selector('#monitoree-nbs-export')
+    end
+
+    # Everyone has access to patient details
+    assert_selector('#patient-page')
+
+    if user.can_view_patient_assessments?
+      assert_selector('#assessments-table', count: 1)
+    else
+      assert_no_selector('#assessments-table')
+    end
+
+    if user.can_view_patient_laboratories?
+      assert_selector('#labs-table', count: 1)
+    else
+      assert_no_selector('#labs-table')
+    end
+
+    if user.can_view_patient_close_contacts?
+      assert_selector('#close-contacts-table', count: 1)
+    else
+      assert_no_selector('#close-contacts-table')
+    end
+
+    if user.can_modify_subject_status?
+      assert_selector('#histories', count: 1)
+      assert_selector('#monitoring-actions', count: 1)
+    else
+      assert_no_selector('#monitoring-actions')
+      assert_no_selector('#histories')
+    end
+  end
 end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1231](https://tracker.codev.mitre.org/browse/SARAALERT-1231)

When the reports table was refactored as part of 1.19.0, the frontend check to not render the component unless the user can view assessments was not added back in. This means roles that don't have access (such as Enrollers) see an empty reports table. It never loads the assessments for these roles as we have additional checks on the backend, but it still renders an empty table with the create, log, and pause action buttons. It doesn’t allow these roles to create a report or log a contact attempt, but it does allow them to pause/resume notifications.

This PR fixes the above and also adds system tests to check the patient page rendered components for Enrollers (hence the added IDs for easy selection).

# How to Replicate
Login as an an Enroller or any other role that doesn't have access to the assessments and notice it shows up as an empty table on a monitoree page.

# Solution
Add back check for permissions before rendering component.

# Important Changes
`app/views/patients/show.html.erb`
- Added back permissions check around reports table component.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

View patient page as a role that does not have access to the assessments and verify the component is no longer rendered.
