### PR TITLE
SARAALERT-1093: Household updates refactor, bugfixes, and tests

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -253,6 +253,9 @@ class PatientsController < ApplicationController
     # Don't do anything if there hasn't been a change to the responder at all
     redirect_to(root_url) && return if current_patient.responder_id == new_hoh_id
 
+    # Don't allow the user to set this record as a new HoH if they are a dependent already
+    render(json: { error: 'Selected Head of Household is no longer valid as they are a dependent in an existing household.' }, status: 406) && return if new_hoh.responder_id != new_hoh_id.id
+
     if new_hoh_id == current_patient.id
       comment = "User removed #{current_patient.first_name} #{current_patient.last_name} from the household. #{old_hoh.first_name} #{old_hoh.last_name}"\
                 ' will no longer be responsible for handling their reporting.'

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -254,8 +254,8 @@ class PatientsController < ApplicationController
     # ----- Error Checking -----
 
     # Check to make sure selected HoH record exists.
-    unless Patient.where(purged: false).exists?(new_hoh_id)
-      error_message = "Move to household action failed: selected Head of Household with ID #{new_hoh_id} does not exist."
+    unless current_user_patients.exists?(new_hoh_id)
+      error_message = "Move to household action failed: selected Head of Household with ID #{new_hoh_id} is not accessible."
       render(json: { error: error_message }, status: :forbidden) && return
     end
 
@@ -362,8 +362,8 @@ class PatientsController < ApplicationController
     # ----- Error Checking -----
 
     # Check to make sure selected HoH record exists.
-    unless Patient.where(purged: false).exists?(new_hoh_id)
-      error_message = "Change head of household action failed: selected Head of Household with ID #{new_hoh_id} does not exist."
+    unless current_user_patients.exists?(new_hoh_id)
+      error_message = "Change head of household action failed: selected Head of Household with ID #{new_hoh_id} is not accessible."
       render(json: { error: error_message }, status: :forbidden) && return
     end
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -368,7 +368,7 @@ class PatientsController < ApplicationController
     end
 
     # Check to make sure user has access to update all of these records.
-    unless current_user_patients.where(id: household_ids).count == household_ids.length
+    unless current_user_patients.where(id: household_ids).size == household_ids.length
       error_message = 'Change head of household action failed: user does not have permissions to update current monitoree or one or more of their dependents.'
       render(json: { error: error_message }, status: :forbidden) && return
     end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -270,7 +270,8 @@ class PatientsController < ApplicationController
 
     # Do not allow the user to set this record as a new HoH if they are a dependent already.
     if new_hoh.responder_id != new_hoh_id
-      error_message = 'Move to household action failed: Selected Head of Household is not valid as they are a dependent in an existing household. Please refresh.'
+      error_message = 'Move to household action failed: Selected Head of Household is not valid as they are a dependent in an existing household. '\
+                      'Please refresh.'
       render(json: { error: error_message }, status: 406) && return
     end
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -272,14 +272,14 @@ class PatientsController < ApplicationController
     if new_hoh.responder_id != new_hoh_id
       error_message = 'Move to household action failed: Selected Head of Household is not valid as they are a dependent in an existing household. '\
                       'Please refresh.'
-      render(json: { error: error_message }, status: 406) && return
+      render(json: { error: error_message }, status: :bad_request) && return
     end
 
     # Don't allow a HoH to be moved to a household.
     if current_patient.head_of_household
       error_message = 'Move to household action failed: Monitoree is a head of household and therefore cannot be moved to a household '\
                       'through the Move to Household action. Please refresh.'
-      render(json: { error: error_message }, status: 406) && return
+      render(json: { error: error_message }, status: :bad_request) && return
     end
 
     # ----- Record Updates -----
@@ -289,7 +289,7 @@ class PatientsController < ApplicationController
 
     if !updated
       error_message = 'Move to household action failed: Monitoree was unable to be be updated.'
-      render(json: { error: error_message, status: 403 }) && return
+      render(json: { error: error_message, status: :forbidden }) && return
     else
       # Create history item for new HoH
       comment = "User added monitoree with ID #{current_patient.id} to a household. #{new_hoh.first_name} #{new_hoh.last_name}"\
@@ -321,7 +321,7 @@ class PatientsController < ApplicationController
     # If the current patients is a HoH, they can't be removed.
     if current_patient.head_of_household
       error_message = 'Remove from household  action failed: Monitoree is a head of household. Please refresh.'
