### PR TITLE
SARAALERT-1287: Optimize Export Performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem 'roo'
 
 # Excel Export
 gem 'caxlsx'
+gem 'fast_excel'
 
 # Fast XML
 gem 'ox'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,8 @@ GEM
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
     faraday-net_http (1.0.1)
+    fast_excel (0.3.0)
+      ffi (> 1.9, < 2)
     ffi (1.15.0)
     ffi-hunspell (0.6.1)
       ffi (~> 1.0)
@@ -449,6 +451,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   fakeredis
+  fast_excel
   ffi-hunspell
   fhir_models
   gemsurance

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -102,10 +102,9 @@ class ExportController < ApplicationController
           name: 'Monitorees',
           tab: 'Monitorees List'
         },
-        # assessment fields and headers need to be duplicated because they may be modified
         assessments: {
-          checked: FULL_HISTORY_ASSESSMENTS_FIELDS.dup,
-          headers: FULL_HISTORY_ASSESSMENTS_HEADERS.dup,
+          checked: FULL_HISTORY_ASSESSMENTS_FIELDS,
+          headers: FULL_HISTORY_ASSESSMENTS_HEADERS,
           name: 'Reports',
           tab: 'Reports'
         },
@@ -141,7 +140,7 @@ class ExportController < ApplicationController
 
     # NOTE: separate implementation used for single patient export for performance and to keep this endpoint's logic separate from main export logic
     # Get all of the field data based on the config
-    field_data, symptom_names = get_field_data(FULL_HISTORY_PATIENT_CONFIG)
+    field_data = get_field_data(FULL_HISTORY_PATIENT_CONFIG, patients)
 
     # Create export file
     workbook = FastExcel.open
@@ -157,7 +156,7 @@ class ExportController < ApplicationController
     end
 
     # Get export data hashes for each data type from config and write data to each sheet
-    exported_data = get_export_data(patients, FULL_HISTORY_PATIENT_CONFIG[:data], symptom_names)
+    exported_data = get_export_data(patients, FULL_HISTORY_PATIENT_CONFIG[:data])
     FULL_HISTORY_PATIENT_CONFIG[:data].each_key do |data_type|
       last_row_nums[data_type] = write_xlsx_rows(exported_data, data_type, sheets[data_type], field_data[data_type][:checked], last_row_nums[data_type])
     end

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -140,7 +140,7 @@ class ExportController < ApplicationController
 
     # NOTE: separate implementation used for single patient export for performance and to keep this endpoint's logic separate from main export logic
     # Get all of the field data based on the config
-    field_data = get_field_data(FULL_HISTORY_PATIENT_CONFIG, patients)
+    field_data, symptom_names = get_field_data(FULL_HISTORY_PATIENT_CONFIG, patients)
 
     # Create export file
     workbook = FastExcel.open
@@ -156,7 +156,7 @@ class ExportController < ApplicationController
     end
 
     # Get export data hashes for each data type from config and write data to each sheet
-    exported_data = get_export_data(patients, FULL_HISTORY_PATIENT_CONFIG[:data], field_data)
+    exported_data = get_export_data(patients, FULL_HISTORY_PATIENT_CONFIG[:data], field_data, symptom_names)
     FULL_HISTORY_PATIENT_CONFIG[:data].each_key do |data_type|
       exported_data[data_type]&.each do |record|
         # fast_excel unfortunately does not provide a method to modify the @last_row_number class variable so it needs to be manually kept track of

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -139,53 +139,30 @@ class ExportController < ApplicationController
 
     History.monitoree_data_downloaded(patient: patients.first, created_by: current_user.email)
 
-    config = {
-      format: 'xlsx',
-      separate_files: false,
-      data: {
-        patients: {
-          checked: FULL_HISTORY_PATIENTS_FIELDS,
-          headers: FULL_HISTORY_PATIENTS_HEADERS,
-          tab: 'Monitorees List'
-        },
-        # assessment fields and headers need to be duplicated because they may be modified
-        assessments: {
-          checked: FULL_HISTORY_ASSESSMENTS_FIELDS.dup,
-          headers: FULL_HISTORY_ASSESSMENTS_HEADERS.dup,
-          tab: 'Reports'
-        },
-        laboratories: {
-          checked: FULL_HISTORY_LABORATORIES_FIELDS,
-          headers: FULL_HISTORY_LABORATORIES_HEADERS,
-          tab: 'Lab Results'
-        },
-        histories: {
-          checked: FULL_HISTORY_HISTORIES_FIELDS,
-          headers: FULL_HISTORY_HISTORIES_HEADERS,
-          tab: 'Edit Histories'
-        }
-      }
-    }
+    # NOTE: separate implementation used for single patient export for performance and to keep this endpoint's logic separate from main export logic
+    # Get all of the field data based on the config
+    field_data, symptom_names = get_field_data(FULL_HISTORY_PATIENT_CONFIG)
 
-    data_types = CUSTOM_EXPORT_OPTIONS.keys.select { |data_type| config.dig(:data, data_type, :checked).present? }
-    field_data = get_field_data(config)
-
+    # Create export file
     workbook = FastExcel.open
     sheets = {}
     last_row_nums = {}
-    data_types.each do |data_type|
-      worksheet = workbook.add_worksheet(config.dig(:data, data_type, :tab) || CUSTOM_EXPORT_OPTIONS.dig(data_type, :label))
+    FULL_HISTORY_PATIENT_CONFIG[:data].each_key do |data_type|
+      # Add separate worksheet for each data type
+      worksheet = workbook.add_worksheet(FULL_HISTORY_PATIENT_CONFIG[:data][data_type][:tab])
       worksheet.auto_width = true
       worksheet.append_row(field_data.dig(data_type, :headers))
       last_row_nums[data_type] = 0
       sheets[data_type] = worksheet
     end
 
-    exported_data = get_export_data(patients, config[:data])
-    data_types.each do |data_type|
+    # Get export data hashes for each data type from config and write data to each sheet
+    exported_data = get_export_data(patients, FULL_HISTORY_PATIENT_CONFIG[:data], symptom_names)
+    FULL_HISTORY_PATIENT_CONFIG[:data].each_key do |data_type|
       last_row_nums[data_type] = write_xlsx_rows(exported_data, data_type, sheets[data_type], field_data[data_type][:checked], last_row_nums[data_type])
     end
 
+    # Send file
     send_data Base64.encode64(workbook.read_string)
   end
 

--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'axlsx'
-
 # ExportController: for exporting subjects
 class ExportController < ApplicationController
   include ImportExport

--- a/app/controllers/jurisdictions_controller.rb
+++ b/app/controllers/jurisdictions_controller.rb
@@ -9,12 +9,12 @@ class JurisdictionsController < ApplicationController
 
   # Get jurisdiction ids and paths of viewable jurisdictions
   def jurisdiction_paths
-    render json: { jurisdiction_paths: Hash[current_user.jurisdiction.subtree.pluck(:id, :path).map { |id, path| [id, path] }] }
+    render json: { jurisdiction_paths: Hash[current_user.jurisdiction.subtree.pluck(:id, :path)] }
   end
 
   # Get all jurisdiction ids and paths
   def all_jurisdiction_paths
-    render json: { all_jurisdiction_paths: Hash[Jurisdiction.all.pluck(:id, :path).map { |id, path| [id, path] }] }
+    render json: { all_jurisdiction_paths: Hash[Jurisdiction.all.pluck(:id, :path)] }
   end
 
   # Get list of assigned users unique to jurisdiction

--- a/app/helpers/patient_details_helper.rb
+++ b/app/helpers/patient_details_helper.rb
@@ -45,7 +45,7 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
       transferred_at: latest_transfer_at || '',
       reason_for_closure: monitoring_reason || '',
       public_health_action: public_health_action || '',
-      status: status&.to_s&.humanize&.downcase&.gsub('exposure ', '')&.gsub('isolation ', '') || '',
+      status: status&.to_s&.humanize&.downcase&.sub('exposure ', '')&.sub('isolation ', '') || '',
       closed_at: closed_at || '',
       transferred_from: latest_transfer&.from_path || '',
       transferred_to: latest_transfer&.to_path || '',

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -581,7 +581,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
       details[:closed_at] = patient[:closed_at]&.rfc2822 || '' if fields.include?(:closed_at)
       details[:transferred_at] = patient[:latest_transfer_at]&.rfc2822 || '' if fields.include?(:transferred_at)
       details[:latest_report] = patient[:latest_assessment_at]&.rfc2822 || '' if fields.include?(:latest_report)
-      details[:status] = patient.status.to_s.gsub('_', ' ').gsub('exposure ', '')&.gsub('isolation ', '') if fields.include?(:status)
+      details[:status] = patient.status.to_s.gsub('_', ' ').sub('exposure ', '')&.sub('isolation ', '') if fields.include?(:status)
       details[:report_eligibility] = patient.report_eligibility if fields.include?(:report_eligibility)
       details[:is_hoh] = patient.head_of_household?
 

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -10,7 +10,7 @@ class ExportJob < ApplicationJob
   OUTER_BATCH_SIZE = ENV['EXPORT_OUTER_BATCH_SIZE']&.to_i || 10_000
 
   # Inner batch size limits number of Patient records details help in memory at once before writing to file.
-  INNER_BATCH_SIZE = ENV['EXPORT_INNER_BATCH_SIZE']&.to_i || 100
+  INNER_BATCH_SIZE = ENV['EXPORT_INNER_BATCH_SIZE']&.to_i || 500
 
   def perform(config)
     # Get user in order to query viewable patients

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -10,7 +10,7 @@ class ExportJob < ApplicationJob
   OUTER_BATCH_SIZE = ENV['EXPORT_OUTER_BATCH_SIZE']&.to_i || 10_000
 
   # Inner batch size limits number of Patient records details help in memory at once before writing to file.
-  INNER_BATCH_SIZE = ENV['EXPORT_INNER_BATCH_SIZE']&.to_i || 500
+  INNER_BATCH_SIZE = ENV['EXPORT_INNER_BATCH_SIZE']&.to_i || 100
 
   def perform(config)
     # Get user in order to query viewable patients
@@ -25,45 +25,14 @@ class ExportJob < ApplicationJob
     return if data.nil?
 
     # Construct export
-    lookups = []
-
     patients = patients_by_query(user, data.dig(:patients, :query) || {})
+    files = write_export_data_to_files(config, patients, OUTER_BATCH_SIZE, INNER_BATCH_SIZE)
+    return unless files.present?
 
-    # NOTE: in_batches appears to NOT sort within batches, so explicit ordering on ID is also done deeper down.
-    # The reorder('') here allows this ordering done later on to work properly.
-    patients.reorder('').in_batches(of: OUTER_BATCH_SIZE).each_with_index do |patients_group, index|
-      files = write_export_data_to_files(config, patients_group, index, INNER_BATCH_SIZE)
-      lookups.concat(create_lookups(config, files))
-    end
-
-    return if lookups.empty?
-
-    # Sort lookups by filename so that they are grouped together accordingly after batching
-    lookups = lookups.sort_by { |lookup| lookup[:filename] }
+    # Sort files by filename so that they are grouped together accordingly after batching
+    files = files.sort_by { |file| file[:filename] }
 
     # Send an email to user
-    UserMailer.download_email(user, EXPORT_TYPES[config[:export_type]][:label] || 'default', lookups, OUTER_BATCH_SIZE).deliver_later
-  end
-
-  # Creates lookups for files
-  def create_lookups(config, files)
-    lookups = []
-
-    # Write
-    files&.each do |file|
-      lookup = SecureRandom.uuid
-      if ActiveRecord::Base.logger.formatter.nil?
-        download = Download.insert(user_id: config[:user_id], export_type: config[:export_type], filename: file[:filename],
-                                   lookup: lookup, contents: file[:content], created_at: DateTime.now, updated_at: DateTime.now)
-      else
-        ActiveRecord::Base.logger.silence do
-          download = Download.insert(user_id: config[:user_id], export_type: config[:export_type], filename: file[:filename],
-                                     lookup: lookup, contents: file[:content], created_at: DateTime.now, updated_at: DateTime.now)
-        end
-      end
-      lookups << { lookup: lookup, filename: file[:filename] }
-    end
-
-    lookups
+    UserMailer.download_email(user, EXPORT_TYPES[config[:export_type]][:label] || 'default', files, OUTER_BATCH_SIZE).deliver_later
   end
 end

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -32,7 +32,6 @@ class ExportJob < ApplicationJob
     # NOTE: in_batches appears to NOT sort within batches, so explicit ordering on ID is also done deeper down.
     # The reorder('') here allows this ordering done later on to work properly.
     patients.reorder('').in_batches(of: OUTER_BATCH_SIZE).each_with_index do |patients_group, index|
-      puts "OUTER BATCH #{index}"
       files = write_export_data_to_files(config, patients_group, index, INNER_BATCH_SIZE)
       lookups.concat(create_lookups(config, files))
     end

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -32,6 +32,7 @@ class ExportJob < ApplicationJob
     # NOTE: in_batches appears to NOT sort within batches, so explicit ordering on ID is also done deeper down.
     # The reorder('') here allows this ordering done later on to work properly.
     patients.reorder('').in_batches(of: OUTER_BATCH_SIZE).each_with_index do |patients_group, index|
+      puts "OUTER BATCH #{index}"
       files = write_export_data_to_files(config, patients_group, index, INNER_BATCH_SIZE)
       lookups.concat(create_lookups(config, files))
     end

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -558,13 +558,19 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
     if fields.include?(:jurisdiction_name)
       jurisdiction_names = Hash[Jurisdiction.find(patients.pluck(:jurisdiction_id).uniq).pluck(:id, :name).map { |id, name| [id, name] }]
     end
-    if fields.include?(:jurisdiction_path)
-      jurisdiction_paths = Hash[Jurisdiction.find(patients.pluck(:jurisdiction_id).uniq).pluck(:id, :path).map { |id, path| [id, path] }]
+    if (fields & %i[jurisdiction_path transferred_from transferred_to]).size.positive?
+      jur_ids = patients.pluck(:jurisdiction_id).uniq
+      jur_ids = (jur_ids + patients.pluck(:latest_transfer_from)).uniq if fields.include?(:transferred_from)
+      jurisdiction_paths = Hash[Jurisdiction.find(jur_ids).pluck(:id, :path).map { |id, path| [id, path] }]
     end
 
-    patients_transfers = get_patients_transfers(patients) if (fields & %i[transferred_from transferred_to]).any?
-    patients_laboratories = get_patients_laboratories(patients) if (fields & PATIENT_LAB_FIELDS).any?
-    patients_creators = Hash[User.find(patients.pluck(:creator_id)).pluck(:id, :email)] if fields.include?(:creator)
+    patients_creators = Hash[patients.joins('INNER JOIN users ON patients.creator_id = users.id').pluck('users.id', 'users.email')] if fields.include?(:creator)
+    if (fields & PATIENT_LAB_FIELDS).any?
+      patients_laboratories = Laboratory.where(patient_id: patients.pluck(:id))
+                                        .order(specimen_collection: :desc)
+                                        .group_by(&:patient_id)
+                                        .transform_values { |v| v.take(2) }
+    end
 
     # construct patient details
     patients_details = []
@@ -580,9 +586,9 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
       patient_details[:jurisdiction_path] = jurisdiction_paths[patient.jurisdiction_id] || '' if fields.include?(:jurisdiction_path)
 
       # populate latest transfer from and to if requested
-      if patients_transfers&.key?(patient.id)
-        patient_details[:transferred_from] = patients_transfers[patient.id][:transferred_from] if fields.include?(:transferred_from)
-        patient_details[:transferred_to] = patients_transfers[patient.id][:transferred_to] if fields.include?(:transferred_to)
+      if patient[:latest_transfer_from].present?
+        patient_details[:transferred_from] = jurisdiction_paths[patient.latest_transfer_from]
+        patient_details[:transferred_to] = jurisdiction_paths[patient.jurisdiction_id]
       end
 
       # populate labs if requested
@@ -654,49 +660,22 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
     patient_details
   end
 
-  # Gets a hash of the latest transfers of each patient
-  def get_patients_transfers(patients)
-    transfers = Transfer.latest_transfers(patients)
-    jurisdictions = Jurisdiction.find(transfers.pluck(:from_jurisdiction_id, :to_jurisdiction_id).flatten.uniq)
-    jurisdiction_paths = Hash[jurisdictions.pluck(:id, :path).map { |id, path| [id, path] }]
-    Hash[transfers.pluck(:patient_id, :created_at, :from_jurisdiction_id, :to_jurisdiction_id)
-                  .map do |patient_id, created_at, from_jurisdiction_id, to_jurisdiction_id|
-                    [patient_id, {
-                      transferred_at: created_at.rfc2822,
-                      transferred_from: jurisdiction_paths[from_jurisdiction_id],
-                      transferred_to: jurisdiction_paths[to_jurisdiction_id]
-                    }]
-                  end
-        ]
-  end
-
-  # Gets a hash of the 2 latest laboratories of each patient
-  def get_patients_laboratories(patients)
-    Laboratory.where(patient_id: patients.pluck(:id)).order(specimen_collection: :desc).group_by(&:patient_id).transform_values { |v| v.take(2) }
-  end
-
   # Extracts assessment data values given relevant fields
   def extract_assessments_details(patients_identifiers, assessments, fields)
     if fields.include?(:symptoms)
-      # conditions_assessments_map = Hash[assessments.joins(:reported_condition).pluck('conditions.id', :assessment_id).map { |cid, aid| [cid, aid] }]
-      # assessments_hash = Hash[conditions_assessments_map.values.map { |aid| [aid, { symptoms: {} }] }]
       conditions_hash = Hash[assessments.joins(:reported_condition).pluck('conditions.id', :assessment_id).map { |id, assessment_id| [id, assessment_id] }]
                         .transform_values { |assessment_id| { assessment_id: assessment_id, symptoms: {} } }
 
       # Uses index_symptoms_on_condition_id
       all_symptoms = Symptom.where(condition_id: conditions_hash.keys)
-      # all_symptoms = Symptom.where(condition_id: conditions_assessments_map.keys)
       all_symptoms.where(type: 'BoolSymptom').pluck(:condition_id, :name, :bool_value).each do |(condition_id, name, bool_value)|
         conditions_hash[condition_id][:symptoms][name] = bool_value
-        # assessments_hash[conditions_assessments_map[condition_id]][:symptoms][name] = bool_value
       end
       all_symptoms.where(type: 'IntegerSymptom').pluck(:condition_id, :name, :bool_value).each do |(condition_id, name, int_value)|
         conditions_hash[condition_id][:symptoms][name] = int_value
-        # assessments_hash[conditions_assessments_map[condition_id]][:symptoms][name] = int_value
       end
       all_symptoms.where(type: 'FloatSymptom').pluck(:condition_id, :name, :bool_value).each do |(condition_id, name, float_value)|
         conditions_hash[condition_id][:symptoms][name] = float_value
-        # assessments_hash[conditions_assessments_map[condition_id]][:symptoms][name] = float_value
       end
       assessments_hash = Hash[conditions_hash.map { |_, condition| [condition[:assessment_id], condition[:symptoms]] }]
     end
@@ -756,11 +735,6 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
       (PATIENT_ALTERNATIVE_IDENTIFIERS & fields).each { |identifier| transfer[identifier] = patients_identifiers[transfer[:patient_id]][identifier] }
       transfer
     end
-
-    # user_emails = Hash[User.find(transfers.map(&:who_id).uniq).pluck(:id, :email).map { |id, email| [id, email] }]
-    # jurisdiction_ids = [transfers.map(&:from_jurisdiction_id), transfers.map(&:to_jurisdiction_id)].flatten.uniq
-    # jurisdiction_paths = Hash[Jurisdiction.find(jurisdiction_ids).pluck(:id, :path).map { |id, path| [id, path] }]
-    # transfers.map { |transfer| transfer.custom_details(fields, patients_identifiers[transfer.patient_id], user_emails, jurisdiction_paths) }
   end
 
   # Extracts history data values given relevant fields
