### PR TITLE
SARAALERT-1120: Reformatting role names in admin audit table

### DIFF
--- a/app/javascript/components/admin/AuditModal.js
+++ b/app/javascript/components/admin/AuditModal.js
@@ -200,7 +200,8 @@ class AuditModal extends React.Component {
         } else {
           return (
             <span>
-              <b>Role</b>: Changed from &quot;{change.details[0]}&quot; to &quot;{change.details[1]}&quot;
+              <b>Role</b>: Changed from &quot;{_.map(change.details[0].split('_'), _.capitalize).join(' ')}&quot; to &quot;
+              {_.map(change.details[1].split('_'), _.capitalize).join(' ')}&quot;
             </span>
           );
         }

--- a/app/javascript/components/admin/AuditModal.js
+++ b/app/javascript/components/admin/AuditModal.js
@@ -126,14 +126,6 @@ class AuditModal extends React.Component {
   }
 
   /**
-   * Formats role values coming from the database to be human readable (capitalized and space separated)
-   * @param {*} role - the role string to be converted
-   */
-  formatRole(role) {
-    return _.map(role.split('_'), _.capitalize).join(' ');
-  }
-
-  /**
    * Formatting method for displaying each audit action in the table.
    * @param {Object} data - Data about the cell this filter is called on.
    */
@@ -208,8 +200,8 @@ class AuditModal extends React.Component {
         } else {
           return (
             <span>
-              <b>Role</b>: Changed from &quot;{this.formatRole(change.details[0])}&quot; to &quot;
-              {this.formatRole(change.details[1])}&quot;
+              <b>Role</b>: Changed from &quot;{_.startCase(change.details[0])}&quot; to &quot;
+              {_.startCase(change.details[1])}&quot;
             </span>
           );
         }

--- a/app/javascript/components/admin/AuditModal.js
+++ b/app/javascript/components/admin/AuditModal.js
@@ -126,6 +126,14 @@ class AuditModal extends React.Component {
   }
 
   /**
+   * Formats role values coming from the database to be human readable (capitalized and space separated)
+   * @param {*} role - the role string to be converted
+   */
+  formatRole(role) {
+    return _.map(role.split('_'), _.capitalize).join(' ');
+  }
+
+  /**
    * Formatting method for displaying each audit action in the table.
    * @param {Object} data - Data about the cell this filter is called on.
    */
@@ -200,8 +208,8 @@ class AuditModal extends React.Component {
         } else {
           return (
             <span>
-              <b>Role</b>: Changed from &quot;{_.map(change.details[0].split('_'), _.capitalize).join(' ')}&quot; to &quot;
-              {_.map(change.details[1].split('_'), _.capitalize).join(' ')}&quot;
+              <b>Role</b>: Changed from &quot;{this.formatRole(change.details[0])}&quot; to &quot;
+              {this.formatRole(change.details[1])}&quot;
             </span>
           );
         }


### PR DESCRIPTION


# Description
Jira Ticket: SARAALERT-1120

Before, in the admin audit table user roles would render as the values we use to represent them in the backend: lower-case, separated by underscores. This adds formatting to make them consistent with how we represent the roles elsewhere such as in the dropdown menu. 

Screenshots:
![old_screenshot](https://user-images.githubusercontent.com/16108095/106831616-3362bd00-665e-11eb-9c27-61b13ef8c179.png)

<img width="1012" alt="Screen Shot 2021-02-03 at 8 26 17 PM" src="https://user-images.githubusercontent.com/16108095/106831592-2c3baf00-665e-11eb-8edd-b57725c45396.png">


# (Bugfix) How to Replicate
Insert steps for how to replicate the bug this PR addresses.

# Important Changes

app/javascript/components/admin/AuditModal.js
- only file changed, adds formatting code to the original and modified role values. 

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [x] Firefox
* [ ] Safari
* [ ] IE11

To replicate the test, start the server and log in as an admin user. Pick a user at random from the admin table, change their role value a few times, then look at the audit table. 
