### PR TITLE
SARAALERT-1121, SARAALERT-1156: Twilio Error Handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -138,7 +138,10 @@ group :test do
   gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'simplecov-lcov'
+  gem 'timecop'
+  gem 'vcr'
   gem 'webdrivers'
+  gem 'webmock'
 end
 
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -138,7 +138,6 @@ group :test do
   gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'simplecov-lcov'
-  gem 'timecop'
   gem 'vcr'
   gem 'webdrivers'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
     childprocess (3.0.0)
     concurrent-ruby (1.1.8)
     connection_pool (2.2.3)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     css_parser (1.9.0)
       addressable
@@ -189,6 +191,7 @@ GEM
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hana (1.3.7)
+    hashdiff (1.0.1)
     html_tokenizer (0.0.7)
     htmlentities (4.3.4)
     http-accept (1.7.0)
@@ -404,6 +407,7 @@ GEM
     valid_email2 (3.6.0)
       activemodel (>= 3.2)
       mail (~> 2.5)
+    vcr (6.0.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.1.0)
@@ -415,6 +419,10 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
+    webmock (3.11.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (4.3.0)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -495,8 +503,10 @@ DEPENDENCIES
   twilio-ruby
   tzinfo-data
   valid_email2
+  vcr
   web-console (>= 3.3.0)
   webdrivers
+  webmock
   webpacker (~> 4.0)
   will_paginate
 

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -91,6 +91,7 @@ class AssessmentsController < ApplicationController
                               .where('created_at >= ?', ADMIN_OPTIONS['reporting_limit'].minutes.ago).exists? &&
              !(params.permit(:response_status)['response_status'].in? %w[opt_out opt_in])
         assessment_placeholder = {}
+        assessment_placeholder = assessment_placeholder.merge(params.permit(:error_code).to_h)
         assessment_placeholder = assessment_placeholder.merge(params.permit(:response_status).to_h)
         assessment_placeholder = assessment_placeholder.merge(params.permit(:threshold_hash).to_h)
         assessment_placeholder = assessment_placeholder.merge(params.permit({ symptoms: %i[name value type label notes required] }).to_h)

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -45,7 +45,7 @@ class ConsumeAssessmentsJob < ApplicationJob
         # Error occured in twilio studio flow
         if message['error_code'].present?
           TwilioSender.handle_twilio_error_codes(patient, message['error_code'])
-          # Will attempt to resend assessment if phone is off or if unknown error occurs
+          # Will attempt to resend assessment if phone is off
           patient.update(last_assessment_reminder_sent: nil) if message['error_code']&.in? TwilioSender.retry_eligible_error_codes
           queue.commit
           next

--- a/app/jobs/produce_assessment_job.rb
+++ b/app/jobs/produce_assessment_job.rb
@@ -11,6 +11,7 @@ class ProduceAssessmentJob < ApplicationJob
     queue = Redis::Queue.new('q_bridge', 'bp_q_bridge', redis: Rails.application.config.redis)
     report = {
       response_status: assessment['response_status'],
+      error_code: assessment['error_code'],
       threshold_condition_hash: assessment['threshold_hash'],
       reported_symptoms_array: assessment['symptoms'],
       experiencing_symptoms: assessment['experiencing_symptoms'],

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -29,7 +29,7 @@ class PatientMailer < ApplicationMailer
     return if patient&.primary_telephone.blank?
 
     if patient.blocked_sms
-      handle_twilio_error_codes(patient, TwilioSender::TWILIO_ERROR_CODES[:blocked_number])
+      TwilioSender.handle_twilio_error_codes(patient, TwilioSender::TWILIO_ERROR_CODES[:blocked_number])
       return
     end
 
@@ -52,7 +52,7 @@ class PatientMailer < ApplicationMailer
       return
     end
     if patient.blocked_sms
-      handle_twilio_error_codes(patient, TwilioSender::TWILIO_ERROR_CODES[:blocked_number])
+      TwilioSender.handle_twilio_error_codes(patient, TwilioSender::TWILIO_ERROR_CODES[:blocked_number])
       return
     end
 
@@ -80,7 +80,7 @@ class PatientMailer < ApplicationMailer
       return
     end
     if patient.blocked_sms
-      handle_twilio_error_codes(patient, TwilioSender::TWILIO_ERROR_CODES[:blocked_number])
+      TwilioSender.handle_twilio_error_codes(patient, TwilioSender::TWILIO_ERROR_CODES[:blocked_number])
       return
     end
 

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -202,7 +202,7 @@ class PatientMailer < ApplicationMailer
               else
                 "Sara Alert sent a report reminder to this monitoree's HoH via #{patient.responder.preferred_contact_method}."
               end
-    History.report_reminder(patient: patient, comment: comment) unless patient.id == patient.responder_id
+    History.report_reminder(patient: patient, comment: comment)
   end
 
   def add_fail_history_blank_field(patient, type)

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -29,7 +29,7 @@ class PatientMailer < ApplicationMailer
     return if patient&.primary_telephone.blank?
 
     if patient.blocked_sms
-      TwilioSender.handle_twilio_error_codes(patient, TwilioSender::TWILIO_ERROR_CODES[:blocked_number])
+      TwilioSender.handle_twilio_error_codes(patient, TwilioSender::TWILIO_ERROR_CODES[:blocked_number][:code])
       return
     end
 
@@ -52,7 +52,7 @@ class PatientMailer < ApplicationMailer
       return
     end
     if patient.blocked_sms
-      TwilioSender.handle_twilio_error_codes(patient, TwilioSender::TWILIO_ERROR_CODES[:blocked_number])
+      TwilioSender.handle_twilio_error_codes(patient, TwilioSender::TWILIO_ERROR_CODES[:blocked_number][:code])
       return
     end
 
@@ -80,7 +80,7 @@ class PatientMailer < ApplicationMailer
       return
     end
     if patient.blocked_sms
-      TwilioSender.handle_twilio_error_codes(patient, TwilioSender::TWILIO_ERROR_CODES[:blocked_number])
+      TwilioSender.handle_twilio_error_codes(patient, TwilioSender::TWILIO_ERROR_CODES[:blocked_number][:code])
       return
     end
 

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -202,7 +202,7 @@ class PatientMailer < ApplicationMailer
               else
                 "Sara Alert sent a report reminder to this monitoree's HoH via #{patient.responder.preferred_contact_method}."
               end
-    History.report_reminder(patient: patient, comment: comment) unless patient&.preferred_contact_method.nil? && patient&.id == patient&.responder_id
+    History.report_reminder(patient: patient, comment: comment) unless patient.id == patient.responder_id
   end
 
   def add_fail_history_blank_field(patient, type)

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -197,7 +197,7 @@ class PatientMailer < ApplicationMailer
   private
 
   def add_success_history(patient)
-    comment = if patient.id == patient&.responder_id
+    comment = if patient.id == patient.responder_id
                 "Sara Alert sent a report reminder to this monitoree via #{patient.preferred_contact_method}."
               else
                 "Sara Alert sent a report reminder to this monitoree's HoH via #{patient.responder.preferred_contact_method}."

--- a/app/mailers/twilio_sender.rb
+++ b/app/mailers/twilio_sender.rb
@@ -2,23 +2,91 @@
 
 # TwilioSender: Methods to interact with Twilio REST API
 class TwilioSender
+  TWILIO_ERROR_CODES = {
+    invalid_to_number: '21211',
+    blocked_number: '21610',
+    invalid_number: '21614',
+    unsupported_region: '21408',
+    unreachable_unavailable: '30003',
+    unavailable_ineligible: '30004',
+    non_existent_or_off: '30005',
+    sms_ineligible: '30006',
+    carrier_filter: '30007',
+    unknown_error: '30008'
+  }.freeze
+
   @client = Twilio::REST::Client.new(ENV['TWILLIO_API_ACCOUNT'], ENV['TWILLIO_API_KEY'])
-  def self.send_sms(patient, contents)
+  def self.handle_twilio_error_codes(patient, error_code)
+    case error_code
+    # Invalid To Number https://www.twilio.com/docs/api/errors/21211
+    when TWILIO_ERROR_CODES[:invalid_to_number]
+      dispatch_errored_contact_history_items(patient, 'Invalid recipient phone number.')
+    # Blocked Number Error https://www.twilio.com/docs/api/errors/21610
+    when TWILIO_ERROR_CODES[:blocked_number]
+      dispatch_errored_contact_history_items(patient, 'Recipient phone number blocked communication with Sara Alert')
+      monitoree_number = Phonelib.parse(phone_numbers[:monitoree_number], 'US').full_e164
+      BlockedNumber.create(phone_number: monitoree_number) unless BlockedNumber.exists?(phone_number: monitoree_number)
+    # Invalid Mobile Number Error https://www.twilio.com/docs/api/errors/21614
+    when TWILIO_ERROR_CODES[:invalid_number]
+      dispatch_errored_contact_history_items(patient, 'Invalid recipient phone number.')
+    # Unsupported Region Error https://www.twilio.com/docs/api/errors/21408
+    when TWILIO_ERROR_CODES[:unsupported_region]
+      dispatch_errored_contact_history_items(patient, 'Recipient phone number is in an unsupported region.')
+    # Unreachable Destination Handset Error https://www.twilio.com/docs/api/errors/30003
+    when TWILIO_ERROR_CODES[:unreachable_unavailable]
+      error_message = 'Recipient phone is off, may not be eligible to receive SMS messages, or is otherwise unavailable.'
+      dispatch_errored_contact_history_items(patient, error_message)
+    # Message Blocked Error https://www.twilio.com/docs/api/errors/30004
+    when TWILIO_ERROR_CODES[:unavailable_ineligible]
+      error_message = 'Recipient may have blocked communications with SaraAlert, recipient phone may be unavailable or ineligible to receive SMS text messages.'
+      dispatch_errored_contact_history_items(patient, error_message)
+    # Unknown Destination Handset Error https://www.twilio.com/docs/api/errors/30005
+    when TWILIO_ERROR_CODES[:non_existent_or_off]
+      error_message = 'Recipient phone number may not exist, the phone may be off or the phone is not eligible to receive SMS text messages.'
+      dispatch_errored_contact_history_items(patient, error_message)
+    # Landline or Unreachable Carrier Error https://www.twilio.com/docs/api/errors/30006
+    when TWILIO_ERROR_CODES[:sms_ineligible]
+      error_message = 'Recipient phone number may not eligible to receive SMS text messages, or carrier network may be unreachable.'
+      dispatch_errored_contact_history_items(patient, error_message)
+    # Message Filtered By Carrier Error https://www.twilio.com/docs/api/errors/30007
+    when TWILIO_ERROR_CODES[:carrier_filter]
+      dispatch_errored_contact_history_items(patient, 'Message has been filtered by carrier network.')
+    # Unknown Error https://www.twilio.com/docs/api/errors/30008
+    when TWILIO_ERROR_CODES[:unknown_error]
+      error_message = 'An unknown error has been encountered by the messaging system. '
+      error_message += 'The system will retry in an hour if it is still in monitoree’s preferred contact period.'
+      dispatch_errored_contact_history_items(patient, error_message)
+    else
+      dispatch_errored_contact_history_items(patient, 'An unknown error has been encountered by the messaging system.')
+    end
+  end
+
+  def self.retry_eligible_error_codes
+    TWILIO_ERROR_CODES.values_at(:unreachable_unavailable)
+  end
+
+  # send_sms takes an array of patients for cases where messages for multiple patients need to
+  # be sent to a single patient at the same time ie: weblinks for all of a HoHs dependents
+  def self.send_sms(patient, messages)
+    params = { messages_array: messages, medium: 'SINGLE_SMS' }
     from = ENV['TWILLIO_MESSAGING_SERVICE_SID'] || ENV['TWILLIO_SENDING_NUMBER']
     begin
-      @client.messages.create(
+      @client.studio.v1.flows(ENV['TWILLIO_STUDIO_FLOW']).executions.create(
         to: Phonelib.parse(patient.primary_telephone, 'US').full_e164,
-        body: contents,
+        parameters: params,
         from: from
       )
     rescue Twilio::REST::RestError => e
       Rails.logger.warn e.error_message
+      # The error codes will be caught here in cases where a messaging service is not used
+      error_code = e&.code&.to_s
+      handle_twilio_error_codes(patient, error_code)
       return false
     end
     true
   end
 
-  def self.start_studio_flow(patient, params)
+  def self.start_studio_flow_assessment(patient, params)
     # Studio API trigger does not support use of messaging service SID for calls
     from = if params[:medium] == 'VOICE'
              ENV['TWILLIO_SENDING_NUMBER']
@@ -34,6 +102,9 @@ class TwilioSender
       )
     rescue Twilio::REST::RestError => e
       Rails.logger.warn e.error_message
+      # The error codes will be caught here in cases where a messaging service is not used
+      error_code = e&.code&.to_s
+      handle_twilio_error_codes(patient, error_code)
       return false
     end
     true
@@ -46,18 +117,38 @@ class TwilioSender
       Rails.logger.warn e.error_message
       return
     end
-
     # Get a message out of the studio execution which we can get the To/From numbers out of
     # The opt-in/out could come from an incoming message trigger OR an existing execution
     # The message pulled from an existing execution will be the first inbound message found within the execution
     message = execution&.context&.[]('trigger')&.[]('message') || execution&.context&.[]('widgets')&.values&.select do |x|
                                                                     x&.[]('inbound')
                                                                   end&.[](0)&.[]('inbound')
-    phone_number_from = message&.[]('From')
-    phone_number_to = message&.[]('To')
+    # Alternatively, the execution could be of type SINGLE_SMS where we sent a single outbound message
+    message = execution&.context&.[]('widgets')&.values&.select { |x| x&.[]('To') }&.[](0) if message.nil?
+
+    return nil if message.nil?
+
+    if !message&.[]('outbound').nil? || (message&.[]('Direction')&.include? 'outbound')
+      phone_number_from = message&.[]('To')
+      phone_number_to = message&.[]('From')
+    else
+      phone_number_from = message&.[]('From')
+      phone_number_to = message&.[]('To')
+    end
 
     return { monitoree_number: phone_number_from, sara_number: phone_number_to } if !phone_number_from.nil? && !phone_number_to.nil?
 
     nil
+  end
+
+  def self.dispatch_errored_contact_history_items(patient, error_message)
+    pats = if patient&.responder_id == patient.id && (patient.preferred_contact_method != 'SMS Texted Weblink')
+             # If errored contact was for a communication for all dependents ie: sms_assessment or voice_assessment
+             patient&.active_dependents_and_self
+           else
+             # If errored contact was for a particular dependent ie: weblink assessment
+             [patient, patient&.responder]
+           end
+    History.errored_report_reminder_group_of_patients(patients: pats, error_message: error_message)
   end
 end

--- a/app/mailers/twilio_sender.rb
+++ b/app/mailers/twilio_sender.rb
@@ -25,7 +25,9 @@ class TwilioSender
     if error_code == TWILIO_ERROR_CODES[:blocked_number][:code] && !BlockedNumber.exists?(phone_number: patient.primary_telephone)
       BlockedNumber.create(phone_number: patient.primary_telephone)
     end
-    err_msg = TWILIO_ERROR_CODES.find{ |_k, v| v[:code] == error_code }&.second[:message] || 'An unknown error has been encountered by the messaging system.'
+    err_msg = TWILIO_ERROR_CODES.find do |_k, v|
+                v[:code] == error_code
+              end.second&.[](:message) || 'An unknown error has been encountered by the messaging system.'
     dispatch_errored_contact_history_items(patient, err_msg)
   end
 

--- a/app/mailers/twilio_sender.rb
+++ b/app/mailers/twilio_sender.rb
@@ -27,7 +27,7 @@ class TwilioSender
     end
     err_msg = TWILIO_ERROR_CODES.find do |_k, v|
                 v[:code] == error_code
-              end.second&.[](:message) || 'An unknown error has been encountered by the messaging system.'
+              end&.second&.[](:message) || 'An unknown error has been encountered by the messaging system.'
     dispatch_errored_contact_history_items(patient, err_msg)
   end
 

--- a/app/mailers/twilio_sender.rb
+++ b/app/mailers/twilio_sender.rb
@@ -25,7 +25,7 @@ class TwilioSender
     if error_code == TWILIO_ERROR_CODES[:blocked_number][:code] && !BlockedNumber.exists?(phone_number: patient.primary_telephone)
       BlockedNumber.create(phone_number: patient.primary_telephone)
     end
-    err_msg = find { |_k, v| v[:code] == error_code }&.second & [:message] || 'An unknown error has been encountered by the messaging system.'
+    err_msg = TWILIO_ERROR_CODES.find{ |_k, v| v[:code] == error_code }&.second[:message] || 'An unknown error has been encountered by the messaging system.'
     dispatch_errored_contact_history_items(patient, err_msg)
   end
 

--- a/app/mailers/twilio_sender.rb
+++ b/app/mailers/twilio_sender.rb
@@ -22,7 +22,9 @@ class TwilioSender
 
   @client = Twilio::REST::Client.new(ENV['TWILLIO_API_ACCOUNT'], ENV['TWILLIO_API_KEY'])
   def self.handle_twilio_error_codes(patient, error_code)
-    BlockedNumber.create(phone_number: patient.primary_telephone) if error_code == (TWILIO_ERROR_CODES[:blocked_number][:code]) && !BlockedNumber.exists?
+    if error_code == TWILIO_ERROR_CODES[:blocked_number][:code] && !BlockedNumber.exists?(phone_number: patient.primary_telephone)
+      BlockedNumber.create(phone_number: patient.primary_telephone)
+    end
     err_msg = find { |_k, v| v[:code] == error_code }&.second & [:message] || 'An unknown error has been encountered by the messaging system.'
     dispatch_errored_contact_history_items(patient, err_msg)
   end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -18,6 +18,7 @@ class History < ApplicationRecord
     reports_reviewed: 'Reports Reviewed',
     report_reviewed: 'Report Reviewed',
     report_reminder: 'Report Reminder',
+    errored_report_reminder: 'Unsuccessful Report Reminder',
     report_note: 'Report Note',
     lab_result: 'Lab Result',
     lab_result_edit: 'Lab Result Edit',
@@ -123,6 +124,31 @@ class History < ApplicationRecord
       .where(history_type: [HISTORY_TYPES[:reports_reviewed], HISTORY_TYPES[:report_reviewed]])
   }
 
+  def self.errored_report_reminder_group_of_patients(patients: nil, created_by: 'Sara Alert System', comment: 'Failed Contact Attempt', error_message: nil)
+    histories = []
+    patients.uniq.each do |pat|
+      if pat.responder == pat
+        recipient = 'this monitoree'
+        responder = pat
+      else
+        recipient = "this monitoree's head of household"
+        responder = pat.responder
+      end
+      details = if !error_message.nil?
+                  ' Error details: ' + error_message
+                else
+                  ''
+                end
+      comment = if responder&.preferred_contact_method&.include?('SMS')
+                  "Sara Alert attempted to send an SMS to #{recipient} at #{responder.primary_telephone}, but the message could not be delivered.#{details}"
+                else
+                  "Sara Alert attempted to call #{recipient} at #{responder.primary_telephone}, but the call could not be completed.#{details}"
+                end
+      histories << History.new(created_by: created_by, comment: comment, patient_id: pat.id, history_type: HISTORY_TYPES[:errored_report_reminder])
+    end
+    History.import! histories
+  end
+
   def self.record_edit(patient: nil, created_by: 'Sara Alert System', comment: 'User edited a record.')
     create_history(patient, created_by, HISTORY_TYPES[:record_edit], comment)
   end
@@ -156,7 +182,12 @@ class History < ApplicationRecord
   end
 
   def self.report_reminder(patient: nil, created_by: 'Sara Alert System', comment: 'User sent a report reminder to the monitoree.')
-    create_history(patient, created_by, HISTORY_TYPES[:report_reminder], comment) unless patient&.preferred_contact_method.nil?
+    create_history(patient, created_by, HISTORY_TYPES[:report_reminder],
+                   comment)
+  end
+
+  def self.errored_report_reminder(patient: nil, created_by: 'Sara Alert System', comment: 'Unsuccessful report reminder.')
+    create_history(patient, created_by, HISTORY_TYPES[:errored_report_reminder], comment)
   end
 
   def self.vaccination(patient: nil, created_by: 'Sara Alert System', comment: 'User added a new vaccination.')

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -134,11 +134,7 @@ class History < ApplicationRecord
         recipient = "this monitoree's head of household"
         responder = pat.responder
       end
-      details = if !error_message.nil?
-                  ' Error details: ' + error_message
-                else
-                  ''
-                end
+      details = error_message.present? ? ' Error details: ' + error_message : ''
       comment = if responder&.preferred_contact_method&.include?('SMS')
                   "Sara Alert attempted to send an SMS to #{recipient} at #{responder.primary_telephone}, but the message could not be delivered.#{details}"
                 else

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -851,6 +851,11 @@ class Patient < ApplicationRecord
     active_dependents.where.not(id: id)
   end
 
+  # Get all dependents and always include self even if self is not active
+  def active_dependents_and_self
+    ([self] + active_dependents).uniq
+  end
+
   # Get this patient's dependents excluding itself
   def dependents_exclude_self
     dependents.where.not(id: id)

--- a/config/twilio/assessment_studio_flow.json
+++ b/config/twilio/assessment_studio_flow.json
@@ -1,5 +1,5 @@
 {
-  "description": "SaraAlertProdFlow",
+  "description": "SaraAlertDemoFlow",
   "states": [
     {
       "name": "Trigger",
@@ -14,14 +14,14 @@
           "event": "incomingCall"
         },
         {
-          "next": "initialize_retry_count",
+          "next": "initialize_variables",
           "event": "incomingRequest"
         }
       ],
       "properties": {
         "offset": {
-          "x": 1380,
-          "y": -960
+          "x": 1170,
+          "y": -1130
         }
       }
     },
@@ -44,8 +44,8 @@
       ],
       "properties": {
         "offset": {
-          "x": -540,
-          "y": 40
+          "x": -890,
+          "y": -250
         },
         "service": "{{trigger.message.InstanceSid}}",
         "channel": "{{trigger.message.ChannelSid}}",
@@ -117,8 +117,8 @@
       "properties": {
         "input": "{{widgets.sms_assessment_prompt.inbound.Body}}",
         "offset": {
-          "x": -530,
-          "y": 740
+          "x": -550,
+          "y": 530
         }
       }
     },
