### PR TITLE
SARAALERT-1275: Advanced Filter Delete/Clearing Bug

### DIFF
--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -538,6 +538,9 @@ class AdvancedFilter extends React.Component {
 
   // Render the options for the select that represents fields to filter on
   renderOptions = (current, index) => {
+    const selectedValue = this.getFormattedOptions().find(option => {
+      return option.value === current;
+    });
     const Option = props => {
       return (
         <components.Option {...props}>
@@ -549,9 +552,7 @@ class AdvancedFilter extends React.Component {
     return (
       <Select
         options={this.getFormattedOptions()}
-        value={this.getFormattedOptions().find(option => {
-          return option.value === current;
-        })}
+        value={selectedValue || null}
         isOptionDisabled={option => option.disabled}
         components={{ Option }}
         onChange={event => {

--- a/app/javascript/tests/public_health/query/AdvancedFilter.test.js
+++ b/app/javascript/tests/public_health/query/AdvancedFilter.test.js
@@ -198,14 +198,16 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find(DateInput).prop('date')).toEqual(mockFilter2.contents[1].value);
   });
 
-  it('Clicking "+" button adds another filter statement row', () => {
+  it('Clicking "+" button adds another filter statement row and updates state', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
     _.times(4, (i) => {
       expect(wrapper.find('.advanced-filter-statement').length).toEqual(i+1);
+      expect(wrapper.state('activeFilterOptions').length).toEqual(i+1);
       wrapper.find('#add-filter-row').simulate('click');
     });
     expect(wrapper.find('.advanced-filter-statement').length).toEqual(5);
+    expect(wrapper.state('activeFilterOptions').length).toEqual(5);
   });
 
   it('Clicking "+" button displays "AND" row', () => {
@@ -231,20 +233,63 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find('.advanced-filter-statement').length).toEqual(5);
   });
 
-  it('Clicking "-" button removes filter statement row', () => {
+  it('Clicking "-" button removes filter statement row and updates state', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    _.times(4, (i) => {
+    _.times(4, () => {
       wrapper.find('#add-filter-row').simulate('click');
     });
     expect(wrapper.find('.advanced-filter-statement').length).toEqual(5);
+    expect(wrapper.state('activeFilterOptions').length).toEqual(5);
     expect(wrapper.find('.remove-filter-row').length).toEqual(5);
     expect(wrapper.find('.and-row').length).toEqual(4);
     _.times(5, (i) => {
       let random = _.random(1, wrapper.find('.remove-filter-row').length);
       wrapper.find('.remove-filter-row').at(random-1).simulate('click');
       expect(wrapper.find('.advanced-filter-statement').length).toEqual(4-i);
+      expect(wrapper.state('activeFilterOptions').length).toEqual(4-i);
+      expect(wrapper.find('.remove-filter-row').length).toEqual(4-i);
+      expect(wrapper.find('.and-row').length).toEqual(3-i > 0 ? 3-i : 0);
     });
+  });
+
+  it('Clicking "-" button removes properly updates state and dropdown value', () => {
+    const wrapper = getWrapper();
+    wrapper.find(Button).simulate('click');
+    _.times(4, () => {
+      wrapper.find('#add-filter-row').simulate('click');
+    });
+    wrapper.find('.advanced-filter-select').at(0).simulate('change', { value: mockFilterDefaultBoolOption.filterOption.name });
+    wrapper.find('.advanced-filter-select').at(1).simulate('change', { value: mockFilterOptionsOption.filterOption.name });
+    wrapper.find('.advanced-filter-select').at(2).simulate('change', { value: mockFilterDefaultNumberOption.filterOption.name });
+    wrapper.find('.advanced-filter-select').at(3).simulate('change', { value: mockFilterDefaultSearchOption.filterOption.name });
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultBoolOption, mockFilterOptionsOption, mockFilterDefaultNumberOption, mockFilterDefaultSearchOption, { filterOption: null } ]);
+    expect(wrapper.find('.advanced-filter-select').at(0).prop('value').value).toEqual(mockFilterDefaultBoolOption.filterOption.name);
+    expect(wrapper.find('.advanced-filter-select').at(1).prop('value').value).toEqual(mockFilterOptionsOption.filterOption.name);
+    expect(wrapper.find('.advanced-filter-select').at(2).prop('value').value).toEqual(mockFilterDefaultNumberOption.filterOption.name);
+    expect(wrapper.find('.advanced-filter-select').at(3).prop('value').value).toEqual(mockFilterDefaultSearchOption.filterOption.name);
+    expect(wrapper.find('.advanced-filter-select').at(4).prop('value')).toEqual(null);
+    wrapper.find('.remove-filter-row').at(3).simulate('click');
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultBoolOption, mockFilterOptionsOption, mockFilterDefaultNumberOption, { filterOption: null } ]);
+    expect(wrapper.find('.advanced-filter-select').at(0).prop('value').value).toEqual(mockFilterDefaultBoolOption.filterOption.name);
+    expect(wrapper.find('.advanced-filter-select').at(1).prop('value').value).toEqual(mockFilterOptionsOption.filterOption.name);
+    expect(wrapper.find('.advanced-filter-select').at(2).prop('value').value).toEqual(mockFilterDefaultNumberOption.filterOption.name);
+    expect(wrapper.find('.advanced-filter-select').at(3).prop('value')).toEqual(null);
+    wrapper.find('.remove-filter-row').at(1).simulate('click');
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultBoolOption, mockFilterDefaultNumberOption, { filterOption: null } ]);
+    expect(wrapper.find('.advanced-filter-select').at(0).prop('value').value).toEqual(mockFilterDefaultBoolOption.filterOption.name);
+    expect(wrapper.find('.advanced-filter-select').at(1).prop('value').value).toEqual(mockFilterDefaultNumberOption.filterOption.name);
+    expect(wrapper.find('.advanced-filter-select').at(2).prop('value')).toEqual(null);
+    wrapper.find('.remove-filter-row').at(1).simulate('click');
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultBoolOption, { filterOption: null } ]);
+    expect(wrapper.find('.advanced-filter-select').at(0).prop('value').value).toEqual(mockFilterDefaultBoolOption.filterOption.name);
+    expect(wrapper.find('.advanced-filter-select').at(1).prop('value')).toEqual(null);
+    wrapper.find('.remove-filter-row').at(0).simulate('click');
+    expect(wrapper.state('activeFilterOptions')).toEqual([ { filterOption: null } ]);
+    expect(wrapper.find('.advanced-filter-select').at(0).prop('value')).toEqual(null);
+    wrapper.find('.remove-filter-row').at(0).simulate('click');
+    expect(wrapper.state('activeFilterOptions')).toEqual([ ]);
+    expect(wrapper.find('.advanced-filter-select').length).toEqual(0);
   });
 
   it('Properly renders advanced filter boolean type statement', () => {


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1274](https://tracker.codev.mitre.org/browse/SARAALERT-1275)

Deleting first filter in advanced filter makes second blank filter assume first value

# (Bugfix) How to Replicate
1. Open new advanced filter
2. Select an option from the dropdown
3. Click the plus-sign to add new filter
4. click the minus on the first option and note that the yet-unselected filter assumes the deleted value

# (Bugfix) Solution
When a value isn't set in the Options Select, the value would be `undefined`, which does not trigger an update back to the placeholder.  Updated to make sure that value is `null`, which does trigger the placeholder update.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`AdvancedFilter.js`
- Ensure the select dropdown value is set to null if not defined

`AdvancedFilter.test.js`
- Updated tests to include one that would fail if this bug occurs again in the future

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
