### PR TITLE
SARAALERT-1099: Close Contacts Modal Updates

### DIFF
--- a/app/javascript/components/close_contact/CloseContact.js
+++ b/app/javascript/components/close_contact/CloseContact.js
@@ -22,7 +22,11 @@ class CloseContact extends React.Component {
     super(props);
     this.state = {
       showModal: false,
-      disableCreate: true,
+      disableCreate:
+        !this.props.close_contact.first_name &&
+        !this.props.close_contact.last_name &&
+        !this.props.close_contact.primary_telephone &&
+        !this.props.close_contact.email,
       loading: false,
       errors: {},
       first_name: this.props.close_contact.first_name || '',
@@ -49,7 +53,11 @@ class CloseContact extends React.Component {
       // (because the rest of this method hasnt had time to fire, and change 'show' to false)
       // When they click cancel, we want to null out all of the fields
       newState = {
-        disableCreate: true,
+        disableCreate:
+          !this.props.close_contact.first_name &&
+          !this.props.close_contact.last_name &&
+          !this.props.close_contact.primary_telephone &&
+          !this.props.close_contact.email,
         errors: {},
         first_name: this.props.close_contact.first_name || '',
         last_name: this.props.close_contact.last_name || '',
@@ -69,6 +77,7 @@ class CloseContact extends React.Component {
   handleDateChange = event => this.setState({ last_date_of_exposure: event });
 
   handleChange = event => {
+    event.target.value = _.trimEnd(event.target.value);
     let value;
     let disableCreate = false;
     const possiblyRequiredFields = ['first_name', 'last_name', 'primary_telephone', 'email'];
@@ -160,7 +169,7 @@ class CloseContact extends React.Component {
             </Form.Group>
           </Row>
           <Row>
-            <Form.Group as={Col} controlId="primary_telephone">
+            <Form.Group as={Col} lg="12" controlId="primary_telephone">
               <Form.Label className="nav-input-label">Phone Number {schema?.fields?.primary_telephone?._exclusive?.required && '*'}</Form.Label>
               <PhoneInput
                 id="primary_telephone"
@@ -173,7 +182,7 @@ class CloseContact extends React.Component {
                 {this.state.errors['primary_telephone']}
               </Form.Control.Feedback>
             </Form.Group>
-            <Form.Group as={Col} controlId="email">
+            <Form.Group as={Col} lg="12" controlId="email">
               <Form.Label className="nav-input-label">Email {schema?.fields?.email?._exclusive?.required && '*'} </Form.Label>
               <Form.Control size="lg" className="form-square" value={this.state.email || ''} onChange={this.handleChange} />
               <Form.Control.Feedback className="d-block" type="invalid">
@@ -183,7 +192,7 @@ class CloseContact extends React.Component {
           </Row>
           <hr></hr>
           <Row>
-            <Form.Group as={Col} controlId="last_date_of_exposure">
+            <Form.Group as={Col} lg="12" controlId="last_date_of_exposure">
               <Form.Label className="nav-input-label">Last Date of Exposure {schema?.fields?.last_date_of_exposure?._exclusive?.required && '*'}</Form.Label>
               <DateInput
                 id="last_date_of_exposure"
@@ -202,7 +211,7 @@ class CloseContact extends React.Component {
                 {this.state.errors['last_date_of_exposure']}
               </Form.Control.Feedback>
             </Form.Group>
-            <Form.Group as={Col} controlId="assigned_user">
+            <Form.Group as={Col} lg="12" controlId="assigned_user">
               <Form.Label className="nav-input-label">
                 Assigned User {schema?.fields?.assigned_user?._exclusive?.required && '*'}
                 <InfoTooltip tooltipTextKey="assignedUser" location="top"></InfoTooltip>
@@ -266,27 +275,11 @@ class CloseContact extends React.Component {
           {/* Typically we pair the ReactTooltip up directly next to the mount point. However, due to the disabled attribute on the button */}
           {/* above, this Tooltip should be placed outside the parent component (to prevent unwanted parent opacity settings from being inherited) */}
           {/* This does not impact component functionality at all. */}
-          <ReactTooltip
-            id="create-tooltip"
-            multiline={true}
-            place="top"
-            type="dark"
-            effect="solid"
-            offset={{ left: 113 }}
-            arrowColor="#ffffff00"
-            className="tooltip-container text-left"
-            disable={!this.state.disableCreate}>
-            <div>
-              {' '}
-              Please enter at least one of the following:
-              <ul className="m-0 pl-3">
-                <li>First Name</li>
-                <li>Last Name</li>
-                <li>Phone Number</li>
-                <li>Email</li>
-              </ul>
-            </div>
-          </ReactTooltip>
+          {this.state.disableCreate && (
+            <ReactTooltip id="create-tooltip" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container text-left">
+              Please enter one of the following: First Name, Last Name, Phone Number or Email
+            </ReactTooltip>
+          )}
         </Modal.Footer>
       </Modal>
     );

--- a/app/javascript/components/close_contact/CloseContact.js
+++ b/app/javascript/components/close_contact/CloseContact.js
@@ -77,9 +77,13 @@ class CloseContact extends React.Component {
   handleDateChange = event => this.setState({ last_date_of_exposure: event });
 
   handleChange = event => {
-    event.target.value = _.trimEnd(event.target.value);
+    if (event?.target?.value && typeof event.target.value === 'string' && event.target.value.match(/^\s*$/) !== null) {
+      // Empty spaces are allowed to be typed (for example, a first name may be 'Mary Beth')
+      // But empty starting first spaces should not be allowed
+      event.target.value = '';
+    }
     let value;
-    let disableCreate = false;
+    let disableCreate = this.state.disableCreate;
     const possiblyRequiredFields = ['first_name', 'last_name', 'primary_telephone', 'email'];
     if (possiblyRequiredFields.includes(event.target.id)) {
       // This checks that at least one of the possiblyRequiredFields is set to a truthy value
@@ -147,8 +151,8 @@ class CloseContact extends React.Component {
   createModal(title, toggle, submit) {
     return (
       <Modal size="lg" show centered onHide={toggle}>
+        <h1 className="sr-only">{title}</h1>
         <Modal.Header>
-          <h1 className="sr-only">{title}</h1>
           <Modal.Title>{title}</Modal.Title>
         </Modal.Header>
         <Modal.Body className="px-5">

--- a/app/javascript/components/close_contact/CloseContact.js
+++ b/app/javascript/components/close_contact/CloseContact.js
@@ -8,6 +8,7 @@ import libphonenumber from 'google-libphonenumber';
 import DateInput from '../util/DateInput';
 import moment from 'moment';
 import InfoTooltip from '../util/InfoTooltip';
+import ReactTooltip from 'react-tooltip';
 
 const PNF = libphonenumber.PhoneNumberFormat;
 const phoneUtil = libphonenumber.PhoneNumberUtil.getInstance();
@@ -21,6 +22,7 @@ class CloseContact extends React.Component {
     super(props);
     this.state = {
       showModal: false,
+      disableCreate: true,
       loading: false,
       errors: {},
       first_name: this.props.close_contact.first_name || '',
@@ -47,6 +49,8 @@ class CloseContact extends React.Component {
       // (because the rest of this method hasnt had time to fire, and change 'show' to false)
       // When they click cancel, we want to null out all of the fields
       newState = {
+        disableCreate: true,
+        errors: {},
         first_name: this.props.close_contact.first_name || '',
         last_name: this.props.close_contact.last_name || '',
         primary_telephone: this.props.close_contact.primary_telephone || '',
@@ -66,6 +70,12 @@ class CloseContact extends React.Component {
 
   handleChange = event => {
     let value;
+    let disableCreate = false;
+    const possiblyRequiredFields = ['first_name', 'last_name', 'primary_telephone', 'email'];
+    if (possiblyRequiredFields.includes(event.target.id)) {
+      // This checks that at least one of the possiblyRequiredFields is set to a truthy value
+      disableCreate = !possiblyRequiredFields.some(field => (field === event.target.id ? !!event.target.value : !!this.state[`${field}`]));
+    }
     if (event?.target?.id && event.target.id === 'assigned_user') {
       if (isNaN(event.target.value) || parseInt(event.target.value) > 999999) return;
       // trim() call included since there is a bug with yup validation for numbers that allows whitespace entry
@@ -75,7 +85,7 @@ class CloseContact extends React.Component {
     } else {
       value = event.target.value;
     }
-    this.setState({ [event.target.id]: value });
+    this.setState({ [event.target.id]: value, disableCreate });
   };
 
   contactAttempt = async () => {
@@ -132,137 +142,151 @@ class CloseContact extends React.Component {
           <h1 className="sr-only">{title}</h1>
           <Modal.Title>{title}</Modal.Title>
         </Modal.Header>
-        <Modal.Body>
-          <Form>
-            <Row>
-              <Form.Group as={Col} controlId="first_name">
-                <Form.Label className="nav-input-label">First Name {schema?.fields?.first_name?._exclusive?.required && '*'} </Form.Label>
-                <Form.Control size="lg" className="form-square" value={this.state.first_name || ''} onChange={this.handleChange} />
-                <Form.Control.Feedback className="d-block" type="invalid">
-                  {this.state.errors['first_name']}
-                </Form.Control.Feedback>
-              </Form.Group>
-            </Row>
-            <Row>
-              <Form.Group as={Col} controlId="last_name">
-                <Form.Label className="nav-input-label">Last Name {schema?.fields?.last_name?._exclusive?.required && '*'} </Form.Label>
-                <Form.Control size="lg" className="form-square" value={this.state.last_name || ''} onChange={this.handleChange} />
-                <Form.Control.Feedback className="d-block" type="invalid">
-                  {this.state.errors['last_name']}
-                </Form.Control.Feedback>
-              </Form.Group>
-            </Row>
-            <Row>
-              <Form.Group as={Col} controlId="primary_telephone">
-                <Form.Label className="nav-input-label">Phone Number {schema?.fields?.primary_telephone?._exclusive?.required && '*'}</Form.Label>
-                <PhoneInput
-                  id="primary_telephone"
-                  className="form-square"
-                  value={this.state.primary_telephone}
-                  onChange={this.handleChange}
-                  isInvalid={!!this.state.errors['primary_telephone']}
-                />
-                <Form.Control.Feedback className="d-block" type="invalid">
-                  {this.state.errors['primary_telephone']}
-                </Form.Control.Feedback>
-              </Form.Group>
-            </Row>
-            <Row>
-              <Form.Group as={Col} controlId="email">
-                <Form.Label className="nav-input-label">Email {schema?.fields?.email?._exclusive?.required && '*'} </Form.Label>
-                <Form.Control size="lg" className="form-square" value={this.state.email || ''} onChange={this.handleChange} />
-                <Form.Control.Feedback className="d-block" type="invalid">
-                  {this.state.errors['email']}
-                </Form.Control.Feedback>
-              </Form.Group>
-            </Row>
-            <Row>
-              <Form.Group as={Col} controlId="last_date_of_exposure">
-                <Form.Label className="nav-input-label">Last Date of Exposure {schema?.fields?.last_date_of_exposure?._exclusive?.required && '*'}</Form.Label>
-                <DateInput
-                  id="last_date_of_exposure"
-                  date={this.state.last_date_of_exposure}
-                  minDate={'2020-01-01'}
-                  maxDate={moment()
-                    .add(30, 'days')
-                    .format('YYYY-MM-DD')}
-                  onChange={this.handleDateChange}
-                  placement="top"
-                  isInvalid={!!this.state.errors['last_date_of_exposure']}
-                  customClass="form-control-lg"
-                  ariaLabel="Last Date of Exposure Input"
-                />
-                <Form.Control.Feedback className="d-block" type="invalid">
-                  {this.state.errors['last_date_of_exposure']}
-                </Form.Control.Feedback>
-              </Form.Group>
-            </Row>
-            <Row>
-              <Form.Group as={Col} className="mb-2 pt-2" controlId="assigned_user">
-                <Form.Label className="nav-input-label">
-                  Assigned User {schema?.fields?.assigned_user?._exclusive?.required && '*'}
-                  <InfoTooltip tooltipTextKey="assignedUser" location="top"></InfoTooltip>
-                </Form.Label>
-                <Form.Control
-                  isInvalid={this.state.errors['assigned_user']}
-                  as="input"
-                  list="assigned_users"
-                  autoComplete="off"
-                  size="lg"
-                  className="d-block"
-                  onChange={this.handleChange}
-                  value={this.state.assigned_user || ''}
-                />
-                <datalist id="assigned_users">
-                  {this.props.assigned_users?.map(num => {
-                    return (
-                      <option value={num} key={num}>
-                        {num}
-                      </option>
-                    );
-                  })}
-                </datalist>
-                <Form.Control.Feedback className="d-block" type="invalid">
-                  {this.state.errors['assigned_user']}
-                </Form.Control.Feedback>
-              </Form.Group>
-            </Row>
-            <Row>
-              <Form.Group as={Col}>
-                <Form.Label htmlFor="notes" className="nav-input-label">
-                  Notes
-                  {schema?.fields?.notes?._exclusive?.required && '*'}
-                </Form.Label>
-                <Form.Control
-                  id="notes"
-                  as="textarea"
-                  rows="5"
-                  className="form-square"
-                  value={this.state.notes || ''}
-                  placeholder={this.closeContactNotePlaceholder}
-                  maxLength="2000"
-                  onChange={this.handleChange}
-                />
-                <Form.Label className="notes-character-limit"> {2000 - this.state.notes.length} characters remaining </Form.Label>
-                <Form.Control.Feedback className="d-block" type="invalid">
-                  {this.state.errors['notes']}
-                </Form.Control.Feedback>
-              </Form.Group>
-            </Row>
-          </Form>
+        <Modal.Body className="px-5">
+          <Row className="mt-3">
+            <Form.Group as={Col} lg="12" controlId="first_name">
+              <Form.Label className="nav-input-label">First Name {schema?.fields?.first_name?._exclusive?.required && '*'} </Form.Label>
+              <Form.Control size="lg" className="form-square" value={this.state.first_name || ''} onChange={this.handleChange} />
+              <Form.Control.Feedback className="d-block" type="invalid">
+                {this.state.errors['first_name']}
+              </Form.Control.Feedback>
+            </Form.Group>
+            <Form.Group as={Col} lg="12" controlId="last_name">
+              <Form.Label className="nav-input-label">Last Name {schema?.fields?.last_name?._exclusive?.required && '*'} </Form.Label>
+              <Form.Control size="lg" className="form-square" value={this.state.last_name || ''} onChange={this.handleChange} />
+              <Form.Control.Feedback className="d-block" type="invalid">
+                {this.state.errors['last_name']}
+              </Form.Control.Feedback>
+            </Form.Group>
+          </Row>
+          <Row>
+            <Form.Group as={Col} controlId="primary_telephone">
+              <Form.Label className="nav-input-label">Phone Number {schema?.fields?.primary_telephone?._exclusive?.required && '*'}</Form.Label>
+              <PhoneInput
+                id="primary_telephone"
+                className="form-square"
+                value={this.state.primary_telephone}
+                onChange={this.handleChange}
+                isInvalid={!!this.state.errors['primary_telephone']}
+              />
+              <Form.Control.Feedback className="d-block" type="invalid">
+                {this.state.errors['primary_telephone']}
+              </Form.Control.Feedback>
+            </Form.Group>
+            <Form.Group as={Col} controlId="email">
+              <Form.Label className="nav-input-label">Email {schema?.fields?.email?._exclusive?.required && '*'} </Form.Label>
+              <Form.Control size="lg" className="form-square" value={this.state.email || ''} onChange={this.handleChange} />
+              <Form.Control.Feedback className="d-block" type="invalid">
+                {this.state.errors['email']}
+              </Form.Control.Feedback>
+            </Form.Group>
+          </Row>
+          <hr></hr>
+          <Row>
+            <Form.Group as={Col} controlId="last_date_of_exposure">
+              <Form.Label className="nav-input-label">Last Date of Exposure {schema?.fields?.last_date_of_exposure?._exclusive?.required && '*'}</Form.Label>
+              <DateInput
+                id="last_date_of_exposure"
+                date={this.state.last_date_of_exposure}
+                minDate={'2020-01-01'}
+                maxDate={moment()
+                  .add(30, 'days')
+                  .format('YYYY-MM-DD')}
+                onChange={this.handleDateChange}
+                placement="top"
+                isInvalid={!!this.state.errors['last_date_of_exposure']}
+                customClass="form-control-lg"
+                ariaLabel="Last Date of Exposure Input"
+              />
+              <Form.Control.Feedback className="d-block" type="invalid">
+                {this.state.errors['last_date_of_exposure']}
+              </Form.Control.Feedback>
+            </Form.Group>
+            <Form.Group as={Col} controlId="assigned_user">
+              <Form.Label className="nav-input-label">
+                Assigned User {schema?.fields?.assigned_user?._exclusive?.required && '*'}
+                <InfoTooltip tooltipTextKey="assignedUser" location="top"></InfoTooltip>
+              </Form.Label>
+              <Form.Control
+                isInvalid={this.state.errors['assigned_user']}
+                as="input"
+                list="assigned_users"
+                autoComplete="off"
+                size="lg"
+                className="d-block"
+                onChange={this.handleChange}
+                value={this.state.assigned_user || ''}
+              />
+              <datalist id="assigned_users">
+                {this.props.assigned_users?.map(num => {
+                  return (
+                    <option value={num} key={num}>
+                      {num}
+                    </option>
+                  );
+                })}
+              </datalist>
+              <Form.Control.Feedback className="d-block" type="invalid">
+                {this.state.errors['assigned_user']}
+              </Form.Control.Feedback>
+            </Form.Group>
+          </Row>
+          <Row>
+            <Form.Group as={Col}>
+              <Form.Label htmlFor="notes" className="nav-input-label">
+                Notes
+                {schema?.fields?.notes?._exclusive?.required && '*'}
+              </Form.Label>
+              <Form.Control
+                id="notes"
+                as="textarea"
+                rows="5"
+                className="form-square"
+                value={this.state.notes || ''}
+                placeholder={this.closeContactNotePlaceholder}
+                maxLength="2000"
+                onChange={this.handleChange}
+              />
+              <Form.Label className="notes-character-limit"> {2000 - this.state.notes.length} characters remaining </Form.Label>
+              <Form.Control.Feedback className="d-block" type="invalid">
+                {this.state.errors['notes']}
+              </Form.Control.Feedback>
+            </Form.Group>
+          </Row>
         </Modal.Body>
         <Modal.Footer>
           <Button variant="secondary btn-square" onClick={toggle}>
             Cancel
           </Button>
-          <Button
-            variant="primary btn-square"
-            onClick={submit}
-            disabled={
-              !(this.state.first_name || this.state.last_name || this.state.email || this.state.primary_telephone || this.state.notes) || this.state.loading
-            }>
-            {this.props.close_contact.id ? 'Update' : 'Create'}
+          <Button variant="primary btn-square" onClick={submit} disabled={this.state.disableCreate || this.state.loading}>
+            <span data-for="create-tooltip" data-tip="" className="ml-1">
+              {this.props.close_contact.id ? 'Update' : 'Create'}
+            </span>
           </Button>
+          {/* Typically we pair the ReactTooltip up directly next to the mount point. However, due to the disabled attribute on the button */}
+          {/* above, this Tooltip should be placed outside the parent component (to prevent unwanted parent opacity settings from being inherited) */}
+          {/* This does not impact component functionality at all. */}
+          <ReactTooltip
+            id="create-tooltip"
+            multiline={true}
+            place="top"
+            type="dark"
+            effect="solid"
+            offset={{ left: 113 }}
+            arrowColor="#ffffff00"
+            className="tooltip-container text-left"
+            disable={!this.state.disableCreate}>
+            <div>
+              {' '}
+              Please enter at least one of the following:
+              <ul className="m-0 pl-3">
+                <li>First Name</li>
+                <li>Last Name</li>
+                <li>Phone Number</li>
+                <li>Email</li>
+              </ul>
+            </div>
+          </ReactTooltip>
         </Modal.Footer>
       </Modal>
     );

--- a/app/javascript/components/close_contact/CloseContact.js
+++ b/app/javascript/components/close_contact/CloseContact.js
@@ -281,7 +281,7 @@ class CloseContact extends React.Component {
           {/* This does not impact component functionality at all. */}
           {this.state.disableCreate && (
             <ReactTooltip id="create-tooltip" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container text-left">
-              Please enter one of the following: First Name, Last Name, Phone Number or Email
+              Please enter one of the following: First Name, Last Name, Phone Number, or Email
             </ReactTooltip>
           )}
         </Modal.Footer>

--- a/app/javascript/tests/close_contact/CloseContact.test.js
+++ b/app/javascript/tests/close_contact/CloseContact.test.js
@@ -9,13 +9,13 @@ import { mockCloseContact1, mockCloseContact2, mockCloseContact3 } from '../mock
 const authyToken = 'Q1z4yZXLdN+tZod6dBSIlMbZ3yWAUFdY44U06QWffEP76nx1WGMHIz8rYxEUZsl9sspS3ePF2ZNmSue8wFpJGg==';
 const ASSIGNED_USERS = [ 123234, 512678, 910132 ]
 const testInputValues = [
-  { field: 'first_name', value: 'Anthony', inputType: 'FormControl' },
-  { field: 'last_name', value: 'Stark', inputType: 'FormControl' },
-  { field: 'primary_telephone', value: '1234567890', inputType: 'PhoneInput' },
-  { field: 'email', value: 'tinman@starkindustries.com', inputType: 'FormControl' },
-  { field: 'last_date_of_exposure', value: '2020-05-16', inputType: 'DateInput' },
-  { field: 'assigned_user', value: ASSIGNED_USERS[0], inputType: 'FormControl' },
-  { field: 'notes', value: 'Inevitable', inputType: 'FormControl' },
+  { field: 'first_name', value: 'Anthony' },
+  { field: 'last_name', value: 'Stark' },
+  { field: 'primary_telephone', value: '1234567890' },
+  { field: 'email', value: 'tinman@starkindustries.com' },
+  { field: 'last_date_of_exposure', value: '2020-05-16' },
+  { field: 'assigned_user', value: ASSIGNED_USERS[0] },
+  { field: 'notes', value: 'Inevitable' },
 ]
 
 function getShallowWrapper(closeContact) {
@@ -92,17 +92,17 @@ describe('CloseContact', () => {
     expect(emptyCCWrapper.find(Modal.Header).find('ModalTitle').text()).toEqual('Close Contact');
     expect(emptyCCWrapper.find(Modal.Body).exists()).toBeTruthy();
     // Using `toContain` instead of `toEqual` to avoid any whitespace issues
-    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormLabel').text()).toContain(`First Name`);
-    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormLabel').text()).toContain(`Last Name`);
-    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(2).find('FormLabel').text()).toContain(`Phone Number`);
-    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(3).find('FormLabel').text()).toContain(`Email`);
-    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(4).find('FormLabel').text()).toContain(`Last Date of Exposure`);
-    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(5).find('FormLabel').text()).toContain(`Assigned User`); // There's also the InfoTooltip
-    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(5).find('FormLabel').containsMatchingElement(<InfoTooltip />)).toBeTruthy();
+    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormLabel').at(0).text()).toContain(`First Name`);
+    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormLabel').at(1).text()).toContain(`Last Name`);
+    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormLabel').at(0).text()).toContain(`Phone Number`);
+    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormLabel').at(1).text()).toContain(`Email`);
+    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(2).find('FormLabel').at(0).text()).toContain(`Last Date of Exposure`);
+    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(2).find('FormLabel').at(1).text()).toContain(`Assigned User`); // There's also the InfoTooltip
+    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(2).find('FormLabel').containsMatchingElement(<InfoTooltip />)).toBeTruthy();
     expect(emptyCCWrapper.find(InfoTooltip).prop('tooltipTextKey')).toEqual('assignedUser');
 
-    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(6).find('FormLabel').at(0).text()).toContain('Notes');
-    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(6).find('FormLabel').at(1).text()).toContain('2000 characters remaining');
+    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(3).find('FormLabel').at(0).text()).toContain('Notes');
+    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(3).find('FormLabel').at(1).text()).toContain('2000 characters remaining');
     expect(emptyCCWrapper.find(Modal.Footer).exists()).toBeTruthy();
     expect(emptyCCWrapper.find(Modal.Footer).find(Button).at(0).text()).toEqual('Cancel');
     expect(emptyCCWrapper.find(Modal.Footer).find(Button).at(1).text()).toEqual('Create');
@@ -119,18 +119,48 @@ describe('CloseContact', () => {
     emptyCCWrapper.find(Button).at(0).simulate('click');
     expect(emptyCCWrapper.state('showModal')).toBeTruthy();
 
-    // This iteration assumes the testInputValues order matches the order of the elements in the DOM
-    testInputValues.forEach((iv, index) => {
-      expect(emptyCCWrapper.state(iv.field)).toBeFalsy();
-      if (iv.inputType === 'DateInput') {
-        emptyCCWrapper.find(Modal.Body).find('Row').at(index).find(iv.inputType).simulate('change', iv.value)
-        expect(handleDateChangeSpy).toHaveBeenCalled();
-      } else {
-        emptyCCWrapper.find(Modal.Body).find('Row').at(index).find(iv.inputType).simulate('change', { target: { id: iv.field, value: iv.value } })
-        expect(handleChangeSpy).toHaveBeenCalled();
-      }
-      expect(emptyCCWrapper.state(iv.field)).toEqual(iv.value);
-    });
+    let value;
+    value = testInputValues.find(x => x.field === 'first_name').value
+    expect(emptyCCWrapper.state('first_name')).toBeFalsy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: value } })
+    expect(handleChangeSpy).toHaveBeenCalled();
+    expect(emptyCCWrapper.state('first_name')).toEqual(value);
+
+    value = testInputValues.find(x => x.field === 'last_name').value
+    expect(emptyCCWrapper.state('last_name')).toBeFalsy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(1).simulate('change', { target: { id: 'last_name', value: value } })
+    expect(handleChangeSpy).toHaveBeenCalled();
+    expect(emptyCCWrapper.state('last_name')).toEqual(value);
+
+    value = testInputValues.find(x => x.field === 'primary_telephone').value
+    expect(emptyCCWrapper.state('primary_telephone')).toBeFalsy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: value } })
+    expect(handleChangeSpy).toHaveBeenCalled();
+    expect(emptyCCWrapper.state('primary_telephone')).toEqual(value);
+
+    value = testInputValues.find(x => x.field === 'email').value
+    expect(emptyCCWrapper.state('email')).toBeFalsy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: value } })
+    expect(handleChangeSpy).toHaveBeenCalled();
+    expect(emptyCCWrapper.state('email')).toEqual(value);
+
+    value = testInputValues.find(x => x.field === 'last_date_of_exposure').value
+    expect(emptyCCWrapper.state('last_date_of_exposure')).toBeFalsy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(2).find('DateInput').simulate('change', value )
+    expect(handleDateChangeSpy).toHaveBeenCalled();
+    expect(emptyCCWrapper.state('last_date_of_exposure')).toEqual(value);
+
+    value = testInputValues.find(x => x.field === 'assigned_user').value
+    expect(emptyCCWrapper.state('assigned_user')).toBeFalsy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(2).find('FormControl').simulate('change', { target: { id: 'assigned_user', value: value } })
+    expect(handleChangeSpy).toHaveBeenCalled();
+    expect(emptyCCWrapper.state('assigned_user')).toEqual(value);
+
+    value = testInputValues.find(x => x.field === 'notes').value
+    expect(emptyCCWrapper.state('notes')).toBeFalsy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(3).find('FormControl').simulate('change', { target: { id: 'notes', value: value } })
+    expect(handleChangeSpy).toHaveBeenCalled();
+    expect(emptyCCWrapper.state('notes')).toEqual(value);
   });
 
   it('Properly creates the correct assigned user dropdown options', () => {
@@ -149,14 +179,21 @@ describe('CloseContact', () => {
     emptyCCWrapper.find(Button).at(0).simulate('click');
     expect(emptyCCWrapper.state('showModal')).toBeTruthy();
 
-    // This iteration assumes the testInputValues order matches the order of the elements in the DOM
-    testInputValues.forEach((iv, index) => {
-      if (iv.inputType === 'DateInput') {
-        emptyCCWrapper.find(Modal.Body).find('Row').at(index).find(iv.inputType).simulate('change', iv.value)
-      } else {
-        emptyCCWrapper.find(Modal.Body).find('Row').at(index).find(iv.inputType).simulate('change', { target: { id: iv.field, value: iv.value } })
-      }
-    });
+    let value;
+    value = testInputValues.find(x => x.field === 'first_name').value
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: value } })
+    value = testInputValues.find(x => x.field === 'last_name').value
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(1).simulate('change', { target: { id: 'last_name', value: value } })
+    value = testInputValues.find(x => x.field === 'primary_telephone').value
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: value } })
+    value = testInputValues.find(x => x.field === 'email').value
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: value } })
+    value = testInputValues.find(x => x.field === 'last_date_of_exposure').value
+    emptyCCWrapper.find(Modal.Body).find('Row').at(2).find('DateInput').simulate('change', value )
+    value = testInputValues.find(x => x.field === 'assigned_user').value
+    emptyCCWrapper.find(Modal.Body).find('Row').at(2).find('FormControl').simulate('change', { target: { id: 'assigned_user', value: value } })
+    value = testInputValues.find(x => x.field === 'notes').value
+    emptyCCWrapper.find(Modal.Body).find('Row').at(3).find('FormControl').simulate('change', { target: { id: 'notes', value: value } })
 
     emptyCCWrapper.find(Button).at(1).simulate('click');
     // Once the modal is closed, the values should default back to their nulled out original values
@@ -176,14 +213,21 @@ describe('CloseContact', () => {
     existingCCWrapper.find(Button).at(0).simulate('click');
     expect(existingCCWrapper.state('showModal')).toBeTruthy();
 
-    // This iteration assumes the testInputValues order matches the order of the elements in the DOM
-    testInputValues.forEach((iv, index) => {
-      if (iv.inputType === 'DateInput') {
-        existingCCWrapper.find(Modal.Body).find('Row').at(index).find(iv.inputType).simulate('change', iv.value)
-      } else {
-        existingCCWrapper.find(Modal.Body).find('Row').at(index).find(iv.inputType).simulate('change', { target: { id: iv.field, value: iv.value } })
-      }
-    });
+    let value;
+    value = testInputValues.find(x => x.field === 'first_name').value
+    existingCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: value } })
+    value = testInputValues.find(x => x.field === 'last_name').value
+    existingCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(1).simulate('change', { target: { id: 'last_name', value: value } })
+    value = testInputValues.find(x => x.field === 'primary_telephone').value
+    existingCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: value } })
+    value = testInputValues.find(x => x.field === 'email').value
+    existingCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: value } })
+    value = testInputValues.find(x => x.field === 'last_date_of_exposure').value
+    existingCCWrapper.find(Modal.Body).find('Row').at(2).find('DateInput').simulate('change', value )
+    value = testInputValues.find(x => x.field === 'assigned_user').value
+    existingCCWrapper.find(Modal.Body).find('Row').at(2).find('FormControl').simulate('change', { target: { id: 'assigned_user', value: value } })
+    value = testInputValues.find(x => x.field === 'notes').value
+    existingCCWrapper.find(Modal.Body).find('Row').at(3).find('FormControl').simulate('change', { target: { id: 'notes', value: value } })
 
     existingCCWrapper.find(Button).at(3).simulate('click');
     // Once the modal is closed, the values should default back to their nulled out original values
