### PR TITLE
SARAALERT-1192: Performance testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ sara_database_*
 
 # Ignore temporary excel files
 ~$*
+
+# JMeter
+*.jmx
+*.jtl
+*.hprof
+jmeter.log

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@
 stages:
   - create-image-1
   - create-image-2
+  - benchmarking
 
 build-push-development-test-image:
   stage: create-image-1
@@ -44,3 +45,80 @@ build-push-staging-nginx-image:
     - docker build -f Nginx.Dockerfile --tag $ARTIFACTORY_HOST/$ARTIFACTORY_NAMESPACE_1/$ARTIFACTORY_NAMESPACE_3:latest --build-arg sara_alert_image="$ARTIFACTORY_HOST/$ARTIFACTORY_NAMESPACE_1/$ARTIFACTORY_NAMESPACE_2:latest" .
     - docker push $ARTIFACTORY_HOST/$ARTIFACTORY_NAMESPACE_1/$ARTIFACTORY_NAMESPACE_3:latest
   allow_failure: false
+
+
+jmeter-benchmark:
+  stage: benchmarking
+  artifacts:
+    paths:
+      - jmeter.jtl
+    expire_in: 1 week
+    when: always
+  tags:
+    - sara-perf-shell
+  except:
+    - schedules
+  cache:
+    policy: pull-push
+    paths:
+      - public/assets/
+      - public/packs/
+      - public/packs-test/
+      - node_modules/
+  script:
+    - bundle install
+    - yarn install
+    - bundle exec rails assets:precompile
+    # Expect around 25 minutes to populate a new DB
+    - rails db:migrate || (mysql --user=disease_trakker -e 'CREATE DATABASE IF NOT EXISTS disease_trakker_development;'; bundle exec rails db:drop; bundle exec rails db:create; mysql --user=disease_trakker disease_trakker_development < /home/gitlab-runner/sara_database_1607023723.sql; bundle exec rails db:migrate)
+    - ./script/run_jmeter_tests.sh
+
+send-assessments-job-benchmark:
+  stage: benchmarking
+  artifacts:
+    paths:
+      - script/benchmarks/output/SendAssessmentsJob_*
+    expire_in: 1 week
+    when: always
+  tags:
+    - sara-perf-shell
+  except:
+    - schedules
+  only:
+    - master
+    - /^[0-9]{1,}(\.[0-9]{1,})+$/
+    - $SEND_ASSESSMENT_BMK != null
+    - SA-1192/perfTestFixed
+  variables:
+    CAP_STDOUT: "true"
+    NO_MEMPROF: "true"
+  script:
+    - bundle install
+    # Expect around 25 minutes to populate a new DB
+    - rails db:migrate || (mysql --user=disease_trakker -e 'CREATE DATABASE IF NOT EXISTS disease_trakker_development;'; bundle exec rails db:drop; bundle exec rails db:create; mysql --user=disease_trakker disease_trakker_development < /home/gitlab-runner/sara_database_1607023723.sql; bundle exec rails db:migrate)
+    - ruby ./script/benchmarks/send_assessments_job_benchmark.rb
+
+close-patients-job-benchmark:
+  stage: benchmarking
+  artifacts:
+    paths:
+      - script/benchmarks/output/ClosePatientsJob_*
+    expire_in: 1 week
+    when: always
+  tags:
+    - sara-perf-shell
+  except:
+    - schedules
+  only:
+    - master
+    - /^[0-9]{1,}(\.[0-9]{1,})+$/
+    - $SEND_ASSESSMENT_BMK != null
+    - SA-1192/perfTestFixed
+  variables:
+    CAP_STDOUT: "true"
+    NO_MEMPROF: "true"
+  script:
+    - bundle install
+    # Expect around 25 minutes to populate a new DB
+    - rails db:migrate || (mysql --user=disease_trakker -e 'CREATE DATABASE IF NOT EXISTS disease_trakker_development;'; bundle exec rails db:drop; bundle exec rails db:create; mysql --user=disease_trakker disease_trakker_development < /home/gitlab-runner/sara_database_1607023723.sql; bundle exec rails db:migrate)
+    - ruby ./script/benchmarks/close_patients_job_benchmark.rb