@@ -135,7 +135,7 @@
           "event": "timeout"
         },
         {
-          "next": "send_assessment_sms_error",
+          "next": "bad_response_sms_error",
           "event": "deliveryFailure"
         }
       ],
@@ -247,7 +247,7 @@
       "type": "make-outgoing-call-v2",
       "transitions": [
         {
-          "next": "split_1",
+          "next": "split_on_answered_by",
           "event": "answered"
         },
         {
@@ -267,8 +267,8 @@
         "machine_detection_speech_threshold": "2400",
         "detect_answering_machine": true,
         "offset": {
-          "x": 1050,
-          "y": 570
+          "x": 1490,
+          "y": 320
         },
         "recording_channels": "mono",
         "timeout": 60,
@@ -292,14 +292,14 @@
         }
       ],
       "properties": {
-        "voice": "Polly.Joanna",
+        "voice": "{{flow.variables.voice}}",
         "offset": {
-          "x": 1050,
-          "y": 1120
+          "x": 1490,
+          "y": 870
         },
         "loop": 1,
         "say": "{{flow.data.intro}}",
-        "language": "en-US"
+        "language": "{{flow.variables.language}}"
       }
     },
     {
@@ -314,26 +314,27 @@
           "event": "speech"
         },
         {
-          "next": "increment_retry_count_en",
+          "next": "increment_retry_count_voice",
           "event": "timeout"
         }
       ],
       "properties": {
-        "voice": "Polly.Joanna",
-        "speech_timeout": "auto",
+        "voice": "{{flow.variables.voice}}",
         "offset": {
-          "x": 1090,
-          "y": 1540
+          "x": 1490,
+          "y": 1200
         },
-        "loop": 1,
-        "hints": "yes, yeah, yup, no, nope, nah",
+        "hints": "yes, no, si, oui, non",
         "finish_on_key": "#",
         "say": "{{flow.data.prompt}}",
-        "language": "en-US",
+        "language": "{{flow.variables.language}}",
         "stop_gather": true,
-        "gather_language": "en-US",
+        "speech_model": "numbers_and_commands",
         "profanity_filter": "true",
-        "timeout": 6
+        "timeout": 5,
+        "speech_timeout": "auto",
+        "loop": 1,
+        "gather_language": "{{flow.variables.language}}"
       }
     },
     {
@@ -341,7 +342,7 @@
       "type": "split-based-on",
       "transitions": [
         {
-          "next": "increment_retry_count_en",
+          "next": "increment_retry_count_voice",
           "event": "noMatch"
         },
         {
@@ -349,12 +350,12 @@
           "event": "match",
           "conditions": [
             {
-              "friendly_name": "If value matches_any_of yes,Yes,no,No",
+              "friendly_name": "If value matches_any_of no",
               "arguments": [
                 "{{widgets.voice_reply_to_prompt.SpeechResult}}"
               ],
               "type": "matches_any_of",
-              "value": "no,No.,nope,Nope.,nope."
+              "value": "no,No.,NO,nope,Nope.,nope.,Non, non, NON, Non. NON., non."
             }
           ]
         },
@@ -363,12 +364,12 @@
           "event": "match",
           "conditions": [
             {
-              "friendly_name": "If value matches_any_of yes,Yes,Yes.,Yeah,yeah,Yeah.",
+              "friendly_name": "If value matches_any_of yes",
               "arguments": [
                 "{{widgets.voice_reply_to_prompt.SpeechResult}}"
               ],
               "type": "matches_any_of",
-              "value": "yes,Yes,Yes.,Yeah,yeah,Yeah."
+              "value": "yes,Yes,Yes.,Yeah,yeah,Yeah.,si, Si,oui, OUI, Oui, oui.,OUI.,Oui."
             }
           ]
         }
@@ -376,8 +377,8 @@
       "properties": {
         "input": "{{widgets.voice_reply_to_prompt.SpeechResult}}",
         "offset": {
-          "x": 1230,
-          "y": 1880
+          "x": 1670,
+          "y": 1630
         }
       }
     },
@@ -391,14 +392,14 @@
         }
       ],
       "properties": {
-        "voice": "Polly.Joanna",
+        "voice": "{{flow.variables.voice}}",
         "offset": {
-          "x": 1630,
-          "y": 1630
+          "x": 2070,
+          "y": 1380
         },
         "loop": 1,
         "say": "{{flow.data.try_again}}",
-        "language": "en-US"
+        "language": "{{flow.variables.language}}"
       }
     },
     {
@@ -414,8 +415,8 @@
       ],
       "properties": {
         "offset": {
-          "x": 1630,
-          "y": 1080
+          "x": 2070,
+          "y": 830
         },
         "method": "POST",
         "content_type": "application/json;charset=utf-8",
@@ -424,7 +425,7 @@
       }
     },
     {
-      "name": "split_1",
+      "name": "split_on_answered_by",
       "type": "split-based-on",
       "transitions": [
         {
@@ -449,8 +450,8 @@
       "properties": {
         "input": "{{widgets.call_user.AnsweredBy}}",
         "offset": {
-          "x": 870,
-          "y": 850
+          "x": 1310,
+          "y": 600
         }
       }
     },
@@ -467,8 +468,8 @@
       ],
       "properties": {
         "offset": {
-          "x": -1670,
-          "y": 1720
+          "x": -2080,
+          "y": 1730
         },
         "method": "POST",
         "content_type": "application/json;charset=utf-8",
@@ -489,12 +490,12 @@
       ],
       "properties": {
         "offset": {
-          "x": -2080,
-          "y": 1720
+          "x": -420,
+          "y": 370
         },
         "method": "POST",
         "content_type": "application/json;charset=utf-8",
-        "body": "{\"response_status\": \"error_sms\", \n\"patient_submission_token\": \"{{flow.data.patient_submission_token}}\",\n\"threshold_hash\": \"{{flow.data.threshold_hash}}\"}",
+        "body": "{\"response_status\": \"error_sms\", \"error_code\": \"{{widgets.sms_assessment_prompt.ErrorCode}}\", \"patient_submission_token\": \"{{flow.data.patient_submission_token}}\", \"threshold_hash\": \"{{flow.data.threshold_hash}}\"}",
         "url": "FILL_WITH_CUSTOM_CALLBACK_URL"
       }
     },