@@ -801,7 +775,6 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
 
     # 2) Get export data in batches to decrease size of export data hash maintained in memory
     patients_group.in_batches(of: inner_batch_size) do |batch_group|
-      puts 'INNER BATCH'
       # The config should be passed to this function rather than data, because it determines values
       # based on the original configuration.
       exported_data = get_export_data(batch_group.order(:id), config[:data])
@@ -834,6 +807,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
       files = []
       workbooks = {}
       sheets = {}
+      last_row_nums = {}
 
       # 1) This initial loops creates all of the files and column headers which should not be done in the batched loop
       CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
@@ -844,20 +818,20 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
         worksheet = workbook.add_worksheet(config.dig(:data, data_type, :tab) || CUSTOM_EXPORT_OPTIONS.dig(data_type, :label))
         worksheet.auto_width = true
         worksheet.append_row(field_data.dig(data_type, :headers))
+        last_row_nums[data_type] = 0
         sheets[data_type] = worksheet
         workbooks[data_type] = workbook
       end
 
       # 2) Get export data in batches to decrease size of export data hash maintained in memory
       patients_group.in_batches(of: inner_batch_size) do |batch_group|
-        puts 'INNER BATCH'
         exported_data = get_export_data(batch_group.order(:id), config[:data])
 
         #  Write to appropriate sheets (in each file)
         CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
           next unless config.dig(:data, data_type, :checked).present?
 
-          write_xlsx_rows(exported_data, data_type, sheets[data_type], field_data[data_type][:checked])
+          last_row_nums[data_type] = write_xlsx_rows(exported_data, data_type, sheets[data_type], field_data[data_type][:checked], last_row_nums[data_type])
         end
       end
 
@@ -874,6 +848,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
       workbook = FastExcel.open(constant_memory: true)
       sheets = {}
       fields = {}
+      last_row_nums = {}
 
       # 1) This initial loops writes all of column headers which should not be done in the batched loop
       CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
@@ -885,18 +860,18 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
         worksheet = workbook.add_worksheet(config.dig(:data, data_type, :tab) || CUSTOM_EXPORT_OPTIONS.dig(data_type, :label))
         worksheet.auto_width = true
         worksheet.append_row(field_data.dig(data_type, :headers))
+        last_row_nums[data_type] = 0
         sheets[data_type] = worksheet
       end
 
       # 2) Get export data in batches to decrease size of export data hash maintained in memory
       patients_group.in_batches(of: inner_batch_size) do |batch_group|
-        puts 'INNER BATCH'
         exported_data = get_export_data(batch_group.order(:id), config[:data])
 
         CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
           next unless config.dig(:data, data_type, :checked).present?
 
-          write_xlsx_rows(exported_data, data_type, sheets[data_type], field_data[data_type][:checked])
+          last_row_nums[data_type] = write_xlsx_rows(exported_data, data_type, sheets[data_type], field_data[data_type][:checked], last_row_nums[data_type])
         end
       end
 
@@ -905,10 +880,16 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
     end
   end
 
-  def write_xlsx_rows(exported_data, data_type, worksheet, fields)
+  def write_xlsx_rows(exported_data, data_type, worksheet, fields, last_row_num)
     exported_data[data_type]&.each do |record|
-      worksheet.append_row(fields.map { |field| record[field] })
+      # fast_excel unfortunately does not provide a method to modify the @last_row_number class variable so it needs to be manually kept track of
+      last_row_num += 1
+      fields.each_with_index do |field, col_index|
+        # write_string is used instead of append_row because it does not provide the capability to write data as strings
+        worksheet.write_string(last_row_num, col_index, record[field].to_s, nil)
+      end
     end
+    last_row_num
   end
 
   # Gets data for this batch of patients that may not have already been present in the export config (such as specific symptoms).

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -2,6 +2,7 @@
 
 # Helper methods for the import and export controllers
 module ImportExport # rubocop:todo Metrics/ModuleLength
+  include ImportExportConstants
   include ValidationHelper
   include PatientQueryHelper
   include AssessmentQueryHelper
@@ -12,507 +13,226 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
   include Utils
   include ExcelSanitizer
 
-  EXPORT_TYPES = {
-    csv_linelist_exposure: { label: 'Line list CSV (exposure)', filename: 'Sara-Alert-Linelist-Exposure' },
-    csv_linelist_isolation: { label: 'Line list CSV (isolation)', filename: 'Sara-Alert-Linelist-Isolation' },
-    sara_alert_format_exposure: { label: 'Sara Alert Format (exposure)', filename: 'Sara-Alert-Format-Exposure' },
-    sara_alert_format_isolation: { label: 'Sara Alert Format (isolation)', filename: 'Sara-Alert-Format-Isolation' },
-    full_history_patients_all: { label: 'Excel Export For All Monitorees', filename: 'Sara-Alert-Full-Export' },
-    full_history_patients_purgeable: { label: 'Excel Export For Purge-Eligible Monitorees', filename: 'Sara-Alert-Purge-Eligible-Export' },
-    custom: { label: 'Custom Export', filename: 'Sara-Alert-Custom-Export' }
-  }.freeze
-
-  EXPORT_FORMATS = %w[csv xlsx].freeze
-
-  EPI_X_FIELDS = [:user_defined_id_statelocal, :flight_or_vessel_number, nil, nil, :user_defined_id_cdc, nil, nil, :primary_language, :date_of_arrival,
-                  :port_of_entry_into_usa, :last_name, :first_name, :date_of_birth, :sex, nil, nil, :address_line_1, :address_city, :address_state,
-                  :address_zip, :monitored_address_line_1, :monitored_address_city, :monitored_address_state, :monitored_address_zip, nil, nil, nil, nil,
-                  :primary_telephone, :secondary_telephone, :email, nil, nil, nil, :potential_exposure_location, :potential_exposure_country,
-                  :date_of_departure, nil, nil, nil, nil, :contact_of_known_case, :was_in_health_care_facility_with_known_cases].freeze
-
-  EPI_X_HEADERS = ['Local-ID', 'Flight No', 'Date of notice', 'MDH Assignee', 'DGMQ ID', 'CARE ID', 'CARE Cell Number', 'Language', 'Arrival Date and Time',
-                   'Arrival City', 'Last Name', 'First Name', 'Date of Birth', 'Gender', 'Passport Country', 'Passport Number', 'Permanent Street Address',
-                   'Permanent City', 'Permanent State or Country', 'Postal Code', 'Temporary Street Address 1', 'Temporary City 1', 'Temporary State 1',
-                   'Temporary Postal Code 1', 'Temporary Street Address 2', 'Temporary City 2', 'Temporary State 2', 'Temporary Postal Code 2',
-                   'Phone Number 1', 'Phone Number 2', 'Email 1', 'Email 2', 'Emergency Contact Name', 'Emergency Contact Telephone Number',
-                   'Emergency Contact Email', 'Countries Visited with Widespread Transmission in Past 14 Days', 'Departure Date',
-                   'DHS Observed Vomiting, Diarrhea or Bleeding', 'Temperature taken by DHS', 'Fever/Chills in the past 48 hours',
-                   'Vomiting/Diarrhea in the past 48 hours', 'Lived in Same Household or Had Other Contact with a Person Sick with disease in Past 14 Days',
-                   'Worked in Health Care Facility or Laboratory in Country with Widespread Transmission in Past 14 Days',
-                   'Touched Body of Someone who Died in Country with Widespread Transmission in Past 14 Days',
-                   'DHS Traveler Health Declaration Outcome: Released', 'DHS Traveler Health Declaration Outcome: Referred to Tertiary for Add\'l Assessment',
-                   'Disposition of Travelers Referred for CDC Assessment: Released to Continue Travel',
-                   'Disposition of Travelers Referred for CDC Assessment: Coordinated Disposition with State Health Dept.',
-                   'Disposition of Travelers Referred for CDC Assessment: Referred for Additional Medical Evaluation',
-                   'Disposition of Travelers Referred for CDC Assessment: Other', 'Final Disposition of Traveler\'s Medical Evaluation (If applicable)',
-                   'Exposure Assessment', 'Contact Made?', 'Monitoring needed?', 'Notes'].freeze
-
-  LINELIST_FIELDS = %i[id name jurisdiction_name assigned_user user_defined_id_statelocal sex date_of_birth end_of_monitoring exposure_risk_assessment
-                       monitoring_plan latest_assessment_at latest_transfer_at monitoring_reason public_health_action status closed_at transferred_from
-                       transferred_to expected_purge_ts symptom_onset extended_isolation].freeze
-
-  LINELIST_HEADERS = ['Patient ID', 'Monitoree', 'Jurisdiction', 'Assigned User', 'State/Local ID', 'Sex', 'Date of Birth', 'End of Monitoring', 'Risk Level',
-                      'Monitoring Plan', 'Latest Report', 'Transferred At', 'Reason For Closure', 'Latest Public Health Action', 'Status', 'Closed At',
-                      'Transferred From', 'Transferred To', 'Expected Purge Date', 'Symptom Onset', 'Extended Isolation'].freeze
-
-  SARA_ALERT_FORMAT_FIELDS = %i[first_name middle_name last_name date_of_birth sex white black_or_african_american american_indian_or_alaska_native asian
-                                native_hawaiian_or_other_pacific_islander ethnicity primary_language secondary_language interpretation_required nationality
-                                user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss address_line_1 address_city address_state address_line_2
-                                address_zip address_county foreign_address_line_1 foreign_address_city foreign_address_country foreign_address_line_2
-                                foreign_address_zip foreign_address_line_3 foreign_address_state monitored_address_line_1 monitored_address_city
-                                monitored_address_state monitored_address_line_2 monitored_address_zip monitored_address_county foreign_monitored_address_line_1
-                                foreign_monitored_address_city foreign_monitored_address_state foreign_monitored_address_line_2 foreign_monitored_address_zip
-                                foreign_monitored_address_county preferred_contact_method primary_telephone primary_telephone_type secondary_telephone
-                                secondary_telephone_type preferred_contact_time email port_of_origin date_of_departure source_of_report flight_or_vessel_number
-                                flight_or_vessel_carrier port_of_entry_into_usa date_of_arrival travel_related_notes additional_planned_travel_type
-                                additional_planned_travel_destination additional_planned_travel_destination_state additional_planned_travel_destination_country
-                                additional_planned_travel_port_of_departure additional_planned_travel_start_date additional_planned_travel_end_date
-                                additional_planned_travel_related_notes last_date_of_exposure potential_exposure_location potential_exposure_country
-                                contact_of_known_case contact_of_known_case_id travel_to_affected_country_or_area was_in_health_care_facility_with_known_cases
-                                was_in_health_care_facility_with_known_cases_facility_name laboratory_personnel laboratory_personnel_facility_name
-                                healthcare_personnel healthcare_personnel_facility_name crew_on_passenger_or_cargo_flight member_of_a_common_exposure_cohort
-                                member_of_a_common_exposure_cohort_type exposure_risk_assessment monitoring_plan exposure_notes full_status symptom_onset
-                                case_status lab_1_type lab_1_specimen_collection lab_1_report lab_1_result lab_2_type lab_2_specimen_collection lab_2_report
-                                lab_2_result jurisdiction_path assigned_user gender_identity sexual_orientation race_other race_unknown
-                                race_refused_to_answer].freeze
-
-  SARA_ALERT_FORMAT_HEADERS = ['First Name', 'Middle Name', 'Last Name', 'Date of Birth', 'Sex at Birth', 'White', 'Black or African American',
-                               'American Indian or Alaska Native', 'Asian', 'Native Hawaiian or Other Pacific Islander', 'Ethnicity', 'Primary Language',
-                               'Secondary Language', 'Interpretation Required?', 'Nationality', 'Identifier (STATE/LOCAL)', 'Identifier (CDC)',
-                               'Identifier (NNDSS)', 'Address Line 1', 'Address City', 'Address State', 'Address Line 2', 'Address Zip', 'Address County',
-                               'Foreign Address Line 1', 'Foreign Address City', 'Foreign Address Country', 'Foreign Address Line 2', 'Foreign Address Zip',
-                               'Foreign Address Line 3', 'Foreign Address State', 'Monitored Address Line 1', 'Monitored Address City',
-                               'Monitored Address State', 'Monitored Address Line 2', 'Monitored Address Zip', 'Monitored Address County',
-                               'Foreign Monitored Address Line 1', 'Foreign Monitored Address City', 'Foreign Monitored Address State',
-                               'Foreign Monitored Address Line 2', 'Foreign Monitored Address Zip', 'Foreign Monitored Address County',
-                               'Preferred Contact Method', 'Primary Telephone', 'Primary Telephone Type', 'Secondary Telephone', 'Secondary Telephone Type',
-                               'Preferred Contact Time', 'Email', 'Port of Origin', 'Date of Departure', 'Source of Report', 'Flight or Vessel Number',
-                               'Flight or Vessel Carrier', 'Port of Entry Into USA', 'Date of Arrival', 'Travel Related Notes',
-                               'Additional Planned Travel Type', 'Additional Planned Travel Destination', 'Additional Planned Travel Destination State',
-                               'Additional Planned Travel Destination Country', 'Additional Planned Travel Port of Departure',
-                               'Additional Planned Travel Start Date', 'Additional Planned Travel End Date', 'Additional Planned Travel Related Notes',
-                               'Last Date of Exposure', 'Potential Exposure Location', 'Potential Exposure Country', 'Contact of Known Case?',
-                               'Contact of Known Case ID', 'Travel from Affected Country or Area?', 'Was in Health Care Facility With Known Cases?',
-                               'Health Care Facility with Known Cases Name', 'Laboratory Personnel?', 'Laboratory Personnel Facility Name',
-                               'Health Care Personnel?', 'Health Care Personnel Facility Name', 'Crew on Passenger or Cargo Flight?',
-                               'Member of a Common Exposure Cohort?', 'Common Exposure Cohort Name', 'Exposure Risk Assessment', 'Monitoring Plan',
-                               'Exposure Notes', 'Status', 'Symptom Onset Date', 'Case Status', 'Lab 1 Test Type', 'Lab 1 Specimen Collection Date',
-                               'Lab 1 Report Date', 'Lab 1 Result', 'Lab 2 Test Type', 'Lab 2 Specimen Collection Date', 'Lab 2 Report Date', 'Lab 2 Result',
-                               'Full Assigned Jurisdiction Path', 'Assigned User', 'Gender Identity', 'Sexual Orientation', 'Race Other', 'Race Unknown',
-                               'Race Refused to Answer'].freeze
-
-  # Extended Isolation Date is intentionally appended to the end even if new fields are added to Sara Alert Format to maintain more consistency in the ordering
-  # of fields between Sara Alert Format and Full History Patients
-  FULL_HISTORY_PATIENTS_FIELDS = ([:id] + SARA_ALERT_FORMAT_FIELDS + [:extended_isolation]).freeze
-
-  FULL_HISTORY_PATIENTS_HEADERS = (['Patient ID'] + SARA_ALERT_FORMAT_HEADERS + ['Extended Isolation Date']).freeze
-
-  FULL_HISTORY_ASSESSMENTS_FIELDS = %i[patient_id symptomatic who_reported created_at updated_at symptoms].freeze
-
-  FULL_HISTORY_ASSESSMENTS_HEADERS = ['Patient ID', 'Symptomatic', 'Who Reported', 'Created At', 'Updated At', 'Symptoms Reported'].freeze
-
-  FULL_HISTORY_LABORATORIES_FIELDS = %i[patient_id lab_type specimen_collection report result created_at updated_at].freeze
-
-  FULL_HISTORY_LABORATORIES_HEADERS = ['Patient ID', 'Lab Type', 'Specimen Collection Date', 'Report Date', 'Result', 'Created At', 'Updated At'].freeze
-
-  FULL_HISTORY_HISTORIES_FIELDS = %i[patient_id comment created_by history_type created_at updated_at].freeze
-
-  FULL_HISTORY_HISTORIES_HEADERS = ['Patient ID', 'Comment', 'Created By', 'History Type', 'Created At', 'Updated At'].freeze
-
-  PATIENT_ALTERNATIVE_IDENTIFIERS = %i[user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss].freeze
-
-  PATIENT_RACE_FIELDS = %i[white black_or_african_american american_indian_or_alaska_native asian native_hawaiian_or_other_pacific_islander race_other
-                           race_unknown race_refused_to_answer].freeze
-
-  PATIENT_LAB_FIELDS = %i[lab_1_type lab_1_specimen_collection lab_1_report lab_1_result lab_2_type lab_2_specimen_collection lab_2_report lab_2_result].freeze
-
-  PATIENT_FIELD_TYPES = {
-    numbers: %i[id assigned_user responder_id],
-    strings: %i[first_name middle_name last_name sex ethnicity primary_language secondary_language nationality user_defined_id_statelocal user_defined_id_cdc
-                user_defined_id_nndss address_line_1 address_city address_state address_line_2 address_zip address_county foreign_address_line_1
-                foreign_address_city foreign_address_country foreign_address_line_2 foreign_address_zip foreign_address_line_3 foreign_address_state
-                monitored_address_line_1 monitored_address_city monitoring_address_state monitored_address_state monitored_address_line_2 monitored_address_zip
-                monitored_address_county foreign_monitored_address_line_1 foreign_monitored_address_city foreign_monitored_address_state
-                foreign_monitored_address_line_2 foreign_monitored_address_zip foreign_monitored_address_county preferred_contact_method primary_telephone_type
-                secondary_telephone_type preferred_contact_time email port_of_origin source_of_report source_of_report_specify flight_or_vessel_number
-                flight_or_vessel_carrier port_of_entry_into_usa travel_related_notes additional_planned_travel_type additional_planned_travel_destination
-                additional_planned_travel_destination_state additional_planned_travel_destination_country additional_planned_travel_port_of_departure
-                additional_planned_travel_related_notes potential_exposure_location potential_exposure_country contact_of_known_case_id
-                was_in_health_care_facility_with_known_cases_facility_name laboratory_personnel_facility_name healthcare_personnel_facility_name
-                member_of_a_common_exposure_cohort_type exposure_risk_assessment monitoring_plan exposure_notes case_status gender_identity
-                sexual_orientation risk_level monitoring_reason public_health_action],
-    dates: %i[date_of_birth date_of_departure date_of_arrival additional_planned_travel_start_date additional_planned_travel_end_date last_date_of_exposure
-              symptom_onset extended_isolation],
-    timestamps: %i[created_at updated_at closed_at latest_assessment_at latest_transfer_at last_assessment_reminder_sent],
-    booleans: %i[interpretation_required isolation continuous_exposure contact_of_known_case travel_to_affected_country_or_area
-                 was_in_health_care_facility_with_known_cases laboratory_personnel healthcare_personnel crew_on_passenger_or_cargo_flight
-                 member_of_a_common_exposure_cohort head_of_household pause_notifications].concat(PATIENT_RACE_FIELDS),
-    phones: %i[primary_telephone secondary_telephone]
-  }.freeze
-
-  PATIENT_FIELD_NAMES = {
-    # Enrollment Info - Identification and Demographics - Identifiers
-    id: 'Sara Alert ID',
-    user_defined_id_statelocal: 'State/Local ID',
-    user_defined_id_cdc: 'CDC ID',
-    user_defined_id_nndss: 'NNDSS ID',
-    # Enrollment Info - Identification and Demographics - Name
-    first_name: 'First Name',
-    last_name: 'Last Name',
-    middle_name: 'Middle Name',
-    # Enrollment Info - Identification and Demographics - Date of Birth
-    date_of_birth: 'Date of Birth',
-    age: 'Age',
-    # Enrollment Info - Identification and Demographics - Sex at Birth
-    sex: 'Sex at Birth',
-    # Enrollment Info - Identification and Demographics - Gender Identity and Sexual Orientation
-    gender_identity: 'Gender Identity',
-    sexual_orientation: 'Sexual Orientation',
-    # Enrollment Info - Identification and Demographics - Race, Ethnicity, and Nationality
-    race: 'Race (All Race Fields)',
-    white: 'White',
-    black_or_african_american: 'Black or African American',
-    american_indian_or_alaska_native: 'American Indian or Alaska Native',
-    asian: 'Asian',
-    native_hawaiian_or_other_pacific_islander: 'Native Hawaiian or Other Pacific Islander',
-    race_other: 'Race Other',
-    race_unknown: 'Race Unknown',
-    race_refused_to_answer: 'Race Refused to Answer',
-    ethnicity: 'Ethnicity',
-    nationality: 'Nationality',
-    # Enrollment Info - Identification and Demographics - Language
-    primary_language: 'Primary Language',
-    secondary_language: 'Secondary Language',
-    interpretation_required: 'Interpretation Required',
-    # Enrollment Info - Home and Monitored Address - Home Address (USA)
-    address_line_1: 'Address Line 1',
-    address_line_2: 'Address Line 2',
-    address_city: 'Address City',
-    address_state: 'Address State',
-    address_zip: 'Address Zip',
-    address_county: 'Address County',
-    # Enrollment Info - Home and Monitored Address - Home Address (Foreign)
-    foreign_address_line_1: 'Foreign Address Line 1',
-    foreign_address_line_2: 'Foreign Address Line 2',
-    foreign_address_city: 'Foreign Address City',
-    foreign_address_country: 'Foreign Address Country',
-    foreign_address_zip: 'Foreign Address Zip',
-    foreign_address_line_3: 'Foreign Address Line 3',
-    foreign_address_state: 'Foreign Address State',
-    # Enrollment Info - Home and Monitored Address - Monitored Address (USA)
-    monitored_address_line_1: 'Monitored Address Line 1',
-    monitored_address_line_2: 'Monitored Address Line 2',
-    monitored_address_city: 'Monitored Address City',
-    monitored_address_state: 'Monitored Address State',
-    monitored_address_zip: 'Monitored Address Zip',
-    monitored_address_county: 'Monitored Address County',
-    # Enrollment Info - Home and Monitored Address - Monitored Address (Foreign)
-    foreign_monitored_address_line_1: 'Foreign Monitored Address Line 1',
-    foreign_monitored_address_line_2: 'Foreign Monitored Address Line 2',
-    foreign_monitored_address_city: 'Foreign Monitored Address City',
-    foreign_monitored_address_state: 'Foreign Monitored Address State',
-    foreign_monitored_address_zip: 'Foreign Monitored Address Zip',
-    foreign_monitored_address_county: 'Foreign Monitored Address County',
-    # Enrollment Info - Contact Information
-    preferred_contact_method: 'Preferred Contact Method',
-    preferred_contact_time: 'Preferred Contact Time',
-    primary_telephone: 'Primary Telephone',
-    primary_telephone_type: 'Primary Telephone Type',
-    secondary_telephone: 'Secondary Telephone',
-    secondary_telephone_type: 'Secondary Telephone Type',
-    email: 'Email',
-    # Enrollment Info - Travel - Arrival Information
-    port_of_origin: 'Port of Origin',
-    date_of_departure: 'Date of Departure',
-    flight_or_vessel_number: 'Flight or Vessel Number',
-    flight_or_vessel_carrier: 'Flight or Vessel Carrier',
-    port_of_entry_into_usa: 'Port of Entry Into USA',
-    date_of_arrival: 'Date of Arrival',
-    source_of_report: 'Source of Report',
-    source_of_report_specify: 'Source of Report Specify',
-    travel_related_notes: 'Travel Related Notes',
-    # Enrollment Info - Travel - Additional Planned Travel
-    additional_planned_travel_type: 'Additional Planned Travel Type',
-    additional_planned_travel_destination: 'Additional Planned Travel Destination',
-    additional_planned_travel_destination_state: 'Additional Planned Travel Destination State',
-    additional_planned_travel_destination_country: 'Additional Planned Travel Destination Country',
-    additional_planned_travel_port_of_departure: 'Additional Planned Travel Port of Departure',
-    additional_planned_travel_start_date: 'Additional Planned Travel Start Date',
-    additional_planned_travel_end_date: 'Additional Planned Travel End Date',
-    additional_planned_travel_related_notes: 'Additional Planned Travel Related Notes',
-    # Enrollment Info - Potential Exposure Information - Exposure Location and Notes
-    potential_exposure_location: 'Potential Exposure Location',
-    potential_exposure_country: 'Potential Exposure Country',
-    # Enrollment Info - Potential Exposure Information - Risk Factors
-    contact_of_known_case: 'Contact of Known Case',
-    contact_of_known_case_id: 'Contact of Known Case ID',
-    travel_to_affected_country_or_area: 'Travel from Affected Country or Area',
-    was_in_health_care_facility_with_known_cases: 'Was in Health Care Facility With Known Cases',
-    was_in_health_care_facility_with_known_cases_facility_name: 'Health Care Facility with Known Cases Name',
-    laboratory_personnel: 'Laboratory Personnel',
-    laboratory_personnel_facility_name: 'Laboratory Personnel Facility Name',
-    healthcare_personnel: 'Health Care Personnel',
-    healthcare_personnel_facility_name: 'Health Care Personnel Facility Name',
-    crew_on_passenger_or_cargo_flight: 'Crew on Passenger or Cargo Flight',
-    member_of_a_common_exposure_cohort: 'Member of a Common Exposure Cohort',
-    member_of_a_common_exposure_cohort_type: 'Common Exposure Cohort Name',
-    exposure_notes: 'Exposure Notes',
-    # Enrollment Info - Record Creation and Updates
-    creator: 'Enroller',
-    created_at: 'Monitoree Created Date',
-    updated_at: 'Monitoree Updated Date',
-    # Monitoring Info - Linelist Info
-    workflow: 'Current Workflow',
-    status: 'Status',
-    # Monitoring Info - Monitoring Actions
-    monitoring_status: 'Monitoring Status',
-    exposure_risk_assessment: 'Exposure Risk Assessment',
-    monitoring_plan: 'Monitoring Plan',
-    case_status: 'Case Status',
-    public_health_action: 'Latest Public Health Action',
-    jurisdiction_path: 'Full Assigned Jurisdiction Path',
-    jurisdiction_name: 'Assigned Jurisdiction',
-    assigned_user: 'Assigned User',
-    # Monitoring Info - Monitoring Period
-    last_date_of_exposure: 'Last Date of Exposure',
-    continuous_exposure: 'Continuous Exposure',
-    symptom_onset: 'Symptom Onset Date',
-    symptom_onset_defined_by: 'Symptom Onset Defined By',
-    extended_isolation: 'Extended Isolation Date',
-    end_of_monitoring: 'End of Monitoring',
-    closed_at: 'Closure Date',
-    monitoring_reason: 'Reason For Closure',
-    expected_purge_ts: 'Expected Purge Date',
-    # Monitoring Info - Reporting Info
-    responder_id: 'ID of Reporter',
-    head_of_household: 'Head of Household',
-    pause_notifications: 'Paused Notifications',
-    last_assessment_reminder_sent: 'Last Assessment Reminder Sent Date',
-    # CSV Linelist Export Specific Fields
-    name: 'Name',
-    latest_assessment_at: 'Latest Report',
-    latest_transfer_at: 'Transferred At',
-    transferred_from: 'Transferred From',
-    transferred_to: 'Transferred To'
-  }.freeze
-
-  ASSESSMENT_FIELD_NAMES = {
-    patient_id: 'Sara Alert ID',
-    user_defined_id_statelocal: 'State/Local ID',
-    user_defined_id_cdc: 'CDC ID',
-    user_defined_id_nndss: 'NNDSS ID',
-    id: 'Report ID',
-    symptomatic: 'Needs Review',
-    who_reported: 'Who Reported',
-    created_at: 'Report Created Date',
-    updated_at: 'Report Updated Date',
-    symptoms: 'Symptoms Reported'
-  }.freeze
-
-  LABORATORY_FIELD_NAMES = {
-    patient_id: 'Sara Alert ID',
-    user_defined_id_statelocal: 'State/Local ID',
-    user_defined_id_cdc: 'CDC ID',
-    user_defined_id_nndss: 'NNDSS ID',
-    id: 'Lab Report ID',
-    lab_type: 'Lab Type',
-    specimen_collection: 'Specimen Collection Date',
-    report: 'Report Date',
-    result: 'Lab Result',
-    created_at: 'Lab Report Created Date',
-    updated_at: 'Lab Report Updated Date'
-  }.freeze
-
-  CLOSE_CONTACT_FIELD_NAMES = {
-    patient_id: 'Sara Alert ID',
-    user_defined_id_statelocal: 'State/Local ID',
-    user_defined_id_cdc: 'CDC ID',
-    user_defined_id_nndss: 'NNDSS ID',
-    id: 'Close Contact ID',
-    first_name: 'First Name',
-    last_name: 'Last Name',
-    primary_telephone: 'Primary Telephone',
-    email: 'Email',
-    contact_attempts: 'Contact Attempts',
-    last_date_of_exposure: 'Last Date of Exposure',
-    assigned_user: 'Assigned User',
-    notes: 'Notes',
-    enrolled_id: 'Enrolled ID',
-    created_at: 'Close Contact Created Date',
-    updated_at: 'Close Contact Updated Date'
-  }.freeze
-
-  TRANSFER_FIELD_NAMES = {
-    patient_id: 'Sara Alert ID',
-    user_defined_id_statelocal: 'State/Local ID',
-    user_defined_id_cdc: 'CDC ID',
-    user_defined_id_nndss: 'NNDSS ID',
-    id: 'Transfer ID',
-    who: 'Who Initiated Transfer',
-    from_jurisdiction: 'From Jurisdiction',
-    to_jurisdiction: 'To Jurisdiction',
-    created_at: 'Transfer Created Date',
-    updated_at: 'Transfer Updated Date'
-  }.freeze
-
-  HISTORY_FIELD_NAMES = {
-    patient_id: 'Sara Alert ID',
-    user_defined_id_statelocal: 'State/Local ID',
-    user_defined_id_cdc: 'CDC ID',
-    user_defined_id_nndss: 'NNDSS ID',
-    id: 'History ID',
-    created_by: 'History Creator',
-    history_type: 'History Type',
-    comment: 'History Comment',
-    created_at: 'History Created Date',
-    updated_at: 'History Updated Date'
-  }.freeze
-
-  ALL_FIELDS_NAMES = {
-    patients: PATIENT_FIELD_NAMES,
-    assessments: ASSESSMENT_FIELD_NAMES,
-    laboratories: LABORATORY_FIELD_NAMES,
-    close_contacts: CLOSE_CONTACT_FIELD_NAMES,
-    transfers: TRANSFER_FIELD_NAMES,
-    histories: HISTORY_FIELD_NAMES
-  }.freeze
-
-  # Creates react checkbox tree node with children populated
-  def self.rct_node(schema, label, fields)
-    return if ALL_FIELDS_NAMES[schema].nil?
-
-    {
-      value: "#{schema}-#{label&.gsub(' ', '_')&.gsub(',', '')&.downcase}",
-      label: label,
-      children: fields.map { |field| { value: field&.to_s, label: ALL_FIELDS_NAMES[schema][field] } }
-    }
+  # Writes export data to file(s)
+  def write_export_data_to_files(config, patients, outer_batch_size, inner_batch_size)
+    case config[:format]
+    when 'csv'
+      csv_export(config, patients, outer_batch_size, inner_batch_size)
+    when 'xlsx'
+      xlsx_export(config, patients, outer_batch_size, inner_batch_size)
+    end
   end
 