--- a/Gemfile
+++ b/Gemfile
@@ -107,13 +107,17 @@ gem 'audited'
 gem 'order_as_specified'
 
 group :development, :test do
+  gem 'benchmark-ips'
   gem 'brakeman'
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'erb_lint'
   gem 'factory_bot_rails'
   gem 'ffi-hunspell'
   gem 'gemsurance'
+  gem 'memory_profiler'
   gem 'rubocop'
+  gem 'ruby-jmeter'
+  gem 'stackprof'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
     bcp47 (0.3.3)
       i18n
     bcrypt (3.1.16)
+    benchmark-ips (2.8.4)
     better_html (1.0.16)
       actionview (>= 4.0)
       activesupport (>= 4.0)
@@ -137,6 +138,8 @@ GEM
       devise (>= 4.3.0, < 5.0)
     diff-lcs (1.4.4)
     docile (1.3.5)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     doorkeeper (5.4.0)
       railties (>= 5)
     ecma-re-validator (0.3.0)
@@ -185,6 +188,9 @@ GEM
     hana (1.3.7)
     html_tokenizer (0.0.7)
     htmlentities (4.3.4)
+    http-accept (1.7.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     httpclient (2.8.3)
     i18n (1.8.8)
       concurrent-ruby (~> 1.0)
@@ -212,6 +218,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
+    memory_profiler (1.0.0)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -227,6 +234,7 @@ GEM
     multi_json (1.15.0)
     multipart-post (2.1.1)
     mysql2 (0.5.3)
+    netrc (0.11.0)
     newrelic_rpm (6.15.0)
     nio4r (2.5.5)
     nokogiri (1.11.1)
@@ -301,6 +309,11 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.4)
     roo (2.8.3)
       nokogiri (~> 1)
@@ -320,6 +333,9 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
+    ruby-jmeter (3.1.08)
+      nokogiri
+      rest-client
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.4)
     ruby_dep (1.5.0)
@@ -364,6 +380,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    stackprof (0.2.16)
     thor (1.1.0)
     tilt (2.0.10)
     timecop (0.9.4)
@@ -373,6 +390,9 @@ GEM
       nokogiri (>= 1.6, < 2.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.7)
     unicode-display_width (2.0.0)
     uniform_notifier (1.13.2)
     uri_template (0.7.0)
@@ -413,6 +433,7 @@ DEPENDENCIES
   activerecord_where_assoc
   ancestry
   audited
+  benchmark-ips
   bootsnap (>= 1.4.2)
   brakeman
   bullet
@@ -436,6 +457,7 @@ DEPENDENCIES
   letter_opener
   listen (>= 3.0.5, < 3.2)
   local_time
+  memory_profiler
   minitest-retry
   mocha
   mysql2 (>= 0.4.4)
@@ -452,6 +474,7 @@ DEPENDENCIES
   roo
   rspec-mocks
   rubocop
+  ruby-jmeter
   rubyzip
   sara-schema
   sass-rails (>= 6)
@@ -463,6 +486,7 @@ DEPENDENCIES
   simplecov-lcov
   spring
   spring-watcher-listen (~> 2.0.0)
+  stackprof
   timecop
   twilio-ruby
   tzinfo-data