@@ -511,12 +512,12 @@
       ],
       "properties": {
         "offset": {
-          "x": 1710,
-          "y": 820
+          "x": 2150,
+          "y": 570
         },
         "method": "POST",
         "content_type": "application/json;charset=utf-8",
-        "body": "{\"response_status\": \"error_voice\", \"patient_submission_token\": \"{{flow.data.patient_submission_token}}\",\n\"threshold_hash\": \"{{flow.data.threshold_hash}}\"}",
+        "body": "{\"response_status\": \"error_voice\",\"error_code\":\"{{widgets.call_user.ErrorCode}}\", \"patient_submission_token\": \"{{flow.data.patient_submission_token}}\",\n\"threshold_hash\": \"{{flow.data.threshold_hash}}\"}",
         "url": "FILL_WITH_CUSTOM_CALLBACK_URL"
       }
     },
@@ -530,316 +531,11 @@
       ],
       "properties": {
         "offset": {
-          "x": 1310,
-          "y": -690
+          "x": 1230,
+          "y": -780
         },
         "loop": 1,
         "say": "Hello, you have reached Sara Alert outside of your daily report requirement, please contact your public health department directly if you are experiencing symptoms."
-      }
-    },
-    {
-      "name": "split_on_language",
-      "type": "split-based-on",
-      "transitions": [
-        {
-          "event": "noMatch"
-        },
-        {
-          "next": "call_user",
-          "event": "match",
-          "conditions": [
-            {
-              "friendly_name": "If value equal_to EN",
-              "arguments": [
-                "{{flow.data.language}}"
-              ],
-              "type": "equal_to",
-              "value": "EN"
-            }
-          ]
-        },
-        {
-          "next": "call_user_spanish",
-          "event": "match",
-          "conditions": [
-            {
-              "friendly_name": "If value equal_to ES",
-              "arguments": [
-                "{{flow.data.language}}"
-              ],
-              "type": "equal_to",
-              "value": "ES"
-            }
-          ]
-        },
-        {
-          "next": "call_user_french",
-          "event": "match",
-          "conditions": [
-            {
-              "friendly_name": "If value equal_to FR",
-              "arguments": [
-                "{{flow.data.language}}"
-              ],
-              "type": "equal_to",
-              "value": "FR"
-            }
-          ]
-        },
-        {
-          "next": "voice_send_error_somali",
-          "event": "match",
-          "conditions": [
-            {
-              "friendly_name": "If value equal_to SO",
-              "arguments": [
-                "{{flow.data.language}}"
-              ],
-              "type": "equal_to",
-              "value": "SO"
-            }
-          ]
-        }
-      ],
-      "properties": {
-        "input": "{{flow.data.language}}",
-        "offset": {
-          "x": 1920,
-          "y": -20
-        }
-      }
-    },
-    {
-      "name": "call_user_spanish",
-      "type": "make-outgoing-call-v2",
-      "transitions": [
-        {
-          "next": "voice_split_spanish",
-          "event": "answered"
-        },
-        {
-          "event": "busy"
-        },
-        {
-          "next": "voice_send_no_answer_spanish",
-          "event": "noAnswer"
-        },
-        {
-          "next": "voice_send_error_spanish",
-          "event": "failed"
-        }
-      ],
-      "properties": {
-        "machine_detection_speech_threshold": "2400",
-        "detect_answering_machine": true,
-        "offset": {
-          "x": 2190,
-          "y": 550
-        },
-        "recording_channels": "mono",
-        "timeout": 60,
-        "machine_detection": "Enable",
-        "trim": "do-not-trim",
-        "record": false,
-        "machine_detection_speech_end_threshold": "1200",
-        "machine_detection_timeout": "30",
-        "from": "{{flow.channel.address}}",
-        "to": "{{contact.channel.address}}",
-        "machine_detection_silence_timeout": "10000"
-      }
-    },
-    {
-      "name": "voice_split_spanish",
-      "type": "split-based-on",
-      "transitions": [
-        {
-          "next": "voice_send_no_answer_spanish",
-          "event": "noMatch"
-        },
-        {
-          "next": "welcome_prompt_spanish",
-          "event": "match",
-          "conditions": [
-            {
-              "friendly_name": "If value equal_to human",
-              "arguments": [
-                "{{widgets.call_user_spanish.AnsweredBy}}"
-              ],
-              "type": "matches_any_of",
-              "value": "human, unknown"
-            }
-          ]
-        }
-      ],
-      "properties": {
-        "input": "{{widgets.call_user_spanish.AnsweredBy}}",
-        "offset": {
-          "x": 2210,
-          "y": 930
-        }
-      }
-    },
-    {
-      "name": "voice_send_error_spanish",
-      "type": "make-http-request",
-      "transitions": [
-        {
-          "event": "success"
-        },
-        {
-          "event": "failed"
-        }
-      ],
-      "properties": {
-        "offset": {
-          "x": 3100,
-          "y": 1130
-        },
-        "method": "POST",
-        "content_type": "application/json;charset=utf-8",
-        "body": "{\"response_status\": \"error_voice\", \"patient_submission_token\": \"{{flow.data.patient_submission_token}}\",\n\"threshold_hash\": \"{{flow.data.threshold_hash}}\"}",
-        "url": "FILL_WITH_CUSTOM_CALLBACK_URL"
-      }
-    },
-    {
-      "name": "voice_send_no_answer_spanish",
-      "type": "make-http-request",
-      "transitions": [
-        {
-          "event": "success"
-        },
-        {
-          "event": "failed"
-        }
-      ],
-      "properties": {
-        "offset": {
-          "x": 2760,
-          "y": 1140
-        },
-        "method": "POST",
-        "content_type": "application/json;charset=utf-8",
-        "body": "{\"response_status\": \"no_answer_voice\", \"patient_submission_token\": \"{{flow.data.patient_submission_token}}\",\n\"threshold_hash\": \"{{flow.data.threshold_hash}}\"}",
-        "url": "FILL_WITH_CUSTOM_CALLBACK_URL"
-      }
-    },
-    {
-      "name": "welcome_prompt_spanish",
-      "type": "say-play",
-      "transitions": [
-        {
-          "next": "voice_reply_to_prompt_spanish",
-          "event": "audioComplete"
-        }
-      ],
-      "properties": {
-        "voice": "Polly.Conchita",
-        "offset": {
-          "x": 2390,
-          "y": 1200
-        },
-        "loop": 1,
-        "say": "{{flow.data.intro}}",
-        "language": "es-ES"
-      }
-    },
-    {
-      "name": "voice_reply_to_prompt_spanish",
-      "type": "gather-input-on-call",
-      "transitions": [
-        {
-          "event": "keypress"
-        },
-        {
-          "next": "check_yes_no_voice_spanish",
-          "event": "speech"
-        },
-        {
-          "next": "increment_retry_count_es",
-          "event": "timeout"
-        }
-      ],
-      "properties": {
-        "voice": "Polly.Conchita",
-        "speech_timeout": "auto",
-        "offset": {
-          "x": 2420,
-          "y": 1450
-        },
-        "loop": 1,
-        "hints": "si, no",
-        "finish_on_key": "#",
-        "say": "{{flow.data.prompt}}",
-        "language": "es-ES",
-        "stop_gather": true,
-        "gather_language": "es-ES",
-        "profanity_filter": "true",
-        "timeout": 6
-      }
-    },
-    {
-      "name": "lets_try_again_spanish",
-      "type": "say-play",
-      "transitions": [
-        {
-          "next": "voice_reply_to_prompt_spanish",
-          "event": "audioComplete"
-        }
-      ],
-      "properties": {
-        "voice": "Polly.Conchita",
-        "offset": {
-          "x": 2890,
-          "y": 1450
-        },
-        "loop": 1,
-        "say": "{{flow.data.try_again}}",
-        "language": "es-ES"
-      }
-    },
-    {
-      "name": "check_yes_no_voice_spanish",
-      "type": "split-based-on",
-      "transitions": [
-        {
-          "next": "increment_retry_count_es",
-          "event": "noMatch"
-        },
-        {
-          "next": "voice_send_assessment_yes",
-          "event": "match",
-          "conditions": [
-            {
-              "friendly_name": "If value matches_any_of si, Si",
-              "arguments": [
-                "{{widgets.voice_reply_to_prompt_spanish.SpeechResult}}"
-              ],
-              "type": "matches_any_of",
-              "value": "si, Si"
-            }
-          ]
-        },
-        {
-          "next": "voice_send_assessment_no",
-          "event": "match",
-          "conditions": [
-            {
-              "friendly_name": "If value matches_any_of no, No",
-              "arguments": [
-                "{{widgets.voice_reply_to_prompt_spanish.SpeechResult}}"
-              ],
-              "type": "matches_any_of",
-              "value": "no, No, NO"
-            }
-          ]
-        }
-      ],
-      "properties": {
-        "input": "{{widgets.voice_reply_to_prompt_spanish.SpeechResult}}",
-        "offset": {
-          "x": 2430,
-          "y": 1750
-        }
       }
     },
     {
@@ -847,7 +543,7 @@
       "type": "make-http-request",
       "transitions": [
         {
-          "next": "thank_you_split_on_language",
+          "next": "thank_you_voice",
           "event": "success"
         },
         {
@@ -856,8 +552,8 @@
       ],
       "properties": {
         "offset": {
-          "x": 2360,
-          "y": 2970
+          "x": 1730,
+          "y": 2000
         },
         "method": "POST",
         "content_type": "application/json;charset=utf-8",
@@ -866,7 +562,7 @@
       }
     },
     {
-      "name": "thank_you_voice_spanish",
+      "name": "thank_you_voice",
       "type": "say-play",
       "transitions": [
         {
@@ -874,14 +570,14 @@
         }
       ],
       "properties": {
-        "voice": "Polly.Conchita",
+        "voice": "{{flow.variables.voice}}",
         "offset": {
-          "x": 2650,
-          "y": 3840
+          "x": 1980,
+          "y": 2320
         },
         "loop": 1,
         "say": "{{flow.data.thanks}}",
-        "language": "es-ES"
+        "language": "{{flow.variables.language}}"
       }
     },
     {
@@ -889,7 +585,7 @@
       "type": "make-http-request",
       "transitions": [
         {
-          "next": "thank_you_split_on_language",
+          "next": "thank_you_voice",
           "event": "success"
         },
         {
@@ -898,267 +594,12 @@
       ],
       "properties": {
         "offset": {
-          "x": 2810,
-          "y": 2970
+          "x": 2200,
+          "y": 1990
         },
         "method": "POST",
         "content_type": "application/json;charset=utf-8",
         "body": "{\"response_status\": \"success_voice\", \n\"experiencing_symptoms\":\"No\", \"patient_submission_token\": \"{{flow.data.patient_submission_token}}\",\n\"threshold_hash\": \"{{flow.data.threshold_hash}}\"}",
-        "url": "FILL_WITH_CUSTOM_CALLBACK_URL"
-      }
-    },
-    {
-      "name": "call_user_french",
-      "type": "make-outgoing-call-v2",
-      "transitions": [
-        {
-          "next": "voice_split_french",
-          "event": "answered"
-        },
-        {
-          "event": "busy"
-        },
-        {
-          "next": "voice_send_no_answer_french",
-          "event": "noAnswer"
-        },
-        {
-          "next": "voice_send_error_french",
-          "event": "failed"
-        }
-      ],
-      "properties": {
-        "machine_detection_speech_threshold": "2400",
-        "detect_answering_machine": true,
-        "offset": {
-          "x": 3400,
-          "y": 550
-        },
-        "recording_channels": "mono",
-        "timeout": 60,
-        "machine_detection": "Enable",
-        "trim": "do-not-trim",
-        "record": false,
-        "machine_detection_speech_end_threshold": "1200",
-        "machine_detection_timeout": "30",
-        "from": "{{flow.channel.address}}",
-        "to": "{{contact.channel.address}}",
-        "machine_detection_silence_timeout": "10000"
-      }
-    },
-    {
-      "name": "voice_split_french",
-      "type": "split-based-on",
-      "transitions": [
-        {
-          "next": "voice_send_no_answer_french",
-          "event": "noMatch"
-        },
-        {
-          "next": "welcome_prompt_french",
-          "event": "match",
-          "conditions": [
-            {
-              "friendly_name": "If value equal_to human",
-              "arguments": [
-                "{{widgets.call_user_french.AnsweredBy}}"
-              ],
-              "type": "matches_any_of",
-              "value": "human, unknown"
-            }
-          ]
-        }
-      ],
-      "properties": {
-        "input": "{{widgets.call_user_french.AnsweredBy}}",
-        "offset": {
-          "x": 3420,
-          "y": 930
-        }
-      }
-    },
-    {
-      "name": "welcome_prompt_french",
-      "type": "say-play",
-      "transitions": [
-        {
-          "next": "voice_reply_to_prompt_french",
-          "event": "audioComplete"
-        }
-      ],
-      "properties": {
-        "voice": "Polly.Chantal",
-        "offset": {
-          "x": 3600,
-          "y": 1200
-        },
-        "loop": 1,
-        "say": "{{flow.data.intro}}",
-        "language": "fr-CA"
-      }
-    },
-    {
-      "name": "voice_send_no_answer_french",
-      "type": "make-http-request",
-      "transitions": [
-        {
-          "event": "success"
-        },
-        {
-          "event": "failed"
-        }
-      ],
-      "properties": {
-        "offset": {
-          "x": 3970,
-          "y": 1140
-        },
-        "method": "POST",
-        "content_type": "application/json;charset=utf-8",
-        "body": "{\"response_status\": \"no_answer_voice\", \"patient_submission_token\": \"{{flow.data.patient_submission_token}}\",\n\"threshold_hash\": \"{{flow.data.threshold_hash}}\"}",
-        "url": "FILL_WITH_CUSTOM_CALLBACK_URL"
-      }
-    },
-    {
-      "name": "voice_send_error_french",
-      "type": "make-http-request",
-      "transitions": [
-        {
-          "event": "success"
-        },
-        {
-          "event": "failed"
-        }
-      ],
-      "properties": {
-        "offset": {
-          "x": 4300,
-          "y": 1140
-        },
-        "method": "POST",
-        "content_type": "application/json;charset=utf-8",
-        "body": "{\"response_status\": \"error_voice\", \"patient_submission_token\": \"{{flow.data.patient_submission_token}}\",\n\"threshold_hash\": \"{{flow.data.threshold_hash}}\"}",
-        "url": "FILL_WITH_CUSTOM_CALLBACK_URL"
-      }
-    },
-    {
-      "name": "voice_reply_to_prompt_french",
-      "type": "gather-input-on-call",
-      "transitions": [
-        {
-          "event": "keypress"
-        },
-        {
-          "next": "check_yes_no_voice_french",
-          "event": "speech"
-        },
-        {
-          "next": "increment_retry_count_fr",
-          "event": "timeout"
-        }
-      ],
-      "properties": {
-        "voice": "Polly.Chantal",
-        "speech_timeout": "auto",
-        "offset": {
-          "x": 3630,
-          "y": 1450
-        },
-        "loop": 1,
-        "hints": "si, no",
-        "finish_on_key": "#",
-        "say": "{{flow.data.prompt}}",
-        "language": "fr-CA",
-        "stop_gather": true,
-        "gather_language": "es-ES",
-        "profanity_filter": "true",
-        "timeout": 6
-      }
-    },
-    {
-      "name": "lets_try_again_french",
-      "type": "say-play",
-      "transitions": [
-        {
-          "next": "voice_reply_to_prompt_french",
-          "event": "audioComplete"
-        }
-      ],
-      "properties": {
-        "voice": "Polly.Chantal",
-        "offset": {
-          "x": 4030,
-          "y": 1450
-        },
-        "loop": 1,
-        "say": "{{flow.data.try_again}}",
-        "language": "fr-CA"
-      }
-    },
-    {
-      "name": "check_yes_no_voice_french",
-      "type": "split-based-on",
-      "transitions": [
-        {
-          "next": "increment_retry_count_fr",
-          "event": "noMatch"
-        },
-        {
-          "next": "voice_send_assessment_yes",
-          "event": "match",
-          "conditions": [
-            {
-              "friendly_name": "If value matches_any_of oui",
-              "arguments": [
-                "{{widgets.voice_reply_to_prompt_french.SpeechResult}}"
-              ],
-              "type": "matches_any_of",
-              "value": "oui, OUI, Oui, oui.,OUI.,Oui."
-            }
-          ]
-        },
-        {
-          "next": "voice_send_assessment_no",
-          "event": "match",
-          "conditions": [
-            {
-              "friendly_name": "If value matches_any_of non",
-              "arguments": [
-                "{{widgets.voice_reply_to_prompt_french.SpeechResult}}"
-              ],
-              "type": "matches_any_of",
-              "value": "Non, non, NON, Non. NON., non."
-            }
-          ]
-        }
-      ],
-      "properties": {
-        "input": "{{widgets.voice_reply_to_prompt_french.SpeechResult}}",
-        "offset": {
-          "x": 3640,
-          "y": 1750
-        }
-      }
-    },
-    {
-      "name": "voice_send_error_somali",
-      "type": "make-http-request",
-      "transitions": [
-        {
-          "event": "success"
-        },
-        {
-          "event": "failed"
-        }
-      ],
-      "properties": {
-        "offset": {
-          "x": 4000,
-          "y": 550
-        },
-        "method": "POST",
-        "content_type": "application/json;charset=utf-8",
-        "body": "{\"response_status\": \"error_voice\", \"patient_submission_token\": \"{{flow.data.patient_submission_token}}\",\n\"threshold_hash\": \"{{flow.data.threshold_hash}}\"}",
         "url": "FILL_WITH_CUSTOM_CALLBACK_URL"
       }
     },
@@ -1201,8 +642,8 @@
       "properties": {
         "input": "{{trigger.message.OptOutType}}",
         "offset": {
-          "x": -1230,
-          "y": -730
+          "x": 10,
+          "y": -740
         }
       }
     },
@@ -1228,7 +669,7 @@
           ]
         },
         {
-          "next": "split_on_language",
+          "next": "set_language_voice_options",
           "event": "match",
           "conditions": [
             {
@@ -1240,13 +681,27 @@
               "value": "VOICE"
             }
           ]
+        },
+        {
+          "next": "split_on_iterator",
+          "event": "match",
+          "conditions": [
+            {
+              "friendly_name": "If value equal_to SINGLE_SMS",
+              "arguments": [
+                "{{flow.data.medium}}"
+              ],
+              "type": "equal_to",
+              "value": "SINGLE_SMS"
+            }
+          ]
         }
       ],
       "properties": {
         "input": "{{flow.data.medium}}",
         "offset": {
-          "x": 1640,
-          "y": -410
+          "x": 900,
+          "y": -470
         }
       }
     },