-  PATIENTS_EXPORT_OPTIONS = {
-    label: 'Monitorees',
-    nodes: [
-      {
-        value: 'patients',
-        label: 'Monitoree Details',
-        children: [
-          {
-            value: 'patients-enrollment',
-            label: 'Enrollment Info',
-            children: [
-              {
-                value: 'patients-enrollment-identification-and-demographics',
-                label: 'Identification and Demographics',
-                children: [
-                  rct_node(:patients, 'Identifiers', %i[id user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss]),
-                  rct_node(:patients, 'Name', %i[first_name last_name middle_name]),
-                  rct_node(:patients, 'Date of Birth', %i[date_of_birth age]),
-                  { value: :sex, label: ALL_FIELDS_NAMES[:patients][:sex] },
-                  rct_node(:patients, 'Gender Identity and Sexual Orientation', %i[gender_identity sexual_orientation]),
-                  rct_node(:patients, 'Race, Ethnicity, and Nationality', %i[race ethnicity nationality]),
-                  rct_node(:patients, 'Language', %i[primary_language secondary_language interpretation_required])
-                ]
-              },
-              {
-                value: 'patients-enrollment-home-and-monitored-address',
-                label: 'Home and Monitored Address',
-                children: [
-                  rct_node(:patients, 'Home Address (USA)', %i[address_line_1 address_line_2 address_city address_state address_zip address_county]),
-                  rct_node(:patients, 'Home Address (Foreign)', %i[foreign_address_line_1 foreign_address_line_2 foreign_address_city foreign_address_country
-                                                                   foreign_address_zip foreign_address_line_3 foreign_address_state]),
-                  rct_node(:patients, 'Monitored Address (USA)', %i[monitored_address_line_1 monitored_address_line_2 monitored_address_city
-                                                                    monitored_address_state monitored_address_zip monitored_address_county]),
-                  rct_node(:patients, 'Monitored Address (Foreign)', %i[foreign_monitored_address_line_1 foreign_monitored_address_line_2
-                                                                        foreign_monitored_address_city foreign_monitored_address_state
-                                                                        foreign_monitored_address_zip foreign_monitored_address_county])
-                ]
-              },
-              rct_node(:patients, 'Contact Information', %i[preferred_contact_method preferred_contact_time primary_telephone primary_telephone_type
-                                                            secondary_telephone secondary_telephone_type email]),
-              {
-                value: 'patients-enrollment-travel',
-                label: 'Travel',
-                children: [
-                  rct_node(:patients, 'Arrival Information', %i[port_of_origin date_of_departure flight_or_vessel_number flight_or_vessel_carrier
-                                                                port_of_entry_into_usa date_of_arrival source_of_report source_of_report_specify
-                                                                travel_related_notes]),
-                  rct_node(:patients, 'Additional Planned Travel', %i[additional_planned_travel_type additional_planned_travel_destination
-                                                                      additional_planned_travel_destination_state additional_planned_travel_destination_country
-                                                                      additional_planned_travel_port_of_departure additional_planned_travel_start_date
-                                                                      additional_planned_travel_end_date additional_planned_travel_related_notes])
-                ]
-              },
-              {
-                value: 'patients-enrollment-potential_exposure_information',
-                label: 'Potential Exposure Information',
-                children: [
-                  rct_node(:patients, 'Exposure Location and Notes', %i[potential_exposure_location potential_exposure_country]),
-                  rct_node(:patients, 'Exposure Risk Factors', %i[contact_of_known_case contact_of_known_case_id travel_to_affected_country_or_area
-                                                                  was_in_health_care_facility_with_known_cases
-                                                                  was_in_health_care_facility_with_known_cases_facility_name laboratory_personnel
-                                                                  laboratory_personnel_facility_name healthcare_personnel healthcare_personnel_facility_name
-                                                                  crew_on_passenger_or_cargo_flight member_of_a_common_exposure_cohort
-                                                                  member_of_a_common_exposure_cohort_type exposure_notes])
-                ]
-              },
-              rct_node(:patients, 'Record Creation and Updates', %i[creator created_at updated_at])
-            ]
-          },
-          {
-            value: 'patients-monitoring',
-            label: 'Monitoring Info',
-            children: [
-              rct_node(:patients, 'Linelist Info', %i[workflow status]),
-              rct_node(:patients, 'Monitoring Actions', %i[monitoring_status exposure_risk_assessment monitoring_plan case_status public_health_action
-                                                           jurisdiction_path jurisdiction_name assigned_user]),
-              rct_node(:patients, 'Monitoring Period', %i[last_date_of_exposure continuous_exposure symptom_onset symptom_onset_defined_by
-                                                          extended_isolation end_of_monitoring closed_at monitoring_reason expected_purge_ts]),
-              rct_node(:patients, 'Reporting Info', %i[responder_id head_of_household pause_notifications last_assessment_reminder_sent])
-            ]
-          }
-        ]
-      }
-    ]
-  }.freeze
+  # Creates a list of csv files from exported data
+  def csv_export(config, patients, outer_batch_size, inner_batch_size)
+    files = []
 
-  ASSESSMENTS_EXPORT_OPTIONS = {
-    label: 'Reports',
-    nodes: [rct_node(:assessments, 'Reports', %i[patient_id user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss id symptomatic
-                                                 who_reported created_at updated_at symptoms])]
-  }.freeze
+    # Determine selected data types for export
+    data_types = CUSTOM_EXPORT_OPTIONS.keys.select { |data_type| config.dig(:data, data_type, :checked).present? }
 
-  LABORATORIES_EXPORT_OPTIONS = {
-    label: 'Lab Results',
-    nodes: [rct_node(:laboratories, 'Lab Results', %i[patient_id user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss id lab_type
-                                                      specimen_collection report result created_at updated_at])]
-  }.freeze
+    # Get all of the field data based on the config
+    field_data = get_field_data(config)
 
-  CLOSE_CONTACTS_EXPORT_OPTIONS = {
-    label: 'Close Contacts',
-    nodes: [rct_node(:close_contacts, 'Close Contacts', %i[patient_id user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss id first_name
-                                                           last_name primary_telephone email contact_attempts last_date_of_exposure assigned_user notes
-                                                           enrolled_id created_at updated_at])]
-  }.freeze
+    # Declare variables in scope outside of batch loop
+    csvs = nil
+    packages = nil
+    total_inner_batches = (patients.size / inner_batch_size.to_f).ceil
 
-  TRANSFERS_EXPORT_OPTIONS = {
-    label: 'Transfers',
-    nodes: [rct_node(:transfers, 'Transfers', %i[patient_id user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss id who from_jurisdiction
-                                                 to_jurisdiction created_at updated_at])]
-  }.freeze
+    # NOTE: in_batches appears to NOT sort within batches, so explicit ordering on ID is also done deeper down.
+    # The reorder('') here allows this ordering done later on to work properly.
+    patients.reorder('').in_batches(of: inner_batch_size).each_with_index do |batch_group, inner_batch_index|
+      # 1) Create file(s) for new batch
+      if (inner_batch_index % (outer_batch_size / inner_batch_size)).zero?
+        # One file for all data types, each data type in a different tab
+        csvs = {}
+        packages = {}
+        data_types.each do |data_type|
+          # Create CSV with column headers
+          package = CSV.generate(headers: true) do |csv|
+            csv << field_data.dig(data_type, :headers)
+            csvs[data_type] = csv
+          end
+          packages[data_type] = package
+        end
+      end
 
-  HISTORIES_EXPORT_OPTIONS = {
-    label: 'Histories',
-    nodes: [rct_node(:histories, 'History', %i[patient_id user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss id created_by history_type
-                                               comment created_at updated_at])]
-  }.freeze
+      # 2) Get export data in batches to decrease size of export data hash maintained in memory
+      exported_data = get_export_data(batch_group.order(:id), config[:data])
+      data_types.each do |data_type|
+        exported_data[data_type]&.each do |record|
+          csvs[data_type] << field_data[data_type][:checked].map { |field| record[field] }
+        end
+      end
 
