### PR TITLE
SARAALERT-1121: Twilio Error Message Updates for Households

### DIFF
--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -87,7 +87,8 @@ class PatientMailer < ApplicationMailer
       add_success_history(patient)
     # If an SMS sent for HoH and dependents
     elsif success_hoh && success_deps != 0
-      comment = "Sara Alert sent a report reminder to this monitoree for themselves and #{success_deps} of their dependents via #{patient.preferred_contact_method}."
+      method = patient.preferred_contact_method
+      comment = "Sara Alert sent a report reminder to this monitoree for themselves and #{success_deps} of their dependents via #{method}."
       History.report_reminder(patient: patient, comment: comment)
     # If SMS was sent only for dependents
     elsif !success_hoh && success_deps != 0

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -87,11 +87,11 @@ class PatientMailer < ApplicationMailer
       add_success_history(dependent)
     # If an SMS sent for HoH and dependents
     elsif success_hoh && success_deps != 0
-      comment = "Sara Alert sent #{success_deps}report reminders to this monitoree for themselves and their dependents via #{parent.preferred_contact_method}."
+      comment = "Sara Alert sent #{success_deps}report reminders to this monitoree for themselves and their dependents via #{patient.preferred_contact_method}."
       History.report_reminder(patient: patient, comment: comment)
     # If SMS was sent only for dependents
     elsif !success_hoh && success_deps != 0
-      comment = "Sara Alert sent #{success_deps}report reminder to this monitoree for their dependent(s) via #{parent.preferred_contact_method}."
+      comment = "Sara Alert sent #{success_deps}report reminder to this monitoree for their dependent(s) via #{patient.preferred_contact_method}."
       History.report_reminder(patient: patient, comment: comment)
     end
   end

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -87,7 +87,7 @@ class PatientMailer < ApplicationMailer
       add_success_history(patient)
     # If an SMS sent for HoH and dependents
     elsif success_hoh && success_deps != 0
-      comment = "Sara Alert sent #{success_deps} report reminders to this monitoree for themselves and their dependents via #{patient.preferred_contact_method}."
+      comment = "Sara Alert sent a report reminder to this monitoree for themselves and #{success_deps} of their dependents via #{patient.preferred_contact_method}."
       History.report_reminder(patient: patient, comment: comment)
     # If SMS was sent only for dependents
     elsif !success_hoh && success_deps != 0

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -87,11 +87,11 @@ class PatientMailer < ApplicationMailer
       add_success_history(patient)
     # If an SMS sent for HoH and dependents
     elsif success_hoh && success_deps != 0
-      comment = "Sara Alert sent #{success_deps}report reminders to this monitoree for themselves and their dependents via #{patient.preferred_contact_method}."
+      comment = "Sara Alert sent #{success_deps} report reminders to this monitoree for themselves and their dependents via #{patient.preferred_contact_method}."
       History.report_reminder(patient: patient, comment: comment)
     # If SMS was sent only for dependents
     elsif !success_hoh && success_deps != 0
-      comment = "Sara Alert sent #{success_deps}report reminder to this monitoree for their dependent(s) via #{patient.preferred_contact_method}."
+      comment = "Sara Alert sent #{success_deps} report reminder to this monitoree for their dependent(s) via #{patient.preferred_contact_method}."
       History.report_reminder(patient: patient, comment: comment)
     end
   end

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -84,7 +84,7 @@ class PatientMailer < ApplicationMailer
     # Finally add a success history item for the HoH
     # If an SMS was only sent for HoH
     if success_hoh && success_deps.zero?
-      add_success_history(dependent)
+      add_success_history(patient)
     # If an SMS sent for HoH and dependents
     elsif success_hoh && success_deps != 0
       comment = "Sara Alert sent #{success_deps}report reminders to this monitoree for themselves and their dependents via #{patient.preferred_contact_method}."

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -82,12 +82,14 @@ class PatientMailer < ApplicationMailer
       end
     end
     # Finally add a success history item for the HoH
-    # If an SMS was only sent to HoH
+    # If an SMS was only sent for HoH
     if success_hoh && success_deps.zero?
       add_success_history(dependent)
+    # If an SMS sent for HoH and dependents
     elsif success_hoh && success_deps != 0
       comment = "Sara Alert sent #{success_deps}report reminders to this monitoree for themselves and their dependents via #{parent.preferred_contact_method}."
       History.report_reminder(patient: patient, comment: comment)
+    # If SMS was sent only for dependents
     elsif !success_hoh && success_deps != 0
       comment = "Sara Alert sent #{success_deps}report reminder to this monitoree for their dependent(s) via #{parent.preferred_contact_method}."
       History.report_reminder(patient: patient, comment: comment)

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -132,7 +132,7 @@ class PatientMailer < ApplicationMailer
                thanks: I18n.t('assessments.sms.prompt.thanks', locale: lang) }
 
     patient.update(last_assessment_reminder_sent: DateTime.now) # Update last send attempt timestamp before Twilio sms assessment
-    patient.active_dependents.uniq.collect { |pat| add_success_history(pat) } if TwilioSender.start_studio_flow_assessment(patient, params)
+    patient.active_dependents_and_self.uniq.collect { |pat| add_success_history(pat) } if TwilioSender.start_studio_flow_assessment(patient, params)
   end
 
   def assessment_voice(patient)
@@ -175,7 +175,7 @@ class PatientMailer < ApplicationMailer
                thanks: I18n.t('assessments.phone.thanks', locale: lang) }
 
     patient.update(last_assessment_reminder_sent: DateTime.now) # Update last send attempt timestamp before Twilio call
