### PR TITLE
SARAALERT-1212: Dashboard Jurisdiction "Scope" Bugfix

### DIFF
--- a/app/views/patients/_patients.html.erb
+++ b/app/views/patients/_patients.html.erb
@@ -171,6 +171,7 @@
       if (assigned_jurisdiction !== 'all') {
         options.append($('<option></option>').attr('value', 'exact').text('Exact Match'));
       }
+      $('#scope').val(scope);
     }
   });
 </script>


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1212

Before, we had a bug where, whenever the jurisdiction was changed in the patient index interface, the scope would be changed to "all" even if it had been "exact match" beforehand. This updates the javascript to change the scope to its set value whenever the page is updated, and modifies the demo.rake to cover the test case that produced the error so we catch these in the future. 

# (Bugfix) How to Replicate
Bug report here: 
https://teams.microsoft.com/l/file/F25865B2-C3D6-40CF-AF62-FD8FEB1033C5?tenantId=c620dc48-1d50-4952-8b39-df4d54d74d82&fileType=pptx&objectUrl=https%3A%2F%2Fmitre.sharepoint.com%2Fsites%2FCoVDT%2FShared%20Documents%2FGeneral%2FProduct%20Owner%20Materials%2FTesting%2FBug%20Reports%2FEnroller%20Scope%20bug.pptx&baseUrl=https%3A%2F%2Fmitre.sharepoint.com%2Fsites%2FCoVDT&serviceName=teams&threadId=19:00d3d45c64ca457795d58c2764d517cd@thread.skype&groupId=7de0f318-3170-4f1c-82eb-95bfe132bfe9

# (Bugfix) Solution
See above: I updated the javascript to change which field is selected to the original value when the options are refreshed. 

# Important Changes
app/views/patients/_patients.html.erb: the change to update the field. 
config/sara/jurisdictions.yml and lib/tasks/demo.rake: changes to our demo code to also create a state without child counties when producing demo and test data, which was the case that first uncovered this bug. 

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [x] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