-  CUSTOM_EXPORT_OPTIONS = {
-    patients: PATIENTS_EXPORT_OPTIONS,
-    assessments: ASSESSMENTS_EXPORT_OPTIONS,
-    laboratories: LABORATORIES_EXPORT_OPTIONS,
-    close_contacts: CLOSE_CONTACTS_EXPORT_OPTIONS,
-    transfers: TRANSFERS_EXPORT_OPTIONS,
-    histories: HISTORIES_EXPORT_OPTIONS
-  }.freeze
+      # 3) Save files to db at the end of each outer batch
+      next unless ((inner_batch_index + 1) % (outer_batch_size / inner_batch_size)).zero? || inner_batch_index == total_inner_batches - 1
+
+      outer_batch_index = inner_batch_index * inner_batch_size / outer_batch_size
+      data_types.each do |data_type|
+        file = { filename: build_export_filename(config, data_type, outer_batch_index, false), content: Base64.encode64(packages[data_type]) }
+        files << save_file(config, file)
+      end
+    end
+
+    files
+  end
+
+  # Creates a list of excel files from exported data
+  def xlsx_export(config, patients, outer_batch_size, inner_batch_size)
+    files = []
+    separate_files = config[:separate_files].present?
+
+    # Determine selected data types for export
+    data_types = CUSTOM_EXPORT_OPTIONS.keys.select { |data_type| config.dig(:data, data_type, :checked).present? }
+
+    # Get all of the field data based on the config
+    field_data = get_field_data(config)
+
+    # Declare variables in scope outside of batch loop
+    workbooks = nil if separate_files
+    workbook = nil unless separate_files
+    sheets = nil
+    last_row_nums = nil
+    total_inner_batches = (patients.size / inner_batch_size.to_f).ceil
+
+    # NOTE: in_batches appears to NOT sort within batches, so explicit ordering on ID is also done deeper down.
+    # The reorder('') here allows this ordering done later on to work properly.
+    patients.reorder('').in_batches(of: inner_batch_size).each_with_index do |batch_group, inner_batch_index|
+      # 1) Create file(s) for new batch
+      if (inner_batch_index % (outer_batch_size / inner_batch_size)).zero?
+        # One file for all data types, each data type in a different tab
+        workbooks = {} if separate_files
+        workbook = FastExcel.open(constant_memory: true) unless separate_files
+        sheets = {}
+        last_row_nums = {}
+        data_types.each do |data_type|
+          workbook = FastExcel.open(constant_memory: true) if separate_files
+          worksheet = workbook.add_worksheet(config.dig(:data, data_type, :tab) || CUSTOM_EXPORT_OPTIONS.dig(data_type, :label))
+          worksheet.auto_width = true
+          worksheet.append_row(field_data.dig(data_type, :headers))
+          last_row_nums[data_type] = 0
+          sheets[data_type] = worksheet
+          workbooks[data_type] = workbook if separate_files
+        end
+      end
+
+      # 2) Get export data in batches to decrease size of export data hash maintained in memory
+      exported_data = get_export_data(batch_group.order(:id), config[:data])
+      data_types.each do |data_type|
+        last_row_nums[data_type] = write_xlsx_rows(exported_data, data_type, sheets[data_type], field_data[data_type][:checked], last_row_nums[data_type])
+      end
+
+      # 3) Save files to db at the end of each outer batch
+      next unless ((inner_batch_index + 1) % (outer_batch_size / inner_batch_size)).zero? || inner_batch_index == total_inner_batches - 1
+
+      outer_batch_index = inner_batch_index * inner_batch_size / outer_batch_size
+      if separate_files
+        data_types.each do |data_type|
+          file = { filename: build_export_filename(config, data_type, outer_batch_index, false), content: Base64.encode64(workbooks[data_type].read_string) }
+          files << save_file(config, file)
+        end
+      else
+        file = { filename: build_export_filename(config, nil, outer_batch_index, false), content: Base64.encode64(workbook.read_string) }
+        files << save_file(config, file)
+      end
+    end
+
+    files
+  end
+
+  # Gets data for this batch of patients that may not have already been present in the export config (such as specific symptoms).
+  def get_field_data(config)
+    data = config[:data].deep_dup
+
+    # Update the checked data (used for obtaining values) with race information
+    update_checked_race_data(data)
+
+    # Update the header data (used for obtaining column names)
+    update_headers(data)
+
+    # Update the checked and header data for assessment symptoms
+    # NOTE: this must be done after updating the general headers above
+    update_assessment_symptom_data(data)
+
+    data
+  end
+
+  def write_xlsx_rows(exported_data, data_type, worksheet, fields, last_row_num)
+    exported_data[data_type]&.each do |record|
+      # fast_excel unfortunately does not provide a method to modify the @last_row_number class variable so it needs to be manually kept track of
+      last_row_num += 1
+      fields.each_with_index do |field, col_index|
+        # write_string is used instead of append_row because it does not provide the capability to write data as strings
+        worksheet.write_string(last_row_num, col_index, record[field].to_s, nil)
+      end
+    end
+    last_row_num
+  end
+
+  # Write file and create lookup
+  def save_file(config, file)
+    lookup = SecureRandom.uuid
+    if ActiveRecord::Base.logger.formatter.nil?
+      download = Download.insert(user_id: config[:user_id], export_type: config[:export_type], filename: file[:filename],
+                                 lookup: lookup, contents: file[:content], created_at: DateTime.now, updated_at: DateTime.now)
+    else
+      ActiveRecord::Base.logger.silence do
+        download = Download.insert(user_id: config[:user_id], export_type: config[:export_type], filename: file[:filename],
+                                   lookup: lookup, contents: file[:content], created_at: DateTime.now, updated_at: DateTime.now)
+      end
+    end
+    { lookup: lookup, filename: file[:filename] }
+  end
+
+  # Finds the symptoms needed for the reports columns
+  def update_assessment_symptom_data(data)
+    # Don't update if assessment symptom data isn't needed
+    return unless data.dig(:assessments, :checked).present? && data[:assessments][:checked].include?(:symptoms)
+
+    # Using Symptom.all for finding distinct symptom names is actually faster here because it can use symptoms_index_chain_1
+    symptom_names = Symptom.all.distinct.pluck(:name).sort
+    symptom_labels = symptom_names.map { |name| Symptom.find_by(name: name).label }
+
+    data[:assessments][:checked].delete(:symptoms)
+    data[:assessments][:checked].concat(symptom_names.map(&:to_sym))
+
+    data[:assessments][:headers].delete('Symptoms Reported')
+    data[:assessments][:headers].concat(symptom_labels)
+  end
+
+  # Finds the race values that should be included if the Race (All Race Fields) option is checked in custom export
+  def update_checked_race_data(data)
+    # Don't update if patient data isn't needed or race data isn't checked
+    return unless data.dig(:patients, :checked).present? && data[:patients][:checked].include?(:race)
+
+    # Replace race field with actual race fields
+    race_index = data[:patients][:checked].index(:race)
+    data[:patients][:checked].delete(:race)
+    data[:patients][:checked].insert(race_index, *PATIENT_RACE_FIELDS)
+  end
+
+  # Update the header data (used for obtaining column names)
+  def update_headers(data)
+    # Populate the headers if they're not already set (which is the case with the custom exports)
+    CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
+      next unless data.dig(data_type, :checked).present? && data.dig(data_type, :headers).blank?
+
+      data[data_type][:headers] = data[data_type][:checked].map { |field| ALL_FIELDS_NAMES.dig(data_type, field) }
+    end
+  end
+
+  # Builds a file name using the base name, index, date, and extension.
+  # Ex: "Sara-Alert-Linelist-Isolation-2020-09-01T14:15:05-04:00-1"
+  def build_export_filename(config, data_type, index, glob)
+    return unless config[:export_type].present? && EXPORT_TYPES.key?(config[:export_type])
+
+    if config[:filename_data_type].present? && data_type.present? && CUSTOM_EXPORT_OPTIONS[data_type].present?
+      data_type_name = config.dig(:data, data_type, :name) || CUSTOM_EXPORT_OPTIONS.dig(data_type, :label)&.gsub(' ', '-')
+    end
+    base_name = "#{EXPORT_TYPES.dig(config[:export_type], :filename)}#{data_type_name ? "-#{data_type_name}" : ''}"
+    timestamp = glob ? '????-??-??T??_??_?????_??' : DateTime.now
+    "#{base_name}-#{timestamp}#{index.present? ? "-#{index + 1}" : ''}.#{config[:format]}"
+  end
 
   # Gets all associated relevant data for patients group based on queries and fields
   def get_export_data(patients, data)
@@ -740,222 +460,5 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
   # Extracts history data values given relevant fields
   def extract_histories_details(patients_identifiers, histories, fields)
     histories.map { |history| history.custom_details(fields, patients_identifiers[history.patient_id]) }
-  end
-
-  # Writes export data to file(s)
-  def write_export_data_to_files(config, patients_group, index, inner_batch_size)
-    case config[:format]
-    when 'csv'
-      csv_export(config, patients_group, index, inner_batch_size)
-    when 'xlsx'
-      xlsx_export(config, patients_group, index, inner_batch_size)
-    end
-  end
-
-  # Creates a list of csv files from exported data
-  def csv_export(config, patients_group, index, inner_batch_size)
-    # Get all of the field data based on the config
-    field_data = get_field_data(config)
-
-    files = []
-    csvs = {}
-    packages = {}
-
-    # 1) Generate CSVs and packages for each data type
-    CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
-      next unless config.dig(:data, data_type, :checked).present?
-
-      # Create CSV with column headers
-      package = CSV.generate(headers: true) do |csv|
-        csv << field_data.dig(data_type, :headers)
-        csvs[data_type] = csv
-      end
-      packages[data_type] = package
-    end
-
-    # 2) Get export data in batches to decrease size of export data hash maintained in memory
-    patients_group.in_batches(of: inner_batch_size) do |batch_group|
-      # The config should be passed to this function rather than data, because it determines values
-      # based on the original configuration.
-      exported_data = get_export_data(batch_group.order(:id), config[:data])
-
-      CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
-        next unless config.dig(:data, data_type, :checked).present?
-
-        exported_data[data_type]&.each do |record|
-          csvs[data_type] << field_data[data_type][:checked].map { |field| record[field] }
-        end
-      end
-    end
-
-    # 3) Write new file for each data type
-    CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
-      next unless config.dig(:data, data_type, :checked).present?
-
-      files << { filename: build_export_filename(config, data_type, index, false), content: Base64.encode64(packages[data_type]) }
-    end
-    files
-  end
-
-  # Creates a list of excel files from exported data
-  def xlsx_export(config, patients_group, index, inner_batch_size)
-    # Get all of the field data based on the config
-    field_data = get_field_data(config)
-
-    # Separate files for each data type
-    if config[:separate_files].present?
-      files = []
-      workbooks = {}
-      sheets = {}
-      last_row_nums = {}
-
-      # 1) This initial loops creates all of the files and column headers which should not be done in the batched loop
-      CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
-        next unless config.dig(:data, data_type, :checked).present?
-
-        # For each data type, create a new file
-        workbook = FastExcel.open(constant_memory: true)
-        worksheet = workbook.add_worksheet(config.dig(:data, data_type, :tab) || CUSTOM_EXPORT_OPTIONS.dig(data_type, :label))
-        worksheet.auto_width = true
-        worksheet.append_row(field_data.dig(data_type, :headers))
-        last_row_nums[data_type] = 0
-        sheets[data_type] = worksheet
-        workbooks[data_type] = workbook
-      end
-
-      # 2) Get export data in batches to decrease size of export data hash maintained in memory
-      patients_group.in_batches(of: inner_batch_size) do |batch_group|
-        exported_data = get_export_data(batch_group.order(:id), config[:data])
-
-        #  Write to appropriate sheets (in each file)
-        CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
-          next unless config.dig(:data, data_type, :checked).present?
-
-          last_row_nums[data_type] = write_xlsx_rows(exported_data, data_type, sheets[data_type], field_data[data_type][:checked], last_row_nums[data_type])
-        end
-      end
-
-      # 3) Build final file for each data type
-      CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
-        next unless config.dig(:data, data_type, :checked).present?
-
-        files << { filename: build_export_filename(config, data_type, index, false), content: Base64.encode64(workbooks[data_type].read_string) }
-      end
-
-      files
-    else
-      # One file for all data types, each data type in a different tab
-      workbook = FastExcel.open(constant_memory: true)
-      sheets = {}
-      fields = {}
-      last_row_nums = {}
-
-      # 1) This initial loops writes all of column headers which should not be done in the batched loop
-      CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
-        next unless config.dig(:data, data_type, :checked).present?
-
-        fields[data_type] = config.dig(:data, data_type, :checked)
-
-        # Create an excel worksheet in the file and add the column headers for this data type
-        worksheet = workbook.add_worksheet(config.dig(:data, data_type, :tab) || CUSTOM_EXPORT_OPTIONS.dig(data_type, :label))
-        worksheet.auto_width = true
-        worksheet.append_row(field_data.dig(data_type, :headers))
-        last_row_nums[data_type] = 0
-        sheets[data_type] = worksheet
-      end
-
-      # 2) Get export data in batches to decrease size of export data hash maintained in memory
-      patients_group.in_batches(of: inner_batch_size) do |batch_group|
-        exported_data = get_export_data(batch_group.order(:id), config[:data])
-
-        CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
-          next unless config.dig(:data, data_type, :checked).present?
-
-          last_row_nums[data_type] = write_xlsx_rows(exported_data, data_type, sheets[data_type], field_data[data_type][:checked], last_row_nums[data_type])
-        end
-      end
-
-      # 3) Return the single file with all data
-      [{ filename: build_export_filename(config, nil, index, false), content: Base64.encode64(workbook.read_string) }]
-    end
-  end
-
-  def write_xlsx_rows(exported_data, data_type, worksheet, fields, last_row_num)
-    exported_data[data_type]&.each do |record|
-      # fast_excel unfortunately does not provide a method to modify the @last_row_number class variable so it needs to be manually kept track of
-      last_row_num += 1
-      fields.each_with_index do |field, col_index|
-        # write_string is used instead of append_row because it does not provide the capability to write data as strings
-        worksheet.write_string(last_row_num, col_index, record[field].to_s, nil)
-      end
-    end
-    last_row_num
-  end
-
-  # Gets data for this batch of patients that may not have already been present in the export config (such as specific symptoms).
-  def get_field_data(config)
-    data = config[:data].deep_dup
-
-    # Update the checked data (used for obtaining values) with race information
-    update_checked_race_data(data)
-
-    # Update the header data (used for obtaining column names)
-    update_headers(data)
-
-    # Update the checked and header data for assessment symptoms
-    # NOTE: this must be done after updating the general headers above
-    update_assessment_symptom_data(data)
-
-    data
-  end
-
-  # Finds the symptoms needed for the reports columns
-  def update_assessment_symptom_data(data)
-    # Don't update if assessment symptom data isn't needed
-    return unless data.dig(:assessments, :checked).present? && data[:assessments][:checked].include?(:symptoms)
-
-    # Using Symptom.all for finding distinct symptom names is actually faster here because it can use symptoms_index_chain_1
-    symptom_names = Symptom.all.distinct.pluck(:name).sort
-    symptom_labels = symptom_names.map { |name| Symptom.find_by(name: name).label }
-
-    data[:assessments][:checked].delete(:symptoms)
-    data[:assessments][:checked].concat(symptom_names.map(&:to_sym))
-
-    data[:assessments][:headers].delete('Symptoms Reported')
-    data[:assessments][:headers].concat(symptom_labels)
-  end
-
-  # Finds the race values that should be included if the Race (All Race Fields) option is checked in custom export
-  def update_checked_race_data(data)
-    # Don't update if patient data isn't needed or race data isn't checked
-    return unless data.dig(:patients, :checked).present? && data[:patients][:checked].include?(:race)
-
-    # Replace race field with actual race fields
-    race_index = data[:patients][:checked].index(:race)
-    data[:patients][:checked].delete(:race)
-    data[:patients][:checked].insert(race_index, *PATIENT_RACE_FIELDS)
-  end
-
-  # Update the header data (used for obtaining column names)
-  def update_headers(data)
-    # Populate the headers if they're not already set (which is the case with the custom exports)
-    CUSTOM_EXPORT_OPTIONS.each_key do |data_type|
-      next unless data.dig(data_type, :checked).present? && data.dig(data_type, :headers).blank?
-
-      data[data_type][:headers] = data[data_type][:checked].map { |field| ALL_FIELDS_NAMES.dig(data_type, field) }
-    end
-  end
-
-  # Builds a file name using the base name, index, date, and extension.
-  # Ex: "Sara-Alert-Linelist-Isolation-2020-09-01T14:15:05-04:00-1"
-  def build_export_filename(config, data_type, index, glob)
-    return unless config[:export_type].present? && EXPORT_TYPES.key?(config[:export_type])
-
-    if config[:filename_data_type].present? && data_type.present? && CUSTOM_EXPORT_OPTIONS[data_type].present?
-      data_type_name = config.dig(:data, data_type, :name) || CUSTOM_EXPORT_OPTIONS.dig(data_type, :label)&.gsub(' ', '-')
-    end
-    base_name = "#{EXPORT_TYPES.dig(config[:export_type], :filename)}#{data_type_name ? "-#{data_type_name}" : ''}"
-    timestamp = glob ? '????-??-??T??_??_?????_??' : DateTime.now
-    "#{base_name}-#{timestamp}#{index.present? ? "-#{index + 1}" : ''}.#{config[:format]}"
   end
 end

--- a/app/lib/import_export_constants.rb
+++ b/app/lib/import_export_constants.rb
@@ -109,13 +109,6 @@ module ImportExportConstants # rubocop:todo Metrics/ModuleLength
 
   FULL_HISTORY_HISTORIES_HEADERS = ['Patient ID', 'Comment', 'Created By', 'History Type', 'Created At', 'Updated At'].freeze
 
-  PATIENT_ALTERNATIVE_IDENTIFIERS = %i[user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss].freeze
-
-  PATIENT_RACE_FIELDS = %i[white black_or_african_american american_indian_or_alaska_native asian native_hawaiian_or_other_pacific_islander race_other
-                           race_unknown race_refused_to_answer].freeze
-
-  PATIENT_LAB_FIELDS = %i[lab_1_type lab_1_specimen_collection lab_1_report lab_1_result lab_2_type lab_2_specimen_collection lab_2_report lab_2_result].freeze
-
   PATIENT_FIELD_TYPES = {
     numbers: %i[id assigned_user responder_id],
     strings: %i[first_name middle_name last_name sex ethnicity primary_language secondary_language nationality user_defined_id_statelocal user_defined_id_cdc
@@ -134,10 +127,14 @@ module ImportExportConstants # rubocop:todo Metrics/ModuleLength
     dates: %i[date_of_birth date_of_departure date_of_arrival additional_planned_travel_start_date additional_planned_travel_end_date last_date_of_exposure
               symptom_onset extended_isolation],
     timestamps: %i[created_at updated_at closed_at latest_assessment_at latest_transfer_at last_assessment_reminder_sent],
+    phones: %i[primary_telephone secondary_telephone],
     booleans: %i[interpretation_required isolation continuous_exposure contact_of_known_case travel_to_affected_country_or_area
                  was_in_health_care_facility_with_known_cases laboratory_personnel healthcare_personnel crew_on_passenger_or_cargo_flight
-                 member_of_a_common_exposure_cohort head_of_household pause_notifications].concat(PATIENT_RACE_FIELDS),
-    phones: %i[primary_telephone secondary_telephone]
+                 member_of_a_common_exposure_cohort head_of_household pause_notifications],
+    races: %i[white black_or_african_american american_indian_or_alaska_native asian native_hawaiian_or_other_pacific_islander race_other race_unknown
+              race_refused_to_answer],
+    alternative_identifiers: %i[user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss],
+    lab_fields: %i[lab_1_type lab_1_specimen_collection lab_1_report lab_1_result lab_2_type lab_2_specimen_collection lab_2_report lab_2_result]
   }.freeze
 
   PATIENT_FIELD_NAMES = {
@@ -502,5 +499,32 @@ module ImportExportConstants # rubocop:todo Metrics/ModuleLength
     close_contacts: CLOSE_CONTACTS_EXPORT_OPTIONS,
     transfers: TRANSFERS_EXPORT_OPTIONS,
     histories: HISTORIES_EXPORT_OPTIONS
+  }.freeze
+
+  FULL_HISTORY_PATIENT_CONFIG = {
+    format: 'xlsx',
+    separate_files: false,
+    data: {
+      patients: {
+        checked: FULL_HISTORY_PATIENTS_FIELDS,
+        headers: FULL_HISTORY_PATIENTS_HEADERS,
+        tab: 'Monitorees List'
+      },
+      assessments: {
+        checked: FULL_HISTORY_ASSESSMENTS_FIELDS,
+        headers: FULL_HISTORY_ASSESSMENTS_HEADERS,
+        tab: 'Reports'
+      },
+      laboratories: {
+        checked: FULL_HISTORY_LABORATORIES_FIELDS,
+        headers: FULL_HISTORY_LABORATORIES_HEADERS,
+        tab: 'Lab Results'
+      },
+      histories: {
+        checked: FULL_HISTORY_HISTORIES_FIELDS,
+        headers: FULL_HISTORY_HISTORIES_HEADERS,
+        tab: 'Edit Histories'
+      }
+    }
   }.freeze
 end

