### PR TITLE
SARAALERT-1098: Changing Jurisdiction to same value should not count as a transfer

### DIFF
--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -43,11 +43,6 @@ class Enrollment extends React.Component {
   }
 
   setEnrollmentState = debounce(enrollmentState => {
-    // save jurisdiction_id as a number if it is in this enrollmentState
-    if (enrollmentState.patient.jurisdiction_id !== undefined) {
-      enrollmentState.patient.jurisdiction_id = parseInt(enrollmentState.patient.jurisdiction_id);
-    }
-
     let currentEnrollmentState = this.state.enrollmentState;
     this.setState({
       enrollmentState: {

--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -92,8 +92,6 @@ class Enrollment extends React.Component {
       ? Object.keys(this.state.enrollmentState.patient).filter(k => _.get(this.state.enrollmentState.patient, k) !== _.get(this.props.patient, k) || k === 'id')
       : Object.keys(this.state.enrollmentState.patient);
 
-    console.log(diffKeys);
-
     let data = new Object({
       patient: this.props.parent_id ? this.state.enrollmentState.patient : _.pick(this.state.enrollmentState.patient, diffKeys),
       propagated_fields: this.state.enrollmentState.propagatedFields,

--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -43,8 +43,11 @@ class Enrollment extends React.Component {
   }
 
   setEnrollmentState = debounce(enrollmentState => {
-    // save jurisdiction_id as a number
-    enrollmentState.patient.jurisdiction_id = parseInt(enrollmentState.patient.jurisdiction_id);
+    // save jurisdiction_id as a number if it is in this enrollmentState
+    if (enrollmentState.patient.jurisdiction_id !== undefined) {
+      enrollmentState.patient.jurisdiction_id = parseInt(enrollmentState.patient.jurisdiction_id);
+    }
+
     let currentEnrollmentState = this.state.enrollmentState;
     this.setState({
       enrollmentState: {

--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -84,10 +84,15 @@ class Enrollment extends React.Component {
     window.onbeforeunload = null;
     axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
 
+    // this.state.enrollmentState.patient.jurisdiction_id is a string while this.props.patient.jurisdiction_id is a number so it was always triggering
+    this.props.patient.jurisdiction_id = this.props.patient.jurisdiction_id.toString();
+
     // If enrolling, include ALL fields in diff keys. If editing, only include the ones that have changed
     let diffKeys = this.props.editMode
       ? Object.keys(this.state.enrollmentState.patient).filter(k => _.get(this.state.enrollmentState.patient, k) !== _.get(this.props.patient, k) || k === 'id')
       : Object.keys(this.state.enrollmentState.patient);
+
+    console.log(diffKeys);
 
     let data = new Object({
       patient: this.props.parent_id ? this.state.enrollmentState.patient : _.pick(this.state.enrollmentState.patient, diffKeys),

--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -43,6 +43,8 @@ class Enrollment extends React.Component {
   }
 
   setEnrollmentState = debounce(enrollmentState => {
+    // save jurisdiction_id as a number
+    enrollmentState.patient.jurisdiction_id = parseInt(enrollmentState.patient.jurisdiction_id);
     let currentEnrollmentState = this.state.enrollmentState;
     this.setState({
       enrollmentState: {
@@ -83,9 +85,6 @@ class Enrollment extends React.Component {
   submit = (_event, groupMember, reenableSubmit) => {
     window.onbeforeunload = null;
     axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
-
-    // this.state.enrollmentState.patient.jurisdiction_id is a string while this.props.patient.jurisdiction_id is a number so it was always triggering
-    this.props.patient.jurisdiction_id = this.props.patient.jurisdiction_id.toString();
 
     // If enrolling, include ALL fields in diff keys. If editing, only include the ones that have changed
     let diffKeys = this.props.editMode

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -245,6 +245,7 @@ class Exposure extends React.Component {
               callback();
             }
           } else {
+            self.setState({ selected_jurisdiction: self.state.current.patient.jurisdiction_id });
             callback();
           }
         });

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -47,7 +47,7 @@ class Exposure extends React.Component {
     let modified = this.state.modified;
     if (event?.target?.id && event.target.id === 'jurisdiction_id') {
       this.setState({ jurisdiction_path: event.target.value });
-      let jurisdiction_id = Object.keys(this.props.jurisdiction_paths).find(id => this.props.jurisdiction_paths[parseInt(id)] === event.target.value);
+      let jurisdiction_id = parseInt(Object.keys(this.props.jurisdiction_paths).find(id => this.props.jurisdiction_paths[parseInt(id)] === event.target.value));
       if (jurisdiction_id) {
         value = jurisdiction_id;
         axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
@@ -226,7 +226,7 @@ class Exposure extends React.Component {
       .then(function() {
         // No validation issues? Invoke callback (move to next step)
         self.setState({ errors: {} }, async () => {
-          if (parseInt(self.state.current.patient.jurisdiction_id) !== self.state.originalJurisdictionId) {
+          if (self.state.current.patient.jurisdiction_id !== self.state.originalJurisdictionId) {
             // If we set it back to the last saved value no need to confirm.
             if (self.state.current.patient.jurisdiction_id === self.state.selected_jurisdiction) {
               callback();

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -634,7 +634,7 @@ class Exposure extends React.Component {
                       </Form.Control.Feedback>
                       {this.props.has_dependents &&
                         this.state.current.patient.jurisdiction_id !== this.state.originalJurisdictionId &&
-                        Object.keys(this.props.jurisdiction_paths).includes(this.state.current.patient.jurisdiction_id) && (
+                        Object.keys(this.props.jurisdiction_paths).includes(this.state.current.patient.jurisdiction_id.toString()) && (
                           <Form.Group className="mt-2">
                             <Form.Check
                               type="switch"

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -83,10 +83,15 @@ class Exposure extends React.Component {
       }
       this.updateLDEandCEValidations({ ...current.patient, [event.target.id]: value });
     }
-    this.setState({
-      current: { ...current, patient: { ...current.patient, [event.target.id]: value } },
-      modified: { ...modified, patient: { ...modified.patient, [event.target.id]: value } },
-    });
+    this.setState(
+      {
+        current: { ...current, patient: { ...current.patient, [event.target.id]: value } },
+        modified: { ...modified, patient: { ...modified.patient, [event.target.id]: value } },
+      },
+      () => {
+        this.props.setEnrollmentState({ ...this.state.modified });
+      }
+    );
   }
 
   handleDateChange(field, date) {
@@ -237,7 +242,6 @@ class Exposure extends React.Component {
 
             if (await confirmDialog(message, options)) {
               self.setState({ selected_jurisdiction: self.state.current.patient.jurisdiction_id });
-              self.props.setEnrollmentState({ ...self.state.modified });
               callback();
             }
           } else {


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1098](https://tracker.codev.mitre.org/browse/SARAALERT-1098)

While using the enrollment wizard if you changed the jurisdiction, clicked next and confirm the change, then click previous, click next again the same popup would appear to confirm the change again. 

This change will make it so a popup is only shown when changing the jurisdiction to a value that is different than the original value (last saved jurisdiction) or a new selection that is different than the last selection and the original value. 

While editing a monitoree if you typed in the jurisdiction field and then saved, even if it ended up being the same value it would save that as a transfer.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Test dialog changes
1. Using the enrollment wizard fill out required sections until you can change jurisdictions. Change from state1 to 'state1, county1', click next, a popup should appear, confirm the changes. (different than the last saved and this is different than the last selected)
2. Click Previous, click next, no popup should appear (this is the last selected value)
3. Click Previous, change to 'state1, county2', click next, a popup should appear, confirm the changes. (this is different than the last selected and different than the last saved)
4. Click Previous, change to 'state1', click next, no popup should appear (this is the same as the last saved value)

Test transfer changes
1. Filter the exposure dashboard to narrow it down to one patient, then select the patient.
2. Click edit details and then click edit on the potential exposure information.
3. In the jurisdiction field change the jurisdiction to a new value
4. Click next and then finish.
5. Click edit details and then click edit on the potential exposure information.
6. In the jurisdiction field delete a character and then change it back, making it the same value.
7. Click next and then finish.
8. Click return to exposure dashboard
9. Click export -> custom format -> Select `Current monitoree records from Dashboard View (1)` and choose Transfers and click export
10. Download and open the file. Confirm that a transfer was recorded for step 4 and that no transfer was recorded for step 7.