### PR TITLE
SARAALERT-1223: Don't send purge emails to locked Admins

### DIFF
--- a/app/jobs/send_purge_warnings_job.rb
+++ b/app/jobs/send_purge_warnings_job.rb
@@ -9,7 +9,7 @@ class SendPurgeWarningsJob < ApplicationJob
     not_sent = []
 
     # Get admin users but skip USA admins and locked users
-    recipients = User.where(role: [Roles::ADMIN, Roles::SUPER_USER], locked_at: nil).where.not(jurisdiction_id: Jurisdiction.find_by(name: 'USA').id)
+    recipients = User.where(role: [Roles::ADMIN, Roles::SUPER_USER], locked_at: nil).where.not(jurisdiction: Jurisdiction.root)
     eligible = recipients.count
 
     # Loop through and send each admin information about their purge eligible monitorees

--- a/app/jobs/send_purge_warnings_job.rb
+++ b/app/jobs/send_purge_warnings_job.rb
@@ -16,6 +16,8 @@ class SendPurgeWarningsJob < ApplicationJob
     recipients.each do |user|
       # Skip for USA admins
       next if user.jurisdiction&.name == 'USA'
+      # Don't send emails to locked users
+      next if !user.locked_at.nil?
 
       # Get num purgeable underneath this admin's purview
       num_purgeable_records = user.viewable_patients.purge_eligible.size

--- a/app/jobs/send_purge_warnings_job.rb
+++ b/app/jobs/send_purge_warnings_job.rb
@@ -14,10 +14,8 @@ class SendPurgeWarningsJob < ApplicationJob
 
     # Loop through and send each admin information about their purge eligible monitorees
     recipients.each do |user|
-      # Skip for USA admins
-      next if user.jurisdiction&.name == 'USA'
-      # Don't send emails to locked users
-      next if !user.locked_at.nil?
+      # Skip for USA admins and locked users
+      next if user.jurisdiction&.name == 'USA' || !user.locked_at.nil?
 
       # Get num purgeable underneath this admin's purview
       num_purgeable_records = user.viewable_patients.purge_eligible.size

--- a/app/jobs/send_purge_warnings_job.rb
+++ b/app/jobs/send_purge_warnings_job.rb
@@ -9,7 +9,7 @@ class SendPurgeWarningsJob < ApplicationJob
     not_sent = []
 
     # Get admin users but skip USA admins and locked users
-    recipients = User.where(role: [Roles::ADMIN, Roles::SUPER_USER], locked_at: nil).where.not(jurisdiction: 'USA')
+    recipients = User.where(role: [Roles::ADMIN, Roles::SUPER_USER], locked_at: nil).where.not(jurisdiction_id: Jurisdiction.find_by(name: 'USA').id)
     eligible = recipients.count
 
     # Loop through and send each admin information about their purge eligible monitorees

--- a/app/jobs/send_purge_warnings_job.rb
+++ b/app/jobs/send_purge_warnings_job.rb
@@ -9,12 +9,11 @@ class SendPurgeWarningsJob < ApplicationJob
     not_sent = []
 
     # Get admin users but skip USA admins and locked users
-    recipients = User.where(role: [Roles::ADMIN, Roles::SUPER_USER], locked_at: nil ).where.not(jurisdiction: 'USA')
+    recipients = User.where(role: [Roles::ADMIN, Roles::SUPER_USER], locked_at: nil).where.not(jurisdiction: 'USA')
     eligible = recipients.count
 
     # Loop through and send each admin information about their purge eligible monitorees
     recipients.each do |user|
-
       # Get num purgeable underneath this admin's purview
       num_purgeable_records = user.viewable_patients.purge_eligible.size
 

--- a/app/jobs/send_purge_warnings_job.rb
+++ b/app/jobs/send_purge_warnings_job.rb
@@ -8,14 +8,12 @@ class SendPurgeWarningsJob < ApplicationJob
     sent = []
     not_sent = []
 
-    # Get admin users
-    recipients = User.where(role: [Roles::ADMIN, Roles::SUPER_USER])
+    # Get admin users but skip USA admins and locked users
+    recipients = User.where(role: [Roles::ADMIN, Roles::SUPER_USER], locked_at: nil ).where.not(jurisdiction: 'USA')
     eligible = recipients.count
 
     # Loop through and send each admin information about their purge eligible monitorees
     recipients.each do |user|
-      # Skip for USA admins and locked users
-      next if user.jurisdiction&.name == 'USA' || !user.locked_at.nil?
 
       # Get num purgeable underneath this admin's purview
       num_purgeable_records = user.viewable_patients.purge_eligible.size

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -15,6 +15,11 @@ class Jurisdiction < ApplicationRecord
 
   has_many :stats, class_name: 'Stat'
 
+  # Find the USA Jurisdiction
+  def self.root
+    Jurisdiction.find_by(name: 'USA')
+  end
+
   # All patients are all those in this or descendent jurisdictions (including purged)
   def all_patients_including_purged
     Patient.includes([:jurisdiction]).where(jurisdiction_id: subtree_ids)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1223](https://tracker.codev.mitre.org/browse/SARAALERT-1223)

Locked admins should not receive emails about purge notices.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

1. Create a locked admin and an unlocked admin with jurisdiction over USA, State 1
2. Create a purge eligible patient in that jurisdiction
3. Start sidekiq up
4. Using the Ruby console enter `SendPurgeWarningsJob.perform_now`
5. Verify that the unlocked admin receives an email while the locked admin does not