-      render(json: { error: error_message }, status: 406) && return
+      render(json: { error: error_message }, status: :bad_request) && return
     end
 
     # ----- Record Updates -----
@@ -332,7 +332,7 @@ class PatientsController < ApplicationController
 
     if !updated
       error_message = 'Remove from household action failed: Monitoree was unable to be be updated.'
-      render(json: { error: error_message, status: 403 }) && return
+      render(json: { error: error_message, status: :forbidden }) && return
     else
       # Create history item for old HoH
       comment = "User removed dependent monitoree with ID #{current_patient.id} from the household. #{old_hoh.first_name} #{old_hoh.last_name}"\
@@ -364,13 +364,13 @@ class PatientsController < ApplicationController
     # Check to make sure selected HoH record exists.
     unless Patient.where(purged: false).exists?(new_hoh_id)
       error_message = "Change head of household action failed: Selected Head of Household with ID #{new_hoh_id} does not exist."
-      render(json: { error: error_message }, status: 403) && return
+      render(json: { error: error_message }, status: :forbidden) && return
     end
 
     # Check to make sure user has access to update all of these records.
     unless current_user_patients.where(id: patient_ids_to_update).count == patient_ids_to_update.length
       error_message = 'Change head of household action failed: User does not have permissions to update current monitoree or one or more of their dependents.'
-      render(json: { error: error_message }, status: 403) && return
+      render(json: { error: error_message }, status: :forbidden) && return
     end
 
     # Do not do anything if there hasn't been a change to the responder at all.
@@ -379,7 +379,7 @@ class PatientsController < ApplicationController
     # If the new head of household was removed from the household, don't allow the change
     unless current_patient.dependents.pluck(:id).include?(new_hoh_id)
       error_message = 'Change head of household action failed: Selected Head of Household is no longer in household. Please refresh.'
-      render(json: { error: error_message }, status: 406) && return
+      render(json: { error: error_message }, status: :bad_request) && return
     end
 
     # ----- Record Updates -----

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -270,14 +270,14 @@ class PatientsController < ApplicationController
 
     # Do not allow the user to set this record as a new HoH if they are a dependent already.
     if new_hoh.responder_id != new_hoh_id
-      error_message = 'Move to household action failed: Selected Head of Household is not valid as they are a dependent in an existing household.'
+      error_message = 'Move to household action failed: Selected Head of Household is not valid as they are a dependent in an existing household. Please refresh.'
       render(json: { error: error_message }, status: 406) && return
     end
 
     # Don't allow a HoH to be moved to a household.
     if current_patient.head_of_household
       error_message = 'Move to household action failed: Monitoree is a head of household and therefore cannot be moved to a household '\
-                      'through the Move to Household action.'
+                      'through the Move to Household action. Please refresh.'
       render(json: { error: error_message }, status: 406) && return
     end
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -288,8 +288,8 @@ class PatientsController < ApplicationController
     updated = current_patient.update(responder_id: new_hoh_id)
 
     if !updated
-      error_message = 'Move to household action failed: Monitoree was unable to be be updated.'
-      render(json: { error: error_message, status: :forbidden }) && return
+      error_message = 'Move to household action failed: monitoree was unable to be be updated.'
+      render(json: { error: error_message }, status: :bad_request) && return
     else
       # Create history item for new HoH
       comment = "User added monitoree with ID #{current_patient.id} to a household. #{new_hoh.first_name} #{new_hoh.last_name}"\
@@ -331,8 +331,8 @@ class PatientsController < ApplicationController
     updated = current_patient.update(responder_id: current_patient.id)
 
     if !updated
-      error_message = 'Remove from household action failed: Monitoree was unable to be be updated.'
-      render(json: { error: error_message, status: :forbidden }) && return
+      error_message = 'Remove from household action failed: monitoree was unable to be be updated.'
+      render(json: { error: error_message }, status: :bad_request) && return
     else
       # Create history item for old HoH
       comment = "User removed dependent monitoree with ID #{current_patient.id} from the household. #{old_hoh.first_name} #{old_hoh.last_name}"\
@@ -389,13 +389,13 @@ class PatientsController < ApplicationController
       Patient.transaction do
         # Change all of the patients in the household, including the current patient to have new_hoh_id as the responder
         current_user_patients.where(id: patient_ids_to_update).each do |patient|