@@ -214,10 +258,46 @@ describe('CloseContact', () => {
     expect(emptyCCWrapper.find('Button').at(0).text()).toContain('Add New Close Contact');
     emptyCCWrapper.find(Button).at(0).simulate('click');
     expect(emptyCCWrapper.state('showModal')).toBeTruthy();
-    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(6).find('FormLabel').at(0).text()).toContain('Notes');
-    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(6).find('FormLabel').at(1).text()).toContain('2000 characters remaining');
-    emptyCCWrapper.find(Modal.Body).find('Row').at(6).find('FormControl').simulate('change', { target: { id: 'notes', value: testNoteString } })
-    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(6).find('FormLabel').at(1).text()).toContain(`${2000-testNoteString.length} characters remaining`);
+    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(3).find('FormLabel').at(0).text()).toContain('Notes');
+    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(3).find('FormLabel').at(1).text()).toContain('2000 characters remaining');
+    emptyCCWrapper.find(Modal.Body).find('Row').at(3).find('FormControl').simulate('change', { target: { id: 'notes', value: testNoteString } })
+    expect(emptyCCWrapper.find(Modal.Body).find('Row').at(3).find('FormLabel').at(1).text()).toContain(`${2000-testNoteString.length} characters remaining`);
   });
 
+  it('Properly enables and disables the submit/create button when the correct fields are entered or removed', () => {
+    const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
+
+    expect(emptyCCWrapper.state('showModal')).toBeFalsy();
+    expect(emptyCCWrapper.find('Button').at(0).text()).toContain('Add New Close Contact');
+    emptyCCWrapper.find(Button).at(0).simulate('click');
+
+    let value;
+    value = testInputValues.find(x => x.field === 'first_name').value
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: value } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: '' } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+
+    value = testInputValues.find(x => x.field === 'last_name').value
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(1).simulate('change', { target: { id: 'last_name', value: value } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(1).simulate('change', { target: { id: 'last_name', value: '' } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+
+    value = testInputValues.find(x => x.field === 'primary_telephone').value
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: value } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: '' } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+
+    value = testInputValues.find(x => x.field === 'email').value
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: value } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: '' } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+  })
 });