--- a/script/assert_jmeter_results.rb
+++ b/script/assert_jmeter_results.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+config = [
+  {
+    label: '01_01_SA_visit_sign_in',
+    failure_thresholds: {}
+  },
+  {
+    label: '01_02_SA_sign_in',
+    failure_thresholds: {}
+  },
+  {
+    label: '01_03_SA_dashboard',
+    failure_thresholds: {
+      avg_latency: 4_000,
+      avg_elapsed: 4_000,
+      failure_percent: 0
+    }
+  },
+  {
+    label: '01_04_SA_assigned_users',
+    failure_thresholds: {
+      avg_latency: 32_000,
+      max_latency: 60_000,
+      avg_elapsed: 32_000,
+      max_elapsed: 60_000,
+      failure_percent: 0
+    }
+  },
+  {
+    label: '01_05_SA_patients',
+    failure_thresholds: {
+      avg_latency: 10_000,
+      max_latency: 15_000,
+      avg_elapsed: 10_000,
+      max_elapsed: 15_000,
+      failure_percent: 0
+    }
+  }
+]
+
+jtl_path = ENV['JTL_PATH'] || 'jmeter.jtl'
+jtl_rows = CSV.read(jtl_path, headers: true)
+
+# rows that do not end with (-0 ... -000)
+jtl_rows.filter { |a| a['label'] !~ /-\d{1,}/ }
+
+# https://stackoverflow.com/questions/36156305/console-table-format-in-ruby
+class Array
+  def to_table
+    column_sizes = reduce([]) do |lengths, row|
+      row.each_with_index.map { |iterand, index| [lengths[index] || 0, iterand.to_s.length].max }
+    end
+    puts head = '-' * (column_sizes.inject(&:+) + (3 * column_sizes.count) + 1)
+    each do |row|
+      row.fill(nil, row.size..(column_sizes.size - 1))
+      row = row.each_with_index.map { |v, i| v.to_s + ' ' * (column_sizes[i] - v.to_s.length) }
+      puts '| ' + row.join(' | ') + ' |'
+    end
+    puts head
+  end
+end
+
+def rows_stats(rows)
+  {
+    avg_latency: rows.map { |row| row['Latency'].to_i }.sum / rows.size,
+    max_latency: rows.map { |row| row['Latency'].to_i }.max,
+    avg_elapsed: rows.map { |row| row['elapsed'].to_i }.sum / rows.size,
+    max_elapsed: rows.map { |row| row['elapsed'].to_i }.max,
+    failure_percent: rows.filter { |row| row['success'] != 'true' }.size / rows.size
+  }
+end
+
+def compare(rows, cfg)
+  rows = rows.filter { |row| row['label'] == cfg[:label] }
+  actual = rows_stats(rows)
+  thresholds = cfg[:failure_thresholds]
+  any_failure = (
+    (thresholds[:avg_latency] && actual[:avg_latency] > thresholds[:avg_latency]) ||
+    (thresholds[:max_latency] && actual[:max_latency] > thresholds[:max_latency]) ||
+    (thresholds[:avg_elapsed] && actual[:avg_elapsed] > thresholds[:avg_elapsed]) ||
+    (thresholds[:max_elapsed] && actual[:max_elapsed] > thresholds[:max_elapsed]) ||
+    (thresholds[:failure_percent] && actual[:failure_percent] > thresholds[:failure_percent])
+  )
+
+  puts 'TEST FAILURE' if any_failure
+  [
+    [
+      cfg[:label].ljust(30, ' ')
+    ],
+    [
+      '',
+      'Avg Latency',
+      'Max Latency',
+      'Avg Elapsed',
+      'Max Elapsed',
+      ' Failure % '
+    ],
+    [
+      'Actual',
+      "#{actual[:avg_latency].to_s.rjust(8, ' ')} ms",
+      "#{actual[:max_latency].to_s.rjust(8, ' ')} ms",
+      "#{actual[:avg_elapsed].to_s.rjust(8, ' ')} ms",
+      "#{actual[:max_elapsed].to_s.rjust(8, ' ')} ms",
+      "#{actual[:failure_percent].to_s.rjust(9, ' ')} %"
+    ],
+    [
+      'Threshold',
+      "#{thresholds[:avg_latency].to_s.rjust(8, ' ') || '-'} ms",
+      "#{thresholds[:max_latency].to_s.rjust(8, ' ') || '-'} ms",
+      "#{thresholds[:avg_elapsed].to_s.rjust(8, ' ') || '-'} ms",
+      "#{thresholds[:max_elapsed].to_s.rjust(8, ' ') || '-'} ms",
+      "#{thresholds[:failure_percent].to_s.rjust(9, ' ') || '-'} %"
+    ]
+  ].to_table
+
+  any_failure
+end
+
+comparisons = config.map { |cfg| compare(jtl_rows, cfg) }
+all_rows_stats = rows_stats(jtl_rows)
+[
+  [
+    'ALL STATS'.ljust(30, ' ')
+  ],
+  [
+    '',
+    'Avg Latency',
+    'Max Latency',
+    'Avg Elapsed',
+    'Max Elapsed',
+    ' Failure % '
+  ],
+  [
+    'Actual',
+    "#{all_rows_stats[:avg_latency].to_s.rjust(8, ' ')} ms",
+    "#{all_rows_stats[:max_latency].to_s.rjust(8, ' ')} ms",
+    "#{all_rows_stats[:avg_elapsed].to_s.rjust(8, ' ')} ms",
+    "#{all_rows_stats[:max_elapsed].to_s.rjust(8, ' ')} ms",
+    "#{all_rows_stats[:failure_percent].to_s.rjust(9, ' ')} %"
+  ]
+].to_table
+
+exit_status = comparisons.include?(true) ? 1 : 0
+puts 'ONE OR MORE TESTS FAILED - SEE ABOVE OUTPUT' if exit_status == 1
+exit(exit_status)

