### PR TITLE
SARAALERT-987: Set time zone offset correctly during DST

### DIFF
--- a/app/helpers/patient_helper.rb
+++ b/app/helpers/patient_helper.rb
@@ -30,17 +30,9 @@ module PatientHelper
   end
 
   def time_zone_offset_for_state(name)
-    # Grab state time zone information by name
-    state = states_with_time_zone_data[normalize_name(name)]
-
-    # Grab time zone offset
-    offset = state.nil? ? -4 : state[:offset]
-
-    # Adjust for DST (if observed)
-    offset -= 1 if state && state[:observes_dst] && !Time.use_zone('Eastern Time (US & Canada)') { Time.now.dst? }
-
-    # Format and return the offset
-    (offset.negative? ? '' : '+') + format('%<offset>.2d', offset: offset) + ':00'
+    # Call TimeZone#now to create a TimeWithZone object that will contextualize
+    # the time to the current truth
+    ActiveSupport::TimeZone[time_zone_for_state(name)].now.formatted_offset
   end
 
   def time_zone_for_state(name)

--- a/app/helpers/patient_helper.rb
+++ b/app/helpers/patient_helper.rb
@@ -7,7 +7,6 @@ module PatientHelper
     PATIENT_HELPER_FILES[:state_names]
   end
 
-  # Offsets are DST
   def states_with_time_zone_data
     PATIENT_HELPER_FILES[:states_with_time_zone_data]
   end

--- a/lib/assets/states_with_time_zone_data.yml
+++ b/lib/assets/states_with_time_zone_data.yml
@@ -1,306 +1,184 @@
 # Offsets are DST
 
-alabama: 
-  :offset: -5
-  :observes_dst: true
+alabama:
   :zone_name: "America/Chicago"
 
-alaska: 
-  :offset: -8
-  :observes_dst: true
+alaska:
   :zone_name: "America/Juneau"
 
-americansamoa: 
-  :offset: -11
-  :observes_dst: false
+americansamoa:
   :zone_name: "Pacific/Pago_Pago"
 
-arizona: 
-  :offset: -7
-  :observes_dst: false
+arizona:
   :zone_name: "America/Phoenix"
 
-arkansas: 
-  :offset: -5
-  :observes_dst: true
+arkansas:
   :zone_name: "America/Chicago"
 
-california: 
-  :offset: -7
-  :observes_dst: true
+california:
   :zone_name: "America/Los_Angeles"
 
-colorado: 
-  :offset: -6
-  :observes_dst: true
+colorado:
   :zone_name: "America/Denver"
 
-connecticut: 
-  :offset: -4
-  :observes_dst: true
+connecticut:
   :zone_name: "America/New_York"
 
-delaware: 
-  :offset: -4
-  :observes_dst: true
+delaware:
   :zone_name: "America/New_York"
 
-districtofcolumbia: 
-  :offset: -4
-  :observes_dst: true
+districtofcolumbia:
   :zone_name: "America/New_York"
 
-federatedstatesofmicronesia: 
-  :offset: 11
-  :observes_dst: false
+federatedstatesofmicronesia:
   :zone_name: "Pacific/Noumea"
 
-florida: 
-  :offset: -4
-  :observes_dst: true
+florida:
   :zone_name: "America/New_York"
 
-georgia: 
-  :offset: -4
-  :observes_dst: true
+georgia:
   :zone_name: "America/New_York"
 
-guam: 
-  :offset: 10
-  :observes_dst: false
+guam:
   :zone_name: "Pacific/Guam"
 
-hawaii: 
-  :offset: -10
-  :observes_dst: false
+hawaii:
   :zone_name: "Pacific/Honolulu"
 
-idaho: 
-  :offset: -6
-  :observes_dst: true
+idaho:
   :zone_name: "America/Denver"
 
-illinois: 
-  :offset: -5
-  :observes_dst: true
+illinois:
   :zone_name: "America/Chicago"
 
-indiana: 
-  :offset: -4
-  :observes_dst: true
+indiana:
   :zone_name: "America/New_York"
 
