### PR TITLE
SARAALERT-1291: History items not created for certain fields in API

### DIFF
--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -159,7 +159,7 @@ class Fhir::R4::ApiController < ActionController::API
     created_by_label = "#{@m2m_workflow ? current_client_application&.name : current_resource_owner&.email} (API)"
 
     # Handle History for monitoree details information updates
-    # NOTE: "isolation" is a special case, becasue it is not a monitoring field, but it has side effects that are handled
+    # NOTE: "isolation" is a special case, because it is not a monitoring field, but it has side effects that are handled
     # alongside monitoring fields
     info_updates = updates.filter { |attr, _value| !PatientHelper.monitoring_fields.include?(attr) || attr == :isolation }
     Patient.detailed_history_edit(patient_before, patient, info_updates&.keys, created_by_label)

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -159,7 +159,9 @@ class Fhir::R4::ApiController < ActionController::API
     created_by_label = "#{@m2m_workflow ? current_client_application&.name : current_resource_owner&.email} (API)"
 
     # Handle History for monitoree details information updates
-    info_updates = updates.filter { |attr, _value| PatientHelper.info_fields.include?(attr) }
+    # NOTE: "isolation" is a special case, becasue it is not a monitoring field, but it has side effects that are handled
+    # alongside monitoring fields
+    info_updates = updates.filter { |attr, _value| !PatientHelper.monitoring_fields.include?(attr) || attr == :isolation }
     Patient.detailed_history_edit(patient_before, patient, info_updates&.keys, created_by_label)
 
     # Handle History for monitoree monitoring information updates

--- a/app/helpers/patient_helper.rb
+++ b/app/helpers/patient_helper.rb
@@ -67,37 +67,4 @@ module PatientHelper
       jurisdiction_id
     ]
   end
-
-  def self.info_fields
-    %i[
-      isolation
-      first_name
-      middle_name
-      last_name
-      secondary_telephone
-      email
-      date_of_birth
-      address_line_1
-      address_line_2
-      address_city
-      address_state
-      address_zip
-      monitored_address_line_1
-      monitored_address_line_2
-      monitored_address_city
-      monitored_address_state
-      monitored_address_zip
-      primary_language
-      interpretation_required
-      white
-      black_or_african_american
-      american_indian_or_alaska_native
-      asian
-      native_hawaiian_or_other_pacific_islander
-      ethnicity
-      sex
-      preferred_contact_method
-      preferred_contact_time
-    ]
-  end
 end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1291](https://tracker.codev.mitre.org/browse/SARAALERT-1291)

History items were not being created for several fields (`travel_related_notes` for example) when those fields were updated via the API. We were only updating fields in an `info_fields` array, which did not contain all possible fields. This PR refactors our approach, so that all current fields will have History items created.

# How to Replicate
On the `1.24.0` branch, do a `PUT` or `PATCH` update on a Patient, and change the Patient's `email` and `travel_related_notes`. A history item will be created detailing the change in `email`, but the item will not include the change in `travel_related_notes`. On this branch, if you do the same update, you should see a history item that lists both changes.

# Solution
The issue was that the `info_fields` array was used to determine which fields get "Record Edit" history items created, but several fields were missing from the `info_fields` array. Instead of just adding the missing items, this PR redefines which updates get a "Record Edit" history item to be any field that is not handled by a "Monitoring Change" history update. So what was previously defined as `info_fields` is now defined implicitly as `!monitoring_fields`. Note that `isolation` has to be included as a special case, because it is an `info_field`, but it also has side effects that are handled alongside other `monitoring_fields`.

# Important Changes
`api_controller.rb`
- Refactored fields passed to `Patient.detailed_history_edit` to include all fields that could have been updated.

`patient_helper.rb`
- Removed unnecessary `info_fields` array.

# Testing
To test this, you can try making updates to a Patient via the API, and noting that History items should be created for all of the updates you can do. The fields that were previously not working correctly are:
* `additional_planned_travel_start_date`
* `port_of_origin`
* `date_of_departure`
* `flight_or_vessel_number`
* `flight_or_vessel_carrier`
* `date_of_arrival`
* `exposure_notes`
* `travel_related_notes`
* `additional_planned_travel_related_notes`
* `primary_telephone_type`
* `secondary_telephone_type`
* `user_defined_id_statelocal`

Now, history items should be created for these fields. You can also test by running the test added in this PR on https://github.com/SaraAlert/SaraAlert/commit/275373829d81c34f2c427d914474604b9519d89b. On that commit the test should fail, but on the most recent commit, the test should now pass.