--- a/script/benchmark.rb
+++ b/script/benchmark.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+# https://ruby-doc.org/stdlib-2.5.0/libdoc/benchmark/rdoc/Benchmark.html
+# https://github.com/evanphx/benchmark-ips
+# https://github.com/SamSaffron/memory_profiler
+# https://github.com/tmm1/stackprof
+# https://www.rubydoc.info/stdlib/fileutils/FileUtils
+# https://ruby-doc.org/core-2.7.0/File.html
+
+require_relative '../config/environment'
+
+##
+# We chose to copy the databse files directly into a temporary backup because
+# it is significantly faster than both populating a new database and restoring
+# a database with a .sql backup file.
+#
+# Why not use a rails transaction in benchmark to just roll back the database?
+# - Rails 7 will implement many performance improvements, one of which is
+#   automatic parallelized queries where queries are not dependent on one
+#   another. A transaction in this method would effectively disable the feature
+#   for a benchmark and produce performance results that may not be accurate.
+#
+# ENV Variables:
+# - MYSQL_PATH: specify the MySQL datadir manually for temporary DB backups
+# - NO_MEMPROF: set this to anything to disable memory-profiler for the benchmark
+def benchmark(name: nil, time_threshold: 3600, setup: nil, teardown: nil, &block)
+  check_mysql_path_env
+  warn_about_memprof
+
+  backup(ENV['MYSQL_PATH'])
+
+  ActionMailer::Base.perform_deliveries = false
+
+  timestamp = Time.now.utc.iso8601
+  stackprof_file = "script/benchmarks/output/#{name}_#{timestamp}_CPU.dump"
+  flamegraph_file = "script/benchmarks/output/#{name}_#{timestamp}_FLM"
+  memprof_file = "script/benchmarks/output/#{name}_#{timestamp}_MEM.log"
+  benchmark_file = "script/benchmarks/output/#{name}_#{timestamp}_BCM.log"
+  $stdout = File.new(benchmark_file, 'w') if ENV['CAP_STDOUT']
+  $stdout.sync = true if ENV['CAP_STDOUT']
+
+  benchmark_report = nil
+
+  if !setup.nil? && defined?(setup&.call)
+    puts 'running setup'
+    setup.call
+  end
+  puts 'starting benchmark'
+
+  Benchmark.bm(20) do |x|
+    MemoryProfiler.start unless ENV['NO_MEMPROF']
+    StackProf.run(mode: :wall, out: stackprof_file, interval: 1000, raw: true) do
+      benchmark_report = x.report(name) do
+        block.call
+      end
+    end
+    MemoryProfiler.stop.pretty_print(normalize_paths: true, scale_bytes: true, to_file: memprof_file) unless ENV['NO_MEMPROF']
+  end
+  puts 'finished benchmark'
+  if !teardown.nil? && defined?(teardown&.call)
+    puts 'running teardown'
+    teardown.call
+  end
+
+  puts 'clearing redis'
+  Sidekiq.redis(&:flushdb)
+
+  puts "\n"
+  puts "\ncat #{benchmark_file}" if ENV['CAP_STDOUT']
+  puts "\ncat #{memprof_file}" unless ENV['NO_MEMPROF']
+  puts "\nstackprof #{stackprof_file}"
+  puts "\nstackprof --flamegraph #{stackprof_file} > #{flamegraph_file}"
+  puts "\nstackprof --flamegraph-viewer=#{flamegraph_file}"
+
+  $stdout = STDOUT if ENV['CAP_STDOUT'] # disable capture of STDOUT
+
+  puts File.read(benchmark_file) if ENV['CAP_STDOUT']
+
+  puts "\n\n"
+  puts "Acceptable real time threshold: #{format('%.3f', time_threshold).rjust(10, ' ')}"
+  puts "    Actual real time threshold: #{format('%.3f', benchmark_report.real).rjust(10, ' ')}"
+
+  restore(ENV['MYSQL_PATH'])
+
+  if time_threshold < benchmark_report.real
+    puts 'TEST FAILED'
+    exit(1)
+  else
+    puts 'TEST PASSED'
+    exit(0)
+  end
+end
+
+def check_mysql_path_env
+  return unless ENV['MYSQL_PATH'].nil? || !File.directory?(ENV['MYSQL_PATH'])
+
+  puts 'MYSQL_PATH env variable not found. Trying to find dir automatically'
+  sql = 'SHOW VARIABLES WHERE Variable_Name LIKE "%dir"'
+  result = ActiveRecord::Base.connection.execute(sql).find { |f| f.first == 'datadir' }&.last
+  if result.nil?
+    puts 'Could not find the MySQL datadir!'
+    puts 'Set the MYSQL_PATH ENV variable to the folder where databases are stored'
+    puts 'If installed on Mac OS with homebrew this is likely at /usr/local/var/mysql/'
+    puts 'If installed on Ubuntu this is likely at /var/lib/mysql/'
+    exit 1
+  end
+  puts "Found MYSQL_PATH at #{result}"
+  ENV['MYSQL_PATH'] = result
+end
+
+def warn_about_memprof
+  return unless (Patient.count > 100_000) && (!ENV['NO_MEMPROF'])
+
+  puts "\n\nWARNING!!!"
+  puts 'Using memory-profiler with large tasks can lead to huge amounts of memory usage.'
+  puts 'Your database appears to be very large. Consider disabling memory-profiler in the benchmark by running'
+  puts "export NO_MEMPROF='true'"
+  puts 'or prepending this to the start of your command'
+  puts "NO_MEMPROF='true' <command>\n\n"
+end
+
+def expected_db_path(mysql_path)
+  File.join(mysql_path, ActiveRecord::Base.connection.current_database)
+end
+
+def expected_backup_path(mysql_path)
+  File.join(mysql_path, "#{ActiveRecord::Base.connection.current_database}-benchmark-backup")
+end
+
+def db_exists?(mysql_path)
+  File.directory? expected_db_path(mysql_path)
+end
+
+def backup_exists?(mysql_path)
+  File.directory? expected_backup_path(mysql_path)
+end
+
+def remove_db(mysql_path)
+  FileUtils.rm_rf expected_db_path(mysql_path)
+end
+
+def remove_backup(mysql_path)
+  FileUtils.rm_rf expected_backup_path(mysql_path)
+end
+
+def backup(mysql_path)
+  puts "Backing up DB for benchmarking from #{expected_db_path(mysql_path)} to #{expected_backup_path(mysql_path)}"
+  raise Exception.new, "DB must exist at #{expected_db_path(mysql_path)} before benchmarking!" unless db_exists?(mysql_path)
+
+  if backup_exists?(mysql_path)
+    puts('Removing old DB backup')
+    remove_backup(mysql_path)
+  end
+  FileUtils.cp_r expected_db_path(mysql_path), expected_backup_path(mysql_path), preserve: true
+end
+
+def restore(mysql_path)
+  puts "Restoring DB for benchmarking from #{expected_backup_path(mysql_path)} to #{expected_db_path(mysql_path)}"
+  raise Exception.new, "DB must exist at #{expected_backup_path(mysql_path)} before benchmarking!" unless backup_exists?(mysql_path)
+
+  if db_exists?(mysql_path)
+    puts('Removing DB before restoring')
+    remove_db(mysql_path)
+  end
+  FileUtils.cp_r expected_backup_path(mysql_path), expected_db_path(mysql_path), preserve: true
+  # Cleanup backup to avoid taking up unnecessary storage space
+  puts 'Removing temporary DB backup folder'
+  remove_backup(mysql_path)
+end

