### PR TITLE
SARAALERT-1274: Update "Foreign Monitored Address State" in Import Formatting Guidance

### DIFF
--- a/app/javascript/components/public_health/PublicHealthHeader.js
+++ b/app/javascript/components/public_health/PublicHealthHeader.js
@@ -128,7 +128,7 @@ class PublicHealthHeader extends React.Component {
           {this.state.importType === 'saf' && (
             <div className="mb-3">
               <a href="https://github.com/SaraAlert/SaraAlert/blob/master/public/Sara%20Alert%20Import%20Format.xlsx?raw=true">Download formatting guidance</a>{' '}
-              (Updated 12/17/2020)
+              (Updated 2/9/2021)
             </div>
           )}
           <Form inline>

--- a/public/Sara Alert Import Format.xlsx
+++ b/public/Sara Alert Import Format.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:88049377ee4aca543265ff56c646eb6c3064982a4c2e35d23c2f0c6e93e939b3
-size 36653
+oid sha256:8b6453912c3d38e3bdca33ec97d99bbea0c8ebd78aeaea65772b327b5e8b6312
+size 36670

--- a/public/Sara Alert Import Format.xlsx
+++ b/public/Sara Alert Import Format.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8b6453912c3d38e3bdca33ec97d99bbea0c8ebd78aeaea65772b327b5e8b6312
-size 36670
+oid sha256:719a05bb5290c69331fdb73762093ad75dc97e3ae8d20487fb8579b8525ca762
+size 36723

--- a/public/Sara Alert Import Format.xlsx
+++ b/public/Sara Alert Import Format.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b056bc13bdfd4fc80d795fd207597d19b306af88f975f8a13e6f7c798840f572
-size 36498
+oid sha256:88049377ee4aca543265ff56c646eb6c3064982a4c2e35d23c2f0c6e93e939b3
+size 36653


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1274](https://tracker.codev.mitre.org/browse/SARAALERT-1274)

This updates the formatting guidance to no longer contain an invalid value for the "Foreign Monitored Address State" field on the "Example" tab.

# Important Changes
`public/Sara Alert Import Format.xlsx`
- On the "Example" tab, the invalid value of "Emahaven" was replaced with "Minnesota" in the "Foreign Monitored Address State" column, since this field is constrained to be a US State.
- On the "Guidance" tab, the description of the "Foreign Monitored Address State" column was updated to indicate that this field must be a US State (or an abbreviation).

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Previously, if you downloaded the formatting guidance for import, and then used the example provided by that guidance, you would get an error indicating that `Emahaven` is not a valid value. To test that this fixes that, you can try importing an Excel file containing the example provided in this PR, and see that the patients will import with no errors. Note that you cannot test downloading the guidance in this PR, since link to the guidance always points to the version of this Excel file that lives on `master`.

I chose reviewers based on who most recently edited this file, feel free to assign others if that makes more sense.