-iowa: 
-  :offset: -5
-  :observes_dst: true
+iowa:
   :zone_name: "America/Chicago"
 
-kansas: 
-  :offset: -5
-  :observes_dst: true
+kansas:
   :zone_name: "America/Chicago"
 
-kentucky: 
-  :offset: -4
-  :observes_dst: true
+kentucky:
   :zone_name: "America/New_York"
 
-louisiana: 
-  :offset: -5
-  :observes_dst: true
+louisiana:
   :zone_name: "America/Chicago"
 
-maine: 
-  :offset: -4
-  :observes_dst: true
+maine:
   :zone_name: "America/New_York"
 
-marshallislands: 
-  :offset: 12
-  :observes_dst: false
+marshallislands:
   :zone_name: "Pacific/Majuro"
 
-maryland: 
-  :offset: -4
-  :observes_dst: true
+maryland:
   :zone_name: "America/New_York"
 
-massachusetts: 
-  :offset: -4
-  :observes_dst: true
+massachusetts:
   :zone_name: "America/New_York"
 
-michigan: 
-  :offset: -4
-  :observes_dst: true
+michigan:
   :zone_name: "America/New_York"
 
-minnesota: 
-  :offset: -5
-  :observes_dst: true
+minnesota:
   :zone_name: "America/Chicago"
 
-mississippi: 
-  :offset: -5
-  :observes_dst: true
+mississippi:
   :zone_name: "America/Chicago"
 
-missouri: 
-  :offset: -5
-  :observes_dst: true
+missouri:
   :zone_name: "America/Chicago"
 
-montana: 
-  :offset: -6
-  :observes_dst: true
+montana:
   :zone_name: "America/Denver"
 
-nebraska: 
-  :offset: -5
-  :observes_dst: true
+nebraska:
   :zone_name: "America/Chicago"
 
-nevada: 
-  :offset: -7
-  :observes_dst: true
+nevada:
   :zone_name: "America/Los_Angeles"
 
-newhampshire: 
-  :offset: -4
-  :observes_dst: true
+newhampshire:
   :zone_name: "America/New_York"
 
-newjersey: 
-  :offset: -4
-  :observes_dst: true
+newjersey:
   :zone_name: "America/New_York"
 
-newmexico: 
-  :offset: -6
-  :observes_dst: true
+newmexico:
   :zone_name: "America/Denver"
 
-newyork: 
-  :offset: -4
-  :observes_dst: true
+newyork:
   :zone_name: "America/New_York"
 
-northcarolina: 
-  :offset: -4
-  :observes_dst: true
+northcarolina:
   :zone_name: "America/New_York"
 
-northdakota: 
-  :offset: -5
-  :observes_dst: true
+northdakota:
   :zone_name: "America/Chicago"
 
-northernmarianaislands: 
-  :offset: 10
-  :observes_dst: false
+northernmarianaislands:
   :zone_name: "Pacific/Guam"
 
-ohio: 
-  :offset: -4
-  :observes_dst: true
+ohio:
   :zone_name: "America/New_York"
 
-oklahoma: 
-  :offset: -5
-  :observes_dst: true
+oklahoma:
   :zone_name: "America/Chicago"
 
-oregon: 
-  :offset: -7
-  :observes_dst: true
+oregon:
   :zone_name: "America/Los_Angeles"
 
-palau: 
-  :offset: 9
-  :observes_dst: false
+palau:
   :zone_name: "Asia/Tokyo"
 
-pennsylvania: 
-  :offset: -4
-  :observes_dst: true
+pennsylvania:
   :zone_name: "America/New_York"
 
-puertorico: 
-  :offset: -4
-  :observes_dst: false
+puertorico:
   :zone_name: "America/Puerto_Rico"
 
-rhodeisland: 
-  :offset: -4
-  :observes_dst: true
+rhodeisland:
   :zone_name: "America/New_York"
 
