### PR TITLE
SARAALERT-1276: Support Continuous Exposure in the API

### DIFF
--- a/app/helpers/fhir_helper.rb
+++ b/app/helpers/fhir_helper.rb
@@ -142,7 +142,7 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
       symptom_onset: symptom_onset,
       user_defined_symptom_onset: !symptom_onset.nil?,
       last_date_of_exposure: from_date_extension(patient, %w[last-date-of-exposure last-exposure-date]),
-      isolation: from_bool_extension(patient, 'isolation'),
+      isolation: from_default_false_bool_extension(patient, 'isolation'),
       jurisdiction_id: from_full_assigned_jurisdiction_path_extension(patient, default_jurisdiction_id),
       monitoring_plan: from_string_extension(patient, 'monitoring-plan'),
       assigned_user: from_positive_integer_extension(patient, 'assigned-user'),
@@ -158,7 +158,7 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
       primary_telephone_type: from_primary_phone_type_extension(patient),
       secondary_telephone_type: from_secondary_phone_type_extension(patient),
       user_defined_id_statelocal: from_statelocal_id_extension(patient),
-      continuous_exposure: from_bool_extension(patient, 'continuous-exposure')
+      continuous_exposure: from_default_false_bool_extension(patient, 'continuous-exposure')
     }
   end
 
@@ -264,9 +264,10 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
     PatientHelper.languages(language&.downcase) ? FHIR::Coding.new(**PatientHelper.languages(language&.downcase)) : nil
   end
 
-  # Helper to understand an extension for isolation status
-  def from_bool_extension(patient, extension_id)
-    patient&.extension&.select { |e| e.url.include?(extension_id) }&.first&.valueBoolean == true
+  # Helper to understand a boolean extension which defaults to false
+  # NOTE: This function should only be used on fields for which nil/null is equivalent to false
+  def from_default_false_bool_extension(patient, extension_id)
+    patient&.extension&.find { |e| e.url.include?(extension_id) }&.valueBoolean == true
   end
 
   def to_bool_extension(value, extension_id)

--- a/app/helpers/fhir_helper.rb
+++ b/app/helpers/fhir_helper.rb
@@ -87,7 +87,8 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
         to_date_extension(patient.date_of_arrival, 'date-of-arrival'),
         to_string_extension(patient.exposure_notes, 'exposure-notes'),
         to_string_extension(patient.travel_related_notes, 'travel-related-notes'),
-        to_string_extension(patient.additional_planned_travel_related_notes, 'additional-planned-travel-notes')
+        to_string_extension(patient.additional_planned_travel_related_notes, 'additional-planned-travel-notes'),
+        to_bool_extension(patient.continuous_exposure, 'continuous-exposure')
       ].reject(&:nil?)
     )
   end
@@ -141,7 +142,7 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
       symptom_onset: symptom_onset,
       user_defined_symptom_onset: !symptom_onset.nil?,
       last_date_of_exposure: from_date_extension(patient, %w[last-date-of-exposure last-exposure-date]),
-      isolation: from_isolation_extension(patient),
+      isolation: from_bool_extension(patient, 'isolation'),
       jurisdiction_id: from_full_assigned_jurisdiction_path_extension(patient, default_jurisdiction_id),
       monitoring_plan: from_string_extension(patient, 'monitoring-plan'),
       assigned_user: from_positive_integer_extension(patient, 'assigned-user'),
@@ -156,7 +157,8 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
       additional_planned_travel_related_notes: from_string_extension(patient, 'additional-planned-travel-notes'),
       primary_telephone_type: from_primary_phone_type_extension(patient),
       secondary_telephone_type: from_secondary_phone_type_extension(patient),
-      user_defined_id_statelocal: from_statelocal_id_extension(patient)
+      user_defined_id_statelocal: from_statelocal_id_extension(patient),
+      continuous_exposure: from_bool_extension(patient, 'continuous-exposure')
     }
   end
 
@@ -263,8 +265,8 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
   end
 
   # Helper to understand an extension for isolation status
-  def from_isolation_extension(patient)
-    patient&.extension&.select { |e| e.url.include?('isolation') }&.first&.valueBoolean == true
+  def from_bool_extension(patient, extension_id)
+    patient&.extension&.select { |e| e.url.include?(extension_id) }&.first&.valueBoolean == true
   end
 
   def to_bool_extension(value, extension_id)