@@ -1263,8 +718,8 @@
       ],
       "properties": {
         "offset": {
-          "x": -1290,
-          "y": 2180
+          "x": 490,
+          "y": 2580
         },
         "method": "POST",
         "content_type": "application/json;charset=utf-8",
@@ -1312,8 +767,8 @@
       "properties": {
         "input": "{{widgets.sms_assessment_prompt.inbound.OptOutType}}",
         "offset": {
-          "x": -1230,
-          "y": 340
+          "x": -1360,
+          "y": 140
         }
       }
     },
@@ -1375,8 +830,8 @@
       ],
       "properties": {
         "offset": {
-          "x": -890,
-          "y": 2170
+          "x": 50,
+          "y": 2580
         },
         "method": "POST",
         "content_type": "application/json;charset=utf-8",
@@ -1385,7 +840,7 @@
       }
     },
     {
-      "name": "initialize_retry_count",
+      "name": "initialize_variables",
       "type": "set-variables",
       "transitions": [
         {
@@ -1398,11 +853,15 @@
           {
             "value": "0",
             "key": "retry_count"
+          },
+          {
+            "value": "0",
+            "key": "iterator"
           }
         ],
         "offset": {
-          "x": 1640,
-          "y": -670
+          "x": 1630,
+          "y": -780
         }
       }
     },
@@ -1484,11 +943,11 @@
       }
     },
     {
-      "name": "split_on_retry_en",
+      "name": "split_on_retry_voice",
       "type": "split-based-on",
       "transitions": [
         {
-          "next": "max_retries_exceeded_en",
+          "next": "max_retries_exceeded",
           "event": "noMatch"
         },
         {
@@ -1509,17 +968,17 @@
       "properties": {
         "input": "{{flow.variables.retry_count}}",
         "offset": {
-          "x": 620,
-          "y": 1720
+          "x": 1060,
+          "y": 1470
         }
       }
     },
     {
-      "name": "increment_retry_count_en",
+      "name": "increment_retry_count_voice",
       "type": "set-variables",
       "transitions": [
         {
-          "next": "split_on_retry_en",
+          "next": "split_on_retry_voice",
           "event": "next"
         }
       ],
@@ -1531,13 +990,13 @@
           }
         ],
         "offset": {
-          "x": 610,
-          "y": 1520
+          "x": 1050,
+          "y": 1270
         }
       }
     },
     {
-      "name": "max_retries_exceeded_en",
+      "name": "max_retries_exceeded",
       "type": "say-play",
       "transitions": [
         {
@@ -1546,14 +1005,14 @@
         }
       ],
       "properties": {
-        "voice": "Polly.Joanna",
+        "voice": "{{flow.variables.voice}}",
         "offset": {
-          "x": 670,
-          "y": 2010
+          "x": 1110,
+          "y": 1760
         },
         "loop": 1,
         "say": "{{flow.data.max_retries_message}}",
-        "language": "en-US"
+        "language": "{{flow.variables.language}}"
       }
     },
     {
@@ -1569,8 +1028,8 @@
       ],
       "properties": {
         "offset": {
-          "x": 2040,
-          "y": 2240
+          "x": 1140,
+          "y": 2030
         },
         "method": "POST",
         "content_type": "application/json;charset=utf-8",
@@ -1601,199 +1060,37 @@
       }
     },
     {
-      "name": "increment_retry_count_es",
-      "type": "set-variables",
+      "name": "bad_response_sms_error",
+      "type": "make-http-request",
       "transitions": [
         {
-          "next": "split_on_retry_es",
-          "event": "next"
+          "event": "success"
+        },
+        {
+          "event": "failed"
         }
       ],
       "properties": {
-        "variables": [
-          {
-            "value": "{%- if flow.variables.retry_count -%}\n  {{flow.variables.retry_count | plus: 1}}\n{%- else -%}\n  0\n{%- endif -%}",
-            "key": "retry_count"
-          }
-        ],
         "offset": {
-          "x": 2000,
-          "y": 1200
-        }
+          "x": -1680,
+          "y": 1710
+        },
+        "method": "POST",
+        "content_type": "application/json;charset=utf-8",
+        "body": "{\"response_status\": \"error_sms\", \"error_code\": {{widgets.bad_response.outbound.ErrorCode}}, \n\"patient_submission_token\": \"{{flow.data.patient_submission_token}}\",\n\"threshold_hash\": \"{{flow.data.threshold_hash}}\"}",
+        "url": "FILL_WITH_CUSTOM_CALLBACK_URL"
       }
     },
     {
-      "name": "split_on_retry_es",
+      "name": "set_language_voice_options",
       "type": "split-based-on",
       "transitions": [
         {
-          "next": "max_retries_exceeded_es",
+          "next": "set_language_EN",
           "event": "noMatch"
         },
         {
-          "next": "lets_try_again_spanish",
-          "event": "match",
-          "conditions": [
-            {
-              "friendly_name": "If value less than 4",
-              "arguments": [
-                "{{flow.variables.retry_count}}"
-              ],
-              "type": "less_than",
-              "value": "4"
-            }
-          ]
-        }
-      ],
-      "properties": {
-        "input": "{{flow.variables.retry_count}}",
-        "offset": {
-          "x": 2010,
-          "y": 1400
-        }
-      }
-    },
-    {
-      "name": "max_retries_exceeded_es",
-      "type": "say-play",
-      "transitions": [
-        {
-          "next": "voice_send_max_retry",
-          "event": "audioComplete"
-        }
-      ],
-      "properties": {
-        "voice": "Polly.Conchita",
-        "offset": {
-          "x": 2020,
-          "y": 1620
-        },
-        "loop": 1,
-        "say": "{{flow.data.max_retries_message}}",
-        "language": "es-ES"
-      }
-    },
-    {
-      "name": "max_retries_exceeded_fr",
-      "type": "say-play",
-      "transitions": [
-        {
-          "next": "voice_send_max_retry",
-          "event": "audioComplete"
-        }
-      ],
-      "properties": {
-        "voice": "Polly.Chantal",
-        "offset": {
-          "x": 3280,
-          "y": 1740
-        },
-        "loop": 1,
-        "say": "{{flow.data.max_retries_message}}",
-        "language": "fr-CA"
-      }
-    },
-    {
-      "name": "split_on_retry_fr",
-      "type": "split-based-on",
-      "transitions": [
-        {
-          "next": "max_retries_exceeded_fr",
-          "event": "noMatch"
-        },
-        {
-          "next": "lets_try_again_french",
-          "event": "match",
-          "conditions": [
-            {
-              "friendly_name": "If value less than 4",
-              "arguments": [
-                "{{flow.variables.retry_count}}"
-              ],
-              "type": "less_than",
-              "value": "4"
-            }
-          ]
-        }
-      ],
-      "properties": {
-        "input": "{{flow.variables.retry_count}}",
-        "offset": {
-          "x": 3270,
-          "y": 1520
-        }
-      }
-    },
-    {
-      "name": "increment_retry_count_fr",
-      "type": "set-variables",
-      "transitions": [
-        {
-          "next": "split_on_retry_fr",
-          "event": "next"
-        }
-      ],
-      "properties": {
-        "variables": [
-          {
-            "value": "{%- if flow.variables.retry_count -%}\n  {{flow.variables.retry_count | plus: 1}}\n{%- else -%}\n  0\n{%- endif -%}",
-            "key": "retry_count"
-          }
-        ],
-        "offset": {
-          "x": 3260,
-          "y": 1320
-        }
-      }
-    },
-    {
-      "name": "thank_you_voice_english",
-      "type": "say-play",
-      "transitions": [
-        {
-          "event": "audioComplete"
-        }
-      ],
-      "properties": {
-        "voice": "Polly.Joanna",
-        "offset": {
-          "x": 2130,
-          "y": 3850
-        },
-        "loop": 1,
-        "say": "{{flow.data.thanks}}",
-        "language": "en-US"
-      }
-    },
-    {
-      "name": "thank_you_voice_french",
-      "type": "say-play",
-      "transitions": [
-        {
-          "event": "audioComplete"
-        }
-      ],
-      "properties": {
-        "voice": "Polly.Chantal",
-        "offset": {
-          "x": 3110,
-          "y": 3820
-        },
-        "loop": 1,
-        "say": "{{flow.data.thanks}}",
-        "language": "fr-CA"
-      }
-    },
-    {
-      "name": "thank_you_split_on_language",
-      "type": "split-based-on",
-      "transitions": [
-        {
-          "next": "thank_you_voice_english",
-          "event": "noMatch"
-        },
-        {
-          "next": "thank_you_voice_english",
+          "next": "set_language_EN",
           "event": "match",
           "conditions": [
             {
@@ -1807,7 +1104,7 @@
           ]
         },
         {
-          "next": "thank_you_voice_spanish",
+          "next": "set_language_ES",
           "event": "match",
           "conditions": [
             {
@@ -1821,7 +1118,7 @@
           ]
         },
         {
-          "next": "thank_you_voice_french",
+          "next": "set_language_FR",
           "event": "match",
           "conditions": [
             {
@@ -1838,8 +1135,208 @@
       "properties": {
         "input": "{{flow.data.language}}",
         "offset": {
+          "x": 1190,
+          "y": -210
+        }
+      }
+    },
+    {
+      "name": "set_language_EN",
+      "type": "set-variables",
+      "transitions": [
+        {
+          "next": "call_user",
+          "event": "next"
+        }
+      ],
+      "properties": {
+        "variables": [
+          {
+            "value": "en-US",
+            "key": "language"
+          },
+          {
+            "value": "Polly.Joanna",
+            "key": "voice"
+          }
+        ],
+        "offset": {
+          "x": 1140,
+          "y": 80
+        }
+      }
+    },
+    {
+      "name": "set_language_ES",
+      "type": "set-variables",
+      "transitions": [
+        {
+          "next": "call_user",
+          "event": "next"
+        }
+      ],
+      "properties": {
+        "variables": [
+          {
+            "value": "es-ES",
+            "key": "language"
+          },
+          {
+            "value": "Polly.Conchita",
+            "key": "voice"
+          }
+        ],
+        "offset": {
+          "x": 1440,
+          "y": 80
+        }
+      }
+    },
+    {
+      "name": "set_language_FR",
+      "type": "set-variables",
+      "transitions": [
+        {
+          "next": "call_user",
+          "event": "next"
+        }
+      ],
+      "properties": {
+        "variables": [
+          {
+            "value": "fr-CA",
+            "key": "language"
+          },
+          {
+            "value": "Polly.Chantal",
+            "key": "voice"
+          }
+        ],
+        "offset": {
+          "x": 1740,
+          "y": 80
+        }
+      }
+    },
+    {
+      "name": "send_single_message_error",
+      "type": "make-http-request",
+      "transitions": [
+        {
+          "next": "increment_params_iterator",
+          "event": "success"
+        },
+        {
+          "next": "increment_params_iterator",
+          "event": "failed"
+        }
+      ],
+      "properties": {
+        "offset": {
+          "x": 3060,
+          "y": 120
+        },
+        "method": "POST",
+        "content_type": "application/json;charset=utf-8",
+        "body": "{% assign i=flow.variables.iterator | plus:0 %}\n{\"response_status\": \"error_sms\", \"error_code\": \"{{widgets.send_single_message.ErrorCode}}\", \"patient_submission_token\": \"{{flow.data.messages_array[i].patient_submission_token}}\", \"threshold_hash\": \"{{flow.data.messages_array[i].threshold_hash}}\"}",
+        "url": "FILL_WITH_CUSTOM_CALLBACK_URL"
+      }
+    },
+    {
+      "name": "send_single_message",
+      "type": "send-and-wait-for-reply",
+      "transitions": [
+        {
+          "next": "no_op_widget",
+          "event": "incomingMessage"
+        },
+        {
+          "next": "no_op_widget",
+          "event": "timeout"
+        },
+        {
+          "next": "send_single_message_error",
+          "event": "deliveryFailure"
+        }
+      ],
+      "properties": {
+        "offset": {
+          "x": 2710,
+          "y": -230
+        },
+        "service": "{{trigger.message.InstanceSid}}",
+        "channel": "{{trigger.message.ChannelSid}}",
+        "from": "{{flow.channel.address}}",
+        "body": "{% assign i=flow.variables.iterator | plus:0 %}\n{{flow.data.messages_array[i].prompt}}",
+        "timeout": "0"
+      }
+    },
+    {
+      "name": "no_op_widget",
+      "type": "set-variables",
+      "transitions": [
+        {
+          "next": "increment_params_iterator",
+          "event": "next"
+        }
+      ],
+      "properties": {
+        "variables": [],
+        "offset": {
+          "x": 2740,
+          "y": 120
+        }
+      }
+    },
+    {
+      "name": "increment_params_iterator",
+      "type": "set-variables",
+      "transitions": [
+        {
+          "next": "split_on_iterator",
+          "event": "next"
+        }
+      ],
+      "properties": {
+        "variables": [
+          {
+            "value": "{{flow.variables.iterator | plus: 1}}",
+            "key": "iterator"
+          }
+        ],
+        "offset": {
+          "x": 2830,
+          "y": 410
+        }
+      }
+    },
+    {
+      "name": "split_on_iterator",
+      "type": "split-based-on",
+      "transitions": [
+        {
+          "event": "noMatch"
+        },
+        {
+          "next": "send_single_message",
+          "event": "match",
+          "conditions": [
+            {
+              "friendly_name": "If value less_than {{flow.data.prompt.messages_array.size}}",
+              "arguments": [
+                "{{flow.variables.iterator}}"
+              ],
+              "type": "less_than",
+              "value": "{{flow.data.messages_array.size}}"
+            }
+          ]
+        }
+      ],
+      "properties": {
+        "input": "{{flow.variables.iterator}}",
+        "offset": {
           "x": 2460,
-          "y": 3240
+          "y": -520
         }
       }
     }

--- a/test/mailers/patient_mailer_test.rb
+++ b/test/mailers/patient_mailer_test.rb
@@ -129,11 +129,17 @@ class PatientMailerTest < ActionMailer::TestCase
     expect_any_instance_of(::Twilio::REST::Studio::V1::FlowContext::ExecutionList).to(receive(:create).with(
                                                                                         from: 'test_messaging_sid',
                                                                                         parameters:
-                                                                                           { medium: 'SINGLE_SMS',
-                                                                                             patient_submission_token: @patient.submission_token,
-                                                                                             prompt: contents,
-                                                                                             threshold_hash:
-                                                                                             @patient.jurisdiction.jurisdiction_path_threshold_hash },
+                                                                                           {
+                                                                                             medium: 'SINGLE_SMS',
+                                                                                             messages_array: [
+                                                                                               {
+                                                                                                 patient_submission_token: @patient.submission_token,
+                                                                                                 prompt: contents,
+                                                                                                 threshold_hash:
+                                                                                               @patient.jurisdiction.jurisdiction_path_threshold_hash
+                                                                                               }
+                                                                                             ]
+                                                                                           },
                                                                                         to: '+15555550111'
                                                                                       ))
 
@@ -153,10 +159,12 @@ class PatientMailerTest < ActionMailer::TestCase
                                                                                         from: 'test',
                                                                                         parameters:
                                                                                            { medium: 'SINGLE_SMS',
-                                                                                             patient_submission_token: @patient.submission_token,
-                                                                                             prompt: contents,
-                                                                                             threshold_hash:
-                                                                                              @patient.jurisdiction.jurisdiction_path_threshold_hash },
+                                                                                             messages_array: [{
+                                                                                               patient_submission_token: @patient.submission_token,
+                                                                                               prompt: contents,
+                                                                                               threshold_hash:
+                                                                                              @patient.jurisdiction.jurisdiction_path_threshold_hash
+                                                                                             }] },
                                                                                         to: '+15555550111'
                                                                                       ))
 
@@ -171,12 +179,17 @@ class PatientMailerTest < ActionMailer::TestCase
     end)
     expect_any_instance_of(::Twilio::REST::Studio::V1::FlowContext::ExecutionList).to(receive(:create).with(
                                                                                         from: 'test_messaging_sid',
-                                                                                        parameters:
-                                                                                           { medium: 'SINGLE_SMS',
-                                                                                             patient_submission_token: @patient.submission_token,
-                                                                                             prompt: contents,
-                                                                                             threshold_hash:
-                                                                                             @patient.jurisdiction.jurisdiction_path_threshold_hash },
+                                                                                        parameters: {
+                                                                                          medium: 'SINGLE_SMS',
+                                                                                          messages_array: [
+                                                                                            {
+                                                                                              patient_submission_token: @patient.submission_token,
+                                                                                              prompt: contents,
+                                                                                              threshold_hash:
+                                                                                              @patient.jurisdiction.jurisdiction_path_threshold_hash
+                                                                                            }
+                                                                                          ]
+                                                                                        },
                                                                                         to: '+15555550111'
                                                                                       ))
 
@@ -194,10 +207,12 @@ class PatientMailerTest < ActionMailer::TestCase
                                                                                         from: 'test',
                                                                                         parameters:
                                                                                            { medium: 'SINGLE_SMS',
-                                                                                             patient_submission_token: @patient.submission_token,
-                                                                                             prompt: contents,
-                                                                                             threshold_hash:
-                                                                                             @patient.jurisdiction.jurisdiction_path_threshold_hash },
+                                                                                             messages_array: [{
+                                                                                               patient_submission_token: @patient.submission_token,
+                                                                                               prompt: contents,
+                                                                                               threshold_hash:
+                                                                                             @patient.jurisdiction.jurisdiction_path_threshold_hash
+                                                                                             }] },
                                                                                         to: '+15555550111'
                                                                                       ))
 
