### PR TITLE
SARAALERT-1321 redirect_to && return

### DIFF
--- a/app/controllers/close_contacts_controller.rb
+++ b/app/controllers/close_contacts_controller.rb
@@ -6,7 +6,8 @@ class CloseContactsController < ApplicationController
 
   # Create a new close contact
   def create
-    redirect_to root_url && return unless current_user.can_create_patient_close_contacts?
+    redirect_to(root_url) && return unless current_user.can_create_patient_close_contacts?
+
     cc = CloseContact.new(first_name: params.permit(:first_name)[:first_name],
                           last_name: params.permit(:last_name)[:last_name],
                           primary_telephone: params.permit(:primary_telephone)[:primary_telephone],
@@ -25,7 +26,8 @@ class CloseContactsController < ApplicationController
 
   # Update an existing close contact
   def update
-    redirect_to root_url && return unless current_user.can_edit_patient_close_contacts?
+    redirect_to(root_url) && return unless current_user.can_edit_patient_close_contacts?
+
     cc = CloseContact.find_by(id: params.permit(:id)[:id])
     cc.update(first_name: params.permit(:first_name)[:first_name],
               last_name: params.permit(:last_name)[:last_name],

--- a/app/controllers/laboratories_controller.rb
+++ b/app/controllers/laboratories_controller.rb
@@ -6,7 +6,8 @@ class LaboratoriesController < ApplicationController
 
   # Create a new lab result
   def create
-    redirect_to root_url && return unless current_user.can_create_patient_laboratories?
+    redirect_to(root_url) && return unless current_user.can_create_patient_laboratories?
+
     lab = Laboratory.new(lab_type: params.permit(:lab_type)[:lab_type],
                          specimen_collection: params.permit(:specimen_collection)[:specimen_collection],
                          report: params.permit(:report)[:report],
@@ -20,7 +21,8 @@ class LaboratoriesController < ApplicationController
 
   # Update an existing lab result
   def update
-    redirect_to root_url && return unless current_user.can_edit_patient_laboratories?
+    redirect_to(root_url) && return unless current_user.can_edit_patient_laboratories?
+
     lab = Laboratory.find_by(id: params.permit(:id)[:id])
     lab.update!(lab_type: params.permit(:lab_type)[:lab_type],
                 specimen_collection: params.permit(:specimen_collection)[:specimen_collection],

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -14,7 +14,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # rubocop:enable Lint/UselessMethodDefinition
 
   def password_expired
-    redirect_to edit_user_registration_url && return
+    redirect_to(edit_user_registration_url) && return
   end
 
   protected


### PR DESCRIPTION
Fix areas where redirect_to was being called without parenthesis and combined with '&& return'

# Description
Jira Ticket: SARAALERT-1321

Uses the correct operator order of precedence when using the common idiot `redirect_to(url) && return` to avoid double render errors.

Additional information:

https://guides.rubyonrails.org/layouts_and_rendering.html#avoiding-double-render-errors'
https://stackoverflow.com/a/37211667

# Important Changes

In all files changed I added parenthesis to fix the potential issue.