--- a/app/helpers/fhir_helper.rb
+++ b/app/helpers/fhir_helper.rb
@@ -142,7 +142,7 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
       symptom_onset: symptom_onset,
       user_defined_symptom_onset: !symptom_onset.nil?,
       last_date_of_exposure: from_date_extension(patient, %w[last-date-of-exposure last-exposure-date]),
-      isolation: from_default_false_bool_extension(patient, 'isolation'),
+      isolation: from_bool_extension(patient, 'isolation') || false,
       jurisdiction_id: from_full_assigned_jurisdiction_path_extension(patient, default_jurisdiction_id),
       monitoring_plan: from_string_extension(patient, 'monitoring-plan'),
       assigned_user: from_positive_integer_extension(patient, 'assigned-user'),
@@ -158,7 +158,7 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
       primary_telephone_type: from_primary_phone_type_extension(patient),
       secondary_telephone_type: from_secondary_phone_type_extension(patient),
       user_defined_id_statelocal: from_statelocal_id_extension(patient),
-      continuous_exposure: from_default_false_bool_extension(patient, 'continuous-exposure')
+      continuous_exposure: from_bool_extension(patient, 'continuous-exposure') || false
     }
   end
 
@@ -264,10 +264,9 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
     PatientHelper.languages(language&.downcase) ? FHIR::Coding.new(**PatientHelper.languages(language&.downcase)) : nil
   end
 
-  # Helper to understand a boolean extension which defaults to false
-  # NOTE: This function should only be used on fields for which nil/null is equivalent to false
-  def from_default_false_bool_extension(patient, extension_id)
-    patient&.extension&.find { |e| e.url.include?(extension_id) }&.valueBoolean == true
+  # Helper to understand a boolean extension
+  def from_bool_extension(patient, extension_id)
+    patient&.extension&.find { |e| e.url.include?(extension_id) }&.valueBoolean
   end
 
   def to_bool_extension(value, extension_id)

--- a/app/helpers/validation_helper.rb
+++ b/app/helpers/validation_helper.rb
@@ -186,7 +186,8 @@ module ValidationHelper # rubocop:todo Metrics/ModuleLength
     specimen_collection: { label: 'Lab Specimen Collection Date', checks: [:date] },
     report: { label: 'Lab Report Date', checks: [:date] },
     result: { label: 'Result', checks: [:enum] },
-    assigned_user: { label: 'Assigned User', checks: [] }
+    assigned_user: { label: 'Assigned User', checks: [] },
+    continuous_exposure: { label: 'Continuous Exposure', checks: [] }
   }.freeze
 
   def validate_date; end

--- a/app/helpers/validation_helper.rb
+++ b/app/helpers/validation_helper.rb
@@ -187,7 +187,7 @@ module ValidationHelper # rubocop:todo Metrics/ModuleLength
     report: { label: 'Lab Report Date', checks: [:date] },
     result: { label: 'Result', checks: [:enum] },
     assigned_user: { label: 'Assigned User', checks: [] },
-    continuous_exposure: { label: 'Continuous Exposure', checks: [] }
+    continuous_exposure: { label: 'Continuous Exposure', checks: [:bool] }
   }.freeze
 
   def validate_date; end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1072,7 +1072,7 @@ class Patient < ApplicationRecord
     patient_before = history_data[:patient_before]
     # NOTE: Attributes are sorted so that case_status always comes before isolation, since a case_status change may trigger
     # an isolation change from the front end, and the case_status message should come first
-    attribute_order = %i[case_status isolation]
+    attribute_order = %i[case_status isolation continuous_exposure last_date_of_exposure]
     history_data[:updates].keys.sort_by { |key| attribute_order.index(key) || Float::INFINITY }&.each do |attribute|
       updated_value = self[attribute]
       next if patient_before[attribute] == updated_value

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -178,7 +178,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     Patient.find_by(id: 2).update!(
       preferred_contact_method: 'SMS Texted Weblink',
       preferred_contact_time: 'Afternoon',
-      last_date_of_exposure: 4.days.ago,
       symptom_onset: 3.days.ago,
       isolation: true,
       primary_telephone: '+15555559999',
@@ -198,7 +197,8 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       secondary_telephone_type: 'Landline',
       black_or_african_american: true,
       asian: true,
-      continuous_exposure: true
+      continuous_exposure: true,
+      last_date_of_exposure: nil
     )
     @patient_2 = Patient.find_by(id: 2).as_fhir
 
