### PR TITLE
SARAALERT-1099: CloseContacts Required Fields Updates

### DIFF
--- a/app/javascript/components/close_contact/CloseContact.js
+++ b/app/javascript/components/close_contact/CloseContact.js
@@ -23,10 +23,8 @@ class CloseContact extends React.Component {
     this.state = {
       showModal: false,
       disableCreate:
-        !this.props.close_contact.first_name &&
-        !this.props.close_contact.last_name &&
-        !this.props.close_contact.primary_telephone &&
-        !this.props.close_contact.email,
+        (!this.props.close_contact.first_name && !this.props.close_contact.last_name) ||
+        (!this.props.close_contact.primary_telephone && !this.props.close_contact.email),
       loading: false,
       errors: {},
       first_name: this.props.close_contact.first_name || '',
@@ -54,10 +52,8 @@ class CloseContact extends React.Component {
       // When they click cancel, we want to null out all of the fields
       newState = {
         disableCreate:
-          !this.props.close_contact.first_name &&
-          !this.props.close_contact.last_name &&
-          !this.props.close_contact.primary_telephone &&
-          !this.props.close_contact.email,
+          (!this.props.close_contact.first_name && !this.props.close_contact.last_name) ||
+          (!this.props.close_contact.primary_telephone && !this.props.close_contact.email),
         errors: {},
         first_name: this.props.close_contact.first_name || '',
         last_name: this.props.close_contact.last_name || '',
@@ -83,12 +79,6 @@ class CloseContact extends React.Component {
       event.target.value = '';
     }
     let value;
-    let disableCreate = this.state.disableCreate;
-    const possiblyRequiredFields = ['first_name', 'last_name', 'primary_telephone', 'email'];
-    if (possiblyRequiredFields.includes(event.target.id)) {
-      // This checks that at least one of the possiblyRequiredFields is set to a truthy value
-      disableCreate = !possiblyRequiredFields.some(field => (field === event.target.id ? !!event.target.value : !!this.state[`${field}`]));
-    }
     if (event?.target?.id && event.target.id === 'assigned_user') {
       if (isNaN(event.target.value) || parseInt(event.target.value) > 999999) return;
       // trim() call included since there is a bug with yup validation for numbers that allows whitespace entry
@@ -98,7 +88,12 @@ class CloseContact extends React.Component {
     } else {
       value = event.target.value;
     }
-    this.setState({ [event.target.id]: value, disableCreate });
+    this.setState({ [event.target.id]: value }, () => {
+      let disableCreate = (!this.state.first_name && !this.state.last_name) || (!this.state.primary_telephone && !this.state.email);
+      this.setState({
+        disableCreate,
+      });
+    });
   };
 
   contactAttempt = async () => {
@@ -281,7 +276,7 @@ class CloseContact extends React.Component {
           {/* This does not impact component functionality at all. */}
           {this.state.disableCreate && (
             <ReactTooltip id="create-tooltip" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container text-left">
-              Please enter one of the following: First Name, Last Name, Phone Number, or Email
+              Please enter at least one name (First Name or Last Name) and at least one reporting method (Phone Number or Email).
             </ReactTooltip>
           )}
         </Modal.Footer>

--- a/app/javascript/tests/close_contact/CloseContact.test.js
+++ b/app/javascript/tests/close_contact/CloseContact.test.js
@@ -265,49 +265,94 @@ describe('CloseContact', () => {
   });
 
   it('Properly enables and disables the submit/create button when the correct fields are entered or removed', () => {
+    // This test is slightly excessive, but it tests every combination for non-allowable fields
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
 
     expect(emptyCCWrapper.state('showModal')).toBeFalsy();
     expect(emptyCCWrapper.find('Button').at(0).text()).toContain('Add New Close Contact');
     emptyCCWrapper.find(Button).at(0).simulate('click');
 
-    let value;
+    let value, value1, value2;
     value = testInputValues.find(x => x.field === 'first_name').value
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: value } })
-    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
-    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
-    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: '' } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: '' } })
 
     value = testInputValues.find(x => x.field === 'last_name').value
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(1).simulate('change', { target: { id: 'last_name', value: value } })
-    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
-    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
-    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(1).simulate('change', { target: { id: 'last_name', value: '' } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(1).simulate('change', { target: { id: 'last_name', value: '' } })
 
     value = testInputValues.find(x => x.field === 'primary_telephone').value
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: value } })
-    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
-    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
-    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: '' } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: '' } })
 
     value = testInputValues.find(x => x.field === 'email').value
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: value } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: '' } })
+
+    value1 = testInputValues.find(x => x.field === 'first_name').value
+    value2 = testInputValues.find(x => x.field === 'primary_telephone').value
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: value1 } })
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: value2 } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: '' } })
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: '' } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+
+    value1 = testInputValues.find(x => x.field === 'first_name').value
+    value2 = testInputValues.find(x => x.field === 'email').value
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: value1 } })
+      emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: value2 } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: '' } })
+      emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: '' } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+
+    value1 = testInputValues.find(x => x.field === 'last_name').value
+    value2 = testInputValues.find(x => x.field === 'primary_telephone').value
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'last_name', value: value1 } })
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: value2 } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'last_name', value: '' } })
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: '' } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+
+    value1 = testInputValues.find(x => x.field === 'last_name').value
+    value2 = testInputValues.find(x => x.field === 'email').value
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'last_name', value: value1 } })
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: value2 } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'last_name', value: '' } })
     emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: '' } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();