--- a/script/benchmarks/close_patients_job_benchmark.rb
+++ b/script/benchmarks/close_patients_job_benchmark.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../benchmark'
+
+benchmark(
+  name: 'ClosePatientsJob',
+  time_threshold: 20 * 60, # 20 minutes
+  setup: proc {
+    puts 'updating patients'
+    max_num_to_close = 20_000
+    Patient.limit(max_num_to_close).update_all(
+      isolation: false,
+      continuous_exposure: false,
+      latest_assessment_at: DateTime.now,
+      symptom_onset: nil,
+      public_health_action: 'None',
+      purged: false,
+      monitoring: true,
+      created_at: 100.days.ago,
+      last_date_of_exposure: 100.days.ago
+    )
+  }
+) { ClosePatientsJob.perform_now }

--- a/script/benchmarks/output/.gitignore
+++ b/script/benchmarks/output/.gitignore
@@ -1,0 +1,3 @@
+*.log
+*.dump
+*_FLM

--- a/script/benchmarks/send_assessments_job_benchmark.rb
+++ b/script/benchmarks/send_assessments_job_benchmark.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative '../../config/environment'
+require_relative '../benchmark'
+
+benchmark(
+  name: 'SendAssessmentsJob',
+  time_threshold: 25 * 60 # 25 minutes
+) { SendAssessmentsJob.perform_now }