--- a/app/javascript/tests/close_contact/CloseContact.test.js
+++ b/app/javascript/tests/close_contact/CloseContact.test.js
@@ -12,7 +12,7 @@ const testInputValues = [
   { field: 'first_name', value: 'Anthony' },
   { field: 'last_name', value: 'Stark' },
   { field: 'primary_telephone', value: '1234567890' },
-  { field: 'email', value: 'tinman@starkindustries.com' },
+  { field: 'email', value: 'tinman@example.com' },
   { field: 'last_date_of_exposure', value: '2020-05-16' },
   { field: 'assigned_user', value: ASSIGNED_USERS[0] },
   { field: 'notes', value: 'Inevitable' },

--- a/app/javascript/tests/close_contact/CloseContact.test.js
+++ b/app/javascript/tests/close_contact/CloseContact.test.js
@@ -274,30 +274,42 @@ describe('CloseContact', () => {
     let value;
     value = testInputValues.find(x => x.field === 'first_name').value
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: value } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: '' } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
 
     value = testInputValues.find(x => x.field === 'last_name').value
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(1).simulate('change', { target: { id: 'last_name', value: value } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(1).simulate('change', { target: { id: 'last_name', value: '' } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
 
     value = testInputValues.find(x => x.field === 'primary_telephone').value
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: value } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: '' } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
 
     value = testInputValues.find(x => x.field === 'email').value
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: value } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: '' } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
   })
 });