--- a/app/javascript/tests/close_contact/CloseContact.test.js
+++ b/app/javascript/tests/close_contact/CloseContact.test.js
@@ -284,7 +284,7 @@ describe('CloseContact', () => {
     emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: '' } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
-  })
+  });
 
   it('Properly enables and disables the submit/create button when First Name and Email is entered', () => {
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
@@ -299,14 +299,14 @@ describe('CloseContact', () => {
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: value1 } })
-      emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: value2 } })
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: value2 } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: '' } })
-      emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: '' } })
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: '' } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
-  })
+  });
 
   it('Properly enables and disables the submit/create button when Last Name and Phone is entered', () => {
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
@@ -328,7 +328,7 @@ describe('CloseContact', () => {
     emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: '' } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
-  })
+  });
 
   it('Properly enables and disables the submit/create button when Last Name and Email is entered', () => {
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
@@ -350,7 +350,7 @@ describe('CloseContact', () => {
     emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: '' } })
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
-  })
+  });
 
   it('Properly keeps the buttons disabled when all the required fields are not added', () => {
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
@@ -390,5 +390,5 @@ describe('CloseContact', () => {
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: '' } })
-  })
+  });
 });

--- a/app/javascript/tests/close_contact/CloseContact.test.js
+++ b/app/javascript/tests/close_contact/CloseContact.test.js
@@ -264,15 +264,101 @@ describe('CloseContact', () => {
     expect(emptyCCWrapper.find(Modal.Body).find('Row').at(3).find('FormLabel').at(1).text()).toContain(`${2000-testNoteString.length} characters remaining`);
   });
 