--- a/app/lib/import_export_constants.rb
+++ b/app/lib/import_export_constants.rb
@@ -137,31 +137,6 @@ module ImportExportConstants # rubocop:todo Metrics/ModuleLength
     lab_fields: %i[lab_1_type lab_1_specimen_collection lab_1_report lab_1_result lab_2_type lab_2_specimen_collection lab_2_report lab_2_result]
   }.freeze
 
-  ASSESSMENT_FIELD_TYPES = {
-    unfiltered: %i[id patient_id symptomatic who_reported created_at updated_at],
-    remove_formula_start: %i[who_reported]
-  }.freeze
-
-  LABORATORY_FIELD_TYPES = {
-    unfiltered: %i[id patient_id lab_type result created_at updated_at],
-    dates: %i[specimen_collection report]
-  }.freeze
-
-  CLOSE_CONTACT_FIELD_TYPES = {
-    unfiltered: %i[id patient_id contact_attempts last_date_of_exposure assigned_user enrolled_id created_at updated_at],
-    remove_formula_start: %i[first_name last_name email notes],
-    phones: %i[primary_telephone]
-  }.freeze
-
-  TRANSFER_FIELD_TYPES = {
-    unfiltered: %i[id patient_id created_at updated_at]
-  }.freeze
-
-  HISTORY_FIELD_TYPES = {
-    unfiltered: %i[id patient_id history_type created_at updated_at],
-    remove_formula_start: %i[created_by comment]
-  }.freeze
-
   PATIENT_FIELD_NAMES = {
     # Enrollment Info - Identification and Demographics - Identifiers
     id: 'Sara Alert ID',

--- a/app/lib/import_export_constants.rb
+++ b/app/lib/import_export_constants.rb
@@ -137,6 +137,31 @@ module ImportExportConstants # rubocop:todo Metrics/ModuleLength
     lab_fields: %i[lab_1_type lab_1_specimen_collection lab_1_report lab_1_result lab_2_type lab_2_specimen_collection lab_2_report lab_2_result]
   }.freeze
 