@@ -925,7 +925,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Kirlin44', json_response['name'].first['family']
     assert_equal 'SMS Texted Weblink', json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-method' }.first['valueString']
     assert_equal 'Afternoon', json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-time' }.first['valueString']
-    assert_equal 4.days.ago.strftime('%Y-%m-%d'), json_response['extension'].filter { |e| e['url'].include? 'last-date-of-exposure' }.first['valueDate']
+    assert json_response['extension'].filter { |e| e['url'].include? 'continuous-exposure' }.first['valueBoolean']
     assert_equal 3.days.ago.strftime('%Y-%m-%d'), json_response['extension'].filter { |e| e['url'].include? 'symptom-onset-date' }.first['valueDate']
     assert p.user_defined_symptom_onset
     assert json_response['extension'].filter { |e| e['url'].include? 'isolation' }.first['valueBoolean']
@@ -974,7 +974,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       'birthDate' => @patient_2.birthDate,
       'name' => @patient_2.name,
       'address' => @patient_2.address,
-      'extension' => @patient_2.extension.find { |e| e.url.include? 'last-date-of-exposure' },
+      'extension' => @patient_1.extension.find { |e| e.url.include? 'last-date-of-exposure' },
       'active' => false,
       'resourceType' => 'Patient'
     }
@@ -1004,7 +1004,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       'birthDate' => @patient_2.birthDate,
       'name' => @patient_2.name,
       'address' => @patient_2.address,
-      'extension' => @patient_2.extension.find { |e| e.url.include? 'last-date-of-exposure' },
+      'extension' => @patient_1.extension.find { |e| e.url.include? 'last-date-of-exposure' },
       'active' => false,
       'resourceType' => 'Patient',
       'telecom' => [

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -2058,22 +2058,46 @@ class PatientTest < ActiveSupport::TestCase
     assert patient.valid?
   end
 
-  test 'validates last_date_of_exposure is present when isolation is false in api context' do
+  test 'validates last_date_of_exposure is present when isolation and continuous_exposure are false in api context' do
     patient = valid_patient
 
     patient.isolation = true
+    patient.continuous_exposure = false
     patient.last_date_of_exposure = nil
     assert patient.valid?(:api)
 
     patient.isolation = false
+    patient.continuous_exposure = true
+    patient.last_date_of_exposure = nil
+    assert patient.valid?(:api)
+
+    patient.isolation = false
+    patient.continuous_exposure = false
     patient.last_date_of_exposure = Time.now - 1.day
     assert patient.valid?(:api)
 
     patient.isolation = false
+    patient.continuous_exposure = false
     patient.last_date_of_exposure = nil
     assert_not patient.valid?(:api)
     assert patient.valid?(:import)
     assert patient.valid?
+  end
+
+  test 'validates continuous_exposure is false when last_date_of_exposure is present' do
+    patient = valid_patient
+
+    patient.continuous_exposure = true
+    patient.last_date_of_exposure = nil
+    assert patient.valid?(:api)
+
+    patient.continuous_exposure = true
+    patient.last_date_of_exposure = ''
+    assert patient.valid?(:api)
+
+    patient.continuous_exposure = true
+    patient.last_date_of_exposure = Time.now - 1.day
+    assert_not patient.valid?(:api)
   end
 
   test 'ten_day_quarantine_candidates scope checks purged, monitoring, isolation, and continuous_exposure' do


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1276](https://tracker.codev.mitre.org/browse/SARAALERT-1276)

This PR implements support for reading/writing continuous exposure via the API. Additionally, it adds validation so that `continuous_exposure` and `last_date_of_exposure` cannot both be set. 

# Important Changes
`fhir_helper.rb`
- Add support for `continuous_exposure` in the `patient_from_fhir` and `patient_to_fhir` methods.

`patient.rb`
- Add validation on the Patient model (API context only) so that `continuous_exposure` and `last_date_of_exposure` are mutually exclusive.

# Testing
To test this, you can make API requests and verify:
- Reading and writing of `continuous_exposure` via the API
- An error is returned if both `continuous_exposure` and `last_date_of_exposure` are set
- `continuous_exposure` or `last_date_of_exposure` must be set if `isolation` is `false`.
- When `continuous_exposure` is changed via the UI, the History message for `continuous_exposure` is logged before the message for `last_date_of_exposure` (This was a minor fix unrelated to the other changes, just something I noticed and was easy to loop in).

# Notes
Here is the corresponding documentation PR: https://github.com/SaraAlert/saraalert-fhir-ig/pull/8.