### PR TITLE
(Bugfix) Fix for Isolation Notes field in Enrollment/Edit Wizard

### DIFF
--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -298,9 +298,12 @@ class Exposure extends React.Component {
           </Form.Group>
         </Form.Row>
         <Form.Row>
-          <Form.Group as={Col} md="24" controlId="exposure_notes" className="mb-2">
-            <Form.Label className="nav-input-label ml-1">NOTES{schema?.fields?.exposure_notes?._exclusive?.required && ' *'}</Form.Label>
+          <Form.Group as={Col} md="24" className="mb-2">
+            <Form.Label htmlFor="exposure_notes" className="nav-input-label ml-1">
+              NOTES{schema?.fields?.exposure_notes?._exclusive?.required && ' *'}
+            </Form.Label>
             <Form.Control
+              id="exposure_notes"
               isInvalid={this.state.errors['exposure_notes']}
               as="textarea"
               rows="4"
@@ -550,9 +553,12 @@ class Exposure extends React.Component {
           </Form.Group>
         </Form.Row>
         <Form.Row>
-          <Form.Group as={Col} md="24" controlId="exposure_notes" className="pt-3 mb-2">
-            <Form.Label className="nav-input-label">NOTES{schema?.fields?.exposure_notes?._exclusive?.required && ' *'}</Form.Label>
+          <Form.Group as={Col} md="24" className="pt-3 mb-2">
+            <Form.Label htmlFor="exposure_notes" className="nav-input-label">
+              NOTES{schema?.fields?.exposure_notes?._exclusive?.required && ' *'}
+            </Form.Label>
             <Form.Control
+              id="exposure_notes"
               isInvalid={this.state.errors['exposure_notes']}
               as="textarea"
               rows="4"

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -298,12 +298,9 @@ class Exposure extends React.Component {
           </Form.Group>
         </Form.Row>
         <Form.Row>
-          <Form.Group as={Col} md="24" className="mb-2">
-            <Form.Label htmlFor="isolation_notes" className="nav-input-label ml-1">
-              NOTES{schema?.fields?.exposure_notes?._exclusive?.required && ' *'}
-            </Form.Label>
+          <Form.Group as={Col} md="24" controlId="exposure_notes" className="mb-2">
+            <Form.Label className="nav-input-label ml-1">NOTES{schema?.fields?.exposure_notes?._exclusive?.required && ' *'}</Form.Label>
             <Form.Control
-              id="isolation_notes"
               isInvalid={this.state.errors['exposure_notes']}
               as="textarea"
               rows="4"
@@ -553,12 +550,9 @@ class Exposure extends React.Component {
           </Form.Group>
         </Form.Row>
         <Form.Row>
-          <Form.Group as={Col} md="24" className="pt-3 mb-2">
-            <Form.Label htmlFor="exposure_notes" className="nav-input-label">
-              NOTES{schema?.fields?.exposure_notes?._exclusive?.required && ' *'}
-            </Form.Label>
+          <Form.Group as={Col} md="24" controlId="exposure_notes" className="pt-3 mb-2">
+            <Form.Label className="nav-input-label">NOTES{schema?.fields?.exposure_notes?._exclusive?.required && ' *'}</Form.Label>
             <Form.Control
-              id="exposure_notes"
               isInvalid={this.state.errors['exposure_notes']}
               as="textarea"
               rows="4"


### PR DESCRIPTION
# Description
As part of 1.21 we changed the ID on the isolation/case notes field which caused issues because the `handleChange` function expects the ID to match the field name which is `exposure_notes` in both cases. 

# (Bugfix) How to Replicate
Open enrollment wizard in isolation and try and type in case notes field.

# (Bugfix) Solution
See above description.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/javascript/components/enrollment/steps/Exposure.js`
- Above fix.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.

- [ ] Verify exposure notes work when enrolling in exposure workflow
- [ ] Verify case notes work when enrolling in isolation workflow
- [ ] Verify exposure notes work when editing record in exposure workflow
- [ ] Verify case notes work when editing record in isolation workflow