+  ASSESSMENT_FIELD_TYPES = {
+    unfiltered: %i[id patient_id symptomatic who_reported created_at updated_at],
+    remove_formula_start: %i[who_reported]
+  }.freeze
+
+  LABORATORY_FIELD_TYPES = {
+    unfiltered: %i[id patient_id lab_type result created_at updated_at],
+    dates: %i[specimen_collection report]
+  }.freeze
+
+  CLOSE_CONTACT_FIELD_TYPES = {
+    unfiltered: %i[id patient_id contact_attempts last_date_of_exposure assigned_user enrolled_id created_at updated_at],
+    remove_formula_start: %i[first_name last_name email notes],
+    phones: %i[primary_telephone]
+  }.freeze
+
+  TRANSFER_FIELD_TYPES = {
+    unfiltered: %i[id patient_id created_at updated_at]
+  }.freeze
+
+  HISTORY_FIELD_TYPES = {
+    unfiltered: %i[id patient_id history_type created_at updated_at],
+    remove_formula_start: %i[created_by comment]
+  }.freeze
+
   PATIENT_FIELD_NAMES = {
     # Enrollment Info - Identification and Demographics - Identifiers
     id: 'Sara Alert ID',

--- a/app/lib/import_export_constants.rb
+++ b/app/lib/import_export_constants.rb
@@ -1,0 +1,506 @@
+# frozen_string_literal: true
+
+# Constants for imports and exports
+module ImportExportConstants # rubocop:todo Metrics/ModuleLength
+  EXPORT_TYPES = {
+    csv_linelist_exposure: { label: 'Line list CSV (exposure)', filename: 'Sara-Alert-Linelist-Exposure' },
+    csv_linelist_isolation: { label: 'Line list CSV (isolation)', filename: 'Sara-Alert-Linelist-Isolation' },
+    sara_alert_format_exposure: { label: 'Sara Alert Format (exposure)', filename: 'Sara-Alert-Format-Exposure' },
+    sara_alert_format_isolation: { label: 'Sara Alert Format (isolation)', filename: 'Sara-Alert-Format-Isolation' },
+    full_history_patients_all: { label: 'Excel Export For All Monitorees', filename: 'Sara-Alert-Full-Export' },
+    full_history_patients_purgeable: { label: 'Excel Export For Purge-Eligible Monitorees', filename: 'Sara-Alert-Purge-Eligible-Export' },
+    custom: { label: 'Custom Export', filename: 'Sara-Alert-Custom-Export' }
+  }.freeze
+
+  EXPORT_FORMATS = %w[csv xlsx].freeze
+
+  EPI_X_FIELDS = [:user_defined_id_statelocal, :flight_or_vessel_number, nil, nil, :user_defined_id_cdc, nil, nil, :primary_language, :date_of_arrival,
+                  :port_of_entry_into_usa, :last_name, :first_name, :date_of_birth, :sex, nil, nil, :address_line_1, :address_city, :address_state,
+                  :address_zip, :monitored_address_line_1, :monitored_address_city, :monitored_address_state, :monitored_address_zip, nil, nil, nil, nil,
+                  :primary_telephone, :secondary_telephone, :email, nil, nil, nil, :potential_exposure_location, :potential_exposure_country,
+                  :date_of_departure, nil, nil, nil, nil, :contact_of_known_case, :was_in_health_care_facility_with_known_cases].freeze
+
+  EPI_X_HEADERS = ['Local-ID', 'Flight No', 'Date of notice', 'MDH Assignee', 'DGMQ ID', 'CARE ID', 'CARE Cell Number', 'Language', 'Arrival Date and Time',
+                   'Arrival City', 'Last Name', 'First Name', 'Date of Birth', 'Gender', 'Passport Country', 'Passport Number', 'Permanent Street Address',
+                   'Permanent City', 'Permanent State or Country', 'Postal Code', 'Temporary Street Address 1', 'Temporary City 1', 'Temporary State 1',
+                   'Temporary Postal Code 1', 'Temporary Street Address 2', 'Temporary City 2', 'Temporary State 2', 'Temporary Postal Code 2',
+                   'Phone Number 1', 'Phone Number 2', 'Email 1', 'Email 2', 'Emergency Contact Name', 'Emergency Contact Telephone Number',
+                   'Emergency Contact Email', 'Countries Visited with Widespread Transmission in Past 14 Days', 'Departure Date',
+                   'DHS Observed Vomiting, Diarrhea or Bleeding', 'Temperature taken by DHS', 'Fever/Chills in the past 48 hours',
+                   'Vomiting/Diarrhea in the past 48 hours', 'Lived in Same Household or Had Other Contact with a Person Sick with disease in Past 14 Days',
+                   'Worked in Health Care Facility or Laboratory in Country with Widespread Transmission in Past 14 Days',
+                   'Touched Body of Someone who Died in Country with Widespread Transmission in Past 14 Days',
+                   'DHS Traveler Health Declaration Outcome: Released', 'DHS Traveler Health Declaration Outcome: Referred to Tertiary for Add\'l Assessment',
+                   'Disposition of Travelers Referred for CDC Assessment: Released to Continue Travel',
+                   'Disposition of Travelers Referred for CDC Assessment: Coordinated Disposition with State Health Dept.',
+                   'Disposition of Travelers Referred for CDC Assessment: Referred for Additional Medical Evaluation',
+                   'Disposition of Travelers Referred for CDC Assessment: Other', 'Final Disposition of Traveler\'s Medical Evaluation (If applicable)',
+                   'Exposure Assessment', 'Contact Made?', 'Monitoring needed?', 'Notes'].freeze
+
+  LINELIST_FIELDS = %i[id name jurisdiction_name assigned_user user_defined_id_statelocal sex date_of_birth end_of_monitoring exposure_risk_assessment
+                       monitoring_plan latest_assessment_at latest_transfer_at monitoring_reason public_health_action status closed_at transferred_from
+                       transferred_to expected_purge_ts symptom_onset extended_isolation].freeze
+
+  LINELIST_HEADERS = ['Patient ID', 'Monitoree', 'Jurisdiction', 'Assigned User', 'State/Local ID', 'Sex', 'Date of Birth', 'End of Monitoring', 'Risk Level',
+                      'Monitoring Plan', 'Latest Report', 'Transferred At', 'Reason For Closure', 'Latest Public Health Action', 'Status', 'Closed At',
+                      'Transferred From', 'Transferred To', 'Expected Purge Date', 'Symptom Onset', 'Extended Isolation'].freeze
+
+  SARA_ALERT_FORMAT_FIELDS = %i[first_name middle_name last_name date_of_birth sex white black_or_african_american american_indian_or_alaska_native asian
+                                native_hawaiian_or_other_pacific_islander ethnicity primary_language secondary_language interpretation_required nationality
+                                user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss address_line_1 address_city address_state address_line_2
+                                address_zip address_county foreign_address_line_1 foreign_address_city foreign_address_country foreign_address_line_2
+                                foreign_address_zip foreign_address_line_3 foreign_address_state monitored_address_line_1 monitored_address_city
+                                monitored_address_state monitored_address_line_2 monitored_address_zip monitored_address_county foreign_monitored_address_line_1
+                                foreign_monitored_address_city foreign_monitored_address_state foreign_monitored_address_line_2 foreign_monitored_address_zip
+                                foreign_monitored_address_county preferred_contact_method primary_telephone primary_telephone_type secondary_telephone
+                                secondary_telephone_type preferred_contact_time email port_of_origin date_of_departure source_of_report flight_or_vessel_number
+                                flight_or_vessel_carrier port_of_entry_into_usa date_of_arrival travel_related_notes additional_planned_travel_type
+                                additional_planned_travel_destination additional_planned_travel_destination_state additional_planned_travel_destination_country
+                                additional_planned_travel_port_of_departure additional_planned_travel_start_date additional_planned_travel_end_date
+                                additional_planned_travel_related_notes last_date_of_exposure potential_exposure_location potential_exposure_country
+                                contact_of_known_case contact_of_known_case_id travel_to_affected_country_or_area was_in_health_care_facility_with_known_cases
+                                was_in_health_care_facility_with_known_cases_facility_name laboratory_personnel laboratory_personnel_facility_name
+                                healthcare_personnel healthcare_personnel_facility_name crew_on_passenger_or_cargo_flight member_of_a_common_exposure_cohort
+                                member_of_a_common_exposure_cohort_type exposure_risk_assessment monitoring_plan exposure_notes full_status symptom_onset
+                                case_status lab_1_type lab_1_specimen_collection lab_1_report lab_1_result lab_2_type lab_2_specimen_collection lab_2_report
+                                lab_2_result jurisdiction_path assigned_user gender_identity sexual_orientation race_other race_unknown
+                                race_refused_to_answer].freeze
+
+  SARA_ALERT_FORMAT_HEADERS = ['First Name', 'Middle Name', 'Last Name', 'Date of Birth', 'Sex at Birth', 'White', 'Black or African American',
+                               'American Indian or Alaska Native', 'Asian', 'Native Hawaiian or Other Pacific Islander', 'Ethnicity', 'Primary Language',
+                               'Secondary Language', 'Interpretation Required?', 'Nationality', 'Identifier (STATE/LOCAL)', 'Identifier (CDC)',
+                               'Identifier (NNDSS)', 'Address Line 1', 'Address City', 'Address State', 'Address Line 2', 'Address Zip', 'Address County',
+                               'Foreign Address Line 1', 'Foreign Address City', 'Foreign Address Country', 'Foreign Address Line 2', 'Foreign Address Zip',
+                               'Foreign Address Line 3', 'Foreign Address State', 'Monitored Address Line 1', 'Monitored Address City',
+                               'Monitored Address State', 'Monitored Address Line 2', 'Monitored Address Zip', 'Monitored Address County',
+                               'Foreign Monitored Address Line 1', 'Foreign Monitored Address City', 'Foreign Monitored Address State',
+                               'Foreign Monitored Address Line 2', 'Foreign Monitored Address Zip', 'Foreign Monitored Address County',
+                               'Preferred Contact Method', 'Primary Telephone', 'Primary Telephone Type', 'Secondary Telephone', 'Secondary Telephone Type',
+                               'Preferred Contact Time', 'Email', 'Port of Origin', 'Date of Departure', 'Source of Report', 'Flight or Vessel Number',
+                               'Flight or Vessel Carrier', 'Port of Entry Into USA', 'Date of Arrival', 'Travel Related Notes',
+                               'Additional Planned Travel Type', 'Additional Planned Travel Destination', 'Additional Planned Travel Destination State',
+                               'Additional Planned Travel Destination Country', 'Additional Planned Travel Port of Departure',
+                               'Additional Planned Travel Start Date', 'Additional Planned Travel End Date', 'Additional Planned Travel Related Notes',
+                               'Last Date of Exposure', 'Potential Exposure Location', 'Potential Exposure Country', 'Contact of Known Case?',
+                               'Contact of Known Case ID', 'Travel from Affected Country or Area?', 'Was in Health Care Facility With Known Cases?',
+                               'Health Care Facility with Known Cases Name', 'Laboratory Personnel?', 'Laboratory Personnel Facility Name',
+                               'Health Care Personnel?', 'Health Care Personnel Facility Name', 'Crew on Passenger or Cargo Flight?',
+                               'Member of a Common Exposure Cohort?', 'Common Exposure Cohort Name', 'Exposure Risk Assessment', 'Monitoring Plan',
+                               'Exposure Notes', 'Status', 'Symptom Onset Date', 'Case Status', 'Lab 1 Test Type', 'Lab 1 Specimen Collection Date',
+                               'Lab 1 Report Date', 'Lab 1 Result', 'Lab 2 Test Type', 'Lab 2 Specimen Collection Date', 'Lab 2 Report Date', 'Lab 2 Result',
+                               'Full Assigned Jurisdiction Path', 'Assigned User', 'Gender Identity', 'Sexual Orientation', 'Race Other', 'Race Unknown',
+                               'Race Refused to Answer'].freeze
+
+  # Extended Isolation Date is intentionally appended to the end even if new fields are added to Sara Alert Format to maintain more consistency in the ordering
+  # of fields between Sara Alert Format and Full History Patients
+  FULL_HISTORY_PATIENTS_FIELDS = ([:id] + SARA_ALERT_FORMAT_FIELDS + [:extended_isolation]).freeze
+
+  FULL_HISTORY_PATIENTS_HEADERS = (['Patient ID'] + SARA_ALERT_FORMAT_HEADERS + ['Extended Isolation Date']).freeze
+
+  FULL_HISTORY_ASSESSMENTS_FIELDS = %i[patient_id symptomatic who_reported created_at updated_at symptoms].freeze
+
+  FULL_HISTORY_ASSESSMENTS_HEADERS = ['Patient ID', 'Symptomatic', 'Who Reported', 'Created At', 'Updated At', 'Symptoms Reported'].freeze
+
+  FULL_HISTORY_LABORATORIES_FIELDS = %i[patient_id lab_type specimen_collection report result created_at updated_at].freeze
+
+  FULL_HISTORY_LABORATORIES_HEADERS = ['Patient ID', 'Lab Type', 'Specimen Collection Date', 'Report Date', 'Result', 'Created At', 'Updated At'].freeze
+
+  FULL_HISTORY_HISTORIES_FIELDS = %i[patient_id comment created_by history_type created_at updated_at].freeze
+
+  FULL_HISTORY_HISTORIES_HEADERS = ['Patient ID', 'Comment', 'Created By', 'History Type', 'Created At', 'Updated At'].freeze
+
+  PATIENT_ALTERNATIVE_IDENTIFIERS = %i[user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss].freeze
+
+  PATIENT_RACE_FIELDS = %i[white black_or_african_american american_indian_or_alaska_native asian native_hawaiian_or_other_pacific_islander race_other
+                           race_unknown race_refused_to_answer].freeze
+
+  PATIENT_LAB_FIELDS = %i[lab_1_type lab_1_specimen_collection lab_1_report lab_1_result lab_2_type lab_2_specimen_collection lab_2_report lab_2_result].freeze
+
+  PATIENT_FIELD_TYPES = {
+    numbers: %i[id assigned_user responder_id],
+    strings: %i[first_name middle_name last_name sex ethnicity primary_language secondary_language nationality user_defined_id_statelocal user_defined_id_cdc
+                user_defined_id_nndss address_line_1 address_city address_state address_line_2 address_zip address_county foreign_address_line_1
+                foreign_address_city foreign_address_country foreign_address_line_2 foreign_address_zip foreign_address_line_3 foreign_address_state
+                monitored_address_line_1 monitored_address_city monitoring_address_state monitored_address_state monitored_address_line_2 monitored_address_zip
+                monitored_address_county foreign_monitored_address_line_1 foreign_monitored_address_city foreign_monitored_address_state
+                foreign_monitored_address_line_2 foreign_monitored_address_zip foreign_monitored_address_county preferred_contact_method primary_telephone_type
+                secondary_telephone_type preferred_contact_time email port_of_origin source_of_report source_of_report_specify flight_or_vessel_number
+                flight_or_vessel_carrier port_of_entry_into_usa travel_related_notes additional_planned_travel_type additional_planned_travel_destination
+                additional_planned_travel_destination_state additional_planned_travel_destination_country additional_planned_travel_port_of_departure
+                additional_planned_travel_related_notes potential_exposure_location potential_exposure_country contact_of_known_case_id
+                was_in_health_care_facility_with_known_cases_facility_name laboratory_personnel_facility_name healthcare_personnel_facility_name
+                member_of_a_common_exposure_cohort_type exposure_risk_assessment monitoring_plan exposure_notes case_status gender_identity
+                sexual_orientation risk_level monitoring_reason public_health_action],
+    dates: %i[date_of_birth date_of_departure date_of_arrival additional_planned_travel_start_date additional_planned_travel_end_date last_date_of_exposure
+              symptom_onset extended_isolation],
+    timestamps: %i[created_at updated_at closed_at latest_assessment_at latest_transfer_at last_assessment_reminder_sent],
+    booleans: %i[interpretation_required isolation continuous_exposure contact_of_known_case travel_to_affected_country_or_area
+                 was_in_health_care_facility_with_known_cases laboratory_personnel healthcare_personnel crew_on_passenger_or_cargo_flight
+                 member_of_a_common_exposure_cohort head_of_household pause_notifications].concat(PATIENT_RACE_FIELDS),
+    phones: %i[primary_telephone secondary_telephone]
+  }.freeze
+
+  PATIENT_FIELD_NAMES = {
+    # Enrollment Info - Identification and Demographics - Identifiers
+    id: 'Sara Alert ID',
+    user_defined_id_statelocal: 'State/Local ID',
+    user_defined_id_cdc: 'CDC ID',
+    user_defined_id_nndss: 'NNDSS ID',
+    # Enrollment Info - Identification and Demographics - Name
+    first_name: 'First Name',
+    last_name: 'Last Name',
+    middle_name: 'Middle Name',
+    # Enrollment Info - Identification and Demographics - Date of Birth
+    date_of_birth: 'Date of Birth',
+    age: 'Age',
+    # Enrollment Info - Identification and Demographics - Sex at Birth
+    sex: 'Sex at Birth',
+    # Enrollment Info - Identification and Demographics - Gender Identity and Sexual Orientation
+    gender_identity: 'Gender Identity',
+    sexual_orientation: 'Sexual Orientation',
+    # Enrollment Info - Identification and Demographics - Race, Ethnicity, and Nationality
+    race: 'Race (All Race Fields)',
+    white: 'White',
+    black_or_african_american: 'Black or African American',
+    american_indian_or_alaska_native: 'American Indian or Alaska Native',
+    asian: 'Asian',
+    native_hawaiian_or_other_pacific_islander: 'Native Hawaiian or Other Pacific Islander',
+    race_other: 'Race Other',
+    race_unknown: 'Race Unknown',
+    race_refused_to_answer: 'Race Refused to Answer',
+    ethnicity: 'Ethnicity',
+    nationality: 'Nationality',
+    # Enrollment Info - Identification and Demographics - Language
+    primary_language: 'Primary Language',
+    secondary_language: 'Secondary Language',
+    interpretation_required: 'Interpretation Required',
+    # Enrollment Info - Home and Monitored Address - Home Address (USA)
+    address_line_1: 'Address Line 1',
+    address_line_2: 'Address Line 2',
+    address_city: 'Address City',
+    address_state: 'Address State',
+    address_zip: 'Address Zip',
+    address_county: 'Address County',
+    # Enrollment Info - Home and Monitored Address - Home Address (Foreign)
+    foreign_address_line_1: 'Foreign Address Line 1',
+    foreign_address_line_2: 'Foreign Address Line 2',
+    foreign_address_city: 'Foreign Address City',
+    foreign_address_country: 'Foreign Address Country',
+    foreign_address_zip: 'Foreign Address Zip',
+    foreign_address_line_3: 'Foreign Address Line 3',
+    foreign_address_state: 'Foreign Address State',
+    # Enrollment Info - Home and Monitored Address - Monitored Address (USA)
+    monitored_address_line_1: 'Monitored Address Line 1',
+    monitored_address_line_2: 'Monitored Address Line 2',
+    monitored_address_city: 'Monitored Address City',
+    monitored_address_state: 'Monitored Address State',
+    monitored_address_zip: 'Monitored Address Zip',
+    monitored_address_county: 'Monitored Address County',
+    # Enrollment Info - Home and Monitored Address - Monitored Address (Foreign)
+    foreign_monitored_address_line_1: 'Foreign Monitored Address Line 1',
+    foreign_monitored_address_line_2: 'Foreign Monitored Address Line 2',
+    foreign_monitored_address_city: 'Foreign Monitored Address City',
+    foreign_monitored_address_state: 'Foreign Monitored Address State',
+    foreign_monitored_address_zip: 'Foreign Monitored Address Zip',
+    foreign_monitored_address_county: 'Foreign Monitored Address County',
+    # Enrollment Info - Contact Information
+    preferred_contact_method: 'Preferred Contact Method',
+    preferred_contact_time: 'Preferred Contact Time',
+    primary_telephone: 'Primary Telephone',
+    primary_telephone_type: 'Primary Telephone Type',
+    secondary_telephone: 'Secondary Telephone',
+    secondary_telephone_type: 'Secondary Telephone Type',
+    email: 'Email',
+    # Enrollment Info - Travel - Arrival Information
+    port_of_origin: 'Port of Origin',
+    date_of_departure: 'Date of Departure',
+    flight_or_vessel_number: 'Flight or Vessel Number',
+    flight_or_vessel_carrier: 'Flight or Vessel Carrier',
+    port_of_entry_into_usa: 'Port of Entry Into USA',
+    date_of_arrival: 'Date of Arrival',
+    source_of_report: 'Source of Report',
+    source_of_report_specify: 'Source of Report Specify',
+    travel_related_notes: 'Travel Related Notes',
+    # Enrollment Info - Travel - Additional Planned Travel
+    additional_planned_travel_type: 'Additional Planned Travel Type',
+    additional_planned_travel_destination: 'Additional Planned Travel Destination',
+    additional_planned_travel_destination_state: 'Additional Planned Travel Destination State',
+    additional_planned_travel_destination_country: 'Additional Planned Travel Destination Country',
+    additional_planned_travel_port_of_departure: 'Additional Planned Travel Port of Departure',
+    additional_planned_travel_start_date: 'Additional Planned Travel Start Date',
+    additional_planned_travel_end_date: 'Additional Planned Travel End Date',
+    additional_planned_travel_related_notes: 'Additional Planned Travel Related Notes',
+    # Enrollment Info - Potential Exposure Information - Exposure Location and Notes
+    potential_exposure_location: 'Potential Exposure Location',
+    potential_exposure_country: 'Potential Exposure Country',
+    # Enrollment Info - Potential Exposure Information - Risk Factors
+    contact_of_known_case: 'Contact of Known Case',
+    contact_of_known_case_id: 'Contact of Known Case ID',
+    travel_to_affected_country_or_area: 'Travel from Affected Country or Area',
+    was_in_health_care_facility_with_known_cases: 'Was in Health Care Facility With Known Cases',
+    was_in_health_care_facility_with_known_cases_facility_name: 'Health Care Facility with Known Cases Name',
+    laboratory_personnel: 'Laboratory Personnel',
+    laboratory_personnel_facility_name: 'Laboratory Personnel Facility Name',
+    healthcare_personnel: 'Health Care Personnel',
+    healthcare_personnel_facility_name: 'Health Care Personnel Facility Name',
+    crew_on_passenger_or_cargo_flight: 'Crew on Passenger or Cargo Flight',
+    member_of_a_common_exposure_cohort: 'Member of a Common Exposure Cohort',
+    member_of_a_common_exposure_cohort_type: 'Common Exposure Cohort Name',
+    exposure_notes: 'Exposure Notes',
+    # Enrollment Info - Record Creation and Updates
+    creator: 'Enroller',
+    created_at: 'Monitoree Created Date',
+    updated_at: 'Monitoree Updated Date',
+    # Monitoring Info - Linelist Info
+    workflow: 'Current Workflow',
+    status: 'Status',
+    # Monitoring Info - Monitoring Actions
+    monitoring_status: 'Monitoring Status',
+    exposure_risk_assessment: 'Exposure Risk Assessment',
+    monitoring_plan: 'Monitoring Plan',
+    case_status: 'Case Status',
+    public_health_action: 'Latest Public Health Action',
+    jurisdiction_path: 'Full Assigned Jurisdiction Path',
+    jurisdiction_name: 'Assigned Jurisdiction',
+    assigned_user: 'Assigned User',
+    # Monitoring Info - Monitoring Period
+    last_date_of_exposure: 'Last Date of Exposure',
+    continuous_exposure: 'Continuous Exposure',
+    symptom_onset: 'Symptom Onset Date',
+    symptom_onset_defined_by: 'Symptom Onset Defined By',
+    extended_isolation: 'Extended Isolation Date',
+    end_of_monitoring: 'End of Monitoring',
+    closed_at: 'Closure Date',
+    monitoring_reason: 'Reason For Closure',
+    expected_purge_ts: 'Expected Purge Date',
+    # Monitoring Info - Reporting Info
+    responder_id: 'ID of Reporter',
+    head_of_household: 'Head of Household',
+    pause_notifications: 'Paused Notifications',
+    last_assessment_reminder_sent: 'Last Assessment Reminder Sent Date',
+    # CSV Linelist Export Specific Fields
+    name: 'Name',
+    latest_assessment_at: 'Latest Report',
+    latest_transfer_at: 'Transferred At',
+    transferred_from: 'Transferred From',
+    transferred_to: 'Transferred To'
+  }.freeze
+
+  ASSESSMENT_FIELD_NAMES = {
+    patient_id: 'Sara Alert ID',
+    user_defined_id_statelocal: 'State/Local ID',
+    user_defined_id_cdc: 'CDC ID',
+    user_defined_id_nndss: 'NNDSS ID',
+    id: 'Report ID',
+    symptomatic: 'Needs Review',
+    who_reported: 'Who Reported',
+    created_at: 'Report Created Date',
+    updated_at: 'Report Updated Date',
+    symptoms: 'Symptoms Reported'
+  }.freeze
+
+  LABORATORY_FIELD_NAMES = {
+    patient_id: 'Sara Alert ID',
+    user_defined_id_statelocal: 'State/Local ID',
+    user_defined_id_cdc: 'CDC ID',
+    user_defined_id_nndss: 'NNDSS ID',
+    id: 'Lab Report ID',
+    lab_type: 'Lab Type',
+    specimen_collection: 'Specimen Collection Date',
+    report: 'Report Date',
+    result: 'Lab Result',
+    created_at: 'Lab Report Created Date',
+    updated_at: 'Lab Report Updated Date'
+  }.freeze
+
+  CLOSE_CONTACT_FIELD_NAMES = {
+    patient_id: 'Sara Alert ID',
+    user_defined_id_statelocal: 'State/Local ID',
+    user_defined_id_cdc: 'CDC ID',
+    user_defined_id_nndss: 'NNDSS ID',
+    id: 'Close Contact ID',
+    first_name: 'First Name',
+    last_name: 'Last Name',
+    primary_telephone: 'Primary Telephone',
+    email: 'Email',
+    contact_attempts: 'Contact Attempts',
+    last_date_of_exposure: 'Last Date of Exposure',
+    assigned_user: 'Assigned User',
+    notes: 'Notes',
+    enrolled_id: 'Enrolled ID',
+    created_at: 'Close Contact Created Date',
+    updated_at: 'Close Contact Updated Date'
+  }.freeze
+
+  TRANSFER_FIELD_NAMES = {
+    patient_id: 'Sara Alert ID',
+    user_defined_id_statelocal: 'State/Local ID',
+    user_defined_id_cdc: 'CDC ID',
+    user_defined_id_nndss: 'NNDSS ID',
+    id: 'Transfer ID',
+    who: 'Who Initiated Transfer',
+    from_jurisdiction: 'From Jurisdiction',
+    to_jurisdiction: 'To Jurisdiction',
+    created_at: 'Transfer Created Date',
+    updated_at: 'Transfer Updated Date'
+  }.freeze
+
+  HISTORY_FIELD_NAMES = {
+    patient_id: 'Sara Alert ID',
+    user_defined_id_statelocal: 'State/Local ID',
+    user_defined_id_cdc: 'CDC ID',
+    user_defined_id_nndss: 'NNDSS ID',
+    id: 'History ID',
+    created_by: 'History Creator',
+    history_type: 'History Type',
+    comment: 'History Comment',
+    created_at: 'History Created Date',
+    updated_at: 'History Updated Date'
+  }.freeze
+
+  ALL_FIELDS_NAMES = {
+    patients: PATIENT_FIELD_NAMES,
+    assessments: ASSESSMENT_FIELD_NAMES,
+    laboratories: LABORATORY_FIELD_NAMES,
+    close_contacts: CLOSE_CONTACT_FIELD_NAMES,
+    transfers: TRANSFER_FIELD_NAMES,
+    histories: HISTORY_FIELD_NAMES
+  }.freeze
+
+  # Creates react checkbox tree node with children populated
+  def self.rct_node(schema, label, fields)
+    return if ALL_FIELDS_NAMES[schema].nil?
+
+    {
+      value: "#{schema}-#{label&.gsub(' ', '_')&.gsub(',', '')&.downcase}",
+      label: label,
+      children: fields.map { |field| { value: field&.to_s, label: ALL_FIELDS_NAMES[schema][field] } }
+    }
+  end
+
+  PATIENTS_EXPORT_OPTIONS = {
+    label: 'Monitorees',
+    nodes: [
+      {
+        value: 'patients',
+        label: 'Monitoree Details',
+        children: [
+          {
+            value: 'patients-enrollment',
+            label: 'Enrollment Info',
+            children: [
+              {
+                value: 'patients-enrollment-identification-and-demographics',
+                label: 'Identification and Demographics',
+                children: [
+                  rct_node(:patients, 'Identifiers', %i[id user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss]),
+                  rct_node(:patients, 'Name', %i[first_name last_name middle_name]),
+                  rct_node(:patients, 'Date of Birth', %i[date_of_birth age]),
+                  { value: :sex, label: ALL_FIELDS_NAMES[:patients][:sex] },
+                  rct_node(:patients, 'Gender Identity and Sexual Orientation', %i[gender_identity sexual_orientation]),
+                  rct_node(:patients, 'Race, Ethnicity, and Nationality', %i[race ethnicity nationality]),
+                  rct_node(:patients, 'Language', %i[primary_language secondary_language interpretation_required])
+                ]
+              },
+              {
+                value: 'patients-enrollment-home-and-monitored-address',
+                label: 'Home and Monitored Address',
+                children: [
+                  rct_node(:patients, 'Home Address (USA)', %i[address_line_1 address_line_2 address_city address_state address_zip address_county]),
+                  rct_node(:patients, 'Home Address (Foreign)', %i[foreign_address_line_1 foreign_address_line_2 foreign_address_city foreign_address_country
+                                                                   foreign_address_zip foreign_address_line_3 foreign_address_state]),
+                  rct_node(:patients, 'Monitored Address (USA)', %i[monitored_address_line_1 monitored_address_line_2 monitored_address_city
+                                                                    monitored_address_state monitored_address_zip monitored_address_county]),
+                  rct_node(:patients, 'Monitored Address (Foreign)', %i[foreign_monitored_address_line_1 foreign_monitored_address_line_2
+                                                                        foreign_monitored_address_city foreign_monitored_address_state
+                                                                        foreign_monitored_address_zip foreign_monitored_address_county])
+                ]
+              },
+              rct_node(:patients, 'Contact Information', %i[preferred_contact_method preferred_contact_time primary_telephone primary_telephone_type
+                                                            secondary_telephone secondary_telephone_type email]),
+              {
+                value: 'patients-enrollment-travel',
+                label: 'Travel',
+                children: [
+                  rct_node(:patients, 'Arrival Information', %i[port_of_origin date_of_departure flight_or_vessel_number flight_or_vessel_carrier
+                                                                port_of_entry_into_usa date_of_arrival source_of_report source_of_report_specify
+                                                                travel_related_notes]),
+                  rct_node(:patients, 'Additional Planned Travel', %i[additional_planned_travel_type additional_planned_travel_destination
+                                                                      additional_planned_travel_destination_state additional_planned_travel_destination_country
+                                                                      additional_planned_travel_port_of_departure additional_planned_travel_start_date
+                                                                      additional_planned_travel_end_date additional_planned_travel_related_notes])
+                ]
+              },
+              {
+                value: 'patients-enrollment-potential_exposure_information',
+                label: 'Potential Exposure Information',
+                children: [
+                  rct_node(:patients, 'Exposure Location and Notes', %i[potential_exposure_location potential_exposure_country]),
+                  rct_node(:patients, 'Exposure Risk Factors', %i[contact_of_known_case contact_of_known_case_id travel_to_affected_country_or_area
+                                                                  was_in_health_care_facility_with_known_cases
+                                                                  was_in_health_care_facility_with_known_cases_facility_name laboratory_personnel
+                                                                  laboratory_personnel_facility_name healthcare_personnel healthcare_personnel_facility_name
+                                                                  crew_on_passenger_or_cargo_flight member_of_a_common_exposure_cohort
+                                                                  member_of_a_common_exposure_cohort_type exposure_notes])
+                ]
+              },
+              rct_node(:patients, 'Record Creation and Updates', %i[creator created_at updated_at])
+            ]
+          },
+          {
+            value: 'patients-monitoring',
+            label: 'Monitoring Info',
+            children: [
+              rct_node(:patients, 'Linelist Info', %i[workflow status]),
+              rct_node(:patients, 'Monitoring Actions', %i[monitoring_status exposure_risk_assessment monitoring_plan case_status public_health_action
+                                                           jurisdiction_path jurisdiction_name assigned_user]),
+              rct_node(:patients, 'Monitoring Period', %i[last_date_of_exposure continuous_exposure symptom_onset symptom_onset_defined_by
+                                                          extended_isolation end_of_monitoring closed_at monitoring_reason expected_purge_ts]),
+              rct_node(:patients, 'Reporting Info', %i[responder_id head_of_household pause_notifications last_assessment_reminder_sent])
+            ]
+          }
+        ]
+      }
+    ]
+  }.freeze
+
+  ASSESSMENTS_EXPORT_OPTIONS = {
+    label: 'Reports',
+    nodes: [rct_node(:assessments, 'Reports', %i[patient_id user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss id symptomatic
+                                                 who_reported created_at updated_at symptoms])]
+  }.freeze
+
+  LABORATORIES_EXPORT_OPTIONS = {
+    label: 'Lab Results',
+    nodes: [rct_node(:laboratories, 'Lab Results', %i[patient_id user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss id lab_type
+                                                      specimen_collection report result created_at updated_at])]
+  }.freeze
+
+  CLOSE_CONTACTS_EXPORT_OPTIONS = {
+    label: 'Close Contacts',
+    nodes: [rct_node(:close_contacts, 'Close Contacts', %i[patient_id user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss id first_name
+                                                           last_name primary_telephone email contact_attempts last_date_of_exposure assigned_user notes
+                                                           enrolled_id created_at updated_at])]
+  }.freeze
+
+  TRANSFERS_EXPORT_OPTIONS = {
+    label: 'Transfers',
+    nodes: [rct_node(:transfers, 'Transfers', %i[patient_id user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss id who from_jurisdiction
+                                                 to_jurisdiction created_at updated_at])]
+  }.freeze
+
+  HISTORIES_EXPORT_OPTIONS = {
+    label: 'Histories',
+    nodes: [rct_node(:histories, 'History', %i[patient_id user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss id created_by history_type
+                                               comment created_at updated_at])]
+  }.freeze
+
+  CUSTOM_EXPORT_OPTIONS = {
+    patients: PATIENTS_EXPORT_OPTIONS,
+    assessments: ASSESSMENTS_EXPORT_OPTIONS,
+    laboratories: LABORATORIES_EXPORT_OPTIONS,
+    close_contacts: CLOSE_CONTACTS_EXPORT_OPTIONS,
+    transfers: TRANSFERS_EXPORT_OPTIONS,
+    histories: HISTORIES_EXPORT_OPTIONS
+  }.freeze
+end

--- a/app/lib/utils.rb
+++ b/app/lib/utils.rb
@@ -4,7 +4,7 @@
 module Utils
   # Converts phone number from e164 to CDC recommended format
   def format_phone_number(phone)
-    cleaned_phone_number = phone&.gsub('+1', '')
+    cleaned_phone_number = phone&.sub('+1', '')
     return nil if cleaned_phone_number.nil? || cleaned_phone_number.length != 10
 
     cleaned_phone_number.insert(6, '-').insert(3, '-')

--- a/app/lib/utils.rb
+++ b/app/lib/utils.rb
@@ -4,7 +4,6 @@
 module Utils
   # Converts phone number from e164 to CDC recommended format
   def format_phone_number(phone)
-    # cleaned_phone_number = Phonelib.parse(phone).national(false)
     cleaned_phone_number = phone&.gsub('+1', '')
     return nil if cleaned_phone_number.nil? || cleaned_phone_number.length != 10
 

--- a/app/lib/utils.rb
+++ b/app/lib/utils.rb
@@ -4,7 +4,8 @@
 module Utils
   # Converts phone number from e164 to CDC recommended format
   def format_phone_number(phone)
-    cleaned_phone_number = Phonelib.parse(phone).national(false)
+    # cleaned_phone_number = Phonelib.parse(phone).national(false)
+    cleaned_phone_number = phone&.gsub('+1', '')
     return nil if cleaned_phone_number.nil? || cleaned_phone_number.length != 10
 
     cleaned_phone_number.insert(6, '-').insert(3, '-')

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -154,7 +154,8 @@ class Assessment < ApplicationRecord
 
   def custom_details(fields)
     assessment_details = {}
-    assessment_details[:id] = id if fields.include?(:id)
+    # assessment id is always included because it is needed to query symptoms, though it will not be added as a column if user chooses not to export it
+    assessment_details[:id] = id
     assessment_details[:patient_id] = patient_id if fields.include?(:patient_id)
     assessment_details[:symptomatic] = symptomatic || false if fields.include?(:symptomatic)
     assessment_details[:who_reported] = remove_formula_start(who_reported) if fields.include?(:who_reported)

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -5,6 +5,7 @@ class Assessment < ApplicationRecord
   extend OrderAsSpecified
   include PatientHelper
   include ExcelSanitizer
+  include ImportExportConstants
 
   columns.each do |column|
     case column.type
@@ -152,17 +153,10 @@ class Assessment < ApplicationRecord
     )
   end
 
