### PR TITLE
SARAALERT-1106: Removes Duplicate Jurisdiction Change in History

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -239,6 +239,7 @@ class PatientsController < ApplicationController
 
     render(json: patient.errors, status: 422) and return unless patient.update(content)
 
+    allowed_params&.keys&.reject! { |apk| %w[jurisdiction_id assigned_user].include? apk }
     Patient.detailed_history_edit(patient_before, patient, allowed_params&.keys, current_user.email)
     # Add a history update for any changes from moving from isolation to exposure
     patient.update_patient_history_for_isolation(patient_before, content[:isolation]) unless content[:isolation].nil?

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -239,8 +239,8 @@ class PatientsController < ApplicationController
 
     render(json: patient.errors, status: 422) and return unless patient.update(content)
 
-    allowed_params&.keys&.reject! { |apk| %w[jurisdiction_id assigned_user].include? apk }
-    Patient.detailed_history_edit(patient_before, patient, allowed_params&.keys, current_user.email)
+    allowed_fields = allowed_params&.keys&.reject! { |apk| %w[jurisdiction_id assigned_user].include? apk }
+    Patient.detailed_history_edit(patient_before, patient, allowed_fields, current_user.email)
     # Add a history update for any changes from moving from isolation to exposure
     patient.update_patient_history_for_isolation(patient_before, content[:isolation]) unless content[:isolation].nil?
 


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1106

This Pull Request addresses an issue where changes to a Monitoree's Jurisdiction would appear twice in the History list. This is due to the fact that we maintain items for Jurisdiction Changes, and a detailed list of all changes. When only the Jurisdiction was changed, there would be two entries (see image).
![image](https://user-images.githubusercontent.com/17532163/108076782-cbd34700-7039-11eb-8f19-3d620b1d7802.png)


The fix for this is to filter out `jurisdiction_id` changes from the Detailed List. This prevents the duplication of data.
This solution has been approved by the PO and Development teams.

# (Bugfix) How to Replicate

- In `master` change a monitoree's jurisdiction. Then go view the History. You will see the two entries (like the above image).

# (Bugfix) Solution
- Now, in this branch, do the same. You will notice that any `jurisidiction_id` changes are omitted from the Detailed_History History item.

# Important Changes

`app/models/patient.rb`
- Removes any changes to the `jurisdicton_id` from the `detailed_history_edit` method

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [x] Firefox
* [ ] Safari
* [ ] IE11