@@ -219,10 +234,12 @@ class PatientMailerTest < ActionMailer::TestCase
                                                                                         from: 'test_messaging_sid',
                                                                                         parameters:
                                                                                            { medium: 'SINGLE_SMS',
-                                                                                             patient_submission_token: @patient.submission_token,
-                                                                                             prompt: contents,
-                                                                                             threshold_hash:
-                                                                                             @patient.jurisdiction.jurisdiction_path_threshold_hash },
+                                                                                             messages_array: [{
+                                                                                               patient_submission_token: @patient.submission_token,
+                                                                                               prompt: contents,
+                                                                                               threshold_hash:
+                                                                                             @patient.jurisdiction.jurisdiction_path_threshold_hash
+                                                                                             }] },
                                                                                         to: '+15555550111'
                                                                                       ))
 
@@ -246,10 +263,12 @@ class PatientMailerTest < ActionMailer::TestCase
                                                                                         from: 'test',
                                                                                         parameters:
                                                                                            { medium: 'SINGLE_SMS',
-                                                                                             patient_submission_token: @patient.submission_token,
-                                                                                             prompt: contents,
-                                                                                             threshold_hash:
-                                                                                             @patient.jurisdiction.jurisdiction_path_threshold_hash },
+                                                                                             messages_array: [{
+                                                                                               patient_submission_token: @patient.submission_token,
+                                                                                               prompt: contents,
+                                                                                               threshold_hash:
+                                                                                             @patient.jurisdiction.jurisdiction_path_threshold_hash
+                                                                                             }] },
                                                                                         to: '+15555550111'
                                                                                       ))
 
@@ -273,7 +292,8 @@ class PatientMailerTest < ActionMailer::TestCase
       true
     end)
     PatientMailer.assessment_sms_weblink(@patient).deliver_now
-    assert_equal create_count, 2
+    # 1 Assessment sms weblink will be posted, that post will contain the messages to be sent for the monitoree and their dependent
+    assert_equal create_count, 1
 
     # Assert that both the patient and dependent got history items added
     assert_equal patient_history_count + 1, @patient.histories.count

--- a/test/mailers/twilio_sender_test.rb
+++ b/test/mailers/twilio_sender_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'vcr_setup'
+
+class TwilioSenderTest < ActiveSupport::TestCase
+  def setup
+    ENV['TWILLIO_STUDIO_FLOW'] = 'test'
+    ENV['TWILLIO_SENDING_NUMBER'] = '+15555555555'
+  end
+
+  def test_get_number_from_single_message_execution
+    # SINGLE_SMS execution ie: weblink, enrollment...
+    VCR.use_cassette('get_numbers_from_single_message_execution') do
+      # This is the ID for a test studio flow execution, if changes are made
+      # to the assertions of this test, you'll have to execute a studio flow
+      # in the context of this test run and put the id of that execution here
+      execution_id = 'FNf9193a1e62d1333a20a84ef183e751df'
+      to_from_numbers = TwilioSender.get_phone_numbers_from_flow_execution(execution_id)
+      assert_equal to_from_numbers[:monitoree_number], '+16035555555'
+      assert_equal to_from_numbers[:sara_number], ENV['TWILLIO_SENDING_NUMBER']
+    end
+  end
+
+  def test_get_number_from_voice_assessment_execution
+    # Voice assessment execution
+    VCR.use_cassette('get_numbers_from_voice_assessment_execution') do
+      # This is the ID for a test studio flow execution, if changes are made
+      # to the assertions of this test, you'll have to execute a studio flow
+      # in the context of this test run and put the id of that execution here
+      execution_id = 'FNce1d126c3ed0508a15ba965e4f7197dc'
+      to_from_numbers = TwilioSender.get_phone_numbers_from_flow_execution(execution_id)
+      assert_equal to_from_numbers[:monitoree_number], '+16035555555'
+      assert_equal to_from_numbers[:sara_number], ENV['TWILLIO_SENDING_NUMBER']
+    end
+  end
+
+  def test_get_number_from_sms_assessment_execution
+    # SMS assessment execution
+    VCR.use_cassette('get_number_from_sms_assessment_execution') do
+      # This is the ID for a test studio flow execution, if changes are made
+      # to the assertions of this test, you'll have to execute a studio flow
+      # in the context of this test run and put the id of that execution here
+      execution_id = 'FN304b09128a4f089b8c57a7e3f7cb2221'
+      to_from_numbers = TwilioSender.get_phone_numbers_from_flow_execution(execution_id)
+      assert_equal to_from_numbers[:monitoree_number], '+16035555555'
+      assert_equal to_from_numbers[:sara_number], ENV['TWILLIO_SENDING_NUMBER']
+    end
+  end
+
+  def test_get_number_from_inbound_sms_trigger_execution
+    # Monitoree sends message outside active execution ie: Start/Stop messages
+    VCR.use_cassette('get_numbers_from_inbound_sms_trigger_execution') do
+      # This is the ID for a test studio flow execution, if changes are made
+      # to the assertions of this test, you'll have to execute a studio flow
+      # in the context of this test run and put the id of that execution here
+      execution_id = 'FNc2b09bcf7ecaca4e33db739422281fcc'
+      to_from_numbers = TwilioSender.get_phone_numbers_from_flow_execution(execution_id)
+      assert_equal to_from_numbers[:monitoree_number], '+16035555555'
+      assert_equal to_from_numbers[:sara_number], ENV['TWILLIO_SENDING_NUMBER']
+    end
+  end
+
+  def test_get_number_from_inbound_voice_trigger_execution
+    # Monitoree calls Sara Alert
+    VCR.use_cassette('get_numbers_from_inbound_voice_trigger_execution') do
+      # This is the ID for a test studio flow execution, if changes are made
+      # to the assertions of this test, you'll have to execute a studio flow
+      # in the context of this test run and put the id of that execution here
+      execution_id = 'FN24eda0b89122c73e93e3d59431e9a52a'
+      to_from_numbers = TwilioSender.get_phone_numbers_from_flow_execution(execution_id)
+      assert_equal to_from_numbers[:monitoree_number], '+16035555555'
+      assert_equal to_from_numbers[:sara_number], ENV['TWILLIO_SENDING_NUMBER']
+    end
+  end
+end

--- a/test/test_helpers/consume_assessments_job_test_helper.rb
+++ b/test/test_helpers/consume_assessments_job_test_helper.rb
@@ -45,7 +45,7 @@ module ConsumeAssessmentsJobTestHelper
       }.to_json
     end
 
-    def error_sms_assessment(error_code: TwilioSender::TWILIO_ERROR_CODES[:unkown_number], patient: @patient)
+    def error_sms_assessment(error_code: TwilioSender::TWILIO_ERROR_CODES[:unknown_error], patient: @patient)
       {
         response_status: 'error_sms',
         error_code: error_code,
@@ -54,7 +54,7 @@ module ConsumeAssessmentsJobTestHelper
       }.to_json
     end
 
