### PR TITLE
SARAALERT-1023: Advanced Filter Relative Date Improvements

### DIFF
--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -472,8 +472,14 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
       timespan = filter[:value][:number].to_i.months if filter[:value][:unit] == 'months'
       return patients if timespan.nil?
 
-      timeframe = { after: (timespan.ago - tz_diff).beginning_of_day, before: local_current_time } if filter[:value][:when] == 'past'
-      timeframe = { after: local_current_time, before: (timespan.from_now - tz_diff).end_of_day } if filter[:value][:when] == 'next'
+      case filter[:value][:operator]
+      when 'less-than'
+        timeframe = { after: (timespan.ago - tz_diff).beginning_of_day, before: local_current_time } if filter[:value][:when] == 'past'
+        timeframe = { after: local_current_time, before: (timespan.from_now - tz_diff).end_of_day } if filter[:value][:when] == 'future'
+      when 'more-than'
+        timeframe = { before: (timespan.ago - tz_diff).beginning_of_day } if filter[:value][:when] == 'past'
+        timeframe = { after: (timespan.from_now - tz_diff).end_of_day } if filter[:value][:when] == 'future'
+      end
     end
     return patients if timeframe.nil?
 

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -664,7 +664,7 @@ class AdvancedFilter extends React.Component {
    */
   getRelativeTooltipString(filter, value) {
     const filterName = filter.title.replace(' (Relative Date)', '');
-    let rangeString, before, after;
+    let before, after;
     let statement = '';
     const operatorValue = value.operator.replace('-', ' ');
 
@@ -682,13 +682,11 @@ class AdvancedFilter extends React.Component {
       // set variables for date options including a time stamp
       if (filter.hasTimestamp) {
         if (value.when === 'past') {
-          rangeString = 'dated through today’s date';
           after = moment()
             .subtract(value.number, value.unit)
             .format('MM/DD/YY');
           before = 'now';
         } else {
-          rangeString = 'with today’s date as of the current time';
           after = 'now';
           before = moment()
             .add(value.number, value.unit)
@@ -699,13 +697,11 @@ class AdvancedFilter extends React.Component {
       // set variables for date options without a timestamp
       else {
         if (value.when === 'past') {
-          rangeString = 'dated through today’s date';
           after = moment()
             .subtract(value.number, value.unit)
             .format('MM/DD/YY');
           before = moment().format('MM/DD/YY');
         } else {
-          rangeString = 'with today’s date';
           after = moment().format('MM/DD/YY');
           before = moment()
             .add(value.number, value.unit)
@@ -714,19 +710,23 @@ class AdvancedFilter extends React.Component {
       }
     }
 
-    if (value.operator === 'less-than') {
-      statement = `${filterName} “${operatorValue} ${value.when}” relative date periods include records ${rangeString}. `;
-    }
     statement += `The current setting of "${operatorValue} ${value.number} ${value.unit} in the ${value.when}" will return records with ${filterName} date`;
     if (value.operator === 'less-than') {
-      statement += ` from ${after} through ${before}.`;
-    } else {
+      const timestampString = filter.hasTimestamp ? 'the current time on ' : '';
       if (value.when === 'past') {
-        statement += ` before ${before}.`;
+        statement += ` from ${timestampString}${after} through ${before}. `;
       } else {
-        statement += ` after ${after}.`;
+        statement += ` from ${after} through ${timestampString}${before}. `;
+      }
+    } else {
+      const timestampString = filter.hasTimestamp ? 'the current time on ' : '';
+      if (value.when === 'past') {
+        statement += ` before ${timestampString}${before}. `;
+      } else {
+        statement += ` after ${timestampString}${after}. `;
       }
     }
+    statement += `To filter between two dates, use the "more than" and "less than" filters in combination.`;
     return statement;
   }
 
@@ -1119,7 +1119,7 @@ class AdvancedFilter extends React.Component {
                         this.changeValue(index, { operator: value.operator, number: value.number, unit: value.unit, when: event.target.value });
                       }}>
                       <option value="past">in the past</option>
-                      <option value="future">in the future</option>
+                      {!filterOption.hasTimestamp && <option value="future">in the future</option>}
                     </Form.Control>
                   </Row>
                 )}

--- a/app/javascript/packs/stylesheets/advanced_filter.scss
+++ b/app/javascript/packs/stylesheets/advanced_filter.scss
@@ -18,16 +18,20 @@
   width: 175px !important;
 }
 
+.advanced-filter-operator-input {
+  width: 120px !important;
+}
+
 .advanced-filter-when-input {
-  width: 150px !important;
+  width: 130px !important;
 }
 
 .advanced-filter-number-input {
-  width: 75px !important;
+  width: 70px !important;
 }
 
 .advanced-filter-unit-input {
-  width: 100px !important;
+  width: 110px !important;
 }
 
 .advanced-filter-number-options {

--- a/app/javascript/tests/mocks/mockFilters.js
+++ b/app/javascript/tests/mocks/mockFilters.js
@@ -134,7 +134,7 @@ const mockFilterRelativeOption = {
   value: 'yesterday'
 }
 
-const mockFilterDefaultCustomRelativeOption = {
+const mockFilterDefaultCustomRelativeOption1 = {
   additionalFilterOption: null,
   dateOption: null,
   filterOption: {
@@ -143,6 +143,26 @@ const mockFilterDefaultCustomRelativeOption = {
     description: 'Monitorees with latest report during specified date range (relative to the current date)',
     type: 'relative',
     hasTimestamp: true
+  },
+  numberOption: null,
+  relativeOption: 'custom',
+  value: {
+    operator: 'less-than',
+    number: 1,
+    unit: 'days',
+    when: 'past'
+  }
+}
+
+const mockFilterDefaultCustomRelativeOption2 = {
+  additionalFilterOption: null,
+  dateOption: null,
+  filterOption: {
+    name: 'symptom-onset-relative',
+    title: 'Symptom Onset (Relative Date)',
+    description: 'Monitorees who have a symptom onset date during specified date range (relative to the current date)',
+    type: 'relative',
+    hasTimestamp: false,
   },
   numberOption: null,
   relativeOption: 'custom',
@@ -280,7 +300,8 @@ export {
   mockFilterDateOption,
   mockFilterDefaultRelativeOption,
   mockFilterRelativeOption,
-  mockFilterDefaultCustomRelativeOption,
+  mockFilterDefaultCustomRelativeOption1,
+  mockFilterDefaultCustomRelativeOption2,
   mockFilterCustomRelativeOption,
   mockFilterDefaultSearchOption,
   mockFilterSearchOption,

--- a/app/javascript/tests/mocks/mockFilters.js
+++ b/app/javascript/tests/mocks/mockFilters.js
@@ -147,6 +147,7 @@ const mockFilterDefaultCustomRelativeOption = {
   numberOption: null,
   relativeOption: 'custom',
   value: {
+    operator: 'less-than',
     number: 1,
     unit: 'days',
     when: 'past'
@@ -166,6 +167,7 @@ const mockFilterCustomRelativeOption = {
   numberOption: null,
   relativeOption: 'custom',
   value: {
+    operator: 'more-than',
     number: 2,
     unit: 'weeks',
     when: 'next'

--- a/app/javascript/tests/public_health/query/AdvancedFilter.test.js
+++ b/app/javascript/tests/public_health/query/AdvancedFilter.test.js
@@ -34,9 +34,9 @@ const numberOptionValues = [ 'less-than', 'less-than-equal', 'equal', 'greater-t
 const numberOptionValuesText = [ 'less than', 'less than or equal to', 'equal to', 'greater than or equal to', 'greater than', 'between' ];
 const dateOptionValues = [ 'within', 'before', 'after' ];
 const relativeOptionValues = [ 'today', 'tomorrow', 'yesterday', 'custom' ];
-const relativeOptionValuesText = [ 'today', 'tomorrow', 'yesterday', 'more...' ];
-const relativeOptionWhenValues = [ 'past', 'next' ];
+const relativeOptionOperatorValues = [ 'less-than', 'more-than' ];
 const relativeOptionUnitValues = [ 'day(s)', 'week(s)', 'month(s)' ];
+const relativeOptionWhenValues = [ 'past', 'future' ];
 
 function getWrapper() {
   return shallow(<AdvancedFilter workflow={'exposure'} advancedFilterUpdate={advancedFilterUpdateMock} updateStickySettings={true}
@@ -409,12 +409,13 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual('today');
     expect(wrapper.find('.advanced-filter-relative-options').find('option').length).toEqual(relativeOptionValues.length);
     relativeOptionValues.forEach(function(value, index) {
-      expect(wrapper.find('.advanced-filter-relative-options').find('option').at(index).text()).toEqual(relativeOptionValuesText[index]);
+      expect(wrapper.find('.advanced-filter-relative-options').find('option').at(index).text()).toEqual(value);
       expect(wrapper.find('.advanced-filter-relative-options').find('option').at(index).prop('value')).toEqual(value);
     });
-    expect(wrapper.find('.advanced-filter-when-input').exists()).toBeFalsy();
+    expect(wrapper.find('.advanced-filter-operator-input').exists()).toBeFalsy();
     expect(wrapper.find('.advanced-filter-number-input').exists()).toBeFalsy();
     expect(wrapper.find('.advanced-filter-unit-input').exists()).toBeFalsy();
+    expect(wrapper.find('.advanced-filter-when-input').exists()).toBeFalsy();
     expect(wrapper.find(ReactTooltip).exists()).toBeFalsy();
     expect(wrapper.find('.advanced-filter-additional-filter-options').exists()).toBeFalsy();
   });
@@ -425,33 +426,39 @@ describe('AdvancedFilter', () => {
     wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDefaultCustomRelativeOption.filterOption.name });
     expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterDefaultCustomRelativeOption.filterOption.name);
     wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: 'custom' } });
-    expect(wrapper.find(Form.Control).length).toEqual(4);
+    expect(wrapper.find(Form.Control).length).toEqual(5);
     expect(wrapper.find('.advanced-filter-relative-options').exists()).toBeTruthy();
     expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual('custom');
     expect(wrapper.find('.advanced-filter-relative-options').find('option').length).toEqual(relativeOptionValues.length);
     relativeOptionValues.forEach(function(value, index) {
-      expect(wrapper.find('.advanced-filter-relative-options').find('option').at(index).text()).toEqual(relativeOptionValuesText[index]);
+      expect(wrapper.find('.advanced-filter-relative-options').find('option').at(index).text()).toEqual(value);
       expect(wrapper.find('.advanced-filter-relative-options').find('option').at(index).prop('value')).toEqual(value);
     });
-    expect(wrapper.find('.advanced-filter-when-input').exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual('past');
-    expect(wrapper.find('.advanced-filter-when-input').find('option').length).toEqual(relativeOptionWhenValues.length);
-    relativeOptionWhenValues.forEach(function(value, index) {
-      expect(wrapper.find('.advanced-filter-when-input').find('option').at(index).text()).toEqual(`in the ${value}`);
-      expect(wrapper.find('.advanced-filter-when-input').find('option').at(index).prop('value')).toEqual(value);
+    expect(wrapper.find('.advanced-filter-operator-input').exists()).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.operator);
+    expect(wrapper.find('.advanced-filter-operator-input').find('option').length).toEqual(relativeOptionOperatorValues.length);
+    relativeOptionOperatorValues.forEach(function(value, index) {
+      expect(wrapper.find('.advanced-filter-operator-input').find('option').at(index).text()).toEqual(value.replace('-', ' '));
+      expect(wrapper.find('.advanced-filter-operator-input').find('option').at(index).prop('value')).toEqual(value);
     });
     expect(wrapper.find('.advanced-filter-number-input').exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(1);
+    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.number);
     expect(wrapper.find('.advanced-filter-unit-input').exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual('days');
+    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.unit);
     expect(wrapper.find('.advanced-filter-unit-input').find('option').length).toEqual(relativeOptionUnitValues.length);
     relativeOptionUnitValues.forEach(function(value, index) {
       expect(wrapper.find('.advanced-filter-unit-input').find('option').at(index).text()).toEqual(value);
       expect(wrapper.find('.advanced-filter-unit-input').find('option').at(index).prop('value')).toEqual(value.replace('(', '').replace(')', ''));
     });
+    expect(wrapper.find('.advanced-filter-when-input').exists()).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.when);
+    expect(wrapper.find('.advanced-filter-when-input').find('option').length).toEqual(relativeOptionWhenValues.length);
+    relativeOptionWhenValues.forEach(function(value, index) {
+      expect(wrapper.find('.advanced-filter-when-input').find('option').at(index).text()).toEqual(`in the ${value}`);
+      expect(wrapper.find('.advanced-filter-when-input').find('option').at(index).prop('value')).toEqual(value);
+    });
     expect(wrapper.find('.advanced-filter-additional-filter-options').exists()).toBeFalsy();
     expect(wrapper.find(ReactTooltip).exists()).toBeTruthy();
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Latest Report “past” relative date periods include records dated through today’s date. The current setting of "past 1 days" will return records with Latest Report date from ${moment(new Date()).subtract(1,'d').format('MM/DD/YY')} through now.`);
   });
 
   it('Properly renders advanced filter search type statement', () => {
@@ -640,33 +647,50 @@ describe('AdvancedFilter', () => {
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultCustomRelativeOption ]);
     expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.relativeOption);
-    wrapper.find('.advanced-filter-when-input').simulate('change', { target: { value: mockFilterCustomRelativeOption.value.when } });
+    wrapper.find('.advanced-filter-operator-input').simulate('change', { target: { value: mockFilterCustomRelativeOption.value.operator } });
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')[0].relativeOption).toEqual(mockFilterCustomRelativeOption.relativeOption);
-    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterCustomRelativeOption.value.when);
+    expect(wrapper.state('activeFilterOptions')[0].value.operator).toEqual(mockFilterCustomRelativeOption.value.operator);
     expect(wrapper.state('activeFilterOptions')[0].value.number).toEqual(mockFilterDefaultCustomRelativeOption.value.number);
     expect(wrapper.state('activeFilterOptions')[0].value.unit).toEqual(mockFilterDefaultCustomRelativeOption.value.unit);
+    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterDefaultCustomRelativeOption.value.when);
     expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterCustomRelativeOption.relativeOption);
-    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.when);
+    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.operator);
     expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.number);
     expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.unit);
+    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.when);
     wrapper.find('.advanced-filter-number-input').simulate('change', { target: { value: mockFilterCustomRelativeOption.value.number } });
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')[0].relativeOption).toEqual(mockFilterCustomRelativeOption.relativeOption);
-    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterCustomRelativeOption.value.when);
+    expect(wrapper.state('activeFilterOptions')[0].value.operator).toEqual(mockFilterCustomRelativeOption.value.operator);
     expect(wrapper.state('activeFilterOptions')[0].value.number).toEqual(mockFilterCustomRelativeOption.value.number);
     expect(wrapper.state('activeFilterOptions')[0].value.unit).toEqual(mockFilterDefaultCustomRelativeOption.value.unit);
+    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterDefaultCustomRelativeOption.value.when);
     expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterCustomRelativeOption.relativeOption);
-    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.when);
+    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.operator);
     expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.number);
     expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.unit);
+    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.when);
     wrapper.find('.advanced-filter-unit-input').simulate('change', { target: { value: mockFilterCustomRelativeOption.value.unit } });
+    expect(wrapper.state('activeFilter')).toEqual(null);
+    expect(wrapper.state('activeFilterOptions')[0].relativeOption).toEqual(mockFilterCustomRelativeOption.relativeOption);
+    expect(wrapper.state('activeFilterOptions')[0].value.operator).toEqual(mockFilterCustomRelativeOption.value.operator);
+    expect(wrapper.state('activeFilterOptions')[0].value.number).toEqual(mockFilterCustomRelativeOption.value.number);
+    expect(wrapper.state('activeFilterOptions')[0].value.unit).toEqual(mockFilterCustomRelativeOption.value.unit);
+    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterDefaultCustomRelativeOption.value.when);
+    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterCustomRelativeOption.relativeOption);
+    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.operator);
+    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.number);
+    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.unit);
+    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.when);
+    wrapper.find('.advanced-filter-when-input').simulate('change', { target: { value: mockFilterCustomRelativeOption.value.when } });
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterCustomRelativeOption ]);
     expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterCustomRelativeOption.relativeOption);
-    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.when);
+    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.operator);
     expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.number);
     expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.unit);
+    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.when);
     wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: mockFilterDefaultRelativeOption.relativeOption } });
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultRelativeOption ]);
@@ -749,16 +773,20 @@ describe('AdvancedFilter', () => {
     wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDefaultCustomRelativeOption.filterOption.name });
     expect(wrapper.find(ReactTooltip).exists()).toBeFalsy();
     wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: 'custom' } });
-    expect(wrapper.find(ReactTooltip).exists()).toBeTruthy();
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Latest Report “past” relative date periods include records dated through today’s date. The current setting of "past 1 days" will return records with Latest Report date from ${moment(new Date()).subtract(1,'d').format('MM/DD/YY')} through now.`);
+    expect(wrapper.find(ReactTooltip).exists()).toBeTruthy(); 
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Latest Report “less than past” relative date periods include records dated through today’s date. The current setting of "less than 1 days in the past" will return records with Latest Report date from ${moment(new Date()).subtract(1,'d').format('MM/DD/YY')} through now.`);
     wrapper.find('.advanced-filter-number-input').simulate('change', { target: { value: 3 } });
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Latest Report “past” relative date periods include records dated through today’s date. The current setting of "past 3 days" will return records with Latest Report date from ${moment(new Date()).subtract(3,'d').format('MM/DD/YY')} through now.`);
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Latest Report “less than past” relative date periods include records dated through today’s date. The current setting of "less than 3 days in the past" will return records with Latest Report date from ${moment(new Date()).subtract(3,'d').format('MM/DD/YY')} through now.`);
     wrapper.find('.advanced-filter-unit-input').simulate('change', { target: { value: 'weeks' } });
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Latest Report “past” relative date periods include records dated through today’s date. The current setting of "past 3 weeks" will return records with Latest Report date from ${moment(new Date()).subtract(3,'weeks').format('MM/DD/YY')} through now.`);
-    wrapper.find('.advanced-filter-when-input').simulate('change', { target: { value: 'next' } });
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Latest Report “next” relative date periods include records with today’s date as of the current time. The current setting of "next 3 weeks" will return records with Latest Report date from now through ${moment(new Date()).add(3,'weeks').format('MM/DD/YY')}.`);
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Latest Report “less than past” relative date periods include records dated through today’s date. The current setting of "less than 3 weeks in the past" will return records with Latest Report date from ${moment(new Date()).subtract(3,'weeks').format('MM/DD/YY')} through now.`);
+    wrapper.find('.advanced-filter-when-input').simulate('change', { target: { value: 'future' } });
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Latest Report “less than future” relative date periods include records with today’s date as of the current time. The current setting of "less than 3 weeks in the future" will return records with Latest Report date from now through ${moment(new Date()).add(3,'weeks').format('MM/DD/YY')}.`);
     wrapper.find('.advanced-filter-number-input').simulate('change', { target: { value: 1 } });
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Latest Report “next” relative date periods include records with today’s date as of the current time. The current setting of "next 1 weeks" will return records with Latest Report date from now through ${moment(new Date()).add(1,'weeks').format('MM/DD/YY')}.`);
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Latest Report “less than future” relative date periods include records with today’s date as of the current time. The current setting of "less than 1 weeks in the future" will return records with Latest Report date from now through ${moment(new Date()).add(1,'weeks').format('MM/DD/YY')}.`);
+    wrapper.find('.advanced-filter-operator-input').simulate('change', { target: { value: 'more-than' } });
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`The current setting of "more than 1 weeks in the future" will return records with Latest Report date after ${moment(new Date()).add(1,'w').format('MM/DD/YY')}.`);
+    wrapper.find('.advanced-filter-when-input').simulate('change', { target: { value: 'past' } });
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`The current setting of "more than 1 weeks in the past" will return records with Latest Report date before ${moment(new Date()).subtract(1,'w').format('MM/DD/YY')}.`);
   });
 
   it('Clicking "Save" button opens Filter Name modal', () => {

--- a/app/javascript/tests/public_health/query/AdvancedFilter.test.js
+++ b/app/javascript/tests/public_health/query/AdvancedFilter.test.js
@@ -20,7 +20,8 @@ import {
   mockFilterDateOption,
   mockFilterDefaultRelativeOption,
   mockFilterRelativeOption,
-  mockFilterDefaultCustomRelativeOption,
+  mockFilterDefaultCustomRelativeOption1,
+  mockFilterDefaultCustomRelativeOption2,
   mockFilterCustomRelativeOption,
   mockFilterDefaultAdditionalOption,
   mockFilterAdditionalOption,
@@ -402,8 +403,8 @@ describe('AdvancedFilter', () => {
   it('Properly renders advanced filter relative type statement', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDefaultCustomRelativeOption.filterOption.name });
-    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterDefaultCustomRelativeOption.filterOption.name);
+    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDefaultCustomRelativeOption1.filterOption.name });
+    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterDefaultCustomRelativeOption1.filterOption.name);
     expect(wrapper.find(Form.Control).length).toEqual(1);
     expect(wrapper.find('.advanced-filter-relative-options').exists()).toBeTruthy();
     expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual('today');
@@ -423,8 +424,8 @@ describe('AdvancedFilter', () => {
   it('Properly renders advanced filter relative type custom statement', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDefaultCustomRelativeOption.filterOption.name });
-    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterDefaultCustomRelativeOption.filterOption.name);
+    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDefaultCustomRelativeOption2.filterOption.name });
+    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterDefaultCustomRelativeOption2.filterOption.name);
     wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: 'custom' } });
     expect(wrapper.find(Form.Control).length).toEqual(5);
     expect(wrapper.find('.advanced-filter-relative-options').exists()).toBeTruthy();
@@ -435,23 +436,23 @@ describe('AdvancedFilter', () => {
       expect(wrapper.find('.advanced-filter-relative-options').find('option').at(index).prop('value')).toEqual(value);
     });
     expect(wrapper.find('.advanced-filter-operator-input').exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.operator);
+    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption2.value.operator);
     expect(wrapper.find('.advanced-filter-operator-input').find('option').length).toEqual(relativeOptionOperatorValues.length);
     relativeOptionOperatorValues.forEach(function(value, index) {
       expect(wrapper.find('.advanced-filter-operator-input').find('option').at(index).text()).toEqual(value.replace('-', ' '));
       expect(wrapper.find('.advanced-filter-operator-input').find('option').at(index).prop('value')).toEqual(value);
     });
     expect(wrapper.find('.advanced-filter-number-input').exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.number);
+    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption2.value.number);
     expect(wrapper.find('.advanced-filter-unit-input').exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.unit);
+    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption2.value.unit);
     expect(wrapper.find('.advanced-filter-unit-input').find('option').length).toEqual(relativeOptionUnitValues.length);
     relativeOptionUnitValues.forEach(function(value, index) {
       expect(wrapper.find('.advanced-filter-unit-input').find('option').at(index).text()).toEqual(value);
       expect(wrapper.find('.advanced-filter-unit-input').find('option').at(index).prop('value')).toEqual(value.replace('(', '').replace(')', ''));
     });
     expect(wrapper.find('.advanced-filter-when-input').exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.when);
+    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption2.value.when);
     expect(wrapper.find('.advanced-filter-when-input').find('option').length).toEqual(relativeOptionWhenValues.length);
     relativeOptionWhenValues.forEach(function(value, index) {
       expect(wrapper.find('.advanced-filter-when-input').find('option').at(index).text()).toEqual(`in the ${value}`);
@@ -643,46 +644,46 @@ describe('AdvancedFilter', () => {
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterRelativeOption ]);
     expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterRelativeOption.relativeOption);
-    wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: mockFilterDefaultCustomRelativeOption.relativeOption } });
+    wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: mockFilterDefaultCustomRelativeOption1.relativeOption } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultCustomRelativeOption ]);
-    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.relativeOption);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultCustomRelativeOption1 ]);
+    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption1.relativeOption);
     wrapper.find('.advanced-filter-operator-input').simulate('change', { target: { value: mockFilterCustomRelativeOption.value.operator } });
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')[0].relativeOption).toEqual(mockFilterCustomRelativeOption.relativeOption);
     expect(wrapper.state('activeFilterOptions')[0].value.operator).toEqual(mockFilterCustomRelativeOption.value.operator);
-    expect(wrapper.state('activeFilterOptions')[0].value.number).toEqual(mockFilterDefaultCustomRelativeOption.value.number);
-    expect(wrapper.state('activeFilterOptions')[0].value.unit).toEqual(mockFilterDefaultCustomRelativeOption.value.unit);
-    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterDefaultCustomRelativeOption.value.when);
+    expect(wrapper.state('activeFilterOptions')[0].value.number).toEqual(mockFilterDefaultCustomRelativeOption1.value.number);
+    expect(wrapper.state('activeFilterOptions')[0].value.unit).toEqual(mockFilterDefaultCustomRelativeOption1.value.unit);
+    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterDefaultCustomRelativeOption1.value.when);
     expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterCustomRelativeOption.relativeOption);
     expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.operator);
-    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.number);
-    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.unit);
-    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.when);
+    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption1.value.number);
+    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption1.value.unit);
+    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption1.value.when);
     wrapper.find('.advanced-filter-number-input').simulate('change', { target: { value: mockFilterCustomRelativeOption.value.number } });
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')[0].relativeOption).toEqual(mockFilterCustomRelativeOption.relativeOption);
     expect(wrapper.state('activeFilterOptions')[0].value.operator).toEqual(mockFilterCustomRelativeOption.value.operator);
     expect(wrapper.state('activeFilterOptions')[0].value.number).toEqual(mockFilterCustomRelativeOption.value.number);
-    expect(wrapper.state('activeFilterOptions')[0].value.unit).toEqual(mockFilterDefaultCustomRelativeOption.value.unit);
-    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterDefaultCustomRelativeOption.value.when);
+    expect(wrapper.state('activeFilterOptions')[0].value.unit).toEqual(mockFilterDefaultCustomRelativeOption1.value.unit);
+    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterDefaultCustomRelativeOption1.value.when);
     expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterCustomRelativeOption.relativeOption);
     expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.operator);
     expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.number);
-    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.unit);
-    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.when);
+    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption1.value.unit);
+    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption1.value.when);
     wrapper.find('.advanced-filter-unit-input').simulate('change', { target: { value: mockFilterCustomRelativeOption.value.unit } });
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')[0].relativeOption).toEqual(mockFilterCustomRelativeOption.relativeOption);
     expect(wrapper.state('activeFilterOptions')[0].value.operator).toEqual(mockFilterCustomRelativeOption.value.operator);
     expect(wrapper.state('activeFilterOptions')[0].value.number).toEqual(mockFilterCustomRelativeOption.value.number);
     expect(wrapper.state('activeFilterOptions')[0].value.unit).toEqual(mockFilterCustomRelativeOption.value.unit);
-    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterDefaultCustomRelativeOption.value.when);
+    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterDefaultCustomRelativeOption1.value.when);
     expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterCustomRelativeOption.relativeOption);
     expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.operator);
     expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.number);
     expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.unit);
-    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption.value.when);
+    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption1.value.when);
     wrapper.find('.advanced-filter-when-input').simulate('change', { target: { value: mockFilterCustomRelativeOption.value.when } });
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterCustomRelativeOption ]);
@@ -767,26 +768,44 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterAdditionalOption.value);
   });
 
-  it('Relative date custom tooltip dynamically updates as options change', () => {
+  it('Relative date with timestamp custom tooltip dynamically updates as options change', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDefaultCustomRelativeOption.filterOption.name });
+    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDefaultCustomRelativeOption1.filterOption.name });
     expect(wrapper.find(ReactTooltip).exists()).toBeFalsy();
     wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: 'custom' } });
     expect(wrapper.find(ReactTooltip).exists()).toBeTruthy(); 
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Latest Report “less than past” relative date periods include records dated through today’s date. The current setting of "less than 1 days in the past" will return records with Latest Report date from ${moment(new Date()).subtract(1,'d').format('MM/DD/YY')} through now.`);
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`The current setting of "less than 1 days in the past" will return records with Latest Report date from the current time on ${moment(new Date()).subtract(1,'d').format('MM/DD/YY')} through now. To filter between two dates, use the "more than" and "less than" filters in combination.`);
     wrapper.find('.advanced-filter-number-input').simulate('change', { target: { value: 3 } });
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Latest Report “less than past” relative date periods include records dated through today’s date. The current setting of "less than 3 days in the past" will return records with Latest Report date from ${moment(new Date()).subtract(3,'d').format('MM/DD/YY')} through now.`);
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`The current setting of "less than 3 days in the past" will return records with Latest Report date from the current time on ${moment(new Date()).subtract(3,'d').format('MM/DD/YY')} through now. To filter between two dates, use the "more than" and "less than" filters in combination.`);
     wrapper.find('.advanced-filter-unit-input').simulate('change', { target: { value: 'weeks' } });
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Latest Report “less than past” relative date periods include records dated through today’s date. The current setting of "less than 3 weeks in the past" will return records with Latest Report date from ${moment(new Date()).subtract(3,'weeks').format('MM/DD/YY')} through now.`);
-    wrapper.find('.advanced-filter-when-input').simulate('change', { target: { value: 'future' } });
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Latest Report “less than future” relative date periods include records with today’s date as of the current time. The current setting of "less than 3 weeks in the future" will return records with Latest Report date from now through ${moment(new Date()).add(3,'weeks').format('MM/DD/YY')}.`);
-    wrapper.find('.advanced-filter-number-input').simulate('change', { target: { value: 1 } });
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Latest Report “less than future” relative date periods include records with today’s date as of the current time. The current setting of "less than 1 weeks in the future" will return records with Latest Report date from now through ${moment(new Date()).add(1,'weeks').format('MM/DD/YY')}.`);
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`The current setting of "less than 3 weeks in the past" will return records with Latest Report date from the current time on ${moment(new Date()).subtract(3,'weeks').format('MM/DD/YY')} through now. To filter between two dates, use the "more than" and "less than" filters in combination.`);
     wrapper.find('.advanced-filter-operator-input').simulate('change', { target: { value: 'more-than' } });
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`The current setting of "more than 1 weeks in the future" will return records with Latest Report date after ${moment(new Date()).add(1,'w').format('MM/DD/YY')}.`);
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`The current setting of "more than 3 weeks in the past" will return records with Latest Report date before the current time on ${moment(new Date()).subtract(3,'w').format('MM/DD/YY')}. To filter between two dates, use the "more than" and "less than" filters in combination.`);
+    wrapper.find('.advanced-filter-number-input').simulate('change', { target: { value: 1 } });
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`The current setting of "more than 1 weeks in the past" will return records with Latest Report date before the current time on ${moment(new Date()).subtract(1,'w').format('MM/DD/YY')}. To filter between two dates, use the "more than" and "less than" filters in combination.`);
+  });
+
+  it('Relative date without timestamp custom tooltip dynamically updates as options change', () => {
+    const wrapper = getWrapper();
+    wrapper.find(Button).simulate('click');
+    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDefaultCustomRelativeOption2.filterOption.name });
+    expect(wrapper.find(ReactTooltip).exists()).toBeFalsy();
+    wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: 'custom' } });
+    expect(wrapper.find(ReactTooltip).exists()).toBeTruthy(); 
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`The current setting of "less than 1 days in the past" will return records with Symptom Onset date from ${moment(new Date()).subtract(1,'d').format('MM/DD/YY')} through ${moment(new Date()).format('MM/DD/YY')}. To filter between two dates, use the "more than" and "less than" filters in combination.`);
+    wrapper.find('.advanced-filter-number-input').simulate('change', { target: { value: 3 } });
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`The current setting of "less than 3 days in the past" will return records with Symptom Onset date from ${moment(new Date()).subtract(3,'d').format('MM/DD/YY')} through ${moment(new Date()).format('MM/DD/YY')}. To filter between two dates, use the "more than" and "less than" filters in combination.`);
+    wrapper.find('.advanced-filter-unit-input').simulate('change', { target: { value: 'weeks' } });
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`The current setting of "less than 3 weeks in the past" will return records with Symptom Onset date from ${moment(new Date()).subtract(3,'w').format('MM/DD/YY')} through ${moment(new Date()).format('MM/DD/YY')}. To filter between two dates, use the "more than" and "less than" filters in combination.`);
+    wrapper.find('.advanced-filter-when-input').simulate('change', { target: { value: 'future' } });
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`The current setting of "less than 3 weeks in the future" will return records with Symptom Onset date from ${moment(new Date()).format('MM/DD/YY')} through ${moment(new Date()).add(3,'w').format('MM/DD/YY')}. To filter between two dates, use the "more than" and "less than" filters in combination.`);
+    wrapper.find('.advanced-filter-number-input').simulate('change', { target: { value: 1 } });
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`The current setting of "less than 1 weeks in the future" will return records with Symptom Onset date from ${moment(new Date()).format('MM/DD/YY')} through ${moment(new Date()).add(1,'w').format('MM/DD/YY')}. To filter between two dates, use the "more than" and "less than" filters in combination.`);
+    wrapper.find('.advanced-filter-operator-input').simulate('change', { target: { value: 'more-than' } });
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`The current setting of "more than 1 weeks in the future" will return records with Symptom Onset date after ${moment(new Date()).add(1,'w').format('MM/DD/YY')}. To filter between two dates, use the "more than" and "less than" filters in combination.`);
     wrapper.find('.advanced-filter-when-input').simulate('change', { target: { value: 'past' } });
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`The current setting of "more than 1 weeks in the past" will return records with Latest Report date before ${moment(new Date()).subtract(1,'w').format('MM/DD/YY')}.`);
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`The current setting of "more than 1 weeks in the past" will return records with Symptom Onset date before ${moment(new Date()).subtract(1,'w').format('MM/DD/YY')}. To filter between two dates, use the "more than" and "less than" filters in combination.`);
   });
 
   it('Clicking "Save" button opens Filter Name modal', () => {


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1023](https://tracker.codev.mitre.org/browse/SARAALERT-1023)

Added support for more than x unit in the future/past for all relative date filter options.

# (Feature) Demo/Screenshots
![Screen Shot 2021-02-09 at 12 04 42 PM](https://user-images.githubusercontent.com/35042815/107399697-08012780-6acf-11eb-9028-ccd2fc828d03.png)

![Screen Shot 2021-02-09 at 12 04 36 PM](https://user-images.githubusercontent.com/35042815/107399716-0afc1800-6acf-11eb-9023-2c00e4496ff4.png)

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`AdvancedFilter.js`
- Added operator dropdown as the fourth option for custom relative date filters

`patient_query_helper.rb`
- Additional logic needed for adding more than option to the advanced filter

`advanced_filter.scss`
- Updated styling in order for all the dropdowns to fit on the same line

`AdvancedFilter.test.js`
- Updated/fixed broken tests

`mockFilters.js`
- Updated mocks to incorporate new operator value option

`20210223152748_add_operator_to_relative_date_filters.rb`
- Added migration to update all existing relative date filters to include `less-than` in their value and removed any "in the future" relative date filters as those are no longer supported

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