--- a/script/jmeter/01_public_health_dashboard_jmx_test.rb
+++ b/script/jmeter/01_public_health_dashboard_jmx_test.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'ruby-jmeter'
+
+test do
+  domain = ENV['JMX_DOMAIN'] || 'localhost'
+  port = ENV['JMX_PORT'] || '3000'
+  username = ENV['JMX_USERNAME'] || 'epi_enroller_all@example.com'
+  password = ENV['JMX_PASSWORD'] || '1234567ab!'
+
+  defaults domain: domain
+  defaults port: port
+
+  cache clear_each_iteration: true
+
+  cookies
+
+  threads count: 10, loops: 1 do
+    think_time 500, 3000
+
+    visit name: '01_01_SA_visit_sign_in', url: '/users/sign_in' do
+      # <input type="hidden" name="authenticity_token" value="[FILTERED]">
+      extract regex: 'input type="hidden" name="authenticity_token" value="(.+?)"', name: 'authenticity_token', match_number: 1
+    end
+
+    exists 'authenticity_token' do
+      #  {"authenticity_token"=>"[FILTERED]", "user"=>{"email"=>"[FILTERED]", "password"=>"[FILTERED]"}}
+      submit name: '01_02_SA_sign_in',
+             url: '/users/sign_in',
+             fill_in: {
+               'user[email]': username,
+               'user[password]': password,
+               authenticity_token: '${authenticity_token}'
+             } do
+        think_time 500, 1000
+      end
+    end
+
+    loops count: 20 do
+      visit name: '01_03_SA_dashboard', url: '/public_health' do
+        think_time 500, 1000
+        # <meta name="csrf-token" content="[FILTERED]">
+        extract regex: 'meta name="csrf-token" content="(.+?)"', name: 'csrf_token', match_number: 1
+      end
+
+      exists 'csrf_token' do
+        # {"query"=>{"jurisdiction"=>1, "scope"=>"all", "workflow"=>"exposure", "tab"=>"all"}, "jurisdiction"=>{}}
+        submit name: '01_04_SA_assigned_users',
+               url: '/jurisdictions/assigned_users',
+               fill_in: {
+                 'query[jurisdiction]': 1,
+                 'query[scope]': 'all',
+                 'query[workflow]': 'exposure',
+                 'query[tab]': 'all',
+                 authenticity_token: '${csrf_token}'
+               } do
+          think_time 500, 1000
+        end
+
+        # {
+        #   "query": {
+        #     "workflow": "exposure",
+        #     "tab"=>"all",
+        #     "jurisdiction"=>1,
+        #     "scope"=>"all",
+        #     "user"=>nil,
+        #     "search"=>"",
+        #     "page"=>"[FILTERED]",
+        #     "entries"=>25,
+        #     "tz_offset"=>480
+        #   },
+        #   "cancelToken": {
+        #     "promise": {}
+        #   },
+        #   "public_health": {
+        #     "query": {
+        #       "workflow": "exposure",
+        #       "tab"=>"all",
+        #       "jurisdiction"=>1,
+        #       "scope"=>"all",
+        #       "user"=>nil,
+        #       "search"=>"ryan",
+        #       "page"=>"[FILTERED]",
+        #       "entries"=>25,
+        #       "tz_offset"=>480
+        #     },
+        #     "cancelToken": {
+        #       "promise": {}
+        #     }
+        #   }
+        # }
+        submit name: '01_05_SA_patients',
+               url: '/public_health/patients',
+               fill_in: {
+                 'query[workflow]': 'exposure',
+                 'query[tab]': 'all',
+                 'query[jurisdiction]': 1,
+                 'query[scope]': 'all',
+                 'query[user]': nil,
+                 'query[search]': '',
+                 'query[page]': 1,
+                 'query[entries]': 25,
+                 'query[tz_offset]': 480,
+                 'cancelToken[promise]': {},
+                 'public_health[query][workflow]': 'exposure',
+                 'public_health[query][tab]': 'all',
+                 'public_health[query][jurisdiction]': '1',
+                 'public_health[query][scope]': 'all',
+                 'public_health[query][user]': nil,
+                 'public_health[query][search]': '',
+                 'public_health[query][page]': 1,
+                 'public_health[query][entries]': 25,
+                 'public_health[query][tz_offset]': 480,
+                 'public_health[cancelToken][promise]': {},
+                 authenticity_token: '${csrf_token}'
+               } do
+          think_time 500, 1000
+        end
+      end
+    end
+  end
+
+  if ENV['JMX_GRAPH']
+    latencies_over_time name: 'Response Latencies Over Time'
+    response_codes_per_second name: 'Response Codes per Second'
+    response_times_distribution name: 'Response Times Distribution'
+    response_times_over_time name: 'Response Times Over Time'
+    response_times_percentiles name: 'Response Times Percentiles'
+    transactions_per_second name: 'Transactions per Second'
+  end
+
+  # end.run(path: '/usr/local/bin/', gui: false)
+  # end.jmx(file: 'tmp/public_health_dashboard_jmx_test.jmx')
+end.run(gui: false)