-  it('Properly enables and disables the submit/create button when the correct fields are entered or removed', () => {
-    // This test is slightly excessive, but it tests every combination for non-allowable fields
+  it('Properly enables and disables the submit/create button when First Name and Phone is entered', () => {
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
 
     expect(emptyCCWrapper.state('showModal')).toBeFalsy();
     expect(emptyCCWrapper.find('Button').at(0).text()).toContain('Add New Close Contact');
     emptyCCWrapper.find(Button).at(0).simulate('click');
 
-    let value, value1, value2;
+    let value1, value2;
+    value1 = testInputValues.find(x => x.field === 'first_name').value
+    value2 = testInputValues.find(x => x.field === 'primary_telephone').value
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: value1 } })
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: value2 } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: '' } })
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: '' } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+  })
+
+  it('Properly enables and disables the submit/create button when First Name and Email is entered', () => {
+    const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
+
+    expect(emptyCCWrapper.state('showModal')).toBeFalsy();
+    expect(emptyCCWrapper.find('Button').at(0).text()).toContain('Add New Close Contact');
+    emptyCCWrapper.find(Button).at(0).simulate('click');
+
+    let value1, value2;
+    value1 = testInputValues.find(x => x.field === 'first_name').value
+    value2 = testInputValues.find(x => x.field === 'email').value
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: value1 } })
+      emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: value2 } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: '' } })
+      emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: '' } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+  })
+
+  it('Properly enables and disables the submit/create button when Last Name and Phone is entered', () => {
+    const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
+
+    expect(emptyCCWrapper.state('showModal')).toBeFalsy();
+    expect(emptyCCWrapper.find('Button').at(0).text()).toContain('Add New Close Contact');
+    emptyCCWrapper.find(Button).at(0).simulate('click');
+
+    let value1, value2;
+    value1 = testInputValues.find(x => x.field === 'last_name').value
+    value2 = testInputValues.find(x => x.field === 'primary_telephone').value
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'last_name', value: value1 } })
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: value2 } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'last_name', value: '' } })
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: '' } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+  })
+
+  it('Properly enables and disables the submit/create button when Last Name and Email is entered', () => {
+    const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
+
+    expect(emptyCCWrapper.state('showModal')).toBeFalsy();
+    expect(emptyCCWrapper.find('Button').at(0).text()).toContain('Add New Close Contact');
+    emptyCCWrapper.find(Button).at(0).simulate('click');
+
+    let value1, value2;
+    value1 = testInputValues.find(x => x.field === 'last_name').value
+    value2 = testInputValues.find(x => x.field === 'email').value
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'last_name', value: value1 } })
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: value2 } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
+    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'last_name', value: '' } })
+    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: '' } })
+    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
+    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
+  })
+
+  it('Properly keeps the buttons disabled when all the required fields are not added', () => {
+    const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
+
+    expect(emptyCCWrapper.state('showModal')).toBeFalsy();
+    expect(emptyCCWrapper.find('Button').at(0).text()).toContain('Add New Close Contact');
+    emptyCCWrapper.find(Button).at(0).simulate('click');
+    let value;
     value = testInputValues.find(x => x.field === 'first_name').value
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
@@ -304,57 +390,5 @@ describe('CloseContact', () => {
     expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
     expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: '' } })
-
-    value1 = testInputValues.find(x => x.field === 'first_name').value
-    value2 = testInputValues.find(x => x.field === 'primary_telephone').value
-    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
-    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
-    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: value1 } })
-    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: value2 } })
-    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
-    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
-    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: '' } })
-    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: '' } })
-    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
-    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
-
-    value1 = testInputValues.find(x => x.field === 'first_name').value
-    value2 = testInputValues.find(x => x.field === 'email').value
-    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
-    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
-    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: value1 } })
-      emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: value2 } })
-    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
-    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
-    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'first_name', value: '' } })
-      emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: '' } })
-    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
-    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
-
-    value1 = testInputValues.find(x => x.field === 'last_name').value
-    value2 = testInputValues.find(x => x.field === 'primary_telephone').value
-    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
-    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
-    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'last_name', value: value1 } })
-    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: value2 } })
-    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
-    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
-    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'last_name', value: '' } })
-    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('PhoneInput').simulate('change', { target: { id: 'primary_telephone', value: '' } })
-    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
-    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
-
-    value1 = testInputValues.find(x => x.field === 'last_name').value
-    value2 = testInputValues.find(x => x.field === 'email').value
-    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
-    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
-    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'last_name', value: value1 } })
-    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: value2 } })
-    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeFalsy()
-    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeFalsy();
-    emptyCCWrapper.find(Modal.Body).find('Row').at(0).find('FormControl').at(0).simulate('change', { target: { id: 'last_name', value: '' } })
-    emptyCCWrapper.find(Modal.Body).find('Row').at(1).find('FormControl').simulate('change', { target: { id: 'email', value: '' } })
-    expect(emptyCCWrapper.find(Button).at(2).props().disabled).toBeTruthy()
-    expect(emptyCCWrapper.find('#create-tooltip').exists()).toBeTruthy();
   })
 });


### PR DESCRIPTION
This PR is a followup to the 1099 PR that was recently merged. There was feedback from User Training that suggested that the system should require `Name (First or Last) AND Reporting Method (Email or Phone)` as opposed to what we had before which was `First OR Last OR Email OR Phone`.

This PR updates that logic, and updates the front-end tests to support that new logic.