-    def error_voice_assessment(error_code: TwilioSender::TWILIO_ERROR_CODES[:unkown_number], patient: @patient)
+    def error_voice_assessment(error_code: TwilioSender::TWILIO_ERROR_CODES[:unknown_error], patient: @patient)
       {
         response_status: 'error_voice',
         error_code: error_code,

--- a/test/test_helpers/consume_assessments_job_test_helper.rb
+++ b/test/test_helpers/consume_assessments_job_test_helper.rb
@@ -45,6 +45,24 @@ module ConsumeAssessmentsJobTestHelper
       }.to_json
     end
 
+    def error_sms_assessment(error_code: '30008', patient: @patient)
+      {
+        response_status: 'error_sms',
+        error_code: error_code,
+        threshold_condition_hash: patient.jurisdiction.hierarchical_symptomatic_condition.threshold_condition_hash,
+        patient_submission_token: patient.submission_token
+      }.to_json
+    end
+
+    def error_voice_assessment(error_code: '30008', patient: @patient)
+      {
+        response_status: 'error_voice',
+        error_code: error_code,
+        threshold_condition_hash: patient.jurisdiction.hierarchical_symptomatic_condition.threshold_condition_hash,
+        patient_submission_token: patient.submission_token
+      }.to_json
+    end
+
     def missing_threshold_condition
       {
         response_status: nil,

--- a/test/test_helpers/consume_assessments_job_test_helper.rb
+++ b/test/test_helpers/consume_assessments_job_test_helper.rb
@@ -45,7 +45,7 @@ module ConsumeAssessmentsJobTestHelper
       }.to_json
     end
 
-    def error_sms_assessment(error_code: '30008', patient: @patient)
+    def error_sms_assessment(error_code: TwilioSender::TWILIO_ERROR_CODES[:unkown_number], patient: @patient)
       {
         response_status: 'error_sms',
         error_code: error_code,
@@ -54,7 +54,7 @@ module ConsumeAssessmentsJobTestHelper
       }.to_json
     end
 
-    def error_voice_assessment(error_code: '30008', patient: @patient)
+    def error_voice_assessment(error_code: TwilioSender::TWILIO_ERROR_CODES[:unkown_number], patient: @patient)
       {
         response_status: 'error_voice',
         error_code: error_code,

--- a/test/test_helpers/consume_assessments_job_test_helper.rb
+++ b/test/test_helpers/consume_assessments_job_test_helper.rb
@@ -45,7 +45,7 @@ module ConsumeAssessmentsJobTestHelper
       }.to_json
     end
 
-    def error_sms_assessment(error_code: TwilioSender::TWILIO_ERROR_CODES[:unknown_error], patient: @patient)
+    def error_sms_assessment(error_code: TwilioSender::TWILIO_ERROR_CODES[:unknown_error][:code], patient: @patient)
       {
         response_status: 'error_sms',
         error_code: error_code,
@@ -54,7 +54,7 @@ module ConsumeAssessmentsJobTestHelper
       }.to_json
     end
 