-          patient.update(responder_id: new_hoh_id)
+          patient.update!(responder_id: new_hoh_id)
         end
       end
     rescue ActiveRecord::RecordInvalid => e
-      error_message = 'Change head of household action failed: Monitoree(s) were unable to be be updated.'
+      error_message = 'Change head of household action failed: monitoree(s) were unable to be be updated.'
       Rails.logger.info("#{error_message} Error: #{e}")
-      render(json: { error: error_message, status: :bad_request }) && return
+      render(json: { error: error_message }, status: :bad_request) && return
     end
 
     comment = "User changed head of household from monitoree with ID #{old_hoh.id} to monitoree with ID #{new_hoh_id}."\

--- a/app/javascript/components/subject/ChangeHOH.js
+++ b/app/javascript/components/subject/ChangeHOH.js
@@ -1,7 +1,9 @@
-import React from 'react';
+import axios from 'axios';
 import { PropTypes } from 'prop-types';
 import { Form, Row, Col, Button, Modal } from 'react-bootstrap';
-import axios from 'axios';
+import React from 'react';
+
+import reportError from '../util/ReportError';
 
 class ChangeHOH extends React.Component {
   constructor(props) {
@@ -39,11 +41,12 @@ class ChangeHOH extends React.Component {
           }),
         })
         .then(() => {
-          this.setState({ updateDisabled: false });
-          location.reload(true);
+          this.setState({ updateDisabled: false }, () => {
+            location.reload();
+          });
         })
-        .catch(error => {
-          console.error(error);
+        .catch(err => {
+          reportError(err?.response?.data?.error ? err.response.data.error : err, false);
         });
     });
   }