-  def custom_details(fields, patient_identifiers)
+  def custom_details(fields)
     assessment_details = {}
-    assessment_details[:id] = id if fields.include?(:id)
-    assessment_details[:patient_id] = patient_id if fields.include?(:patient_id)
-    assessment_details[:user_defined_id_statelocal] = patient_identifiers[:user_defined_id_statelocal]
-    assessment_details[:user_defined_id_cdc] = patient_identifiers[:user_defined_id_cdc]
-    assessment_details[:user_defined_id_nndss] = patient_identifiers[:user_defined_id_nndss]
-    assessment_details[:symptomatic] = symptomatic || false if fields.include?(:symptomatic)
-    assessment_details[:who_reported] = remove_formula_start(who_reported) if fields.include?(:who_reported)
-    assessment_details[:created_at] = created_at if fields.include?(:created_at)
-    assessment_details[:updated_at] = updated_at if fields.include?(:updated_at)
+    (fields & ASSESSMENT_FIELD_TYPES[:unfiltered]).each { |field| assessment_details[field] = self[field] }
+    (fields & ASSESSMENT_FIELD_TYPES[:remove_formula_start]).each { |field| assessment_details[field] = remove_formula_start(self[field]) }
     assessment_details
   end
 

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -154,15 +154,15 @@ class Assessment < ApplicationRecord
 
   def custom_details(fields, patient_identifiers)
     assessment_details = {}
-    assessment_details[:id] = id || '' if fields.include?(:id)
-    assessment_details[:patient_id] = patient_id || '' if fields.include?(:patient_id)
+    assessment_details[:id] = id if fields.include?(:id)
+    assessment_details[:patient_id] = patient_id if fields.include?(:patient_id)
     assessment_details[:user_defined_id_statelocal] = patient_identifiers[:user_defined_id_statelocal]
     assessment_details[:user_defined_id_cdc] = patient_identifiers[:user_defined_id_cdc]
     assessment_details[:user_defined_id_nndss] = patient_identifiers[:user_defined_id_nndss]
     assessment_details[:symptomatic] = symptomatic || false if fields.include?(:symptomatic)
-    assessment_details[:who_reported] = remove_formula_start(who_reported) || '' if fields.include?(:who_reported)
-    assessment_details[:created_at] = created_at || '' if fields.include?(:created_at)
-    assessment_details[:updated_at] = updated_at || '' if fields.include?(:updated_at)
+    assessment_details[:who_reported] = remove_formula_start(who_reported) if fields.include?(:who_reported)
+    assessment_details[:created_at] = created_at if fields.include?(:created_at)
+    assessment_details[:updated_at] = updated_at if fields.include?(:updated_at)
     assessment_details
   end
 

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -152,18 +152,6 @@ class Assessment < ApplicationRecord
     )
   end
 
-  def custom_details(fields)
-    assessment_details = {}
-    # assessment id is always included because it is needed to query symptoms, though it will not be added as a column if user chooses not to export it
-    assessment_details[:id] = id
-    assessment_details[:patient_id] = patient_id if fields.include?(:patient_id)
-    assessment_details[:symptomatic] = symptomatic || false if fields.include?(:symptomatic)
-    assessment_details[:who_reported] = remove_formula_start(who_reported) if fields.include?(:who_reported)
-    assessment_details[:created_at] = created_at if fields.include?(:created_at)
-    assessment_details[:updated_at] = updated_at if fields.include?(:updated_at)
-    assessment_details
-  end
-
   private
 
   def update_patient_linelist_after_save

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -5,7 +5,6 @@ class Assessment < ApplicationRecord
   extend OrderAsSpecified
   include PatientHelper
   include ExcelSanitizer
-  include ImportExportConstants
 
   columns.each do |column|
     case column.type
@@ -155,8 +154,12 @@ class Assessment < ApplicationRecord
 
   def custom_details(fields)
     assessment_details = {}
-    (fields & ASSESSMENT_FIELD_TYPES[:unfiltered]).each { |field| assessment_details[field] = self[field] }
-    (fields & ASSESSMENT_FIELD_TYPES[:remove_formula_start]).each { |field| assessment_details[field] = remove_formula_start(self[field]) }
+    assessment_details[:id] = id if fields.include?(:id)
+    assessment_details[:patient_id] = patient_id if fields.include?(:patient_id)
+    assessment_details[:symptomatic] = symptomatic || false if fields.include?(:symptomatic)
+    assessment_details[:who_reported] = remove_formula_start(who_reported) if fields.include?(:who_reported)
+    assessment_details[:created_at] = created_at if fields.include?(:created_at)
+    assessment_details[:updated_at] = updated_at if fields.include?(:updated_at)
     assessment_details
   end
 

--- a/app/models/close_contact.rb
+++ b/app/models/close_contact.rb
@@ -6,22 +6,4 @@ class CloseContact < ApplicationRecord
   include ExcelSanitizer
 
   belongs_to :patient, touch: true
-
-  def custom_details(fields)
-    close_contact_details = {}
-    close_contact_details[:id] = id if fields.include?(:id)
-    close_contact_details[:patient_id] = patient_id if fields.include?(:patient_id)
-    close_contact_details[:first_name] = remove_formula_start(first_name) if fields.include?(:first_name)
-    close_contact_details[:last_name] = remove_formula_start(last_name) if fields.include?(:last_name)
-    close_contact_details[:primary_telephone] = format_phone_number(primary_telephone) if fields.include?(:primary_telephone)
-    close_contact_details[:email] = remove_formula_start(email) if fields.include?(:email)
-    close_contact_details[:contact_attempts] = contact_attempts if fields.include?(:contact_attempts)
-    close_contact_details[:last_date_of_exposure] = last_date_of_exposure if fields.include?(:last_date_of_exposure)
-    close_contact_details[:assigned_user] = assigned_user if fields.include?(:assigned_user)
-    close_contact_details[:notes] = remove_formula_start(notes) if fields.include?(:notes)
-    close_contact_details[:enrolled_id] = enrolled_id if fields.include?(:enrolled_id)
-    close_contact_details[:created_at] = created_at if fields.include?(:created_at)
-    close_contact_details[:updated_at] = updated_at if fields.include?(:updated_at)
-    close_contact_details
-  end
 end

--- a/app/models/close_contact.rb
+++ b/app/models/close_contact.rb
@@ -4,15 +4,24 @@
 class CloseContact < ApplicationRecord
   include Utils
   include ExcelSanitizer
-  include ImportExportConstants
 
   belongs_to :patient, touch: true
 
   def custom_details(fields)
     close_contact_details = {}
-    (fields & CLOSE_CONTACT_FIELD_TYPES[:unfiltered]).each { |field| close_contact_details[field] = self[field] }
-    (fields & CLOSE_CONTACT_FIELD_TYPES[:remove_formula_start]).each { |field| close_contact_details[field] = remove_formula_start(self[field]) }
-    (fields & CLOSE_CONTACT_FIELD_TYPES[:phones]).each { |field| close_contact_details[field] = format_phone_number(self[field]) }
+    close_contact_details[:id] = id if fields.include?(:id)
+    close_contact_details[:patient_id] = patient_id if fields.include?(:patient_id)
+    close_contact_details[:first_name] = remove_formula_start(first_name) if fields.include?(:first_name)
+    close_contact_details[:last_name] = remove_formula_start(last_name) if fields.include?(:last_name)
+    close_contact_details[:primary_telephone] = format_phone_number(primary_telephone) if fields.include?(:primary_telephone)
+    close_contact_details[:email] = remove_formula_start(email) if fields.include?(:email)
+    close_contact_details[:contact_attempts] = contact_attempts if fields.include?(:contact_attempts)
+    close_contact_details[:last_date_of_exposure] = last_date_of_exposure if fields.include?(:last_date_of_exposure)
+    close_contact_details[:assigned_user] = assigned_user if fields.include?(:assigned_user)
+    close_contact_details[:notes] = remove_formula_start(notes) if fields.include?(:notes)
+    close_contact_details[:enrolled_id] = enrolled_id if fields.include?(:enrolled_id)
+    close_contact_details[:created_at] = created_at if fields.include?(:created_at)
+    close_contact_details[:updated_at] = updated_at if fields.include?(:updated_at)
     close_contact_details
   end
 end

--- a/app/models/close_contact.rb
+++ b/app/models/close_contact.rb
@@ -9,22 +9,22 @@ class CloseContact < ApplicationRecord
 
   def custom_details(fields, patient_identifiers)
     close_contact_details = {}
-    close_contact_details[:id] = id || '' if fields.include?(:id)
-    close_contact_details[:patient_id] = patient_id || '' if fields.include?(:patient_id)
+    close_contact_details[:id] = id if fields.include?(:id)
+    close_contact_details[:patient_id] = patient_id if fields.include?(:patient_id)
     close_contact_details[:user_defined_id_statelocal] = patient_identifiers[:user_defined_id_statelocal]
     close_contact_details[:user_defined_id_cdc] = patient_identifiers[:user_defined_id_cdc]
     close_contact_details[:user_defined_id_nndss] = patient_identifiers[:user_defined_id_nndss]
-    close_contact_details[:first_name] = remove_formula_start(first_name) || '' if fields.include?(:first_name)
-    close_contact_details[:last_name] = remove_formula_start(last_name) || '' if fields.include?(:last_name)
-    close_contact_details[:primary_telephone] = format_phone_number(primary_telephone) || '' if fields.include?(:primary_telephone)
-    close_contact_details[:email] = remove_formula_start(email) || '' if fields.include?(:email)
-    close_contact_details[:contact_attempts] = contact_attempts || '' if fields.include?(:contact_attempts)
-    close_contact_details[:last_date_of_exposure] = last_date_of_exposure || '' if fields.include?(:last_date_of_exposure)
-    close_contact_details[:assigned_user] = assigned_user || '' if fields.include?(:assigned_user)
-    close_contact_details[:notes] = remove_formula_start(notes) || '' if fields.include?(:notes)
-    close_contact_details[:enrolled_id] = enrolled_id || '' if fields.include?(:enrolled_id)
-    close_contact_details[:created_at] = created_at || '' if fields.include?(:created_at)
-    close_contact_details[:updated_at] = updated_at || '' if fields.include?(:updated_at)
+    close_contact_details[:first_name] = remove_formula_start(first_name) if fields.include?(:first_name)
+    close_contact_details[:last_name] = remove_formula_start(last_name) if fields.include?(:last_name)
+    close_contact_details[:primary_telephone] = format_phone_number(primary_telephone) if fields.include?(:primary_telephone)
+    close_contact_details[:email] = remove_formula_start(email) if fields.include?(:email)
+    close_contact_details[:contact_attempts] = contact_attempts if fields.include?(:contact_attempts)
+    close_contact_details[:last_date_of_exposure] = last_date_of_exposure if fields.include?(:last_date_of_exposure)
+    close_contact_details[:assigned_user] = assigned_user if fields.include?(:assigned_user)
+    close_contact_details[:notes] = remove_formula_start(notes) if fields.include?(:notes)
+    close_contact_details[:enrolled_id] = enrolled_id if fields.include?(:enrolled_id)
+    close_contact_details[:created_at] = created_at if fields.include?(:created_at)
+    close_contact_details[:updated_at] = updated_at if fields.include?(:updated_at)
     close_contact_details
   end
 end

--- a/app/models/close_contact.rb
+++ b/app/models/close_contact.rb
@@ -4,27 +4,15 @@
 class CloseContact < ApplicationRecord
   include Utils
   include ExcelSanitizer
+  include ImportExportConstants
 
   belongs_to :patient, touch: true
 
-  def custom_details(fields, patient_identifiers)
+  def custom_details(fields)
     close_contact_details = {}
-    close_contact_details[:id] = id if fields.include?(:id)
-    close_contact_details[:patient_id] = patient_id if fields.include?(:patient_id)
-    close_contact_details[:user_defined_id_statelocal] = patient_identifiers[:user_defined_id_statelocal]
-    close_contact_details[:user_defined_id_cdc] = patient_identifiers[:user_defined_id_cdc]
-    close_contact_details[:user_defined_id_nndss] = patient_identifiers[:user_defined_id_nndss]
-    close_contact_details[:first_name] = remove_formula_start(first_name) if fields.include?(:first_name)
-    close_contact_details[:last_name] = remove_formula_start(last_name) if fields.include?(:last_name)
-    close_contact_details[:primary_telephone] = format_phone_number(primary_telephone) if fields.include?(:primary_telephone)
-    close_contact_details[:email] = remove_formula_start(email) if fields.include?(:email)
-    close_contact_details[:contact_attempts] = contact_attempts if fields.include?(:contact_attempts)
-    close_contact_details[:last_date_of_exposure] = last_date_of_exposure if fields.include?(:last_date_of_exposure)
-    close_contact_details[:assigned_user] = assigned_user if fields.include?(:assigned_user)
-    close_contact_details[:notes] = remove_formula_start(notes) if fields.include?(:notes)
-    close_contact_details[:enrolled_id] = enrolled_id if fields.include?(:enrolled_id)
-    close_contact_details[:created_at] = created_at if fields.include?(:created_at)
-    close_contact_details[:updated_at] = updated_at if fields.include?(:updated_at)
+    (fields & CLOSE_CONTACT_FIELD_TYPES[:unfiltered]).each { |field| close_contact_details[field] = self[field] }
+    (fields & CLOSE_CONTACT_FIELD_TYPES[:remove_formula_start]).each { |field| close_contact_details[field] = remove_formula_start(self[field]) }
+    (fields & CLOSE_CONTACT_FIELD_TYPES[:phones]).each { |field| close_contact_details[field] = format_phone_number(self[field]) }
     close_contact_details
   end
 end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -6,6 +6,7 @@ require 'action_view/helpers'
 # History: history model
 class History < ApplicationRecord
   include ExcelSanitizer
+  include ImportExportConstants
 
   HISTORY_TYPES = {
     record_edit: 'Record Edit',
@@ -349,18 +350,10 @@ class History < ApplicationRecord
     }
   end
 
-  def custom_details(fields, patient_identifiers)
+  def custom_details(fields)
     history_details = {}
-    history_details[:id] = id || '' if fields.include?(:id)
-    history_details[:patient_id] = patient_id || '' if fields.include?(:patient_id)
-    history_details[:user_defined_id_statelocal] = patient_identifiers[:user_defined_id_statelocal]
-    history_details[:user_defined_id_cdc] = patient_identifiers[:user_defined_id_cdc]
-    history_details[:user_defined_id_nndss] = patient_identifiers[:user_defined_id_nndss]
-    history_details[:created_by] = remove_formula_start(created_by) || '' if fields.include?(:created_by)
-    history_details[:history_type] = history_type || '' if fields.include?(:history_type)
-    history_details[:comment] = remove_formula_start(comment) || '' if fields.include?(:comment)
-    history_details[:created_at] = created_at || '' if fields.include?(:created_at)
-    history_details[:updated_at] = updated_at || '' if fields.include?(:updated_at)
+    (fields & HISTORY_FIELD_TYPES[:unfiltered]).each { |field| history_details[field] = self[field] }
+    (fields & HISTORY_FIELD_TYPES[:remove_formula_start]).each { |field| history_details[field] = remove_formula_start(self[field]) }
     history_details
   end
 

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -349,18 +349,6 @@ class History < ApplicationRecord
     }
   end
 
-  def custom_details(fields)
-    history_details = {}
-    history_details[:id] = id || '' if fields.include?(:id)
-    history_details[:patient_id] = patient_id || '' if fields.include?(:patient_id)
-    history_details[:created_by] = remove_formula_start(created_by) || '' if fields.include?(:created_by)
-    history_details[:history_type] = history_type || '' if fields.include?(:history_type)
-    history_details[:comment] = remove_formula_start(comment) || '' if fields.include?(:comment)
-    history_details[:created_at] = created_at || '' if fields.include?(:created_at)
-    history_details[:updated_at] = updated_at || '' if fields.include?(:updated_at)
-    history_details
-  end
-
   private_class_method def self.create_history(patient, created_by, type, comment)
     return if patient.nil?
 

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -6,7 +6,6 @@ require 'action_view/helpers'
 # History: history model
 class History < ApplicationRecord
   include ExcelSanitizer
-  include ImportExportConstants
 
   HISTORY_TYPES = {
     record_edit: 'Record Edit',
@@ -352,8 +351,13 @@ class History < ApplicationRecord
 
   def custom_details(fields)
     history_details = {}
-    (fields & HISTORY_FIELD_TYPES[:unfiltered]).each { |field| history_details[field] = self[field] }
-    (fields & HISTORY_FIELD_TYPES[:remove_formula_start]).each { |field| history_details[field] = remove_formula_start(self[field]) }
+    history_details[:id] = id || '' if fields.include?(:id)
+    history_details[:patient_id] = patient_id || '' if fields.include?(:patient_id)
+    history_details[:created_by] = remove_formula_start(created_by) || '' if fields.include?(:created_by)
+    history_details[:history_type] = history_type || '' if fields.include?(:history_type)
+    history_details[:comment] = remove_formula_start(comment) || '' if fields.include?(:comment)
+    history_details[:created_at] = created_at || '' if fields.include?(:created_at)
+    history_details[:updated_at] = updated_at || '' if fields.include?(:updated_at)
     history_details
   end
 

--- a/app/models/laboratory.rb
+++ b/app/models/laboratory.rb
@@ -50,19 +50,6 @@ class Laboratory < ApplicationRecord
     }
   end
 
-  def custom_details(fields)
-    laboratory_details = {}
-    laboratory_details[:id] = id if fields.include?(:id)
-    laboratory_details[:patient_id] = patient_id if fields.include?(:patient_id)
-    laboratory_details[:lab_type] = lab_type if fields.include?(:lab_type)
-    laboratory_details[:specimen_collection] = specimen_collection&.strftime('%F') if fields.include?(:specimen_collection)
-    laboratory_details[:report] = report&.strftime('%F') if fields.include?(:report)
-    laboratory_details[:result] = result if fields.include?(:result)
-    laboratory_details[:created_at] = created_at if fields.include?(:created_at)
-    laboratory_details[:updated_at] = updated_at if fields.include?(:updated_at)
-    laboratory_details
-  end
-
   private
 
   def update_patient_linelist_after_save

--- a/app/models/laboratory.rb
+++ b/app/models/laboratory.rb
@@ -52,17 +52,17 @@ class Laboratory < ApplicationRecord
 
   def custom_details(fields, patient_identifiers)
     laboratory_details = {}
-    laboratory_details[:id] = id || '' if fields.include?(:id)
-    laboratory_details[:patient_id] = patient_id || '' if fields.include?(:patient_id)
+    laboratory_details[:id] = id if fields.include?(:id)
+    laboratory_details[:patient_id] = patient_id if fields.include?(:patient_id)
     laboratory_details[:user_defined_id_statelocal] = patient_identifiers[:user_defined_id_statelocal]
     laboratory_details[:user_defined_id_cdc] = patient_identifiers[:user_defined_id_cdc]
     laboratory_details[:user_defined_id_nndss] = patient_identifiers[:user_defined_id_nndss]
-    laboratory_details[:lab_type] = lab_type || '' if fields.include?(:lab_type)
-    laboratory_details[:specimen_collection] = specimen_collection&.strftime('%F') || '' if fields.include?(:specimen_collection)
-    laboratory_details[:report] = report&.strftime('%F') || '' if fields.include?(:report)
-    laboratory_details[:result] = result || '' if fields.include?(:result)
-    laboratory_details[:created_at] = created_at || '' if fields.include?(:created_at)
-    laboratory_details[:updated_at] = updated_at || '' if fields.include?(:updated_at)
+    laboratory_details[:lab_type] = lab_type if fields.include?(:lab_type)
+    laboratory_details[:specimen_collection] = specimen_collection&.strftime('%F') if fields.include?(:specimen_collection)
+    laboratory_details[:report] = report&.strftime('%F') if fields.include?(:report)
+    laboratory_details[:result] = result if fields.include?(:result)
+    laboratory_details[:created_at] = created_at if fields.include?(:created_at)
+    laboratory_details[:updated_at] = updated_at if fields.include?(:updated_at)
     laboratory_details
   end
 