-    def error_voice_assessment(error_code: TwilioSender::TWILIO_ERROR_CODES[:unknown_error], patient: @patient)
+    def error_voice_assessment(error_code: TwilioSender::TWILIO_ERROR_CODES[:unknown_error][:code], patient: @patient)
       {
         response_status: 'error_voice',
         error_code: error_code,

--- a/test/vcr_cassettes/get_number_from_sms_assessment_execution.yml
+++ b/test/vcr_cassettes/get_number_from_sms_assessment_execution.yml
@@ -1,0 +1,128 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://studio.twilio.com/v1/Flows/<TWILLIO_STUDIO_FLOW>/Executions/FN304b09128a4f089b8c57a7e3f7cb2221/Context
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - twilio-ruby/5.45.1 (ruby/x86_64-darwin19 2.6.6-p146)
+      Accept-Charset:
+      - utf-8
+      Accept:
+      - application/json
+      Authorization:
+      - Basic QUM1ZGE3NDRhODdmNTM0MTgyZWNlZGJjMTljNDcyYTA2YjpmYTBmMTVlZjY1ZDA2YjliZTQzYzBkOTkyZTNkY2RkMw==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Jan 2021 22:48:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '5688'
+      Connection:
+      - keep-alive
+      Twilio-Concurrent-Requests:
+      - '1'
+      Twilio-Request-Id:
+      - RQ440971f112e744e0a4c4e4a142343e7c
+      Twilio-Request-Duration:
+      - '0.030'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match,
+        If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, OPTIONS
+      Access-Control-Expose-Headers:
+      - ETag
+      Access-Control-Allow-Credentials:
+      - 'true'
+      X-Powered-By:
+      - AT-5000
+      X-Shenanigans:
+      - none
+      X-Home-Region:
+      - us1
+      X-Api-Domain:
+      - studio.twilio.com
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '{"url": "https://studio.twilio.com/v1/Flows/<TWILLIO_STUDIO_FLOW>/Executions/FN304b09128a4f089b8c57a7e3f7cb2221/Context",
+        "execution_sid": "FN304b09128a4f089b8c57a7e3f7cb2221", "flow_sid": "<TWILLIO_STUDIO_FLOW>",
+        "context": {"widgets": {"send_message_1": {"outbound": {"Status": "accepted",
+        "ErrorCode": null, "Direction": "outbound-api", "ErrorMessage": null, "From":
+        null, "DateSent": null, "PriceUnit": null, "Price": null, "Sid": "SM0504ca8539b04a23b9fbd4d9c01849e0",
+        "MessagingServiceSid": "<TWILLIO_MESSAGING_SERVICE_SID>", "Body": "Merci d''avoir
+        rempli votre rapport quotidien!", "ApiVersion": "2010-04-01", "DateCreated":
+        "2021-01-26T22:40:56Z", "SubresourceUris": {"media": "/2010-04-01/Accounts/<TWILLIO_API_ACCOUNT>/Messages/SM0504ca8539b04a23b9fbd4d9c01849e0/Media.json"},
+        "To": "+16035555555", "NumMedia": "0", "AccountSid": "<TWILLIO_API_ACCOUNT>",
+        "NumSegments": "0", "DateUpdated": "2021-01-26T22:40:56Z"}}, "send_assessment_data_no":
+        {"body": "", "status_code": 200, "content_type": "text/plain"}, "sms_or_voice":
+        {}, "sms_assessment_prompt": {"inbound": {"Body": "Non", "MessageSid": "SMb8b960f3109f60246dc8332014602b01",
+        "FromZip": "03301", "SmsStatus": "received", "SmsMessageSid": "SMb8b960f3109f60246dc8332014602b01",
+        "AccountSid": "<TWILLIO_API_ACCOUNT>", "MessagingServiceSid": "<TWILLIO_MESSAGING_SERVICE_SID>",
+        "FromCity": "CONCORD", "ApiVersion": "2010-04-01", "To": "<TWILLIO_SENDING_NUMBER>",
+        "From": "+16035555555", "NumMedia": "0", "ToZip": "38646", "ToCountry": "US",
+        "ToState": "MS", "NumSegments": "1", "SmsSid": "SMb8b960f3109f60246dc8332014602b01",
+        "ToCity": "MARKS", "FromState": "NH", "FromCountry": "US"}, "outbound": {"Status":
+        "accepted", "ErrorCode": null, "Direction": "outbound-api", "ErrorMessage":
+        null, "From": null, "DateSent": null, "PriceUnit": null, "Price": null, "Sid":
+        "SM515ea5ac5b7e4a3e93aeca0a3dfd45ff", "MessagingServiceSid": "<TWILLIO_MESSAGING_SERVICE_SID>",
+        "Body": "Il s\u2019agit d\u2019un rapport d\u2019alerte Sara quotidien destin\u00e9
+        aux: MG-66. Cette personne est-elle  y en a-t-il qui pr\u00e9sentent un des
+        sympt\u00f4mes suivants: Toux, Difficult\u00e9s respiratoires, Nouvelle perte
+        de l\u2019odorat, Nouvelle perte de go\u00fbt, Essoufflement, Fi\u00e8vre,
+        Frissons, Tremblements r\u00e9p\u00e9t\u00e9s accompagn\u00e9s de frissons,
+        Douleurs musculaires, Maux de t\u00eate, Maux de gorge, Naus\u00e9es ou vomissements,
+        Diarrh\u00e9e, Fatigue, Congestion nasale ou nez qui coule. Veuillez r\u00e9pondre
+        par \"Oui\" ou par \"Non\"", "ApiVersion": "2010-04-01", "DateCreated": "2021-01-26T22:40:28Z",
+        "SubresourceUris": {"media": "/2010-04-01/Accounts/<TWILLIO_API_ACCOUNT>/Messages/SM515ea5ac5b7e4a3e93aeca0a3dfd45ff/Media.json"},
+        "To": "+16035555555", "NumMedia": "0", "AccountSid": "<TWILLIO_API_ACCOUNT>",
+        "NumSegments": "0", "DateUpdated": "2021-01-26T22:40:28Z"}}, "OptOutTypeNotBlankReply":
+        {}, "check_yes_no": {}, "initialize_retry_count": {"retry_count": "0"}}, "trigger":
+        {"request": {"to": "+16035555555", "from": "<TWILLIO_MESSAGING_SERVICE_SID>",
+        "parameters": {"medium": "SMS", "prompt": "Il s\u2019agit d\u2019un rapport
+        d\u2019alerte Sara quotidien destin\u00e9 aux: MG-66. Cette personne est-elle  y
+        en a-t-il qui pr\u00e9sentent un des sympt\u00f4mes suivants: Toux, Difficult\u00e9s
+        respiratoires, Nouvelle perte de l\u2019odorat, Nouvelle perte de go\u00fbt,
+        Essoufflement, Fi\u00e8vre, Frissons, Tremblements r\u00e9p\u00e9t\u00e9s
+        accompagn\u00e9s de frissons, Douleurs musculaires, Maux de t\u00eate, Maux
+        de gorge, Naus\u00e9es ou vomissements, Diarrh\u00e9e, Fatigue, Congestion
+        nasale ou nez qui coule. Veuillez r\u00e9pondre par \"Oui\" ou par \"Non\"",
+        "language": "FR", "patient_submission_token": "dmHCpUHC-Q", "try_again": "Je
+        suis d\u00e9sol\u00e9, je n''ai pas compris. Veuillez r\u00e9pondre par \"Oui\"
+        ou par \"Non\"", "threshold_hash": "cd03cdd081fa6266ed4f55cada179ff2d67b90a239ec63b661f4e8c129f361f4",
+        "thanks": "Merci d''avoir rempli votre rapport quotidien!", "max_retries_message":
+        "Je suis d\u00e9sol\u00e9, vous avez atteint le nombre maximum de tentatives
+        de r\u00e9ponse. Si vous rencontrez une urgence m\u00e9dicale, veuillez appeler
+        le 911."}}}, "contact": {"channel": {"address": "+16035555555"}}, "flow":
+        {"variables": {"retry_count": "0"}, "data": {"medium": "SMS", "prompt": "Il
+        s\u2019agit d\u2019un rapport d\u2019alerte Sara quotidien destin\u00e9 aux:
+        MG-66. Cette personne est-elle  y en a-t-il qui pr\u00e9sentent un des sympt\u00f4mes
+        suivants: Toux, Difficult\u00e9s respiratoires, Nouvelle perte de l\u2019odorat,
+        Nouvelle perte de go\u00fbt, Essoufflement, Fi\u00e8vre, Frissons, Tremblements
+        r\u00e9p\u00e9t\u00e9s accompagn\u00e9s de frissons, Douleurs musculaires,
+        Maux de t\u00eate, Maux de gorge, Naus\u00e9es ou vomissements, Diarrh\u00e9e,
+        Fatigue, Congestion nasale ou nez qui coule. Veuillez r\u00e9pondre par \"Oui\"
+        ou par \"Non\"", "language": "FR", "patient_submission_token": "dmHCpUHC-Q",
+        "try_again": "Je suis d\u00e9sol\u00e9, je n''ai pas compris. Veuillez r\u00e9pondre
+        par \"Oui\" ou par \"Non\"", "threshold_hash": "cd03cdd081fa6266ed4f55cada179ff2d67b90a239ec63b661f4e8c129f361f4",
+        "thanks": "Merci d''avoir rempli votre rapport quotidien!", "max_retries_message":
+        "Je suis d\u00e9sol\u00e9, vous avez atteint le nombre maximum de tentatives
+        de r\u00e9ponse. Si vous rencontrez une urgence m\u00e9dicale, veuillez appeler
+        le 911."}, "flow_sid": "<TWILLIO_STUDIO_FLOW>", "channel": {"address": "<TWILLIO_MESSAGING_SERVICE_SID>"},
+        "sid": "FN304b09128a4f089b8c57a7e3f7cb2221"}}, "account_sid": "<TWILLIO_API_ACCOUNT>"}'
+  recorded_at: Tue, 26 Jan 2021 22:48:11 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/get_numbers_from_inbound_sms_trigger_execution.yml
+++ b/test/vcr_cassettes/get_numbers_from_inbound_sms_trigger_execution.yml
@@ -1,0 +1,77 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://studio.twilio.com/v1/Flows/<TWILLIO_STUDIO_FLOW>/Executions/FNc2b09bcf7ecaca4e33db739422281fcc/Context
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - twilio-ruby/5.45.1 (ruby/x86_64-darwin19 2.6.6-p146)
+      Accept-Charset:
+      - utf-8
+      Accept:
+      - application/json
+      Authorization:
+      - Basic QUM1ZGE3NDRhODdmNTM0MTgyZWNlZGJjMTljNDcyYTA2YjpmYTBmMTVlZjY1ZDA2YjliZTQzYzBkOTkyZTNkY2RkMw==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Jan 2021 22:09:01 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1252'
+      Connection:
+      - keep-alive
+      Twilio-Concurrent-Requests:
+      - '1'
+      Twilio-Request-Id:
+      - RQa6a78b64edf24440a525cb8bd68cddaf
+      Twilio-Request-Duration:
+      - '0.030'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match,
+        If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, OPTIONS
+      Access-Control-Expose-Headers:
+      - ETag
+      Access-Control-Allow-Credentials:
+      - 'true'
+      X-Powered-By:
+      - AT-5000
+      X-Shenanigans:
+      - none
+      X-Home-Region:
+      - us1
+      X-Api-Domain:
+      - studio.twilio.com
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '{"url": "https://studio.twilio.com/v1/Flows/<TWILLIO_STUDIO_FLOW>/Executions/FNc2b09bcf7ecaca4e33db739422281fcc/Context",
+        "execution_sid": "FNc2b09bcf7ecaca4e33db739422281fcc", "flow_sid": "<TWILLIO_STUDIO_FLOW>",
+        "context": {"widgets": {"OptOutTypeNotBlank": {}, "PostOptOutInfoSTOP": {"body":
+        "", "status_code": 200, "content_type": "text/plain"}}, "trigger": {"message":
+        {"Body": "STOP", "MessageSid": "SMc866b5bd01c0d18ab53010f7a7dbc189", "FromZip":
+        "03301", "OptOutType": "STOP", "SmsStatus": "received", "SmsMessageSid": "SMc866b5bd01c0d18ab53010f7a7dbc189",
+        "AccountSid": "<TWILLIO_API_ACCOUNT>", "MessagingServiceSid": "<TWILLIO_MESSAGING_SERVICE_SID>",
+        "FromCity": "CONCORD", "ApiVersion": "2010-04-01", "To": "<TWILLIO_SENDING_NUMBER>",
+        "From": "+16035555555", "NumMedia": "0", "ToZip": "38646", "ToCountry": "US",
+        "ToState": "MS", "NumSegments": "1", "SmsSid": "SMc866b5bd01c0d18ab53010f7a7dbc189",
+        "ToCity": "MARKS", "FromState": "NH", "FromCountry": "US"}}, "contact": {"channel":
+        {"address": "+16035555555"}}, "flow": {"flow_sid": "<TWILLIO_STUDIO_FLOW>",
+        "channel": {"address": "<TWILLIO_SENDING_NUMBER>"}, "sid": "FNc2b09bcf7ecaca4e33db739422281fcc"}},
+        "account_sid": "<TWILLIO_API_ACCOUNT>"}'
+  recorded_at: Tue, 26 Jan 2021 22:09:01 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/get_numbers_from_inbound_voice_trigger_execution.yml
+++ b/test/vcr_cassettes/get_numbers_from_inbound_voice_trigger_execution.yml
@@ -1,0 +1,84 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://studio.twilio.com/v1/Flows/<TWILLIO_STUDIO_FLOW>/Executions/FN24eda0b89122c73e93e3d59431e9a52a/Context
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - twilio-ruby/5.45.1 (ruby/x86_64-darwin19 2.6.6-p146)
+      Accept-Charset:
+      - utf-8
+      Accept:
+      - application/json
+      Authorization:
+      - Basic QUM1ZGE3NDRhODdmNTM0MTgyZWNlZGJjMTljNDcyYTA2YjpmYTBmMTVlZjY1ZDA2YjliZTQzYzBkOTkyZTNkY2RkMw==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Jan 2021 23:18:10 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1820'
+      Connection:
+      - keep-alive
+      Twilio-Concurrent-Requests:
+      - '1'
+      Twilio-Request-Id:
+      - RQacca98836a1e45e49601bb55a028e639
+      Twilio-Request-Duration:
+      - '0.041'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match,
+        If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, OPTIONS
+      Access-Control-Expose-Headers:
+      - ETag
+      Access-Control-Allow-Credentials:
+      - 'true'
+      X-Powered-By:
+      - AT-5000
+      X-Shenanigans:
+      - none
+      X-Home-Region:
+      - us1
+      X-Api-Domain:
+      - studio.twilio.com
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '{"url": "https://studio.twilio.com/v1/Flows/<TWILLIO_STUDIO_FLOW>/Executions/FN24eda0b89122c73e93e3d59431e9a52a/Context",
+        "execution_sid": "FN24eda0b89122c73e93e3d59431e9a52a", "flow_sid": "<TWILLIO_STUDIO_FLOW>",
+        "context": {"widgets": {"say_incoming_call": {"FromZip": "03301", "From":
+        "+16035555555", "FlowEvent": "audioComplete", "FromCity": "CONCORD", "ApiVersion":
+        "2010-04-01", "To": "<TWILLIO_SENDING_NUMBER>", "ToCity": "MARKS", "CalledState":
+        "MS", "FromState": "NH", "Direction": "inbound", "CallStatus": "in-progress",
+        "ToZip": "38646", "CallerCity": "CONCORD", "FromCountry": "US", "CalledCity":
+        "MARKS", "CalledCountry": "US", "Caller": "+16035555555", "CallerZip": "03301",
+        "AccountSid": "<TWILLIO_API_ACCOUNT>", "Called": "<TWILLIO_SENDING_NUMBER>",
+        "CallerCountry": "US", "CalledZip": "38646", "CallSid": "CA6068e2534436980bc16c2e706afc11fd",
+        "CallerState": "NH", "ToCountry": "US", "ToState": "MS"}}, "trigger": {"call":
+        {"FromZip": "03301", "From": "+16035555555", "FromCity": "CONCORD", "ApiVersion":
+        "2010-04-01", "To": "<TWILLIO_SENDING_NUMBER>", "ToCity": "MARKS", "CalledState":
+        "MS", "FromState": "NH", "Direction": "inbound", "CallerZip": "03301", "CallStatus":
+        "ringing", "ToZip": "38646", "CallerCity": "CONCORD", "FromCountry": "US",
+        "CalledCity": "MARKS", "CalledCountry": "US", "Caller": "+16035555555", "CallerState":
+        "NH", "AccountSid": "<TWILLIO_API_ACCOUNT>", "Called": "<TWILLIO_SENDING_NUMBER>",
+        "CallerCountry": "US", "CalledZip": "38646", "CallSid": "CA6068e2534436980bc16c2e706afc11fd",
+        "ToCountry": "US", "ToState": "MS"}}, "contact": {"channel": {"address": "+16035555555"}},
+        "flow": {"flow_sid": "<TWILLIO_STUDIO_FLOW>", "channel": {"address": "<TWILLIO_SENDING_NUMBER>"},
+        "sid": "FN24eda0b89122c73e93e3d59431e9a52a"}}, "account_sid": "<TWILLIO_API_ACCOUNT>"}'
+  recorded_at: Tue, 26 Jan 2021 23:18:10 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/get_numbers_from_single_message_execution.yml
+++ b/test/vcr_cassettes/get_numbers_from_single_message_execution.yml
@@ -1,0 +1,93 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://studio.twilio.com/v1/Flows/<TWILLIO_STUDIO_FLOW>/Executions/FNf9193a1e62d1333a20a84ef183e751df/Context
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - twilio-ruby/5.45.1 (ruby/x86_64-darwin19 2.6.6-p146)
+      Accept-Charset:
+      - utf-8
+      Accept:
+      - application/json
+      Authorization:
+      - Basic QUM1ZGE3NDRhODdmNTM0MTgyZWNlZGJjMTljNDcyYTA2YjpmYTBmMTVlZjY1ZDA2YjliZTQzYzBkOTkyZTNkY2RkMw==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Jan 2021 20:54:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2626'
+      Connection:
+      - keep-alive
+      Twilio-Concurrent-Requests:
+      - '1'
+      Twilio-Request-Id:
+      - RQ07c6ba0ad8604c69a6942af863207a7f
+      Twilio-Request-Duration:
+      - '0.022'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match,
+        If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, OPTIONS
+      Access-Control-Expose-Headers:
+      - ETag
+      Access-Control-Allow-Credentials:
+      - 'true'
+      X-Powered-By:
+      - AT-5000
+      X-Shenanigans:
+      - none
+      X-Home-Region:
+      - us1
+      X-Api-Domain:
+      - studio.twilio.com
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '{"url": "https://studio.twilio.com/v1/Flows/<TWILLIO_STUDIO_FLOW>/Executions/FNf9193a1e62d1333a20a84ef183e751df/Context",
+        "execution_sid": "FNf9193a1e62d1333a20a84ef183e751df", "flow_sid": "<TWILLIO_STUDIO_FLOW>",
+        "context": {"widgets": {"send_single_message": {"MessageSid": "SM5a3e4eba25ba4aa4beff811a961f4383",
+        "SmsStatus": "failed", "MessagingServiceSid": "<TWILLIO_MESSAGING_SERVICE_SID>",
+        "ApiVersion": "2010-04-01", "ErrorCode": "21610", "To": "+16035555555", "From":
+        "<TWILLIO_SENDING_NUMBER>", "MessageStatus": "failed", "AccountSid": "<TWILLIO_API_ACCOUNT>",
+        "outbound": {"Status": "accepted", "ErrorCode": null, "Direction": "outbound-api",
+        "ErrorMessage": null, "From": null, "DateSent": null, "PriceUnit": null, "Price":
+        null, "Sid": "SM5a3e4eba25ba4aa4beff811a961f4383", "MessagingServiceSid":
+        "<TWILLIO_MESSAGING_SERVICE_SID>", "Body": "Veuillez remplir le rapport quotidien
+        de Sara Alert pour MG-66: http://localhost:3000/r/dmHCpUHC-Q/Z2tPR1o1a1/fr/MG66",
+        "ApiVersion": "2010-04-01", "DateCreated": "2021-01-26T18:52:32Z", "SubresourceUris":
+        {"media": "/2010-04-01/Accounts/<TWILLIO_API_ACCOUNT>/Messages/SM5a3e4eba25ba4aa4beff811a961f4383/Media.json"},
+        "To": "+16035555555", "NumMedia": "0", "AccountSid": "<TWILLIO_API_ACCOUNT>",
+        "NumSegments": "0", "DateUpdated": "2021-01-26T18:52:32Z"}, "executionSid":
+        "FNf9193a1e62d1333a20a84ef183e751df", "SmsSid": "SM5a3e4eba25ba4aa4beff811a961f4383"},
+        "send_single_message_error": {"body": "", "status_code": 200, "content_type":
+        "text/plain"}, "sms_or_voice": {}, "initialize_retry_count": {"retry_count":
+        "0"}}, "trigger": {"request": {"to": "+16035555555", "from": "<TWILLIO_MESSAGING_SERVICE_SID>",
+        "parameters": {"patient_submission_token": "dmHCpUHC-Q", "threshold_hash":
+        "cd03cdd081fa6266ed4f55cada179ff2d67b90a239ec63b661f4e8c129f361f4", "medium":
+        "SINGLE_SMS", "prompt": "Veuillez remplir le rapport quotidien de Sara Alert
+        pour MG-66: http://localhost:3000/r/dmHCpUHC-Q/Z2tPR1o1a1/fr/MG66"}}}, "contact":
+        {"channel": {"address": "+16035555555"}}, "flow": {"variables": {"retry_count":
+        "0"}, "data": {"patient_submission_token": "dmHCpUHC-Q", "threshold_hash":
+        "cd03cdd081fa6266ed4f55cada179ff2d67b90a239ec63b661f4e8c129f361f4", "medium":
+        "SINGLE_SMS", "prompt": "Veuillez remplir le rapport quotidien de Sara Alert
+        pour MG-66: http://localhost:3000/r/dmHCpUHC-Q/Z2tPR1o1a1/fr/MG66"}, "flow_sid":
+        "<TWILLIO_STUDIO_FLOW>", "channel": {"address": "<TWILLIO_MESSAGING_SERVICE_SID>"},
+        "sid": "FNf9193a1e62d1333a20a84ef183e751df"}}, "account_sid": "<TWILLIO_API_ACCOUNT>"}'
+  recorded_at: Tue, 26 Jan 2021 20:54:29 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_cassettes/get_numbers_from_voice_assessment_execution.yml
+++ b/test/vcr_cassettes/get_numbers_from_voice_assessment_execution.yml
@@ -1,0 +1,146 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://studio.twilio.com/v1/Flows/<TWILLIO_STUDIO_FLOW>/Executions/FNce1d126c3ed0508a15ba965e4f7197dc/Context
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - twilio-ruby/5.45.1 (ruby/x86_64-darwin19 2.6.6-p146)
+      Accept-Charset:
+      - utf-8
+      Accept:
+      - application/json
+      Authorization:
+      - Basic QUM1ZGE3NDRhODdmNTM0MTgyZWNlZGJjMTljNDcyYTA2YjpmYTBmMTVlZjY1ZDA2YjliZTQzYzBkOTkyZTNkY2RkMw==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Jan 2021 21:57:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '6727'
+      Connection:
+      - keep-alive
+      Twilio-Concurrent-Requests:
+      - '1'
+      Twilio-Request-Id:
+      - RQ650973ae0eac46d4969b33284a284a73
+      Twilio-Request-Duration:
+      - '0.030'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Headers:
+      - Accept, Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match,
+        If-Unmodified-Since
+      Access-Control-Allow-Methods:
+      - GET, POST, DELETE, OPTIONS
+      Access-Control-Expose-Headers:
+      - ETag
+      Access-Control-Allow-Credentials:
+      - 'true'
+      X-Powered-By:
+      - AT-5000
+      X-Shenanigans:
+      - none
+      X-Home-Region:
+      - us1
+      X-Api-Domain:
+      - studio.twilio.com
+      Strict-Transport-Security:
+      - max-age=31536000
+    body:
+      encoding: UTF-8
+      string: '{"url": "https://studio.twilio.com/v1/Flows/<TWILLIO_STUDIO_FLOW>/Executions/FNce1d126c3ed0508a15ba965e4f7197dc/Context",
+        "execution_sid": "FNce1d126c3ed0508a15ba965e4f7197dc", "flow_sid": "<TWILLIO_STUDIO_FLOW>",
+        "context": {"widgets": {"set_language_FR": {"voice": "Polly.Chantal", "language":
+        "fr-CA"}, "set_language_voice_options": {}, "call_user": {"FromZip": "38646",
+        "From": "<TWILLIO_SENDING_NUMBER>", "FromCity": "MARKS", "ApiVersion": "2010-04-01",
+        "To": "+16035555555", "ToCity": "CONCORD", "CalledState": "NH", "FromState":
+        "MS", "Direction": "outbound-api", "CallStatus": "in-progress", "ToZip": "03301",
+        "CallerCity": "MARKS", "FromCountry": "US", "CalledCity": "CONCORD", "CalledCountry":
+        "US", "Caller": "<TWILLIO_SENDING_NUMBER>", "CallerZip": "38646", "MachineDetectionDuration":
+        "3952", "AccountSid": "<TWILLIO_API_ACCOUNT>", "Called": "+16035555555", "CallerCountry":
+        "US", "CalledZip": "03301", "CallSid": "CAced6df5f5aa6d1f1853923004b763a50",
+        "AnsweredBy": "human", "CallerState": "MS", "ToCountry": "US", "ToState":
+        "NH"}, "voice_send_assessment_yes": {"body": "{\"success\":false,\"error\":{\"message\":\"Too
+        many requests, please create a new URL\\/token\",\"id\":null}}", "status_code":
+        410, "parsed": {"success": false, "error": {"message": "Too many requests,
+        please create a new URL/token", "id": null}}, "content_type": "application/json"},
+        "split_on_retry_en": {}, "welcome_prompt": {"FromZip": "38646", "From": "<TWILLIO_SENDING_NUMBER>",
+        "FlowEvent": "audioComplete", "FromCity": "MARKS", "ApiVersion": "2010-04-01",
+        "To": "+16035555555", "ToCity": "CONCORD", "CalledState": "NH", "FromState":
+        "MS", "Direction": "outbound-api", "CallStatus": "in-progress", "ToZip": "03301",
+        "CallerCity": "MARKS", "FromCountry": "US", "CalledCity": "CONCORD", "CalledCountry":
+        "US", "Caller": "<TWILLIO_SENDING_NUMBER>", "CallerZip": "38646", "MachineDetectionDuration":
+        "3952", "AccountSid": "<TWILLIO_API_ACCOUNT>", "Called": "+16035555555", "CallerCountry":
+        "US", "CalledZip": "03301", "CallSid": "CAced6df5f5aa6d1f1853923004b763a50",
+        "AnsweredBy": "human", "CallerState": "MS", "ToCountry": "US", "ToState":
+        "NH"}, "sms_or_voice": {}, "voice_reply_to_prompt": {"Confidence": "0.91833675",
+        "From": "<TWILLIO_SENDING_NUMBER>", "FlowEvent": "timeout", "FromCity": "MARKS",
+        "ApiVersion": "2010-04-01", "To": "+16035555555", "SpeechResult": "oui", "CallStatus":
+        "in-progress", "CalledState": "NH", "FromState": "MS", "Direction": "outbound-api",
+        "FromZip": "38646", "ToCity": "CONCORD", "ToZip": "03301", "CallerCity": "MARKS",
+        "FromCountry": "US", "Language": "fr-CA", "CalledCity": "CONCORD", "CalledCountry":
+        "US", "Caller": "<TWILLIO_SENDING_NUMBER>", "CallerZip": "38646", "MachineDetectionDuration":
+        "3952", "AccountSid": "<TWILLIO_API_ACCOUNT>", "Called": "+16035555555", "CallerCountry":
+        "US", "CalledZip": "03301", "CallSid": "CAced6df5f5aa6d1f1853923004b763a50",
+        "AnsweredBy": "human", "CallerState": "MS", "ToCountry": "US", "ToState":
+        "NH"}, "check_yes_no_voice": {}, "say_lets_try_again": {"FromZip": "38646",
+        "From": "<TWILLIO_SENDING_NUMBER>", "FlowEvent": "audioComplete", "FromCity":
+        "MARKS", "ApiVersion": "2010-04-01", "To": "+16035555555", "ToCity": "CONCORD",
+        "CalledState": "NH", "FromState": "MS", "Direction": "outbound-api", "CallStatus":
+        "in-progress", "ToZip": "03301", "CallerCity": "MARKS", "FromCountry": "US",
+        "CalledCity": "CONCORD", "CalledCountry": "US", "Caller": "<TWILLIO_SENDING_NUMBER>",
+        "CallerZip": "38646", "MachineDetectionDuration": "3952", "AccountSid": "<TWILLIO_API_ACCOUNT>",
+        "Called": "+16035555555", "CallerCountry": "US", "CalledZip": "03301", "CallSid":
+        "CAced6df5f5aa6d1f1853923004b763a50", "AnsweredBy": "human", "CallerState":
+        "MS", "ToCountry": "US", "ToState": "NH"}, "split_1": {}, "increment_retry_count_en":
+        {"retry_count": "3"}, "initialize_retry_count": {"retry_count": "0"}}, "trigger":
+        {"request": {"to": "+16035555555", "from": "<TWILLIO_SENDING_NUMBER>", "parameters":
+        {"medium": "VOICE", "prompt": " Il s\u2019agit d\u2019un rapport d\u2019alerte
+        Sara quotidien destin\u00e9 aux: M, G, \u00e2ge 66, Cette personne est-elle  y
+        en a-t-il qui pr\u00e9sentent un des sympt\u00f4mes suivants Toux, Difficult\u00e9s
+        respiratoires, Nouvelle perte de l\u2019odorat, Nouvelle perte de go\u00fbt,
+        Essoufflement, Fi\u00e8vre, Frissons, Tremblements r\u00e9p\u00e9t\u00e9s
+        accompagn\u00e9s de frissons, Douleurs musculaires, Maux de t\u00eate, Maux
+        de gorge, Naus\u00e9es ou vomissements, Diarrh\u00e9e, Fatigue, Congestion
+        nasale ou nez qui coule? Veuillez r\u00e9pondre par \"Oui\" ou par \"Non\"",
+        "language": "FR", "patient_submission_token": "dmHCpUHC-Q", "try_again": "Je
+        suis d\u00e9sol\u00e9, je n''ai pas compris. Essayons encore.", "threshold_hash":
+        "cd03cdd081fa6266ed4f55cada179ff2d67b90a239ec63b661f4e8c129f361f4", "intro":
+        "Bonjour, voici Sara, l''assistante de sant\u00e9 publique automatis\u00e9e
+        qui demande votre rapport quotidien.", "thanks": "Merci d''avoir rempli votre
+        rapport quotidien! Au revoir.", "max_retries_message": "Je suis d\u00e9sol\u00e9,
+        vous avez atteint le nombre maximum de tentatives de r\u00e9ponse. Si vous
+        rencontrez une urgence m\u00e9dicale, veuillez appeler le 911."}}}, "contact":
+        {"channel": {"address": "+16035555555"}}, "flow": {"variables": {"retry_count":
+        "3", "voice": "Polly.Chantal", "language": "fr-CA"}, "data": {"medium": "VOICE",
+        "prompt": " Il s\u2019agit d\u2019un rapport d\u2019alerte Sara quotidien
+        destin\u00e9 aux: M, G, \u00e2ge 66, Cette personne est-elle  y en a-t-il
+        qui pr\u00e9sentent un des sympt\u00f4mes suivants Toux, Difficult\u00e9s
+        respiratoires, Nouvelle perte de l\u2019odorat, Nouvelle perte de go\u00fbt,
+        Essoufflement, Fi\u00e8vre, Frissons, Tremblements r\u00e9p\u00e9t\u00e9s
+        accompagn\u00e9s de frissons, Douleurs musculaires, Maux de t\u00eate, Maux
+        de gorge, Naus\u00e9es ou vomissements, Diarrh\u00e9e, Fatigue, Congestion
+        nasale ou nez qui coule? Veuillez r\u00e9pondre par \"Oui\" ou par \"Non\"",
+        "language": "FR", "patient_submission_token": "dmHCpUHC-Q", "try_again": "Je
+        suis d\u00e9sol\u00e9, je n''ai pas compris. Essayons encore.", "threshold_hash":
+        "cd03cdd081fa6266ed4f55cada179ff2d67b90a239ec63b661f4e8c129f361f4", "intro":
+        "Bonjour, voici Sara, l''assistante de sant\u00e9 publique automatis\u00e9e
+        qui demande votre rapport quotidien.", "thanks": "Merci d''avoir rempli votre
+        rapport quotidien! Au revoir.", "max_retries_message": "Je suis d\u00e9sol\u00e9,
+        vous avez atteint le nombre maximum de tentatives de r\u00e9ponse. Si vous
+        rencontrez une urgence m\u00e9dicale, veuillez appeler le 911."}, "flow_sid":
+        "<TWILLIO_STUDIO_FLOW>", "channel": {"address": "<TWILLIO_SENDING_NUMBER>"},
+        "sid": "FNce1d126c3ed0508a15ba965e4f7197dc"}}, "account_sid": "<TWILLIO_API_ACCOUNT>"}'
+  recorded_at: Tue, 26 Jan 2021 21:57:55 GMT
+recorded_with: VCR 6.0.0

--- a/test/vcr_setup.rb
+++ b/test/vcr_setup.rb
@@ -14,11 +14,11 @@ VCR.configure do |c|
   # be provided at every run of the rake tests, provide the following credentials
   # whenever you need to record a cassette that requires valid credentials
   # these should be stored in your local_env.yml file anyhow
-  ENV['TWILLIO_STUDIO_FLOW'] = 'test_studio_flow' unless ENV['TWILLIO_STUDIO_FLOW']
-  ENV['TWILLIO_MESSAGING_SERVICE_SID'] = 'test_msg_service' unless ENV['TWILLIO_MESSAGING_SERVICE_SID']
-  ENV['TWILLIO_SENDING_NUMBER'] = '+15555555555' unless ENV['TWILLIO_SENDING_NUMBER']
-  ENV['TWILLIO_API_ACCOUNT'] =  'test_api_account' unless ENV['TWILLIO_API_ACCOUNT']
-  ENV['TWILLIO_API_KEY'] = 'test_api_key' unless ENV['TWILLIO_API_KEY']
+  ENV['TWILLIO_STUDIO_FLOW'] |= 'test_studio_flow'
+  ENV['TWILLIO_MESSAGING_SERVICE_SID'] |= 'test_msg_service'
+  ENV['TWILLIO_SENDING_NUMBER'] |= '+15555555555'
+  ENV['TWILLIO_API_ACCOUNT'] |= 'test_api_account'
+  ENV['TWILLIO_API_KEY'] |= 'test_api_key'
 
   # Ensure plain text credentials do not show up during logging
   c.filter_sensitive_data('<TWILLIO_STUDIO_FLOW>') { ENV['TWILLIO_STUDIO_FLOW'] }

--- a/test/vcr_setup.rb
+++ b/test/vcr_setup.rb
@@ -14,11 +14,11 @@ VCR.configure do |c|
   # be provided at every run of the rake tests, provide the following credentials
   # whenever you need to record a cassette that requires valid credentials
   # these should be stored in your local_env.yml file anyhow
-  ENV['TWILLIO_STUDIO_FLOW'] |= 'test_studio_flow'
-  ENV['TWILLIO_MESSAGING_SERVICE_SID'] |= 'test_msg_service'
-  ENV['TWILLIO_SENDING_NUMBER'] |= '+15555555555'
-  ENV['TWILLIO_API_ACCOUNT'] |= 'test_api_account'
-  ENV['TWILLIO_API_KEY'] |= 'test_api_key'
+  ENV['TWILLIO_STUDIO_FLOW'] = 'test_studio_flow' unless ENV['TWILLIO_STUDIO_FLOW']
+  ENV['TWILLIO_MESSAGING_SERVICE_SID'] = 'test_msg_service' unless ENV['TWILLIO_MESSAGING_SERVICE_SID']
+  ENV['TWILLIO_SENDING_NUMBER'] = '+15555555555' unless ENV['TWILLIO_SENDING_NUMBER']
+  ENV['TWILLIO_API_ACCOUNT'] =  'test_api_account' unless ENV['TWILLIO_API_ACCOUNT']
+  ENV['TWILLIO_API_KEY'] = 'test_api_key' unless ENV['TWILLIO_API_KEY']
 
   # Ensure plain text credentials do not show up during logging
   c.filter_sensitive_data('<TWILLIO_STUDIO_FLOW>') { ENV['TWILLIO_STUDIO_FLOW'] }

--- a/test/vcr_setup.rb
+++ b/test/vcr_setup.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'vcr'
+# VCR records HTTP interactions to cassettes that can be replayed during unit tests
+# allowing for faster, more predictible web interactions
+VCR.configure do |c|
+  # This is where the various cassettes will be recorded to
+  c.cassette_library_dir = 'test/vcr_cassettes'
+  # This permits non-VCR webmock requests in other tests
+  c.allow_http_connections_when_no_cassette = true
+  c.hook_into :webmock
+
+  # To avoid storing plain text Twilio API keys or requiring the keys
+  # be provided at every run of the rake tests, provide the following credentials
+  # whenever you need to record a cassette that requires valid credentials
+  # these should be stored in your local_env.yml file anyhow
+  ENV['TWILLIO_STUDIO_FLOW'] = 'test_studio_flow' unless ENV['TWILLIO_STUDIO_FLOW']
+  ENV['TWILLIO_MESSAGING_SERVICE_SID'] = 'test_msg_service' unless ENV['TWILLIO_MESSAGING_SERVICE_SID']
+  ENV['TWILLIO_SENDING_NUMBER'] = '+15555555555' unless ENV['TWILLIO_SENDING_NUMBER']
+  ENV['TWILLIO_API_ACCOUNT'] =  'test_api_account' unless ENV['TWILLIO_API_ACCOUNT']
+  ENV['TWILLIO_API_KEY'] = 'test_api_key' unless ENV['TWILLIO_API_KEY']
+
+  # Ensure plain text credentials do not show up during logging
+  c.filter_sensitive_data('<TWILLIO_STUDIO_FLOW>') { ENV['TWILLIO_STUDIO_FLOW'] }
+  c.filter_sensitive_data('<TWILLIO_MESSAGING_SERVICE_SID>') { ENV['TWILLIO_MESSAGING_SERVICE_SID'] }
+  c.filter_sensitive_data('<TWILLIO_SENDING_NUMBER>') { ENV['TWILLIO_SENDING_NUMBER'] }
+  c.filter_sensitive_data('<TWILLIO_API_ACCOUNT>') { ENV['TWILLIO_API_ACCOUNT'] }
+  c.filter_sensitive_data('<TWILLIO_API_KEY>') { ENV['TWILLIO_API_KEY'] }
+  c.default_cassette_options = { record: :once }
+end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1121 ](https://tracker.codev.mitre.org/browse/SARAALERT-1121)[SARAALERT-1156](https://tracker.codev.mitre.org/browse/SARAALERT-1156)

This PR enables detailed history items in the event of errored communications through Twilio.

1. All SMS messages will now be dispatched through the Studio Flow.
2. When any SMS (or call) fails to send in the studio flow we will post back to our report endpoint with an included `error_code` parameter.
3. When the consume assessments job sees that an error coded was included, history items will be added to the appropriate monitorees indicating how/why the communication failed.
4. As part of this PR SARAALERT-1121 is addressed which ensures that both the HoH and monitoree get error/success history item messages regardless of if the HoH is being actively monitored themselves or not.
5. This PR introduces the VCR gem so that we can better test functionality that relies on HTTP interactions with the Twilio API eg: `get_phone_numbers_from_flow_execution`


# (Bugfix) Solution
To test this locally, you'll have to use the test messaging service and the test studio flow. Reach out to me if you don't have the resource IDs for these in your environment variables.


# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