--- a/app/javascript/components/subject/ChangeHOH.js
+++ b/app/javascript/components/subject/ChangeHOH.js
@@ -36,9 +36,6 @@ class ChangeHOH extends React.Component {
       axios
         .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/update_hoh', {
           new_hoh_id: this.state.hoh_selection,
-          household_ids: this.props?.dependents?.map(member => {
-            return member.id;
-          }),
         })
         .then(() => {
           this.setState({ updateDisabled: false }, () => {

--- a/app/javascript/components/subject/MoveToHousehold.js
+++ b/app/javascript/components/subject/MoveToHousehold.js
@@ -252,7 +252,7 @@ class MoveToHousehold extends React.Component {
     this.setState({ isLoading: true }, () => {
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
       axios
-        .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/update_hoh', {
+        .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/move_to_household', {
           new_hoh_id: new_hoh_id,
         })
         .then(() => {

--- a/app/javascript/components/subject/MoveToHousehold.js
+++ b/app/javascript/components/subject/MoveToHousehold.js
@@ -3,7 +3,6 @@ import { PropTypes } from 'prop-types';
 import { Form, Row, Col, Button, Modal, InputGroup, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import axios from 'axios';
 import moment from 'moment-timezone';
-import { toast } from 'react-toastify';
 import _ from 'lodash';
 
 import BadgeHOH from '../util/BadgeHOH';
@@ -258,10 +257,8 @@ class MoveToHousehold extends React.Component {
         .then(() => {
           // Reload the page to see updated HoH
           location.reload();
-          toast.success('Head of Household successfully updated.');
         })
-        .catch(err => {
-          location.reload();
+        .catch(async err => {
           reportError(err?.response?.data?.error ? err.response.data.error : err, false);
         });
     });

--- a/app/javascript/components/subject/MoveToHousehold.js
+++ b/app/javascript/components/subject/MoveToHousehold.js
@@ -258,7 +258,7 @@ class MoveToHousehold extends React.Component {
           // Reload the page to see updated HoH
           location.reload();
         })
-        .catch(async err => {
+        .catch(err => {
           reportError(err?.response?.data?.error ? err.response.data.error : err, false);
         });
     });

--- a/app/javascript/components/subject/MoveToHousehold.js
+++ b/app/javascript/components/subject/MoveToHousehold.js
@@ -3,10 +3,12 @@ import { PropTypes } from 'prop-types';
 import { Form, Row, Col, Button, Modal, InputGroup, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import axios from 'axios';
 import moment from 'moment-timezone';
+import { toast } from 'react-toastify';
 import _ from 'lodash';
 
 import BadgeHOH from '../util/BadgeHOH';
 import CustomTable from '../layout/CustomTable';
+import reportError from '../util/ReportError';
 
 class MoveToHousehold extends React.Component {
   constructor(props) {
@@ -100,33 +102,45 @@ class MoveToHousehold extends React.Component {
    */
   toggleModal = () => {
     let current = this.state.showModal;
-    this.setState(
-      {
-        showModal: !current,
-        isLoading: !current,
-      },
-      () => {
-        if (this.state.showModal) {
+
+    // If toggling off
+    if (current) {
+      // Reset modal when modal is hidden
+      this.resetState();
+    } else {
+      this.setState(
+        {
+          showModal: true,
+          isLoading: true,
+        },
+        () => {
           // Make initial call for table data when modal is shown.
           this.updateTable(this.state.query);
-        } else {
-          // Reset modal when modal is hidden
-          const resetQuery = {
-            ...this.state.query,
-            page: 0,
-            search: '',
-            entries: 5,
-          };
-
-          const resetTable = {
-            ...this.state.table,
-            rowData: [],
-            totalRows: 0,
-          };
-          this.setState({ query: resetQuery, table: resetTable });
         }
-      }
-    );
+      );
+    }
+  };
+
+  resetState = () => {
+    const resetQuery = {
+      ...this.state.query,
+      page: 0,
+      search: '',
+      entries: 5,
+    };
+
+    const resetTable = {
+      ...this.state.table,
+      rowData: [],
+      totalRows: 0,
+    };
+
+    this.setState({
+      showModal: false,
+      isLoading: false,
+      query: resetQuery,
+      table: resetTable,
+    });
   };
 
   /**
@@ -243,10 +257,12 @@ class MoveToHousehold extends React.Component {
         })
         .then(() => {
           // Reload the page to see updated HoH
-          location.reload(true);
+          location.reload();
+          toast.success('Head of Household successfully updated.');
         })
-        .catch(error => {
-          console.error(error);
+        .catch(err => {
+          location.reload();
+          reportError(err?.response?.data?.error ? err.response.data.error : err, false);
         });
     });
   };

--- a/app/javascript/components/subject/RemoveFromHousehold.js
+++ b/app/javascript/components/subject/RemoveFromHousehold.js
@@ -3,6 +3,8 @@ import { PropTypes } from 'prop-types';
 import { Form, Row, Col, Button, Modal } from 'react-bootstrap';
 import axios from 'axios';
 
+import reportError from '../util/ReportError';
+
 class RemoveFromHousehold extends React.Component {
   constructor(props) {
     super(props);
@@ -34,10 +36,10 @@ class RemoveFromHousehold extends React.Component {
       axios
         .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/remove_from_household')
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
-        .catch(error => {
-          console.error(error);
+        .catch(err => {
+          reportError(err?.response?.data?.error ? err.response.data.error : err, false);
         });
     });
   }

--- a/app/javascript/components/subject/RemoveFromHousehold.js
+++ b/app/javascript/components/subject/RemoveFromHousehold.js
@@ -32,9 +32,7 @@ class RemoveFromHousehold extends React.Component {
     this.setState({ loading: true }, () => {
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
       axios
-        .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/update_hoh', {
-          new_hoh_id: this.props.patient.id,
-        })
+        .post(window.BASE_PATH + '/patients/' + this.props.patient.id + '/remove_from_household')
         .then(() => {
           location.reload(true);
         })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,8 @@ Rails.application.routes.draw do
   post '/patients/:id/status/clear', to: 'patients#clear_assessments'
   post '/patients/:id/status/clear/:assessment_id', to: 'patients#clear_assessment'
   post '/patients/:id/update_hoh', to: 'patients#update_hoh'
+  post '/patients/:id/move_to_household', to: 'patients#move_to_household'
+  post '/patients/:id/remove_from_household', to: 'patients#remove_from_household'
   post '/patients/current_case_status', to: 'patients#current_case_status'
 
   resources :patients, param: :submission_token do

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -112,7 +112,7 @@ class PatientsControllerTest < ActionController::TestCase
     assert_equal(desired_hoh.id, dependent.responder_id)
 
     # Verify history item was created for new HoH
-    comment = "User added monitoree with ID #{dependent.id} to a household. #{desired_hoh.first_name} #{desired_hoh.last_name}"\
+    comment = "User added monitoree with ID #{dependent.id} to a household. This monitoree"\
               ' will now be responsible for handling the reporting on their behalf.'
     assert_equal(1, desired_hoh.histories.count)
     assert_equal(comment, desired_hoh.histories.last.comment)
@@ -138,7 +138,7 @@ class PatientsControllerTest < ActionController::TestCase
     }
 
     assert_response(:forbidden)
-    assert_equal('Move to household action failed: Selected Head of Household with ID -9999 does not exist.',
+    assert_equal('Move to household action failed: selected Head of Household with ID -9999 does not exist.',
                  JSON.parse(response.body)['error'])
     assert_not patient.reload.head_of_household
     assert_equal(patient.id, patient.responder_id)
@@ -162,7 +162,7 @@ class PatientsControllerTest < ActionController::TestCase
     }
 
     assert_response(:forbidden)
-    assert_equal('Move to household action failed: User does not have permissions to update current monitoree.',
+    assert_equal('Move to household action failed: user does not have permissions to update current monitoree.',
                  JSON.parse(response.body)['error'])
     assert_not patient.reload.head_of_household
     assert_equal(patient.id, patient.responder_id)
@@ -201,7 +201,7 @@ class PatientsControllerTest < ActionController::TestCase
     }
 
     assert_response(:bad_request)
-    assert_equal('Move to household action failed: Selected Head of Household is not valid as they are a dependent in an existing household. Please refresh.',
+    assert_equal('Move to household action failed: selected Head of Household is not valid as they are a dependent in an existing household. Please refresh.',
                  JSON.parse(response.body)['error'])
     assert_not patient.reload.head_of_household
     assert_not desired_hoh.reload.head_of_household
@@ -228,7 +228,7 @@ class PatientsControllerTest < ActionController::TestCase
 
     assert_response(:bad_request)
     assert_equal(
-      'Move to household action failed: Monitoree is a head of household and therefore cannot be moved to a household through the Move to Household action. '\
+      'Move to household action failed: monitoree is a head of household and therefore cannot be moved to a household through the Move to Household action. '\
       'Please refresh.',
       JSON.parse(response.body)['error']
     )
@@ -287,7 +287,7 @@ class PatientsControllerTest < ActionController::TestCase
     assert_equal(dependent.id, dependent.responder_id)
 
     # Verify history item was created for old HoH
-    comment = "User removed dependent monitoree with ID #{dependent.id} from the household. #{hoh.first_name} #{hoh.last_name}"\
+    comment = "User removed dependent monitoree with ID #{dependent.id} from the household. This monitoree"\
               ' will no longer be responsible for handling their reporting.'
     assert_equal(1, hoh.histories.count)
     assert_equal(comment, hoh.histories.last.comment)
@@ -314,7 +314,7 @@ class PatientsControllerTest < ActionController::TestCase
     }
 
     assert_response(:forbidden)
-    assert_equal('Remove from household action failed: User does not have permissions to update current monitoree.',
+    assert_equal('Remove from household action failed: user does not have permissions to update current monitoree.',
                  JSON.parse(response.body)['error'])
     assert_not patient.reload.head_of_household
     assert_equal(patient.id, patient.responder_id)
@@ -336,7 +336,7 @@ class PatientsControllerTest < ActionController::TestCase
     }
 
     assert_response(:bad_request)
-    assert_equal('Remove from household  action failed: Monitoree is a head of household. Please refresh.',
+    assert_equal('Remove from household action failed: monitoree is a head of household. Please refresh.',
                  JSON.parse(response.body)['error'])
     assert patient.reload.head_of_household
     assert_not dependent.reload.head_of_household
@@ -358,7 +358,7 @@ class PatientsControllerTest < ActionController::TestCase
     sign_in user
 
     post :remove_from_household, params: {
-      id: dependent.id,
+      id: dependent.id
     }
 
     assert_response(:bad_request)
@@ -382,12 +382,11 @@ class PatientsControllerTest < ActionController::TestCase
 
     post :update_hoh, params: {
       id: patient.id,
-      new_hoh_id: -9999,
-      household_ids: []
+      new_hoh_id: -9999
     }
 
     assert_response(:forbidden)
-    assert_equal('Change head of household action failed: Selected Head of Household with ID -9999 does not exist.',
+    assert_equal('Change head of household action failed: selected Head of Household with ID -9999 does not exist.',
                  JSON.parse(response.body)['error'])
     assert_not patient.reload.head_of_household
     assert_equal(patient.id, patient.responder_id)
@@ -408,12 +407,11 @@ class PatientsControllerTest < ActionController::TestCase
 
     post :update_hoh, params: {
       id: hoh.id,
-      new_hoh_id: dependent_2.id,
-      household_ids: [dependent_1.id, dependent_2.id]
+      new_hoh_id: dependent_2.id
     }
 
     assert_response(:forbidden)
-    assert_equal('Change head of household action failed: User does not have permissions to update current monitoree or one or more of their dependents.',
+    assert_equal('Change head of household action failed: user does not have permissions to update current monitoree or one or more of their dependents.',
                  JSON.parse(response.body)['error'])
     assert_not dependent_1.reload.head_of_household
     assert_not dependent_2.reload.head_of_household
@@ -440,7 +438,7 @@ class PatientsControllerTest < ActionController::TestCase
     }
 
     assert_response(:forbidden)
-    assert_equal('Change head of household action failed: User does not have permissions to update current monitoree or one or more of their dependents.',
+    assert_equal('Change head of household action failed: user does not have permissions to update current monitoree or one or more of their dependents.',
                  JSON.parse(response.body)['error'])
     assert_not dependent_1.reload.head_of_household
     assert_not dependent_2.reload.head_of_household
@@ -459,12 +457,11 @@ class PatientsControllerTest < ActionController::TestCase
 
     post :update_hoh, params: {
       id: hoh.id,
-      new_hoh_id: old_dependent.id,
-      household_ids: [old_dependent.id, dependent.id]
+      new_hoh_id: old_dependent.id
     }
 
     assert_response(:bad_request)
-    assert_equal('Change head of household action failed: Selected Head of Household is no longer in household. Please refresh.',
+    assert_equal('Change head of household action failed: selected Head of Household is no longer in household. Please refresh.',
                  JSON.parse(response.body)['error'])
     assert hoh.reload.head_of_household
     assert_not old_dependent.reload.head_of_household
@@ -485,8 +482,7 @@ class PatientsControllerTest < ActionController::TestCase
 
     post :update_hoh, params: {
       id: hoh.id,
-      new_hoh_id: dependent.id,
-      household_ids: [dependent.id]
+      new_hoh_id: dependent.id
     }
     assert_response :success
     assert_not hoh.reload.head_of_household
@@ -518,8 +514,7 @@ class PatientsControllerTest < ActionController::TestCase
 
     post :update_hoh, params: {
       id: hoh.id,
-      new_hoh_id: dependent_2.id,
-      household_ids: [dependent_1.id, dependent_2.id]
+      new_hoh_id: dependent_2.id
     }
 
     assert_response :success
@@ -561,8 +556,7 @@ class PatientsControllerTest < ActionController::TestCase
 
     post :update_hoh, params: {
       id: hoh.id,
-      new_hoh_id: dependent.id,
-      household_ids: [dependent.id]
+      new_hoh_id: dependent.id
     }
 
     assert_response(:bad_request)

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -249,7 +249,7 @@ class PatientsControllerTest < ActionController::TestCase
     sign_in user
 
     post :remove_from_household, params: {
-      id: dependent.id,
+      id: dependent.id
     }
 
     assert_response :success
@@ -281,7 +281,7 @@ class PatientsControllerTest < ActionController::TestCase
     sign_in enroller_user
 
     post :remove_from_household, params: {
-      id: patient.id,
+      id: patient.id
     }
 
     assert_response(:forbidden)

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -126,7 +126,7 @@ class PatientsControllerTest < ActionController::TestCase
     sign_out user
   end
 
-  test 'move_to_household sends error message when new HoH does not exist' do
+  test 'move_to_household sends error message when new HoH is not accessible' do
     user = create(:public_health_enroller_user)
     patient = create(:patient, creator: user)
 
@@ -138,7 +138,7 @@ class PatientsControllerTest < ActionController::TestCase
     }
 
     assert_response(:forbidden)
-    assert_equal('Move to household action failed: selected Head of Household with ID -9999 does not exist.',
+    assert_equal('Move to household action failed: selected Head of Household with ID -9999 is not accessible.',
                  JSON.parse(response.body)['error'])
     assert_not patient.reload.head_of_household
     assert_equal(patient.id, patient.responder_id)
@@ -162,7 +162,7 @@ class PatientsControllerTest < ActionController::TestCase
     }
 
     assert_response(:forbidden)
-    assert_equal('Move to household action failed: user does not have permissions to update current monitoree.',
+    assert_equal("Move to household action failed: selected Head of Household with ID #{desired_hoh.id} is not accessible.",
                  JSON.parse(response.body)['error'])
     assert_not patient.reload.head_of_household
     assert_equal(patient.id, patient.responder_id)
@@ -374,7 +374,7 @@ class PatientsControllerTest < ActionController::TestCase
     sign_out user
   end
 
-  test 'update_hoh sends error message when new HoH does not exist' do
+  test 'update_hoh sends error message when new HoH is not accessible' do
     user = create(:public_health_enroller_user)
     patient = create(:patient, creator: user)
 
@@ -386,7 +386,7 @@ class PatientsControllerTest < ActionController::TestCase
     }
 
     assert_response(:forbidden)
-    assert_equal('Change head of household action failed: selected Head of Household with ID -9999 does not exist.',
+    assert_equal('Change head of household action failed: selected Head of Household with ID -9999 is not accessible.',
                  JSON.parse(response.body)['error'])
     assert_not patient.reload.head_of_household
     assert_equal(patient.id, patient.responder_id)
@@ -426,8 +426,8 @@ class PatientsControllerTest < ActionController::TestCase
 
     # Patient is not viewable by enroller user
     hoh = create(:patient, creator: enroller_user)
-    dependent_1 = create(:patient, creator: enroller_user, responder_id: hoh.id)
-    dependent_2 = create(:patient, creator: public_health_enroller_user, responder_id: hoh.id)
+    dependent_1 = create(:patient, creator: public_health_enroller_user, responder_id: hoh.id)
+    dependent_2 = create(:patient, creator: enroller_user, responder_id: hoh.id)
 
     sign_in enroller_user
 

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -108,6 +108,14 @@ class PatientsControllerTest < ActionController::TestCase
     assert_not dependent.reload.head_of_household
   end
 
+  test 'update_hoh redirects when there is no change' do
+    # TODO
+  end
+
+  test 'update_hoh send error message when new head of household is a dependent' do
+    # TODO
+  end
+
   test 'bulk update status' do
     %i[admin_user analyst_user].each do |role|
       user = create(role)

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -200,7 +200,7 @@ class PatientsControllerTest < ActionController::TestCase
       new_hoh_id: desired_hoh.id
     }
 
-    assert_response(406)
+    assert_response(:bad_request)
     assert_equal('Move to household action failed: Selected Head of Household is not valid as they are a dependent in an existing household. Please refresh.',
                  JSON.parse(response.body)['error'])
     assert_not patient.reload.head_of_household
@@ -226,7 +226,7 @@ class PatientsControllerTest < ActionController::TestCase
       new_hoh_id: desired_hoh.id
     }
 
-    assert_response(406)
+    assert_response(:bad_request)
     assert_equal(
       'Move to household action failed: Monitoree is a head of household and therefore cannot be moved to a household through the Move to Household action. '\
       'Please refresh.',
@@ -306,7 +306,7 @@ class PatientsControllerTest < ActionController::TestCase
       id: patient.id
     }
 
-    assert_response(406)
+    assert_response(:bad_request)
     assert_equal('Remove from household  action failed: Monitoree is a head of household. Please refresh.',
                  JSON.parse(response.body)['error'])
     assert patient.reload.head_of_household
@@ -406,7 +406,7 @@ class PatientsControllerTest < ActionController::TestCase
       household_ids: [old_dependent.id, dependent.id]
     }
 
-    assert_response(406)
+    assert_response(:bad_request)
     assert_equal('Change head of household action failed: Selected Head of Household is no longer in household. Please refresh.',
                  JSON.parse(response.body)['error'])
     assert hoh.reload.head_of_household

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -201,7 +201,7 @@ class PatientsControllerTest < ActionController::TestCase
     }
 
     assert_response(406)
-    assert_equal('Move to household action failed: Selected Head of Household is not valid as they are a dependent in an existing household.',
+    assert_equal('Move to household action failed: Selected Head of Household is not valid as they are a dependent in an existing household. Please refresh.',
                  JSON.parse(response.body)['error'])
     assert_not patient.reload.head_of_household
     assert_not desired_hoh.reload.head_of_household
@@ -228,7 +228,8 @@ class PatientsControllerTest < ActionController::TestCase
 
     assert_response(406)
     assert_equal(
-      'Move to household action failed: Monitoree is a head of household and therefore cannot be moved to a household through the Move to Household action.',
+      'Move to household action failed: Monitoree is a head of household and therefore cannot be moved to a household through the Move to Household action. '\
+      'Please refresh.',
       JSON.parse(response.body)['error']
     )
     assert patient.reload.head_of_household


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1093](https://tracker.codev.mitre.org/browse/SARAALERT-1093)

This PR does the following:
- Addresses bugs related to simultaneous household edits
- Refactors actions for household updates
- Adds additional error checking and many tests for household updates

# (Bugfix) How to Replicate
This PR fixes various issues when a edits to households are happening simultaneously.

**A) Move To Household: User being able to set a HoH as a dependent:**
1. Open two different records (record A and record B) where the monitorees are self reporting (do not select a HH dependent or a HoH).
2. Click “Move To Household” button on both records.
3. In the modal for record A, search for record B and select it as a HoH.
4. In the modal for record B, select any other record.
5. Notice that record B is both a HoH and a dependent.

**B) Move To Household: User being able to set a dependent as a HoH:**
1. Open two different records (record A and record B) where the monitorees are self reporting (do not select a HH dependent or a HoH).
2. Click “Move To Household” button on both records.
3. In the modal for record B, search for record A but DO not select it yet.
4. In the modal for record A, search for any record aside from B and select it as a HoH.
5. In the modal for record B again, now select record A.
6. Notice that record A is both a HoH and a dependent.

**C) User being able to set a record as both a dependent as a a HoH:**
1. Open two different records (record A and record B) where record A is a HoH. record B is not in a HoH, and then a record C which is a dependent of record A (don’t have to open this one).
2. First, click “Move To Household” on record B and search but not select record A.
3. Then, change the HoH from record A to record C by clicking “Change Head of Household” on record A.
4. Then, without refreshing record B, click “Select” on record a.
5. Notice that record A is now both a dependent of record C and HoH of record B

**D) User being able to remove from household after change of household:**
1. Open two different records (record A and record B) where record A is a dependent of record B.
2. First, change the HoH from record B to record A by clicking “Change Head of Household” on record B.
3. Then, without refreshing record A, click “Remove from Household” on record A and verify it works as expected. In this case, the Change HoH change was the one that stuck.
4. Notice that record A was not removed and is the new HoH

**E) User being able to change head of household after removing from household:**
1. Open two different records (record A and record B) where record A is a HoH. record B is a dependent of record A.
2. First, click “Remove From Household” on record B.
3. Then, change on record A, change the HoH from record A to record C by clicking “Change Head of Household”.
4. Notice that record B is now a HoH of record A, when a user first removed them.

# (Bugfix) Solution
Explicit checks were put in place on each action to check for the correct conditions.

# Screenshots
New error messages:
![Screen Shot 2021-01-26 at 7 45 47 PM](https://user-images.githubusercontent.com/11698457/105926066-426abf00-600f-11eb-8ad9-7c6528dbed09.png)
![Screen Shot 2021-01-26 at 7 45 01 PM](https://user-images.githubusercontent.com/11698457/105926067-426abf00-600f-11eb-9bad-35f4df927b4e.png)
![Screen Shot 2021-01-26 at 8 26 11 PM](https://user-images.githubusercontent.com/11698457/105929723-359d9980-6016-11eb-8c3d-f18b6d9c34b5.png)
![Screen Shot 2021-01-26 at 8 25 29 PM](https://user-images.githubusercontent.com/11698457/105929724-359d9980-6016-11eb-9dce-53cb2c4b3979.png)

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/controllers/patients_controller.rb`
- Separated `update_hoh` into three different actions for each possible option: `move_to_household`, `remove_from_household`, and `update_hoh`.
- Addressed above bug.
- Added additional error checking.

`config/routes.rb`
- New routes for above separated out actions.

`app/javascript/components/subject/MoveToHousehold.js`
- Updated to use new `move_to_household` route.
- Added error reporting.
- Extracted out code into separate method.

`app/javascript/components/subject/RemoveFromHousehold.js`
- Updated to use new `remove_from_household` route.
- Added error reporting.

`app/javascript/components/subject/ChangeHOH.js`
- Added error reporting.

`test/controllers/patients_controller_test.rb`
- Lots of new tests for household updates.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.

Many automated test were added, but in addition please test the following via the UI:
- [ ] Each of the bugs outlined above are no longer replicable and instead show a descriptive error message.
- [ ] Test that moving to a household works as expected with updated history items.
- [ ] Test that changing a head of household works as expected with updated history items.
- [ ] Test that removing from a household works as expected with updated history items.
