### PR TITLE
Increased timer on Advanced Filter Toast

### DIFF
--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -451,7 +451,9 @@ class AdvancedFilter extends React.Component {
     axios
       .post(window.BASE_PATH + '/user_filters', { activeFilterOptions: this.state.activeFilterOptions, name: this.state.filterName })
       .catch(err => {
-        toast.error(err?.response?.data?.error ? err.response.data.error : 'Failed to save filter.');
+        toast.error(err?.response?.data?.error ? err.response.data.error : 'Failed to save filter.', {
+          autoClose: 8000,
+        });
       })
       .then(response => {
         if (response?.data) {


### PR DESCRIPTION
# Description
Small update to the autoclose time on a longer error message.

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.

1. Set `MAX_USER_FILTERS` to be something small, like 2.
2. Create max number of advanced filters and then try and create one more
3. Notice error messages stays on screen for longer