-    patient.active_dependents.uniq.collect { |pat| add_success_history(pat) } if TwilioSender.start_studio_flow_assessment(patient, params)
+    patient.active_dependents_and_self.uniq.collect { |pat| add_success_history(pat) } if TwilioSender.start_studio_flow_assessment(patient, params)
   end
 
   def assessment_email(patient)
@@ -198,7 +198,7 @@ class PatientMailer < ApplicationMailer
     mail(to: patient.email&.strip, subject: I18n.t('assessments.email.reminder.subject', locale: @lang || :en)) do |format|
       format.html { render layout: 'main_mailer' }
     end
-    patient.active_dependents.uniq.collect { |pat| add_success_history(pat) }
+    patient.active_dependents_and_self.uniq.collect { |pat| add_success_history(pat) }
   rescue StandardError => e
     patient.update(last_assessment_reminder_sent: nil) # Reset send attempt timestamp on failure
     raise "Failed to send email for patient id: #{patient.id}; #{e.message}"

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -118,7 +118,10 @@ class History < ApplicationRecord
   end
 
   def self.report_reminder(patient: nil, created_by: 'Sara Alert System', comment: 'User sent a report reminder to the monitoree.')
-    create_history(patient, created_by, HISTORY_TYPES[:report_reminder], comment) unless patient&.preferred_contact_method.nil?
+    return if patient&.preferred_contact_method.nil? && patient&.id == patient&.responder_id
+
+    create_history(patient, created_by, HISTORY_TYPES[:report_reminder],
+                   comment)
   end
 
   def self.lab_result(patient: nil, created_by: 'Sara Alert System', comment: 'User added a new lab result.')

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -61,7 +61,7 @@ class History < ApplicationRecord
       # Avoid adding multiple history items if HoH has errored contact attempts for
       # contact attempts to them on behalf of their dependents. This would be the
       # case for failed weblinks
-      next if ((Time.now - pat.histories.last.created_at) / 60) < 5
+      next if !pat&.histories&.last.nil? && ((Time.now - pat&.histories&.last&.created_at) / 60) < 5
 
       if pat.responder == pat
         recipient = 'this monitoree'

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -58,6 +58,11 @@ class History < ApplicationRecord
   def self.errored_report_reminder_group_of_patients(patients: nil, created_by: 'Sara Alert System', comment: 'Failed Contact Attempt', error_message: nil)
     histories = []
     patients.uniq.each do |pat|
+      # Avoid adding multiple history items if HoH has errored contact attempts for
+      # contact attempts to them on behalf of their dependents. This would be the
+      # case for failed weblinks
+      next if ((Time.now - pat.histories.last.created_at) / 60) < 5
+
       if pat.responder == pat
         recipient = 'this monitoree'
         responder = pat

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -592,7 +592,7 @@ class Patient < ApplicationRecord
 
   # Get all dependents and always include self even if self is not active
   def active_dependents_and_self
-    ([self] + [active_dependents]).uniq
+    ([self] + active_dependents).uniq
   end
 
   # Get this patient's dependents excluding itself

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -590,6 +590,11 @@ class Patient < ApplicationRecord
     active_dependents.where.not(id: id)
   end
 
+  # Get all dependents and always include self even if self is not active
+  def active_dependents_and_self
+    ([self] + [active_dependents]).uniq
+  end
+
   # Get this patient's dependents excluding itself
   def dependents_exclude_self
     dependents.where.not(id: id)

--- a/test/mailers/patient_mailer_test.rb
+++ b/test/mailers/patient_mailer_test.rb
@@ -347,6 +347,9 @@ class PatientMailerTest < ActionMailer::TestCase
     dependent = create(:patient)
     dependent.update(responder_id: @patient.id, submission_token: SecureRandom.urlsafe_base64[0, 10])
 
+    dependent_history_count = dependent.histories.count
+    patient_history_count = @patient.histories.count
+
     params = {
       language: 'EN',
       try_again: I18n.t('assessments.sms.prompt.try-again', locale: 'en'),
@@ -370,6 +373,9 @@ class PatientMailerTest < ActionMailer::TestCase
                                                                                                                from: 'test_messaging_sid'
                                                                                                              })
     PatientMailer.assessment_sms(@patient).deliver_now
+    # Assert that both the patient and dependent got history items added
+    assert_equal patient_history_count + 1, @patient.histories.count
+    assert_equal dependent_history_count + 1, dependent.histories.count
   end
 
   test 'assessment sms message content not using messaging service' do

--- a/test/mailers/twilio_sender_test.rb
+++ b/test/mailers/twilio_sender_test.rb
@@ -6,6 +6,7 @@ require 'vcr_setup'
 class TwilioSenderTest < ActiveSupport::TestCase
   def setup
     ENV['TWILLIO_STUDIO_FLOW'] = 'test'
+    ENV['TWILLIO_SENDING_NUMBER'] = '+15555555555'
   end
 
   def test_get_number_from_single_message_execution


### PR DESCRIPTION

# Description
Jira Ticket: SARAALERT-1121

This is an intermediary PR into the larger twilio_error_handling branch, the work in this PR addresses the concerns detailed in ticket SaraAlert 1121 where dependents and HoH were not receiving history items as expected.

# (Bugfix) How to Replicate
Insert steps for how to replicate the bug this PR addresses.
Find a demo patient that is a HoH, from the rails console run `Patient.find(<patientid>).send_assessment(send_now: true)`. Make sure HoH and dependent(s) get report rerminder history items. Do this for a patient with each contact type. 

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