--- a/app/javascript/tests/close_contact/CloseContact.test.js
+++ b/app/javascript/tests/close_contact/CloseContact.test.js
@@ -88,7 +88,7 @@ describe('CloseContact', () => {
     emptyCCWrapper.find(Button).at(0).simulate('click');
     expect(emptyCCWrapper.state('showModal')).toBeTruthy();
     expect(emptyCCWrapper.find(Modal.Header).exists()).toBeTruthy();
-    expect(emptyCCWrapper.find(Modal.Header).find('.sr-only').text()).toEqual('Close Contact');
+    expect(emptyCCWrapper.find(Modal).find('.sr-only').text()).toEqual('Close Contact');
     expect(emptyCCWrapper.find(Modal.Header).find('ModalTitle').text()).toEqual('Close Contact');
     expect(emptyCCWrapper.find(Modal.Body).exists()).toBeTruthy();
     // Using `toContain` instead of `toEqual` to avoid any whitespace issues


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1099

This Pull Request is a followup to SARAALERT-616. It updates the CloseContact Modal to better fit the new elements. The previous pull request lead to the Modal getting too vertically long. This pull request adds a two-column system that better makes use of the screen real estate. It is responsive across all major viewports (the two-to-one column breakpoint change iis at the LG (large) viewport breakpoint). 

This PR also adds required fields per user feedback. The Modal may not be submitted without at least one of First Name, Last Name, Email, or Phone.

This PR also refactors the tests which had been designed with the one-column system in mind.

# Screenshots
<img width="813" alt="image" src="https://user-images.githubusercontent.com/17532163/106672812-b4e31e00-657e-11eb-848e-1885ef271cf1.png">
(The little **D** emoji in the image is from my password manager, and is not there in reality)

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/javascript/components/close_contact/CloseContact.js`
- Refactors this component to add the required fields, and transition to a two column system.

`app/javascript/tests/close_contact/CloseContact.test.js`
-Refactors the tests