### PR TITLE
SARAALERT-1085: Ensure Dashboard sticky filters are set properly

### DIFF
--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -182,42 +182,42 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     when 'name'
       patients = patients.order(last_name: dir).order(first_name: dir).order(id: dir)
     when 'jurisdiction'
-      patients = patients.includes(:jurisdiction).order('jurisdictions.name ' + dir).order(id: dir)
+      patients = patients.includes(:jurisdiction).order('jurisdictions.name ' + dir, id: dir)
     when 'transferred_from'
       patients = patients.joins('INNER JOIN jurisdictions ON jurisdictions.id = patients.latest_transfer_from')
-                         .order('jurisdictions.path ' + dir).order(id: dir)
+                         .order('jurisdictions.path ' + dir, id: dir)
     when 'transferred_to'
-      patients = patients.includes(:jurisdiction).order('jurisdictions.path ' + dir).order(id: dir)
+      patients = patients.includes(:jurisdiction).order('jurisdictions.path ' + dir, id: dir)
     when 'assigned_user'
-      patients = patients.order(Arel.sql('CASE WHEN assigned_user IS NULL THEN 1 ELSE 0 END, assigned_user ' + dir)).order(id: dir)
+      patients = patients.order(Arel.sql('CASE WHEN assigned_user IS NULL THEN 1 ELSE 0 END, assigned_user ' + dir), id: dir)
     when 'state_local_id'
-      patients = patients.order(Arel.sql('CASE WHEN user_defined_id_statelocal IS NULL THEN 1 ELSE 0 END, user_defined_id_statelocal ' + dir)).order(id: dir)
+      patients = patients.order(Arel.sql('CASE WHEN user_defined_id_statelocal IS NULL THEN 1 ELSE 0 END, user_defined_id_statelocal ' + dir), id: dir)
     when 'dob'
