### PR TITLE
(Bugfix) Fixing check for purged on all_patients, viewable_patients, and in API.

### DIFF
--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -545,7 +545,7 @@ class Fhir::R4::ApiController < ActionController::API
       jurisdiction_id = current_client_application[:jurisdiction_id]
       return unless Jurisdiction.exists?(jurisdiction_id)
 
-      Jurisdiction.find_by(id: jurisdiction_id).all_patients
+      Jurisdiction.find_by(id: jurisdiction_id).all_patients.where(purged: false)
     end
   end
 

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -17,7 +17,7 @@ class Jurisdiction < ApplicationRecord
 
   # All patients are all those in this or descendent jurisdictions
   def all_patients
-    Patient.includes([:jurisdiction]).where(purged: false, jurisdiction_id: subtree_ids)
+    Patient.includes([:jurisdiction]).where(jurisdiction_id: subtree_ids)
   end
 
   # All users that are in this or descendent jurisdictions

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,7 @@ class User < ApplicationRecord
 
   # Patients this user can view through their jurisdiction access
   def viewable_patients
-    jurisdiction.all_patients
+    jurisdiction.all_patients.where(purged: false)
   end
 
   # Patients this user has enrolled


### PR DESCRIPTION
# Description
As part of 1.21.0, we added a `purged` check to the `all_patients` method. This affected analytics which use this method and want to include purged. This PR removes that check from `all_patients`, but adds it to the other places `all_patients` is called where it should filter out purged.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/models/jurisdiction.rb`
- Removing newly added purged check.

`app/controllers/fhir/r4/api_controller.rb`
- Adds purged check when getting accessible patients for M2M workflow.

`app/models/user.rb`
- Adding purged check on `viewable_patients` (which is used throughout the app for retrieving data for users).

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.

- [ ] Verify there are not other places where `all_patients` is used that requires a purged check.
- [ ] Verify updated methods work as expected.