-southcarolina: 
-  :offset: -4
-  :observes_dst: true
+southcarolina:
   :zone_name: "America/New_York"
 
-southdakota: 
-  :offset: -5
-  :observes_dst: true
+southdakota:
   :zone_name: "America/Chicago"
 
-tennessee: 
-  :offset: -5
-  :observes_dst: true
+tennessee:
   :zone_name: "America/Chicago"
 
-texas: 
-  :offset: -5
-  :observes_dst: true
+texas:
   :zone_name: "America/Chicago"
 
-utah: 
-  :offset: -6
-  :observes_dst: true
+utah:
   :zone_name: "America/Denver"
 
-vermont: 
-  :offset: -4
-  :observes_dst: true
+vermont:
   :zone_name: "America/New_York"
 
-virginislands: 
-  :offset: -4
-  :observes_dst: false
+virginislands:
   :zone_name: "America/Puerto_Rico"
 
-virginia: 
-  :offset: -4
-  :observes_dst: true
+virginia:
   :zone_name: "America/New_York"
 
-washington: 
-  :offset: -7
-  :observes_dst: true
+washington:
   :zone_name: "America/Los_Angeles"
 
-westvirginia: 
-  :offset: -4
-  :observes_dst: true
+westvirginia:
   :zone_name: "America/New_York"
 
-wisconsin: 
-  :offset: -5
-  :observes_dst: true
+wisconsin:
   :zone_name: "America/Chicago"
 
-wyoming: 
-  :offset: -6
-  :observes_dst: true
+wyoming:
   :zone_name: "America/Denver"
 
-null: 
-  :offset: -4
-  :observes_dst: true
+null:
   :zone_name: "America/New_York"
 
-"": 
-  :offset: -4
-  :observes_dst: true
+"":
   :zone_name: "America/New_York"

--- a/test/helpers/patient_helper_test.rb
+++ b/test/helpers/patient_helper_test.rb
@@ -2,9 +2,7 @@
 
 require 'test_case'
 
-class PatientHelperTest < ActiveSupport::TestCase
-  include PatientHelper
-
+class PatientHelperTest < ActionView::TestCase
   test 'State names are normalized' do
     test_subject = Patient.new(monitored_address_state: 'New  Hampshire', address_state: 'new Hampshire',
                                additional_planned_travel_destination_state: 'NEW HAMPSHIRE ')
@@ -22,5 +20,13 @@ class PatientHelperTest < ActiveSupport::TestCase
     Timecop.freeze(Time.local(2008, 2, 1, 12, 0, 0))
     assert_equal('-05:00', time_zone_offset_for_state('Massachusetts'))
     Timecop.return
+  end
+
+  test 'time zone offset for state returns data' do
+    assert_nothing_raised do
+      state_names.each do |state|
+        time_zone_offset_for_state(state[0])
+      end
+    end
   end
 end

--- a/test/helpers/patient_helper_test.rb
+++ b/test/helpers/patient_helper_test.rb
@@ -13,4 +13,14 @@ class PatientHelperTest < ActiveSupport::TestCase
     assert_equal('New Hampshire', test_subject.address_state)
     assert_equal('New Hampshire', test_subject.additional_planned_travel_destination_state)
   end
+
+  test 'time zone offset for state ' do
+    # DST starts 2nd Sunday in March so pick a date in May to ensure DST.
+    Timecop.freeze(Time.local(2008, 5, 1, 12, 0, 0))
+    assert_equal('-04:00', time_zone_offset_for_state('Massachusetts'))
+    # ST
+    Timecop.freeze(Time.local(2008, 2, 1, 12, 0, 0))
+    assert_equal('-05:00', time_zone_offset_for_state('Massachusetts'))
+    Timecop.return
+  end
 end


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-987

Previous functionality returned Patient time zone offsets based on if Eastern time swapped over to daylight savings time. This change sets offsets based on the address state time zone.

# Important Changes

`patient_helper.rb` - main changes
`patient_helper_test.rb` - added tests that ensure returned values are formatted the same as previous behavior