--- a/app/models/laboratory.rb
+++ b/app/models/laboratory.rb
@@ -3,7 +3,6 @@
 # Laboratory: represents a lab result
 class Laboratory < ApplicationRecord
   include ValidationHelper
-  include ImportExportConstants
 
   belongs_to :patient, touch: true
 
@@ -53,8 +52,14 @@ class Laboratory < ApplicationRecord
 
   def custom_details(fields)
     laboratory_details = {}
-    (fields & LABORATORY_FIELD_TYPES[:unfiltered]).each { |field| laboratory_details[field] = self[field] }
-    (fields & LABORATORY_FIELD_TYPES[:dates]).each { |field| laboratory_details[field] = self[field]&.strftime('%F') }
+    laboratory_details[:id] = id if fields.include?(:id)
+    laboratory_details[:patient_id] = patient_id if fields.include?(:patient_id)
+    laboratory_details[:lab_type] = lab_type if fields.include?(:lab_type)
+    laboratory_details[:specimen_collection] = specimen_collection&.strftime('%F') if fields.include?(:specimen_collection)
+    laboratory_details[:report] = report&.strftime('%F') if fields.include?(:report)
+    laboratory_details[:result] = result if fields.include?(:result)
+    laboratory_details[:created_at] = created_at if fields.include?(:created_at)
+    laboratory_details[:updated_at] = updated_at if fields.include?(:updated_at)
     laboratory_details
   end
 

--- a/app/models/laboratory.rb
+++ b/app/models/laboratory.rb
@@ -3,6 +3,7 @@
 # Laboratory: represents a lab result
 class Laboratory < ApplicationRecord
   include ValidationHelper
+  include ImportExportConstants
 
   belongs_to :patient, touch: true
 
@@ -50,19 +51,10 @@ class Laboratory < ApplicationRecord
     }
   end
 
-  def custom_details(fields, patient_identifiers)
+  def custom_details(fields)
     laboratory_details = {}
-    laboratory_details[:id] = id if fields.include?(:id)
-    laboratory_details[:patient_id] = patient_id if fields.include?(:patient_id)
-    laboratory_details[:user_defined_id_statelocal] = patient_identifiers[:user_defined_id_statelocal]
-    laboratory_details[:user_defined_id_cdc] = patient_identifiers[:user_defined_id_cdc]
-    laboratory_details[:user_defined_id_nndss] = patient_identifiers[:user_defined_id_nndss]
-    laboratory_details[:lab_type] = lab_type if fields.include?(:lab_type)
-    laboratory_details[:specimen_collection] = specimen_collection&.strftime('%F') if fields.include?(:specimen_collection)
-    laboratory_details[:report] = report&.strftime('%F') if fields.include?(:report)
-    laboratory_details[:result] = result if fields.include?(:result)
-    laboratory_details[:created_at] = created_at if fields.include?(:created_at)
-    laboratory_details[:updated_at] = updated_at if fields.include?(:updated_at)
+    (fields & LABORATORY_FIELD_TYPES[:unfiltered]).each { |field| laboratory_details[field] = self[field] }
+    (fields & LABORATORY_FIELD_TYPES[:dates]).each { |field| laboratory_details[field] = self[field]&.strftime('%F') }
     laboratory_details
   end
 

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -2,8 +2,6 @@
 
 # Transfer: transfer model
 class Transfer < ApplicationRecord
-  include ImportExportConstants
-
   belongs_to :to_jurisdiction, class_name: 'Jurisdiction'
   belongs_to :from_jurisdiction, class_name: 'Jurisdiction'
   belongs_to :who, class_name: 'User'
@@ -54,10 +52,13 @@ class Transfer < ApplicationRecord
 
   def custom_details(fields, user_emails, jurisdiction_paths)
     transfer_details = {}
-    (fields & TRANSFER_FIELD_TYPES[:unfiltered].freeze).each { |field| transfer_details[field] = self[field] }
+    transfer_details[:id] = id if fields.include?(:id)
+    transfer_details[:patient_id] = patient_id if fields.include?(:patient_id)
     transfer_details[:who] = user_emails[who_id] if fields.include?(:who)
     transfer_details[:from_jurisdiction] = jurisdiction_paths[from_jurisdiction_id] if fields.include?(:from_jurisdiction)
     transfer_details[:to_jurisdiction] = jurisdiction_paths[to_jurisdiction_id] if fields.include?(:to_jurisdiction)
+    transfer_details[:created_at] = created_at if fields.include?(:created_at)
+    transfer_details[:updated_at] = updated_at if fields.include?(:updated_at)
     transfer_details
   end
 

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -50,21 +50,6 @@ class Transfer < ApplicationRecord
     )
   }
 
-  def custom_details(fields, patient_identifiers, user_emails, jurisdiction_paths)
-    transfer_details = {}
-    transfer_details[:id] = id || '' if fields.include?(:id)
-    transfer_details[:patient_id] = patient_id || '' if fields.include?(:patient_id)
-    transfer_details[:user_defined_id_statelocal] = patient_identifiers[:user_defined_id_statelocal]
-    transfer_details[:user_defined_id_cdc] = patient_identifiers[:user_defined_id_cdc]
-    transfer_details[:user_defined_id_nndss] = patient_identifiers[:user_defined_id_nndss]
-    transfer_details[:who] = user_emails[who_id] || '' if fields.include?(:who)
-    transfer_details[:from_jurisdiction] = jurisdiction_paths[from_jurisdiction_id] || '' if fields.include?(:from_jurisdiction)
-    transfer_details[:to_jurisdiction] = jurisdiction_paths[to_jurisdiction_id] || '' if fields.include?(:to_jurisdiction)
-    transfer_details[:created_at] = created_at || '' if fields.include?(:created_at)
-    transfer_details[:updated_at] = updated_at || '' if fields.include?(:updated_at)
-    transfer_details
-  end
-
   private
 
   def update_patient_linelist_after_save

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -50,18 +50,6 @@ class Transfer < ApplicationRecord
     )
   }
 
-  def custom_details(fields, user_emails, jurisdiction_paths)
-    transfer_details = {}
-    transfer_details[:id] = id if fields.include?(:id)
-    transfer_details[:patient_id] = patient_id if fields.include?(:patient_id)
-    transfer_details[:who] = user_emails[who_id] if fields.include?(:who)
-    transfer_details[:from_jurisdiction] = jurisdiction_paths[from_jurisdiction_id] if fields.include?(:from_jurisdiction)
-    transfer_details[:to_jurisdiction] = jurisdiction_paths[to_jurisdiction_id] if fields.include?(:to_jurisdiction)
-    transfer_details[:created_at] = created_at if fields.include?(:created_at)
-    transfer_details[:updated_at] = updated_at if fields.include?(:updated_at)
-    transfer_details
-  end
-
   private
 
   def update_patient_linelist_after_save

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -2,6 +2,8 @@
 
 # Transfer: transfer model
 class Transfer < ApplicationRecord
+  include ImportExportConstants
+
   belongs_to :to_jurisdiction, class_name: 'Jurisdiction'
   belongs_to :from_jurisdiction, class_name: 'Jurisdiction'
   belongs_to :who, class_name: 'User'
@@ -50,18 +52,12 @@ class Transfer < ApplicationRecord
     )
   }
 
-  def custom_details(fields, patient_identifiers, user_emails, jurisdiction_paths)
+  def custom_details(fields, user_emails, jurisdiction_paths)
     transfer_details = {}
-    transfer_details[:id] = id if fields.include?(:id)
-    transfer_details[:patient_id] = patient_id if fields.include?(:patient_id)
-    transfer_details[:user_defined_id_statelocal] = patient_identifiers[:user_defined_id_statelocal]
-    transfer_details[:user_defined_id_cdc] = patient_identifiers[:user_defined_id_cdc]
-    transfer_details[:user_defined_id_nndss] = patient_identifiers[:user_defined_id_nndss]
+    (fields & TRANSFER_FIELD_TYPES[:unfiltered].freeze).each { |field| transfer_details[field] = self[field] }
     transfer_details[:who] = user_emails[who_id] if fields.include?(:who)
     transfer_details[:from_jurisdiction] = jurisdiction_paths[from_jurisdiction_id] if fields.include?(:from_jurisdiction)
     transfer_details[:to_jurisdiction] = jurisdiction_paths[to_jurisdiction_id] if fields.include?(:to_jurisdiction)
-    transfer_details[:created_at] = created_at if fields.include?(:created_at)
-    transfer_details[:updated_at] = updated_at if fields.include?(:updated_at)
     transfer_details
   end
 

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -50,6 +50,21 @@ class Transfer < ApplicationRecord
     )
   }
 
+  def custom_details(fields, patient_identifiers, user_emails, jurisdiction_paths)
+    transfer_details = {}
+    transfer_details[:id] = id if fields.include?(:id)
+    transfer_details[:patient_id] = patient_id if fields.include?(:patient_id)
+    transfer_details[:user_defined_id_statelocal] = patient_identifiers[:user_defined_id_statelocal]
+    transfer_details[:user_defined_id_cdc] = patient_identifiers[:user_defined_id_cdc]
+    transfer_details[:user_defined_id_nndss] = patient_identifiers[:user_defined_id_nndss]
+    transfer_details[:who] = user_emails[who_id] if fields.include?(:who)
+    transfer_details[:from_jurisdiction] = jurisdiction_paths[from_jurisdiction_id] if fields.include?(:from_jurisdiction)
+    transfer_details[:to_jurisdiction] = jurisdiction_paths[to_jurisdiction_id] if fields.include?(:to_jurisdiction)
+    transfer_details[:created_at] = created_at if fields.include?(:created_at)
+    transfer_details[:updated_at] = updated_at if fields.include?(:updated_at)
+    transfer_details
+  end
+
   private
 
   def update_patient_linelist_after_save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -87,10 +87,10 @@ class User < ApplicationRecord
   def jurisdictions_for_transfer
     if can_transfer_patients?
       # Allow all jurisdictions as valid transfer options.
-      Hash[Jurisdiction.all.where.not(name: 'USA').pluck(:id, :path).map { |id, path| [id, path] }]
+      Hash[Jurisdiction.all.where.not(name: 'USA').pluck(:id, :path)]
     else
       # Otherwise, only show jurisdictions within hierarchy.
-      Hash[jurisdiction.subtree.pluck(:id, :path).map { |id, path| [id, path] }]
+      Hash[jurisdiction.subtree.pluck(:id, :path)]
     end
   end
 

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -9,7 +9,7 @@
                       authenticity_token: form_authenticity_token,
                       can_add_group: current_user.can_create_patient?,
                       has_dependents: @dependents_exclude_hoh.count.positive?,
-                      jurisdiction_paths: Hash[current_user.jurisdiction.subtree.pluck(:id, :path).map { |id, path| [id, path] }],
+                      jurisdiction_paths: Hash[current_user.jurisdiction.subtree.pluck(:id, :path)],
                       assigned_users: @patient.jurisdiction.assigned_users,
                       race_options: ValidationHelper::RACE_OPTIONS,
                       blocked_sms: @patient.blocked_sms

--- a/app/views/patients/new.html.erb
+++ b/app/views/patients/new.html.erb
@@ -8,7 +8,7 @@
                       authenticity_token: form_authenticity_token,
                       can_add_group: current_user.can_create_patient?,
                       has_dependents: false,
-                      jurisdiction_paths: Hash[current_user.jurisdiction.subtree.pluck(:id, :path).map { |id, path| [id, path] }],
+                      jurisdiction_paths: Hash[current_user.jurisdiction.subtree.pluck(:id, :path)],
                       assigned_users: @patient.jurisdiction.assigned_users,
                       race_options: ValidationHelper::RACE_OPTIONS,
                       cc_id: @close_contact&.id

--- a/app/views/patients/new_group_member.html.erb
+++ b/app/views/patients/new_group_member.html.erb
@@ -9,7 +9,7 @@
                       authenticity_token: form_authenticity_token,
                       can_add_group: current_user.can_create_patient?,
                       has_dependents: false,
-                      jurisdiction_paths: Hash[current_user.jurisdiction.subtree.pluck(:id, :path).map { |id, path| [id, path] }],
+                      jurisdiction_paths: Hash[current_user.jurisdiction.subtree.pluck(:id, :path)],
                       assigned_users: @patient.jurisdiction.assigned_users,
                       race_options: ValidationHelper::RACE_OPTIONS
                     }) %>

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -749,7 +749,7 @@ desc 'Backup the database'
     transfers = []
     histories = []
     patient_updates = {}
-    jurisdiction_paths = Hash[jurisdictions.pluck(:id, :path).map {|id, path| [id, path]}]
+    jurisdiction_paths = Hash[jurisdictions.pluck(:id, :path)]
     patients_transfer = existing_patients.pluck(:id, :jurisdiction_id, :assigned_user).sample(existing_patients.count * rand(5..10) / 100)
     patients_transfer.each_with_index do |(patient_id, jur_id, assigned_user), index|
       printf("\rGenerating transfer #{index+1} of #{patients_transfer.length}...")

--- a/test/fixtures/patients.yml
+++ b/test/fixtures/patients.yml
@@ -206,7 +206,7 @@ patient_6:
   last_date_of_exposure: <%= 22.days.ago %>
   public_health_action: 'Recommended medical evaluation of symptoms'
   latest_transfer_at: <%= 7.days.ago %>
-  latest_transfer_from: 5
+  latest_transfer_from: 2
 patient_7:
   id: 7
   created_at: <%= 45.days.ago %>
@@ -262,7 +262,7 @@ patient_8:
   pause_notifications: true
   latest_assessment_at: <%= 5.hours.ago %>
   latest_transfer_at: <%= 7.days.ago %>
-  latest_transfer_from: 2
+  latest_transfer_from: 5
 patient_9:
   id: 9
   created_at: <%= 17.days.ago %>
@@ -818,7 +818,7 @@ patient_43:
   last_date_of_exposure: <%= 5.days.ago %>
   pause_notifications: true
   latest_transfer_at: <%= 12.hours.ago %>
-  latest_transfer_from: 4
+  latest_transfer_from: 5
 patient_44:
   id: 44
   created_at: <%= 9.days.ago %>
@@ -842,7 +842,7 @@ patient_44:
   source_of_report: 'CDC'
   last_date_of_exposure: <%= 9.days.ago %>
   latest_transfer_at: <%= 22.hours.ago %>
-  latest_transfer_from: 5
+  latest_transfer_from: 4
 patient_45:
   id: 45
   created_at: <%= 3.days.ago %>

--- a/test/system/roles/public_health/dashboard/dashboard_verifier.rb
+++ b/test/system/roles/public_health/dashboard/dashboard_verifier.rb
@@ -104,7 +104,7 @@ class PublicHealthDashboardVerifier < ApplicationSystemTestCase
     # verify_patient_field('closed at', patient[:closed_at]) if tab == :closed # local timezone
     # verify_patient_field('transferred at', patient[:latest_transfer_at]) if %i[transferred_in transferred_out].include?(tab) # local timezone
     # verify_patient_field('latest report', patient[:latest_assessment_at]) unless %i[transferred_in transferred_out].include?(tab) # local timezone
-    verify_patient_field('status', patient.status.to_s.gsub('_', ' ').gsub('exposure ', '')&.gsub('isolation ', '')) if tab == :all
+    verify_patient_field('status', patient.status.to_s.gsub('_', ' ').sub('exposure ', '')&.sub('isolation ', '')) if tab == :all
   end
 
   def verify_patient_field(field, value)

--- a/test/system/roles/public_health/dashboard/export_verifier.rb
+++ b/test/system/roles/public_health/dashboard/export_verifier.rb
@@ -307,7 +307,7 @@ class PublicHealthMonitoringExportVerifier < ApplicationSystemTestCase
     # Replace "race" option with actual race field names
     race_index = checked.index(:race)
     checked.delete(:race)
-    checked.insert(race_index, *PATIENT_RACE_FIELDS)
+    checked.insert(race_index, *PATIENT_FIELD_TYPES[:races])
 
     # Validate headers
     checked.each_with_index do |header, col|

--- a/test/system/roles/public_health/dashboard/export_verifier.rb
+++ b/test/system/roles/public_health/dashboard/export_verifier.rb
@@ -323,7 +323,7 @@ class PublicHealthMonitoringExportVerifier < ApplicationSystemTestCase
         if field == :full_status
           assert_equal(patient.status&.to_s&.humanize&.downcase, cell_value || '', "For field: #{field} in Monitorees List (row #{row + 1})")
         elsif field == :status
-          assert_equal(patient.status&.to_s&.humanize&.downcase&.gsub('exposure ', '')&.gsub('isolation ', ''), cell_value,
+          assert_equal(patient.status&.to_s&.humanize&.downcase&.sub('exposure ', '')&.sub('isolation ', ''), cell_value,
                        "For field: #{field} in Monitorees List (row #{row + 1})")
         elsif %i[primary_telephone secondary_telephone].include?(field)
           assert_equal(format_phone_number(patient_details[field]).to_s, cell_value || '', "For field: #{field} in Monitorees List (row #{row + 1})")


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1287](https://tracker.codev.mitre.org/browse/SARAALERT-1287)

- Profile export performance (both memory and speed) and main problematic areas
- Implement changes to improve performance and profiled changes

# (Feature) Demo/Screenshots

Speed and memory for 36k monitorees:
Changes before (top) and after (bottom)
From left to right: csv linelist exposure, sara alert format exposure, excel export for all monitorees, custom export for all monitorees with everything checked off

![Screen Shot 2021-03-08 at 2 40 09 AM](https://user-images.githubusercontent.com/9956561/110289605-aa6dd700-7fb7-11eb-8661-0f098f3a12e3.png)

As show in the graphs above, there is significant performance improvements in terms of speed and memory. The upward spikes in memory (more obvious in the "all" and "custom" exports) are caused by `workbook.read_string` which loads an entire excel file's worth of data from a file on disk to memory to be written to the database. This will improve with @Bialogs 's [ActiveStorage PR](https://github.com/SaraAlert/SaraAlert/pull/550) because these files will be read and saved as StringIO objects.

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`Gemfile`, `Gemfile.lock`, 
- `fast_excel` is now used instead of `Axslx` which was a performance improvement in terms of both speed and memory

`app/controllers/export_controller.rb`
- `full_history_patient` method contains its own implementation of writing to workbook, refactoring batch logic led to this, also wanted to keep any logic specific to this endpoint out of the main export logic

`app/jobs/export_job.rb`
- `INNER_BATCH_SIZE` is now `100` instead of `500`, which leads to improvements in speed and memory
- outer batch loop is handled in `import_export` for better optimization

`app/lib/import_export.rb`
- `patients.in_batches` is only called on `inner_batch_size`, `outer_batch_size` is manually handled, which leads to significant improvements in speed
- number of queries are reduced in methods extracting patient, assessment, and transfer details, which leads to improvements in memory and speed

`app/lib/import_export_constants.rb`
- constants from `import_expot` are moved here
- `History` sheet in excel export is now `Histories` because `History` is a reserved sheet in excel, not sure why `Axslx` didn't complain about it before, but `fast_excel` does

`app/lib/utils.rb`
- use `gsub` instead of `Phonelib` to format phone numbers, which leads to slight performance in speed

`app/models/transfer.rb`
- remove `custom_details` method because query is executed differently now and this is no longer needed

`test/fixtures/patients.yml`
- fix incorrect transfers fixtures data

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Testing this PR mainly consists of ensuring that the expected behavior of the exports after these changes are pretty much the same (with the exception of the `History` sheet name changing to `Histories`), and examining the performance improvements (speed and memory). Most of the export functionality can be verified by the system tests in place, but it would still be good to glance through all the exported sheets anyways.

As for performance benchmarking, I've been using [psrecord](https://github.com/astrofrog/psrecord) for the most part to monitor speed and memory while making these changes (which is what generated the graphs above).
