### PR TITLE
SARAALERT-1248: Making CustomTable Pagination Responsive 

### DIFF
--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
-import { Spinner, Table, Form, InputGroup, Row, Col } from 'react-bootstrap';
+import { Spinner, Table, Form, InputGroup } from 'react-bootstrap';
 import ReactPaginate from 'react-paginate';
 import InfoTooltip from '../util/InfoTooltip';
 
@@ -205,64 +205,67 @@ class CustomTable extends React.Component {
             </tbody>
           </Table>
         </div>
-        <div className="d-flex justify-content-between">
-          <Form inline className="align-middle">
-            <Row className="fixed-row-size">
-              <Col>
-                <InputGroup>
-                  <InputGroup.Prepend>
-                    <InputGroup.Text className="rounded-0">
-                      <i className="fas fa-list"></i>
-                      <span className="ml-1">Show</span>
-                    </InputGroup.Text>
-                  </InputGroup.Prepend>
-                  <Form.Control
-                    as="select"
-                    size="md"
-                    name="entries"
-                    value={this.props.entries}
-                    onChange={this.props.handleEntriesChange}
-                    aria-label="Adjust number of records">
-                    {this.props.entryOptions.map(num => {
-                      return (
-                        <option key={num} value={num}>
-                          {num}
-                        </option>
-                      );
-                    })}
-                  </Form.Control>
-                </InputGroup>
-              </Col>
-              <span className="ml-2 text-nowrap align-self-center">{`Displaying ${this.props.rowData.length} out of ${this.props.totalRows} rows.`}</span>
-            </Row>
-          </Form>
-          {this.props.totalRows > 0 && (
-            <ReactPaginate
-              className=""
-              disableInitialCallback={true}
-              pageCount={Math.ceil(this.props.totalRows / this.props.entries)}
-              pageRangeDisplayed={4}
-              marginPagesDisplayed={1}
-              initialPage={this.props.page}
-              forcePage={this.props.page}
-              onPageChange={this.props.handlePageUpdate}
-              previousLabel="Previous"
-              nextLabel="Next"
-              breakLabel="..."
-              containerClassName="pagination mb-0"
-              activeClassName="active"
-              disabledClassName="disabled"
-              pageClassName="paginate_button page-item"
-              previousClassName="paginate_button page-item"
-              nextClassName="paginate_button page-item"
-              breakClassName="paginate_button page-item"
-              pageLinkClassName="page-link text-primary"
-              previousLinkClassName={this.props.page === 0 ? 'page-link' : 'page-link text-primary'}
-              nextLinkClassName={this.props.page === Math.ceil(this.props.totalRows / this.props.entries) - 1 ? 'page-link' : 'page-link text-primary'}
-              activeLinkClassName="page-link text-light"
-              breakLinkClassName="page-link text-primary"
-            />
-          )}
+        <div className="row-container">
+          <div className="left-container">
+            <div className="left-box-1">
+              <InputGroup>
+                <InputGroup.Prepend>
+                  <InputGroup.Text className="rounded-0">
+                    <i className="fas fa-list"></i>
+                    <span className="ml-1">Show</span>
+                  </InputGroup.Text>
+                </InputGroup.Prepend>
+                <Form.Control
+                  as="select"
+                  size="md"
+                  name="entries"
+                  value={this.props.entries}
+                  onChange={this.props.handleEntriesChange}
+                  aria-label="Adjust number of records">
+                  {this.props.entryOptions.map(num => {
+                    return (
+                      <option key={num} value={num}>
+                        {num}
+                      </option>
+                    );
+                  })}
+                </Form.Control>
+              </InputGroup>
+            </div>
+            <div className="left-box-2">
+              <span className="ml-0 ml-md-2 text-nowrap align-self-center">{`Displaying ${this.props.rowData.length} out of ${this.props.totalRows} rows.`}</span>
+            </div>
+          </div>
+          <div className="right-container">
+            {this.props.totalRows > 0 && (
+              <div style={{ float: 'right' }}>
+                <ReactPaginate
+                  disableInitialCallback={true}
+                  pageCount={Math.ceil(this.props.totalRows / this.props.entries)}
+                  pageRangeDisplayed={4}
+                  marginPagesDisplayed={1}
+                  initialPage={this.props.page}
+                  forcePage={this.props.page}
+                  onPageChange={this.props.handlePageUpdate}
+                  previousLabel="Previous"
+                  nextLabel="Next"
+                  breakLabel="..."
+                  containerClassName="pagination mb-0"
+                  activeClassName="active"
+                  disabledClassName="disabled"
+                  pageClassName="paginate_button page-item"
+                  previousClassName="paginate_button page-item"
+                  nextClassName="paginate_button page-item"
+                  breakClassName="paginate_button page-item"
+                  pageLinkClassName="page-link text-primary"
+                  previousLinkClassName={this.props.page === 0 ? 'page-link' : 'page-link text-primary'}
+                  nextLinkClassName={this.props.page === Math.ceil(this.props.totalRows / this.props.entries) - 1 ? 'page-link' : 'page-link text-primary'}
+                  activeLinkClassName="page-link text-light"
+                  breakLinkClassName="page-link text-primary"
+                />
+              </div>
+            )}
+          </div>
         </div>
       </React.Fragment>
     );