-      patients = patients.order(Arel.sql('CASE WHEN date_of_birth IS NULL THEN 1 ELSE 0 END, date_of_birth ' + dir)).order(id: dir)
+      patients = patients.order(Arel.sql('CASE WHEN date_of_birth IS NULL THEN 1 ELSE 0 END, date_of_birth ' + dir), id: dir)
     when 'end_of_monitoring'
       patients = patients.order(Arel.sql('CASE WHEN continuous_exposure = 1 THEN 1 ELSE 0 END,
-                                 CASE WHEN last_date_of_exposure IS NULL THEN patients.created_at ELSE last_date_of_exposure END ' + dir)).order(id: dir)
+                                 CASE WHEN last_date_of_exposure IS NULL THEN patients.created_at ELSE last_date_of_exposure END ' + dir), id: dir)
     when 'extended_isolation'
-      patients = patients.order(Arel.sql('CASE WHEN extended_isolation IS NULL THEN 1 ELSE 0 END, extended_isolation ' + dir)).order(id: dir)
+      patients = patients.order(Arel.sql('CASE WHEN extended_isolation IS NULL THEN 1 ELSE 0 END, extended_isolation ' + dir), id: dir)
     when 'symptom_onset'
-      patients = patients.order(Arel.sql('CASE WHEN symptom_onset IS NULL THEN 1 ELSE 0 END, symptom_onset ' + dir)).order(id: dir)
+      patients = patients.order(Arel.sql('CASE WHEN symptom_onset IS NULL THEN 1 ELSE 0 END, symptom_onset ' + dir), id: dir)
     when 'risk_level'
       patients = patients.order_by_risk(asc: dir == 'asc').order(id: dir)
     when 'monitoring_plan'
-      patients = patients.order(Arel.sql('monitoring_plan IS NULL, monitoring_plan ' + dir)).order(id: dir)
+      patients = patients.order(Arel.sql('monitoring_plan IS NULL, monitoring_plan ' + dir), id: dir)
     when 'public_health_action'
-      patients = patients.order(Arel.sql('CASE WHEN public_health_action IS NULL THEN 1 ELSE 0 END, public_health_action ' + dir)).order(id: dir)
+      patients = patients.order(Arel.sql('CASE WHEN public_health_action IS NULL THEN 1 ELSE 0 END, public_health_action ' + dir), id: dir)
     when 'expected_purge_date'
-      patients = patients.order(Arel.sql('CASE WHEN closed_at IS NULL THEN 1 ELSE 0 END, updated_at ' + dir)).order(id: dir)
+      patients = patients.order(Arel.sql('CASE WHEN closed_at IS NULL THEN 1 ELSE 0 END, updated_at ' + dir), id: dir)
       # Eligible purge date is a derivative field from `updated_at`
     when 'reason_for_closure'
-      patients = patients.order(Arel.sql('CASE WHEN monitoring_reason IS NULL THEN 1 ELSE 0 END, monitoring_reason ' + dir)).order(id: dir)
+      patients = patients.order(Arel.sql('CASE WHEN monitoring_reason IS NULL THEN 1 ELSE 0 END, monitoring_reason ' + dir), id: dir)
     when 'closed_at'
-      patients = patients.order(Arel.sql('CASE WHEN closed_at IS NULL THEN 1 ELSE 0 END, closed_at ' + dir)).order(id: dir)
+      patients = patients.order(Arel.sql('CASE WHEN closed_at IS NULL THEN 1 ELSE 0 END, closed_at ' + dir), id: dir)
     when 'transferred_at'
-      patients = patients.order(Arel.sql('CASE WHEN latest_transfer_at IS NULL THEN 1 ELSE 0 END, latest_transfer_at ' + dir)).order(id: dir)
+      patients = patients.order(Arel.sql('CASE WHEN latest_transfer_at IS NULL THEN 1 ELSE 0 END, latest_transfer_at ' + dir), id: dir)
     when 'latest_report'
-      patients = patients.order(Arel.sql('CASE WHEN latest_assessment_at IS NULL THEN 1 ELSE 0 END, latest_assessment_at ' + dir)).order(id: dir)
+      patients = patients.order(Arel.sql('CASE WHEN latest_assessment_at IS NULL THEN 1 ELSE 0 END, latest_assessment_at ' + dir), id: dir)
     end
 
     patients

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -180,43 +180,44 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
 
     case order
     when 'name'
-      patients = patients.order(last_name: dir).order(first_name: dir)
+      patients = patients.order(last_name: dir).order(first_name: dir).order(id: dir)
     when 'jurisdiction'
-      patients = patients.includes(:jurisdiction).order('jurisdictions.name ' + dir)
+      patients = patients.includes(:jurisdiction).order('jurisdictions.name ' + dir).order(id: dir)
     when 'transferred_from'
-      patients = patients.joins('INNER JOIN jurisdictions ON jurisdictions.id = patients.latest_transfer_from').order('jurisdictions.path ' + dir)
+      patients = patients.joins('INNER JOIN jurisdictions ON jurisdictions.id = patients.latest_transfer_from')
+                         .order('jurisdictions.path ' + dir).order(id: dir)
     when 'transferred_to'
-      patients = patients.includes(:jurisdiction).order('jurisdictions.path ' + dir)
+      patients = patients.includes(:jurisdiction).order('jurisdictions.path ' + dir).order(id: dir)
     when 'assigned_user'
-      patients = patients.order(Arel.sql('CASE WHEN assigned_user IS NULL THEN 1 ELSE 0 END, assigned_user ' + dir))
+      patients = patients.order(Arel.sql('CASE WHEN assigned_user IS NULL THEN 1 ELSE 0 END, assigned_user ' + dir)).order(id: dir)
     when 'state_local_id'
-      patients = patients.order(Arel.sql('CASE WHEN user_defined_id_statelocal IS NULL THEN 1 ELSE 0 END, user_defined_id_statelocal ' + dir))
+      patients = patients.order(Arel.sql('CASE WHEN user_defined_id_statelocal IS NULL THEN 1 ELSE 0 END, user_defined_id_statelocal ' + dir)).order(id: dir)
     when 'dob'
-      patients = patients.order(Arel.sql('CASE WHEN date_of_birth IS NULL THEN 1 ELSE 0 END, date_of_birth ' + dir))
+      patients = patients.order(Arel.sql('CASE WHEN date_of_birth IS NULL THEN 1 ELSE 0 END, date_of_birth ' + dir)).order(id: dir)
     when 'end_of_monitoring'
       patients = patients.order(Arel.sql('CASE WHEN continuous_exposure = 1 THEN 1 ELSE 0 END,
-                                 CASE WHEN last_date_of_exposure IS NULL THEN patients.created_at ELSE last_date_of_exposure END ' + dir))
+                                 CASE WHEN last_date_of_exposure IS NULL THEN patients.created_at ELSE last_date_of_exposure END ' + dir)).order(id: dir)
     when 'extended_isolation'
-      patients = patients.order(Arel.sql('CASE WHEN extended_isolation IS NULL THEN 1 ELSE 0 END, extended_isolation ' + dir))
+      patients = patients.order(Arel.sql('CASE WHEN extended_isolation IS NULL THEN 1 ELSE 0 END, extended_isolation ' + dir)).order(id: dir)
     when 'symptom_onset'
-      patients = patients.order(Arel.sql('CASE WHEN symptom_onset IS NULL THEN 1 ELSE 0 END, symptom_onset ' + dir))
+      patients = patients.order(Arel.sql('CASE WHEN symptom_onset IS NULL THEN 1 ELSE 0 END, symptom_onset ' + dir)).order(id: dir)
     when 'risk_level'
-      patients = patients.order_by_risk(asc: dir == 'asc')
+      patients = patients.order_by_risk(asc: dir == 'asc').order(id: dir)
     when 'monitoring_plan'
-      patients = patients.order(Arel.sql('monitoring_plan IS NULL, monitoring_plan ' + dir))
+      patients = patients.order(Arel.sql('monitoring_plan IS NULL, monitoring_plan ' + dir)).order(id: dir)
     when 'public_health_action'
-      patients = patients.order(Arel.sql('CASE WHEN public_health_action IS NULL THEN 1 ELSE 0 END, public_health_action ' + dir))
+      patients = patients.order(Arel.sql('CASE WHEN public_health_action IS NULL THEN 1 ELSE 0 END, public_health_action ' + dir)).order(id: dir)
     when 'expected_purge_date'
-      patients = patients.order(Arel.sql('CASE WHEN closed_at IS NULL THEN 1 ELSE 0 END, updated_at ' + dir))
+      patients = patients.order(Arel.sql('CASE WHEN closed_at IS NULL THEN 1 ELSE 0 END, updated_at ' + dir)).order(id: dir)
       # Eligible purge date is a derivative field from `updated_at`
     when 'reason_for_closure'
-      patients = patients.order(Arel.sql('CASE WHEN monitoring_reason IS NULL THEN 1 ELSE 0 END, monitoring_reason ' + dir))
+      patients = patients.order(Arel.sql('CASE WHEN monitoring_reason IS NULL THEN 1 ELSE 0 END, monitoring_reason ' + dir)).order(id: dir)
     when 'closed_at'
-      patients = patients.order(Arel.sql('CASE WHEN closed_at IS NULL THEN 1 ELSE 0 END, closed_at ' + dir))
+      patients = patients.order(Arel.sql('CASE WHEN closed_at IS NULL THEN 1 ELSE 0 END, closed_at ' + dir)).order(id: dir)
     when 'transferred_at'
-      patients = patients.order(Arel.sql('CASE WHEN latest_transfer_at IS NULL THEN 1 ELSE 0 END, latest_transfer_at ' + dir))
+      patients = patients.order(Arel.sql('CASE WHEN latest_transfer_at IS NULL THEN 1 ELSE 0 END, latest_transfer_at ' + dir)).order(id: dir)
     when 'latest_report'
-      patients = patients.order(Arel.sql('CASE WHEN latest_assessment_at IS NULL THEN 1 ELSE 0 END, latest_assessment_at ' + dir))
+      patients = patients.order(Arel.sql('CASE WHEN latest_assessment_at IS NULL THEN 1 ELSE 0 END, latest_assessment_at ' + dir)).order(id: dir)
     end
 
     patients

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -180,7 +180,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
 
     case order
     when 'name'
-      patients = patients.order(last_name: dir).order(first_name: dir).order(id: dir)
+      patients = patients.order(last_name: dir, first_name: dir, id: dir)
     when 'jurisdiction'
       patients = patients.includes(:jurisdiction).order('jurisdictions.name ' + dir, id: dir)
     when 'transferred_from'

--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -9,10 +9,21 @@ class CustomTable extends React.Component {
     super(props);
     this.state = {
       tableQuery: {
-        orderBy: '',
-        sortDirection: '',
+        orderBy: props.orderBy,
+        sortDirection: props.sortDirection,
       },
     };
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.sortDirection !== prevProps.sortDirection || this.props.orderBy !== prevProps.orderBy) {
+      this.setState(state => {
+        const sortDirection = this.props.sortDirection;
+        const orderBy = this.props.orderBy;
+        const tableQuery = { ...state.tableQuery, sortDirection, orderBy };
+        return { tableQuery };
+      });
+    }
   }
 
   /**
@@ -293,12 +304,16 @@ CustomTable.propTypes = {
   getRowClassName: PropTypes.func,
   getCustomTableClassName: PropTypes.func,
   currentUser: PropTypes.string,
+  orderBy: PropTypes.string,
+  sortDirection: PropTypes.string,
 };
 
 CustomTable.defaultProps = {
   handleEdit: () => {},
   handleTableUpdate: () => {},
   handleSelect: () => {},
+  orderBy: '',
+  sortDirection: '',
 };
 
 export default CustomTable;

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -193,9 +193,33 @@ class PatientsTable extends React.Component {
     localStorage.removeItem(`SaraPage`);
     localStorage.removeItem(`SaraSortField`);
     localStorage.removeItem(`SaraSortDirection`);
+
+    const query = {};
+    query.tab = tab;
+
+    // specifically grab jurisdiction & assigned user filter values when coming from the Transferred Out line list (cause they were hidden)
+    if (this.state.query.tab === 'transferred_out') {
+      // Set jurisdiction if it exists in local storage
+      let jurisdiction = localStorage.getItem('SaraJurisdiction');
+      if (jurisdiction) {
+        query.jurisdiction = parseInt(jurisdiction);
+      }
+
+      // Set scope if it exists in local storage
+      let scope = localStorage.getItem('SaraScope');
+      if (scope) {
+        query.scope = scope;
+      }
+
+      // Set assigned user if it exists in local storage
+      let assigned_user = localStorage.getItem('SaraAssignedUser');
+      if (assigned_user) {
+        query.user = assigned_user;
+      }
+    }
     this.setState(
       state => {
-        return { query: { ...state.query, tab, order: '', direction: '', page: 0 } };
+        return { query: { ...state.query, ...query, order: '', direction: '', page: 0 } };
       },
       () => {
         this.updateAssignedUsers(this.state.query);

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -122,30 +122,30 @@ class PatientsTable extends React.Component {
     if (search) {
       query.search = search;
     }
-    // Set page if it exists in local storage
+    // Set page if it exists in local storage & user is in the same workflow as before
+    let priorWorkflow = localStorage.getItem(`Workflow`);
     let page = localStorage.getItem(`SaraPage`);
-    if (query !== {}) {
+    if (page && priorWorkflow && this.props.workflow === priorWorkflow) {
+      query.page = parseInt(page);
+    } else {
       localStorage.removeItem(`SaraPage`);
       query.page = 0;
-    } else if (page && !('page' in query)) {
-      query.page = JSON.parse(page);
     }
+    // Update workflow local storage to be current
+    localStorage.setItem(`Workflow`, this.props.workflow);
     // Set entries if it exists in local storage
     let entries = localStorage.getItem(`SaraEntries`);
     if (parseInt(entries)) {
       query.entries = parseInt(entries);
     }
 
-    // Update Table a single time if an update is needed
-    if (query !== {}) {
-      this.updateTable({ ...this.state.query, ...query });
+    // Update the table a single time
+    this.updateTable({ ...this.state.query, ...query });
 
-      jurisdiction = jurisdiction ? jurisdiction : this.state.query.jurisdiction;
-      scope = scope ? scope : this.state.query.scope;
-      tab = tab ? tab : this.state.query.tab;
-
-      this.updateAssignedUsers(jurisdiction, scope, this.props.workflow, tab);
-    }
+    jurisdiction = jurisdiction ? jurisdiction : this.state.query.jurisdiction;
+    scope = scope ? scope : this.state.query.scope;
+    tab = tab ? tab : this.state.query.tab;
+    this.updateAssignedUsers(jurisdiction, scope, this.props.workflow, tab);
 
     // fetch workflow and tab counts
     Object.keys(this.props.tabs).forEach(tab => {
@@ -204,7 +204,7 @@ class PatientsTable extends React.Component {
       },
       () => {
         this.updateTable(this.state.query);
-        localStorage.setItem(`SaraPage`, JSON.stringify(page));
+        localStorage.setItem(`SaraPage`, page.selected);
       }
     );
   };

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -91,53 +91,60 @@ class PatientsTable extends React.Component {
   }
 
   componentDidMount() {
-    // load saved tab from local storage if present
+    // load local storage variables when present
+    const query = {};
+
+    // Set tab from local storage if it exists and is a valid tab
     let tab = localStorage.getItem(`${this.props.workflow}Tab`);
-    if (tab === null || !(tab in this.props.tabs)) {
-      tab = this.state.query.tab;
-      localStorage.setItem(`${this.props.workflow}Tab`, tab);
+    if (tab === null || !Object.keys(this.props.tabs).includes(tab)) {
+      query.tab = this.state.query.tab;
+      localStorage.setItem(`${this.props.workflow}Tab`, query.tab);
+    } else {
+      query.tab = tab;
     }
-
-    // select tab and fetch patients
-    this.handleTabSelect(tab);
-
     // Set jurisdiction if it exists in local storage
     let jurisdiction = localStorage.getItem('SaraJurisdiction');
     if (jurisdiction) {
-      this.handleJurisdictionChange(parseInt(jurisdiction));
+      query.jurisdiction = parseInt(jurisdiction);
     }
-
+    // Set scope if it exists in local storage
+    let scope = localStorage.getItem('SaraScope');
+    if (scope) {
+      query.scope = scope;
+    }
     // Set assigned user if it exists in local storage
     let assigned_user = localStorage.getItem('SaraAssignedUser');
     if (assigned_user) {
-      this.handleAssignedUserChange(assigned_user);
+      query.user = assigned_user;
     }
-
     // Set search if it exists in local storage
     let search = localStorage.getItem(`SaraSearch`);
     if (search) {
-      this.setState(
-        state => {
-          return {
-            query: { ...state.query, search: search },
-          };
-        },
-        () => {
-          this.updateTable(this.state.query);
-        }
-      );
+      query.search = search;
     }
-
-    // Select page if it exists in local storage
+    // Set page if it exists in local storage
     let page = localStorage.getItem(`SaraPage`);
-    if (page) {
-      this.handlePageUpdate(JSON.parse(page));
+    if (query !== {}) {
+      localStorage.removeItem(`SaraPage`);
+      query.page = 0;
+    } else if (page && !('page' in query)) {
+      query.page = JSON.parse(page);
     }
-
     // Set entries if it exists in local storage
     let entries = localStorage.getItem(`SaraEntries`);
     if (parseInt(entries)) {
-      this.handleEntriesChange(parseInt(entries));
+      query.entries = parseInt(entries);
+    }
+
+    // Update Table a single time if an update is needed
+    if (query !== {}) {
+      this.updateTable({ ...this.state.query, ...query });
+
+      jurisdiction = jurisdiction ? jurisdiction : this.state.query.jurisdiction;
+      scope = scope ? scope : this.state.query.scope;
+      tab = tab ? tab : this.state.query.tab;
+
+      this.updateAssignedUsers(jurisdiction, scope, this.props.workflow, tab);
     }
 
     // fetch workflow and tab counts

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -133,12 +133,12 @@ class PatientsTable extends React.Component {
     let sortField = localStorage.getItem(`SaraSortField`);
     let sortDirection = localStorage.getItem(`SaraSortDirection`);
     if (priorWorkflow && this.props.workflow === priorWorkflow) {
-      if (page) {
+      if (parseInt(page)) {
         query.page = parseInt(page);
       }
       if (sortField && sortDirection) {
         query.order = sortField;
-        query.direction = sortDirection;
+        query.direction = sortDirection === 'asc' ? 'asc' : 'desc';
       }
       // Set a flag so any sticky advanced filter does not reset page & sort settings
       localStorage.setItem('KeepCurrentSettings', true);
@@ -147,10 +147,10 @@ class PatientsTable extends React.Component {
       localStorage.removeItem(`SaraSortField`);
       localStorage.removeItem(`SaraSortDirection`);
       localStorage.setItem('KeepCurrentSettings', false);
+      // Update workflow local storage to be the current workflow
+      localStorage.setItem(`Workflow`, this.props.workflow);
       query.page = 0;
     }
-    // Update workflow local storage to be the current workflow
-    localStorage.setItem(`Workflow`, this.props.workflow);
 
     // Set entries if it exists in local storage
     let entries = localStorage.getItem(`SaraEntries`);
@@ -175,8 +175,6 @@ class PatientsTable extends React.Component {
     if (await confirmDialog('Are you sure you want to clear all filters? All active filters and searches will be cleared.')) {
       localStorage.removeItem(`SaraFilter`);
       localStorage.removeItem(`SaraPage`);
-      localStorage.removeItem(`SaraSortField`);
-      localStorage.removeItem(`SaraSortDirection`);
       localStorage.removeItem(`SaraEntries`);
       localStorage.removeItem(`SaraSearch`);
       localStorage.removeItem(`SaraJurisdiction`);
@@ -197,7 +195,7 @@ class PatientsTable extends React.Component {
     localStorage.removeItem(`SaraSortDirection`);
     this.setState(
       state => {
-        return { query: { ...state.query, tab, page: 0 } };
+        return { query: { ...state.query, tab, order: '', direction: '', page: 0 } };
       },
       () => {
         this.updateAssignedUsers(this.state.query);
@@ -233,8 +231,6 @@ class PatientsTable extends React.Component {
    */
   handleEntriesChange = event => {
     localStorage.removeItem(`SaraPage`);
-    localStorage.removeItem(`SaraSortField`);
-    localStorage.removeItem(`SaraSortDirection`);
     const value = event?.target?.value || event;
     this.setState(
       state => {
@@ -253,8 +249,6 @@ class PatientsTable extends React.Component {
     if (jurisdiction !== this.state.query.jurisdiction) {
       this.updateAssignedUsers({ ...this.state.query, jurisdiction, page: 0 });
       localStorage.removeItem(`SaraPage`);
-      localStorage.removeItem(`SaraSortField`);
-      localStorage.removeItem(`SaraSortDirection`);
       localStorage.setItem(`SaraJurisdiction`, jurisdiction);
     }
   };
@@ -263,8 +257,6 @@ class PatientsTable extends React.Component {
     if (scope !== this.state.query.scope) {
       this.updateAssignedUsers({ ...this.state.query, scope, page: 0 });
       localStorage.removeItem(`SaraPage`);
-      localStorage.removeItem(`SaraSortField`);
-      localStorage.removeItem(`SaraSortDirection`);
       localStorage.setItem(`SaraScope`, scope);
     }
   };
@@ -273,8 +265,6 @@ class PatientsTable extends React.Component {
     if (user !== this.state.query.user) {
       this.updateTable({ ...this.state.query, user, page: 0 });
       localStorage.removeItem(`SaraPage`);
-      localStorage.removeItem(`SaraSortField`);
-      localStorage.removeItem(`SaraSortDirection`);
       if (user) {
         localStorage.setItem(`SaraAssignedUser`, user);
       } else {
@@ -286,8 +276,6 @@ class PatientsTable extends React.Component {
   handleSearchChange = event => {
     this.updateTable({ ...this.state.query, search: event.target?.value, page: 0 });
     localStorage.removeItem(`SaraPage`);
-    localStorage.removeItem(`SaraSortField`);
-    localStorage.removeItem(`SaraSortDirection`);
     localStorage.setItem(`SaraSearch`, event.target.value);
   };
 

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -132,8 +132,11 @@ class PatientsTable extends React.Component {
     let page = localStorage.getItem(`SaraPage`);
     if (page && priorWorkflow && this.props.workflow === priorWorkflow) {
       query.page = parseInt(page);
+      // Set a flag to be leveraged when a sticky advanced filter is applied, so the page is not auto set back to 0
+      localStorage.setItem('KeepSaraPage', true);
     } else {
       localStorage.removeItem(`SaraPage`);
+      localStorage.setItem('KeepSaraPage', false);
       query.page = 0;
     }
     // Update workflow local storage to be the current workflow
@@ -354,12 +357,21 @@ class PatientsTable extends React.Component {
   }, 500);
 
   advancedFilterUpdate = filter => {
-    localStorage.removeItem(`SaraPage`);
+    // When available in local storage, set the pagination number when the page is reloaded with a sticky advanced filter
+    const keepPage = localStorage.getItem('KeepSaraPage') == 'true';
+    const localStoragePage = localStorage.getItem('SaraPage');
+    let page = 0;
+    if (keepPage && localStoragePage) {
+      page = parseInt(localStoragePage);
+      localStorage.removeItem(`KeepSaraPage`);
+    } else {
+      localStorage.removeItem(`SaraPage`);
+    }
     this.setState(
       state => {
         const query = state.query;
         query.filter = filter?.filter(field => field?.filterOption != null);
-        query.page = 0;
+        query.page = page;
         return { query };
       },
       () => {

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -508,7 +508,7 @@ class PatientsTable extends React.Component {
             <Card.Body className="pl-4 pr-4">
               <Row>
                 <Col md="18">
-                  <div className="lead mt-1 mb-3">
+                  <div id="tab-description" className="lead mt-1 mb-3">
                     {this.props.tabs[this.state.query.tab].description} You are currently in the <u>{this.props.workflow}</u> workflow.
                     {this.props.tabs[this.state.query.tab].tooltip && (
                       <InfoTooltip tooltipTextKey={this.props.tabs[this.state.query.tab].tooltip} location="right"></InfoTooltip>
@@ -517,7 +517,7 @@ class PatientsTable extends React.Component {
                 </Col>
                 <Col>
                   <div className="float-right">
-                    <Button size="sm" onClick={this.clearAllFilters}>
+                    <Button id="clear-all-filters" size="sm" onClick={this.clearAllFilters}>
                       <i className="fas fa-eraser"></i>
                       <span className="ml-1">Clear All Filters</span>
                     </Button>
@@ -574,7 +574,7 @@ class PatientsTable extends React.Component {
                     workflow={this.props.workflow}
                     updateStickySettings={true}
                   />
-                  {this.state.query !== 'transferred_out' && (
+                  {this.state.query.tab !== 'transferred_out' && (
                     <DropdownButton
                       as={ButtonGroup}
                       size="sm"

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -269,24 +269,28 @@ class AdvancedFilter extends React.Component {
   };
 
   // Apply the current filter
-  apply = () => {
+  apply = keepStickySettings => {
     const appliedFilter = {
       activeFilter: this.state.activeFilter,
       activeFilterOptions: _.cloneDeep(this.state.activeFilterOptions),
     };
     this.setState({ show: false, applied: true, lastAppliedFilter: appliedFilter }, () => {
-      this.props.advancedFilterUpdate(this.state.activeFilterOptions);
+      this.props.advancedFilterUpdate(this.state.activeFilterOptions, keepStickySettings);
       if (this.props.updateStickySettings && this.state.activeFilter) {
         localStorage.setItem(`SaraFilter`, this.state.activeFilter.id);
       }
     });
   };
 
+  handleApplyClick = () => {
+    this.apply(false);
+  };
+
   // Clear the current filter
   clear = () => {
     this.setState({ activeFilterOptions: [], show: false, activeFilter: null, applied: false }, () => {
       this.add();
-      this.props.advancedFilterUpdate(this.state.activeFilter);
+      this.props.advancedFilterUpdate(this.state.activeFilter, false);
       if (this.props.updateStickySettings) {
         localStorage.setItem(`SaraFilter`, null);
       }
@@ -313,12 +317,18 @@ class AdvancedFilter extends React.Component {
     });
   };
 
-  // Set the active filter
+  /**
+   * Set the active filter
+   *
+   * @param {Object} filter
+   * @param {Bool} apply - only true when called from componentDidMount(), a flag to determine when the filter should be applied to the results
+   *                         results & when other existing sticky settings/filter on the table should persist
+   */
   setFilter = (filter, apply = false) => {
     if (filter) {
       this.setState({ activeFilter: filter, show: true, activeFilterOptions: filter?.contents || [] }, () => {
         if (apply) {
-          this.apply();
+          this.apply(true);
         }
       });
     }
@@ -823,7 +833,7 @@ class AdvancedFilter extends React.Component {
                 <Button id="advanced-filter-reset" variant="danger" onClick={this.reset}>
                   Reset
                 </Button>
-                <Button id="advanced-filter-apply" variant="primary" className="ml-2" onClick={this.apply}>
+                <Button id="advanced-filter-apply" variant="primary" className="ml-2" onClick={this.handleApplyClick}>
                   Apply
                 </Button>
               </div>

--- a/app/javascript/components/public_health/query/AssignedUserFilter.js
+++ b/app/javascript/components/public_health/query/AssignedUserFilter.js
@@ -43,7 +43,7 @@ class AssignedUserFilter extends React.Component {
           type="text"
           autoComplete="off"
           list="assigned_users"
-          value={this.state.assigned_user || ''}
+          defaultValue={this.props.assigned_user !== 'none' ? this.props.assigned_user : ''}
           onChange={event => this.handleAssignedUserChange(event?.target?.value)}
         />
         <datalist id="assigned_users">

--- a/app/javascript/components/public_health/query/AssignedUserFilter.js
+++ b/app/javascript/components/public_health/query/AssignedUserFilter.js
@@ -5,13 +5,6 @@ import { Button, Form, InputGroup, OverlayTrigger, Tooltip } from 'react-bootstr
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 class AssignedUserFilter extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      assigned_user: props.assigned_user !== 'none' ? props.assigned_user : '' || '',
-    };
-  }
-
   handleAssignedUserChange = assigned_user => {
     if (!isNaN(assigned_user) && parseInt(assigned_user) > 0 && parseInt(assigned_user) <= 999999) {
       this.setState({ assigned_user }, () => {

--- a/app/javascript/tests/public_health/Export.test.js
+++ b/app/javascript/tests/public_health/Export.test.js
@@ -22,11 +22,6 @@ function getIsolationWrapper() {
     jurisdiction_paths={mockJurisdictionPaths} jurisdiction={mockJurisdiction1} query={mockQuery2} tabs={mockIsolationTabs} />);
 }
 
-function getInstance() {
-  return shallow(<Export all_monitorees_count={200} authenticity_token={authyToken} current_monitorees_count={32} custom_export_options={{}}
-    jurisdiction_paths={mockJurisdictionPaths} jurisdiction={mockJurisdiction1} query={mockQuery2} tabs={mockIsolationTabs} />).instance();
-}
-
 describe('Export', () => {
   it('Properly renders all main components', () => {
     const wrapper = getExposureWrapper();
@@ -110,7 +105,7 @@ describe('Export', () => {
   });
 
   it('Calls reloadExportPresets method when component mounts', () => {
-    const instance  = getInstance();
+    const instance  = getExposureWrapper().instance();
     const reloadPresetsSpy = jest.spyOn(instance, 'reloadExportPresets');
     expect(reloadPresetsSpy).toHaveBeenCalledTimes(0); 
     instance.componentDidMount();

--- a/app/javascript/tests/public_health/PatientsTable.test.js
+++ b/app/javascript/tests/public_health/PatientsTable.test.js
@@ -30,18 +30,12 @@ function getIsolationWrapper() {
     tabs={mockIsolationTabs} monitoring_reasons={mockMonitoringReasons} setQuery={setQueryMock} setFilteredMonitoreesCount={setMonitoreeCountMock}/>);
 }
 
-// Set to exposure workflow
-function getInstance() {
-  return shallow(<PatientsTable authenticity_token={authyToken} jurisdiction_paths={mockJurisdictionPaths} workflow={'exposure'} jurisdiction={mockJurisdiction1}
-    tabs={mockExposureTabs} monitoring_reasons={mockMonitoringReasons} setQuery={setQueryMock} setFilteredMonitoreesCount={setMonitoreeCountMock}/>).instance();
-}
-
 afterEach(() => {
   jest.clearAllMocks();
 });
 
 describe('PatientsTable', () => {
-  it('Properly renders all main components', () => {
+  it('Properly renders all main components for the exposure workflow', () => {
     const wrapper = getExposureWrapper();
     expect(wrapper.find('#search').exists()).toBeTruthy();
     expect(wrapper.find('#tab-description').exists()).toBeTruthy();
@@ -58,7 +52,24 @@ describe('PatientsTable', () => {
         .toEqual(mockExposureTabs[defaultTab]['description'] + ' You are currently in the exposure workflow.');
   });
 
-  it('Sets state correctly', () => {
+  it('Properly renders all main components for the isolation workflow', () => {
+    const wrapper = getIsolationWrapper();
+    expect(wrapper.find('#search').exists()).toBeTruthy();
+    expect(wrapper.find('#tab-description').exists()).toBeTruthy();
+    expect(wrapper.find('#clear-all-filters').exists()).toBeTruthy();
+    expect(wrapper.containsMatchingElement(JurisdictionFilter)).toBeTruthy();
+    expect(wrapper.containsMatchingElement(AssignedUserFilter)).toBeTruthy();
+    expect(wrapper.containsMatchingElement(AdvancedFilter)).toBeTruthy();
+    expect(wrapper.containsMatchingElement(CustomTable)).toBeTruthy();
+    expect(wrapper.containsMatchingElement(DropdownButton)).toBeTruthy();
+    expect(wrapper.find(Dropdown.Item).length).toEqual(3);
+
+    const defaultTab = Object.keys(mockIsolationTabs)[0]
+    expect(wrapper.find('#tab-description').text())
+        .toEqual(mockIsolationTabs[defaultTab]['description'] + ' You are currently in the isolation workflow.');
+  });
+
+  it('Sets intial state correctly', () => {
     const wrapper = getExposureWrapper();
     expect(_.size(wrapper.state('table').colData)).toEqual(20);
     expect(_.size(wrapper.state('table').displayedColData)).toEqual(0);
@@ -123,30 +134,26 @@ describe('PatientsTable', () => {
   });
 
   it('Calls updateAssignedUsers and updateTable methods when component mounts', () => {
-    const instance = getInstance();
+    const instance = getExposureWrapper().instance();
     const updateAssignedUsersSpy = jest.spyOn(instance, 'updateAssignedUsers');
     expect(updateAssignedUsersSpy).toHaveBeenCalledTimes(0);
     instance.componentDidMount();
     expect(updateAssignedUsersSpy).toHaveBeenCalledTimes(1);
   });
 
-  describe('ExposureDashboard', () => {
-    it('Properly renders all tabs', () => {
-      const wrapper = getExposureWrapper();
-      for (var key of Object.keys(mockExposureTabs)) {
-        expect(wrapper.find('#' + key + '_tab').exists()).toBeTruthy();
-        expect(wrapper.find('#' + key + '_tab').text()).toEqual(mockExposureTabs[key]['label']);
-      }
-    });
+  it('Properly renders all tabs on exposure dashboard', () => {
+    const wrapper = getExposureWrapper();
+    for (var key of Object.keys(mockExposureTabs)) {
+      expect(wrapper.find('#' + key + '_tab').exists()).toBeTruthy();
+      expect(wrapper.find('#' + key + '_tab').text()).toEqual(mockExposureTabs[key]['label']);
+    }
   });
 
-  describe('IsolationDashboard', () => {
-    it('Properly renders all tabs', () => {
-      const wrapper = getIsolationWrapper();
-      for (var key of Object.keys(mockIsolationTabs)) {
-        expect(wrapper.find('#' + key + '_tab').exists()).toBeTruthy();
-        expect(wrapper.find('#' + key + '_tab').text()).toEqual(mockIsolationTabs[key]['label']);
-      }
-    });
+  it('Properly renders all tabs on isolation dashboard', () => {
+    const wrapper = getIsolationWrapper();
+    for (var key of Object.keys(mockIsolationTabs)) {
+      expect(wrapper.find('#' + key + '_tab').exists()).toBeTruthy();
+      expect(wrapper.find('#' + key + '_tab').text()).toEqual(mockIsolationTabs[key]['label']);
+    }
   });
 });

--- a/app/javascript/tests/public_health/PatientsTable.test.js
+++ b/app/javascript/tests/public_health/PatientsTable.test.js
@@ -69,27 +69,33 @@ describe('PatientsTable', () => {
         .toEqual(mockIsolationTabs[defaultTab]['description'] + ' You are currently in the isolation workflow.');
   });
 
-  it('Sets intial state correctly', () => {
+  it('Sets intial state after mount correctly', () => {
     const wrapper = getExposureWrapper();
-    expect(_.size(wrapper.state('table').colData)).toEqual(20);
-    expect(_.size(wrapper.state('table').displayedColData)).toEqual(0);
-    expect(_.size(wrapper.state('table').rowData)).toEqual(0);
-    expect(wrapper.state('table').totalRows).toEqual(0);
-    expect(wrapper.state('loading')).toBeFalsy();
-    expect(wrapper.state('actionsEnabled')).toBeFalsy();
-    expect(_.size(wrapper.state('selectedPatients'))).toEqual(0);
-    expect(wrapper.state('selectAll')).toBeFalsy();
-    expect(wrapper.state('jurisdiction_paths')).toEqual({});
-    expect(_.size(wrapper.state('assigned_users'))).toEqual(0);
-    expect(wrapper.state('query').workflow).toEqual('exposure');
-    expect(wrapper.state('query').tab).toEqual(Object.keys(mockExposureTabs)[0]);
-    expect(wrapper.state('query').jurisdiction).toEqual(mockJurisdiction1.id);
-    expect(wrapper.state('query').scope).toEqual('all');
-    expect(wrapper.state('query').user).toEqual(null);
-    expect(wrapper.state('query').search).toEqual('');
-    expect(wrapper.state('query').page).toEqual(0);
-    expect(wrapper.state('query').entries).toEqual(25);
-    expect(_.size(wrapper.state('entryOptions'))).toEqual(5);
+
+    // componentDidMount is called when mounted and that calls an async method (updateTable),
+    // as a result, we added a timeout to give it time to resolve.
+    setTimeout (() => {
+      expect(_.size(wrapper.state('table').colData)).toEqual(20);
+      expect(_.size(wrapper.state('table').displayedColData)).toEqual(0);
+      expect(_.size(wrapper.state('table').rowData)).toEqual(0);
+      expect(wrapper.state('table').totalRows).toEqual(0);
+      expect(wrapper.state('loading')).toBeFalsy();
+      expect(wrapper.state('actionsEnabled')).toBeFalsy();
+      expect(_.size(wrapper.state('selectedPatients'))).toEqual(0);
+      expect(wrapper.state('selectAll')).toBeFalsy();
+      expect(wrapper.state('jurisdiction_paths')).toEqual({});
+      expect(_.size(wrapper.state('assigned_users'))).toEqual(0);
+      expect(wrapper.state('query').workflow).toEqual('exposure');
+      expect(wrapper.state('query').tab).toEqual(Object.keys(mockExposureTabs)[0]);
+      expect(wrapper.state('query').jurisdiction).toEqual(mockJurisdiction1.id);
+      expect(wrapper.state('query').scope).toEqual('all');
+      expect(wrapper.state('query').user).toEqual(null);
+      expect(wrapper.state('query').search).toEqual('');
+      expect(wrapper.state('query').page).toEqual(0);
+      expect(wrapper.state('query').entries).toEqual(25);
+      expect(_.size(wrapper.state('entryOptions'))).toEqual(5);
+    }, 500)
+
   });
 
   it('Properly renders dropdown', () => {

--- a/app/javascript/tests/public_health/PatientsTable.test.js
+++ b/app/javascript/tests/public_health/PatientsTable.test.js
@@ -38,7 +38,6 @@ function getInstance() {
 
 afterEach(() => {
   jest.clearAllMocks();
-  document.getElementsByTagName('html')[0].innerHTML = '';
 });
 
 describe('PatientsTable', () => {
@@ -89,25 +88,6 @@ describe('PatientsTable', () => {
     });
   });
 
-  // it('Clicking the clear filters button calls clear all filters function', () => {
-  //   // TODO: need to determine how to test with local storage values that have been set
-  //   const wrapper = getExposureWrapper();
-  //   const clearAllFiltersSpy = jest.spyOn(wrapper.instance(), 'clearAllFilters');
-  //   expect(clearAllFiltersSpy).toHaveBeenCalledTimes(0);
-  //   wrapper.find('#clear-all-filters').simulate('click');
-  //   expect(clearAllFiltersSpy).toHaveBeenCalledTimes(1);
-  // });
-
-  // it('Jurisdiction and assigned user filters hidden in Transferred Out line list', () => {
-  //   // TODO: need new wrapper created to ensure other tests are not impacted by testing tab selection
-  //   const wrapper = getExposureWrapper();
-  //   expect(wrapper.find('#transferred_out_tab').exists()).toBeTruthy();
-  //   wrapper.instance().handleTabSelect('transferred_out');
-  //   expect(wrapper.containsMatchingElement(JurisdictionFilter)).toBeFalsy();
-  //   expect(wrapper.containsMatchingElement(AssignedUserFilter)).toBeFalsy();
-  //   expect(wrapper.containsMatchingElement(DropdownButton)).toBeFalsy();
-  // });
-
   it('Inputting text into search bar calls update table function', () => {
     const wrapper = getExposureWrapper();
     const handleSearchChangeSpy = jest.spyOn(wrapper.instance(), 'updateTable');
@@ -150,43 +130,12 @@ describe('PatientsTable', () => {
     expect(updateAssignedUsersSpy).toHaveBeenCalledTimes(1);
   });
 
-  // it('Close records bulk action hidden in the Closed line list', () => {
-  //   // TODO: need new wrapper created to ensure other tests are not impacted by testing tab selection
-  //   const wrapper = getExposureWrapper();
-  //   expect(wrapper.find(Dropdown.Item).length).toEqual(3);
-  //   expect(wrapper.find('#closed_tab').exists()).toBeTruthy();
-  //   wrapper.instance().handleTabSelect('closed');
-  //   expect(wrapper.find(Dropdown.Item).length).toEqual(2);
-  //   dropdownOptions.forEach(function(option) {
-  //     if (option === 'Close Records') {
-  //       expect(wrapper.find(Dropdown.Item).someWhere((item) => item.text() === option)).toBeFalsy();
-  //     } else {
-  //       expect(wrapper.find(Dropdown.Item).someWhere((item) => item.text() === option)).toBeTruthy();
-  //     }
-  //   });
-  // });
-
   describe('ExposureDashboard', () => {
     it('Properly renders all tabs', () => {
       const wrapper = getExposureWrapper();
       for (var key of Object.keys(mockExposureTabs)) {
         expect(wrapper.find('#' + key + '_tab').exists()).toBeTruthy();
         expect(wrapper.find('#' + key + '_tab').text()).toEqual(mockExposureTabs[key]['label']);
-      }
-    });
-
-    it('Sets the tab description properly for each tab', () => {
-      const wrapper = getExposureWrapper();
-      expect(wrapper.state('query').tab).toEqual(Object.keys(mockExposureTabs)[0]);
-      for (var key of Object.keys(mockExposureTabs)) {
-        wrapper.instance().handleTabSelect(key);
-        expect(wrapper.state('query').tab).toEqual(key);
-        expect(wrapper.find('#tab-description').text())
-            .toContain(mockExposureTabs[key]['description'] + ' You are currently in the exposure workflow.');
-        if (mockExposureTabs[key]['tooltip']) {
-          expect(wrapper.find(InfoTooltip).exists()).toBeTruthy();
-          expect(wrapper.find(InfoTooltip).prop('tooltipTextKey')).toEqual(mockExposureTabs[key]['tooltip'])
-        }
       }
     });
   });
@@ -197,21 +146,6 @@ describe('PatientsTable', () => {
       for (var key of Object.keys(mockIsolationTabs)) {
         expect(wrapper.find('#' + key + '_tab').exists()).toBeTruthy();
         expect(wrapper.find('#' + key + '_tab').text()).toEqual(mockIsolationTabs[key]['label']);
-      }
-    });
-
-    it('Sets the tab description properly for each tab', () => {
-      const wrapper = getIsolationWrapper();
-      expect(wrapper.state('query').tab).toEqual(Object.keys(mockIsolationTabs)[0]);
-      for (var key of Object.keys(mockIsolationTabs)) {
-        wrapper.instance().handleTabSelect(key);
-        expect(wrapper.state('query').tab).toEqual(key);
-        expect(wrapper.find('#tab-description').text())
-            .toContain(mockIsolationTabs[key]['description'] + ' You are currently in the isolation workflow.');
-        if (mockIsolationTabs[key]['tooltip']) {
-          expect(wrapper.find(InfoTooltip).exists()).toBeTruthy();
-          expect(wrapper.find(InfoTooltip).prop('tooltipTextKey')).toEqual(mockIsolationTabs[key]['tooltip'])
-        }
       }
     });
   });

--- a/app/javascript/tests/public_health/PatientsTable.test.js
+++ b/app/javascript/tests/public_health/PatientsTable.test.js
@@ -1,0 +1,74 @@
+import React from 'react'
+import { shallow } from 'enzyme';
+import PatientsTable from '../../components/public_health/PatientsTable.js'
+import JurisdictionFilter from '../../components/public_health/query/JurisdictionFilter.js'
+import AssignedUserFilter from '../../components/public_health/query/AssignedUserFilter.js'
+import AdvancedFilter from '../../components/public_health/query/AdvancedFilter.js'
+import CustomTable from '../../components/layout/CustomTable'
+import { mockJurisdiction1, mockJurisdictionPaths } from '../mocks/mockJurisdiction'
+import { mockExposureTabs, mockIsolationTabs } from '../mocks/mockTabs'
+import { mockMonitoringReasons } from '../mocks/mockMonitoringReasons'
+
+const authyToken = "Q1z4yZXLdN+tZod6dBSIlMbZ3yWAUFdY44U06QWffEP76nx1WGMHIz8rYxEUZsl9sspS3ePF2ZNmSue8wFpJGg==";
+const workflow = 'exposure'
+const setQueryMock = jest.fn();
+const setMonitoreeCountMock = jest.fn();
+
+function ExposurePatientTable() {
+  return shallow(<PatientsTable
+    authenticity_token={authyToken}
+    jurisdiction_paths={mockJurisdictionPaths}
+    workflow={workflow}
+    jurisdiction={mockJurisdiction1}
+    tabs={mockExposureTabs}
+    monitoring_reasons={mockMonitoringReasons}
+    setQuery={setQueryMock}
+    setFilteredMonitoreesCount={setMonitoreeCountMock}
+  />);
+}
+
+function IsolationPatientTable() {
+  return shallow(<PatientsTable
+    authenticity_token={authyToken}
+    jurisdiction_paths={mockJurisdictionPaths}
+    workflow={workflow}
+    jurisdiction={mockJurisdiction1}
+    tabs={mockIsolationTabs}
+    monitoring_reasons={mockMonitoringReasons}
+    setQuery={setQueryMock}
+    setFilteredMonitoreesCount={setMonitoreeCountMock}
+  />);
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('PatientsTable', () => {
+  it('Properly renders all main components', () => {
+    const patientTable = ExposurePatientTable();
+    expect(patientTable.find('#search').exists()).toBeTruthy();
+    expect(patientTable.containsMatchingElement(JurisdictionFilter)).toBeTruthy();
+    expect(patientTable.containsMatchingElement(AssignedUserFilter)).toBeTruthy();
+    expect(patientTable.containsMatchingElement(AdvancedFilter)).toBeTruthy();
+    expect(patientTable.containsMatchingElement(CustomTable)).toBeTruthy();
+  });
+
+  describe('ExposureDashboard', () => {
+    it('Properly renders all tabs', () => {
+      const patientTable = ExposurePatientTable();
+      for (var key of Object.keys(mockExposureTabs)) {
+        expect(patientTable.find('#' + key + '_tab').exists()).toBeTruthy();
+      }
+    });
+  });
+
+  describe('IsolationDashboard', () => {
+    it('Properly renders all tabs', () => {
+      const patientTable = IsolationPatientTable();
+      for (var key of Object.keys(mockIsolationTabs)) {
+        expect(patientTable.find('#' + key + '_tab').exists()).toBeTruthy();
+      }
+    });
+  });
+});

--- a/test/system/roles/public_health/patient_page/patient_page_verifier.rb
+++ b/test/system/roles/public_health/patient_page/patient_page_verifier.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'application_system_test_case'
-require 'byebug'
 
 require_relative 'reports_verifier'
 require_relative '../../../lib/system_test_utils'

--- a/test/system/roles/public_health/patient_page/patient_page_verifier.rb
+++ b/test/system/roles/public_health/patient_page/patient_page_verifier.rb
@@ -10,7 +10,7 @@ class PublicHealthPatientPageVerifier < ApplicationSystemTestCase
   @@system_test_utils = SystemTestUtils.new(nil)
 
   def verify_patient_details_and_reports(patient, workflow)
-    sleep(0.2) # wait for any sticky filter to populate so it can be cleared during fill_in
+    sleep(0.5) # wait for any sticky filter to populate so it can be cleared during fill_in
     fill_in('search', with: patient.last_name, fill_options: { clear: :backspace })
     click_on "#{patient.last_name}, #{patient.first_name}"
     verify_patient_details(patient)

--- a/test/system/roles/public_health/patient_page/patient_page_verifier.rb
+++ b/test/system/roles/public_health/patient_page/patient_page_verifier.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'application_system_test_case'
+require 'byebug'
 
 require_relative 'reports_verifier'
 require_relative '../../../lib/system_test_utils'
@@ -10,7 +11,8 @@ class PublicHealthPatientPageVerifier < ApplicationSystemTestCase
   @@system_test_utils = SystemTestUtils.new(nil)
 
   def verify_patient_details_and_reports(patient, workflow)
-    fill_in 'search', with: patient.last_name
+    sleep(0.2) # wait for any sticky filter to populate so it can be cleared during fill_in
+    fill_in('search', with: patient.last_name, fill_options: { clear: :backspace })
     click_on "#{patient.last_name}, #{patient.first_name}"
     verify_patient_details(patient)
     @@public_health_patient_page_reports_verifier.verify_workflow(workflow)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1085](https://tracker.codev.mitre.org/browse/SARAALERT-1085) & [SARAALERT-1272](https://tracker.codev.mitre.org/browse/SARAALERT-1272)

Other Jira tickets that are no longer relevant due to this PR: [SARAALERT-1043](https://tracker.codev.mitre.org/browse/SARAALERT-1043) & [SARAALERT-914](https://tracker.codev.mitre.org/browse/SARAALERT-914)

Resolves several issues identified with sticky filters on the `PatientsTable`. Also includes these bug fixes:
- Bulk Actions drop down is now hidden when on the Transferred Out line list
- Sorted results based on a column sort for the patient table will have the same precise order each time a sort is done
- If a sticky filter value for Assigned User exists, the filter input box will be properly populated now

# (Bugfix) How to Replicate

1. Go to the Non Reporting Line list as a Public Health user and input values into all the filter options (1) jurisdiction (2) assigned user (3) search bar (4) advanced filter (5) different number of entries per page (6) different pagination option.
2. Using the bulk actions, update the case status of some monitoree(s), which will cause the page to reload.
3. In the reloaded page, observe that at least some of these erroneous behaviors occurred: (1) the dashboard was switched back to the red line list (2) the jurisdiction filter doesn't display the input you typed in before (3) the assigned user filter doesn't display the input you typed in (4) the pagination option is now set back to the first page.

# (Bugfix) Solution
The root of this issue was that `setState()` was improperly being call mulitple times in `componentDidMount()`. The `componentDidMount()` function was refactored to minimize the number of `setState()` calls. 

In order to properly display the sticky AssignedUser filter input, the `AssignedUserFilter` constructor was updated so it automatically displays the proper sticky AssignedUser input.

Adidtionally, this uncovered behavior where sorting columns on the PatientsTable wasn't consistenly returning monitorees in the same order which would possibly be confusing to monitorees when they, say, go to a monitoree's page & go right back to the dashboard resulting in them potentially not seeing the same ordering of monitorees. So a secondary order based on monitoree ID was included for all sorted results to avoid this issue. Updates where made to the CustomTable to display in the row header if a sort remained sticky.

For remaining work related to this PR, here are a few tickets that will be addressed in the future:
- [SARAALERT-1265](https://tracker.codev.mitre.org/browse/SARAALERT-1265): There is an bug where a user can apply filters on the dashbaord, log out, and in that same browser, log into a different Sara Alert account. After logging into that second account, if the user goes to the dashbaord, they will observe some of the filters that the pervious account applied are still applied.
- [SARAALERT-1271](https://tracker.codev.mitre.org/browse/SARAALERT-1271): This PR includes an initial pass at a test file for the `PatientsTable`, but tests for certain functions and checking that the sticky filters behave correctly have not been completed due to some roadblocks. This ticket encapsulates the future work to create more tests.
- [SARAALERT-1136](https://tracker.codev.mitre.org/browse/SARAALERT-1136): This PR did not address some issues that still exist regarding the stickiness of the Advanced Filter. There is remaining work that will be covered in the linked ticket to make unsaved filters be sticky in the same way that save filters are sticky when reloading the page and switching workflows.
- [SARAALERT-1292](https://tracker.codev.mitre.org/browse/SARAALERT-1292): For the "Monitoring Dashboards" header option, if a user clicks on this, they are always brought back to the Exposure workflow even if they were originally on the Isolation Dashboard. The linked ticket will adress this situation.

# Important Changes
A few additional comments will be included in the code for the reviewers to consider.

`app/helpers/patient_query_helper.rb`
- Added a secondary order, based on the monitoree's ID, to all sorted patient results to ensure order always remains precise each time a new sort occurrs

`app/javascript/components/layout/CustomTable.js`
- Included new optional props for `orderBy` and `sortDirection` so if the table is expected to already display rows in some sorted order when the user navigates away and back to it, the table properly displays which column is sorted & the direction it's sorted with

`app/javascript/components/public_health/PatientsTable.js`
- Refactored `componentDidMount()` method to resolve the underlying bug and so the number of `setState()` calls is minimized
- Added new boolean parameter to the `advancedFilterUpdate()` function to account for the case the sticky settings/filters should remain when a sticky Advanced Filter is applied.
- Included logic to ensure sorting a column remains sticky when applicable 
- Included a few additional `id` fields in the `render()` for testing purposes
- Fix in `render()` so the Bulk Actions drop down no longer displays when in Transferred Out line list

`app/javascript/components/public_health/query/AdvancedFilter.js`
- Added new boolean arguements to certain functions to account for the case where sticky filters in the PatientsTable should remain when a sticky Advanced filter is initially loaded. 

`app/javascript/components/public_health/query/AssignedUserFilter.js`
- Updated the `defaultValue` for the Assigned User Filter so it properly displayes the sticky filter value.

`app/javascript/tests/public_health/PatientsTable.test.js`
- Initial set of frontend tests for the `PatientsTable`. It primarily tests that certain elements exist when expected. Additional tests for `PatientsTable` functions and sticky filters will be handled in another PR ([SARAALERT-1271](https://tracker.codev.mitre.org/browse/SARAALERT-1271))

`test/system/roles/public_health/patient_page/patient_page_verifier.rb`
- Updated helper function to clear prior sticky filter when searching for a new monitoree

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [x] Firefox
* [ ] Safari
* [ ] IE11

Try any situation you can think of where you would expect sticky filters on the PatientsTable to either continue to be applied or clear out. Validate that the behavior matches your expectations. In addition, attempt the following tests and validate the expected behavior occurs. Here are some guiding principles as to when certain sticky filters should/shouldn't be reapplied. Try some of the situations listed out to see if the behavior adheres to expectations.

For the following scenarios, ALL filters/settings should remain sticky: (1) Jurisdiction (1a) Jurisdiction Scope (2) Assigned User (3) Search Term (4) Advanced Filter [saved ~~and unsaved~~ ] (5) Number of Entries per page (6) Column Sort (7) Page Number
- [ ] Select a moniotree to go to that monitoree's page. Then click the "Return to Exposure/Isolation Dashboard" breadcrumb
- [ ] Perform a Bulk Action for some monitorees
- [ ] Click the "Enroll New Monitoree/Case" button. Then click the "Return to Exposure/Isolation Dashboard" breadcrumb
- [ ] Successfully enroll a new monitoree/case. Then while on the new monitoree's/case's profile page, click the "Return to Exposure/Isolation Dashboard" breadcrumb

For the following scenarios, _only these filters/settings should remain sticky_: (1) Jurisdiction (1a) Jurisdiction Scope (2) Assigned User (3) Search Term (4) Advanced Filter [saved or unsaved] (5) Number of Entries per page (6) Column Sort
- [ ] Navigate between the tabs within a workflow
- [ ] Change any of the existing filters/settings except for Page Number (in particular, ensure you test changing the Advanced Filter)

For the following scenario, _only these filters/settings should remain sticky_: (1) Jurisdiction (1a) Jurisdiction Scope (2) Assigned User (3) Search Term (4) Advanced Filter [ONLY saved] (5) Number of Entries per page 
- [ ] Navigate between the different workflows

**Additional Tests**

- [ ] When switching between workflows, verify that the previously selected tab for a particular workflow is the one displayed when navigating back to it.
- [ ] While on the Non Reporting line list, input something into the Jurisdiction & Assigned User filters. Then click on the Transferred Out line list and observe those filters are no longer displayed. Then click on a different tab. Observe that the Jurisdiction & Assigned User filters are visible again and populated with the sticky input the user previously typed in.
- [ ] Clicking the "Clear all Filters" button resets all table filters/settings back to their defaults. No more previous sticky filters/settings should exist
- [ ] After deleting a filter input, the previous filter input should not display when switching between tabs and workflows
- [ ] When a column is sorted, verify that after performing a bulk action on a monitoree, the reloaded page still displays that same column is sorted through that column's header
- [ ] Verify that the Bulk Actions drop down is hidden when in the Transferred Out line list
- [ ] Test all sortable columns for the patient table
- [ ] Sort the Monitoring Status Column & try to remember the order monitorees that have the same monitoring status appear in. Go to the other workflow and go back to your original workflow. Resort that same column. Verify that the order the monitorees appear is should be precisly the same as the order from the first sort.
- [ ] Test apply an Advanced Filter to a Custom Export to ensure there are no errors.