--- a/script/run_jmeter_tests.sh
+++ b/script/run_jmeter_tests.sh
@@ -1,0 +1,19 @@
+
+bundle exec rails s &
+
+sleep 15
+
+for script in $(ls script/jmeter/); do
+  echo "Executing JMeter test: $script"
+  ruby script/jmeter/$script
+  sleep 5
+done
+
+if [ -f "tmp/pids/server.pid" ]; then
+    echo "Killing rails server with PID $(cat tmp/pids/server.pid)"
+    # -INT does not terminate the server
+    # kill -INT $(cat tmp/pids/server.pid)
+    kill -9 $(cat tmp/pids/server.pid)
+fi
+
+ruby script/assert_jmeter_results.rb


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1192

This PR shows an example JMeter test automated in CI, as well as a standalone example benchmark script for the send assessments job.

Rails 6.1 has this [benchmark generator built-in](https://github.com/rails/rails/tree/master/railties/lib/rails/generators/rails/benchmark) that uses the [benchmark-ips](https://github.com/evanphx/benchmark-ips) gem. We are also free to modify the file to use the vanilla benchmark library (https://ruby-doc.org/stdlib-2.5.0/libdoc/benchmark/rdoc/Benchmark.html)

IMO JMeter is a better solution for load and stress testing, while the rails benchmarking example does well for understanding performance of highly targeted slices of the code with detailed CPU & RAM logging with stackprof and memory_profiler. We would likely benefit by leveraging both methods of testing our app. If we want, then we could also run stackprof with rack so that when we run JMeter we can capture data there as well.

The JMeter testing has been setup to work automatically through our mirrored GitLab repo on all branches. If the database does not need to be rebuilt, then the test takes about 5 minutes. If the database does need to be rebuilt because of a migration failure, then the population of the 1M monitoree database takes the total test time up to about 30 minutes. I set it up to use the 1M monitoree database so that we can be reasonably close to production loads in our JMeter testing. One specific place that might need some discussion/tweaking is the number of threads and loops for the JMeter test.

Ruby JMeter (write JMeter test plans in ruby to run or export): https://github.com/flood-io/ruby-jmeter
JMeter Site: https://jmeter.apache.org/

__JMeter Setup (MacOS)__:
```bash
# there is an issue with the latest, so we need to point to a previous version
brew edit jmeter

# change these lines 
...
url "https://www.apache.org/dyn/closer.lua?path=jmeter/binaries/apache-jmeter-5.2.1.tgz"
mirror "https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-5.2.1.tgz"
sha256 "bbb3cb5fe0b16c1fa139727063f18d9aca6890c7edf53f3a614b8f929f1f1de9"
...

# install jmeter
brew install jmeter

# added to ~.zprofile for covenience
alias jmeter='open /usr/local/bin/jmeter'

```

## Installed JMeter Plugins
On Mac:`Options > Plugins Manager`

<img width="248" alt="Screen Shot 2021-01-20 at 9 37 19 AM" src="https://user-images.githubusercontent.com/24628687/105206014-188f3500-5b03-11eb-9f52-cbe70b01f33b.png">

## JMeter Metrics
The added plugins allow us to generate the below charts in JMeter.

### Response Latencies Over Time
<img width="875" alt="Screen Shot 2021-01-20 at 10 19 35 AM" src="https://user-images.githubusercontent.com/24628687/105211005-ff898280-5b08-11eb-9175-46c64ef73d0b.png">

### Response Codes per Second
<img width="878" alt="Screen Shot 2021-01-20 at 10 19 43 AM" src="https://user-images.githubusercontent.com/24628687/105211021-057f6380-5b09-11eb-89d4-950518ef3c7d.png">

### Response Times Distribution
<img width="876" alt="Screen Shot 2021-01-20 at 10 19 52 AM" src="https://user-images.githubusercontent.com/24628687/105211041-0adcae00-5b09-11eb-8f6a-40a817999bb3.png">

### Response Times Over Time
<img width="880" alt="Screen Shot 2021-01-20 at 10 20 01 AM" src="https://user-images.githubusercontent.com/24628687/105211053-0fa16200-5b09-11eb-912e-0b92ddc67f13.png">

### Response Times Percentiles
<img width="880" alt="Screen Shot 2021-01-20 at 10 20 12 AM" src="https://user-images.githubusercontent.com/24628687/105211071-162fd980-5b09-11eb-87a5-83a1b926f9d1.png">

### Transactions per Second
<img width="877" alt="Screen Shot 2021-01-20 at 10 20 20 AM" src="https://user-images.githubusercontent.com/24628687/105211098-1af48d80-5b09-11eb-9577-1314fd36b849.png">


# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`example_file.js`
- Example change (ex: refactored import function)

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