--- a/app/javascript/packs/stylesheets/custom_table.scss
+++ b/app/javascript/packs/stylesheets/custom_table.scss
@@ -1,29 +1,71 @@
 .sort-header {
-    position: relative;
+  position: relative;
 
-    &__button {
-        &--default {
-            color: #b8b8b8;
-            position: absolute;
-            right: -12px;
-        }
-
-        &--selected {
-            position: absolute;
-            right: -12px;
-        }
+  &__button {
+    &--default {
+      color: #b8b8b8;
+      position: absolute;
+      right: -12px;
     }
+
+    &--selected {
+      position: absolute;
+      right: -12px;
+    }
+  }
 }
 
 .pointer-cursor {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .fixed-row-size {
-    width: 430px;
+  width: 430px;
 }
 
 .opaque-table {
-    opacity: 1;
-    background-color: white;
+  opacity: 1;
+  background-color: white;
+}
+
+.row-container {
+  width: 100%;
+}
+
+.left-container {
+  display: inline-block;
+  width: 430px !important;
+}
+
+.left-box-1 {
+  width: 40%;
+  display: inline-block;
+}
+
+.left-box-2 {
+  width: 60%;
+  display: inline-block;
+}
+.right-container {
+  display: inline;
+  float: right;
+}
+
+// the medium bootstrap breakpoint
+@media only screen and (max-width: 768px) {
+  .left-box-1 {
+    width: 172px; // 40% of 430px
+    display: inline-block;
+  }
+
+  .left-box-2 {
+    width: 100%;
+    display: inline-block;
+  }
+}
+
+@media only screen and (max-width: 1100px) {
+  .left-container {
+    margin-bottom: 12px;
+  }
 }


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1248

The Pagination Component at the bottom of the CustomTable was not behaving in a responsive manner. At smaller viewports, it would either sit over the left-hand content, or be pushed off to the side of the parent container, or both! (as shown in this image). 
![image](https://user-images.githubusercontent.com/17532163/106642520-7174b980-6556-11eb-889e-f9260bad53f1.png)

This pull request adds custom styling to prevent this issue from occurring. It adds a custom viewport breakpoint using media queries which pushes the pagination down onto a new line. This remains properly formatted until EXTREMELY small viewports (smaller than this project supports).

Other ideas were tested with the Pagination Component remaining always on the second line, or maybe being centered on the second line. But these ideas were not favored, and so this PR only includes the drop-down at the viewport breakpoint.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/javascript/components/layout/CustomTable.js`
- Added a two-column system for the "footer" content beneath the main CustomTable. This two-column system closely mirrors bootstraps system, except that it is custom. It is custom for the sole reason that the Bootstrap viewport breakpoints were not sufficient in this case to properly solve the issue. The XL viewport breakpoint was too small to be used.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chromium Browsers
* [x] Firefox
* [x] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
