### PR TITLE
Setting Default Mailer Queue in Application Configuration

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,6 @@ module SARAAlert
     config.exceptions_app = self.routes
 
     # Set default mailer queue
-    config.action_mailer.deliver_later_queue_name = 'mailers'
+    config.action_mailer.deliver_later_queue_name = :mailers
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,8 @@ module SARAAlert
     # Setup which 3rd party queing system to use
     config.active_job.queue_adapter = :sidekiq
     config.exceptions_app = self.routes
+
+    # Set default mailer queue
+    config.action_mailer.deliver_later_queue_name = 'mailers'
   end
 end


### PR DESCRIPTION
# Description
This is in response to a change in Rails 6.1 that changed the default queue user for ActionMailer jobs from `mailers` to `default`.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`config/application.rb`
- Changing the default mailer queue name explicitly to be `mailers`.

# Testing
Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.

To test, do the following:
- Run sidekiq on the default queue in one window
- Run sidekiq on the mailers queue in another
- Run something like `PatientMailer.assessment_sms(Patient.last).deliver_later` and notice it get enqueue in the `mailers` queue instead of `default`
