### PR TITLE
BUGFIX: Fix advanced filter relative date bug

### DIFF
--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -347,6 +347,8 @@ class AdvancedFilter extends React.Component {
           .format('YYYY-MM-DD'),
         end: moment().format('YYYY-MM-DD'),
       };
+    } else if (filterOption.type === 'relative') {
+      value = 'today';
     } else if (filterOption.type === 'search') {
       value = '';
     }
@@ -408,9 +410,9 @@ class AdvancedFilter extends React.Component {
   };
 
   // Change the relative filter option for type relative date
-  changeFilterRelativeOption = (index, value, relativeOption) => {
+  changeFilterRelativeOption = (index, relativeOption) => {
     let activeFilterOptions = [...this.state.activeFilterOptions];
-    let defaultValue = relativeOption === 'custom' ? { number: 1, unit: 'days', when: 'past' } : null;
+    let defaultValue = relativeOption === 'custom' ? { number: 1, unit: 'days', when: 'past' } : relativeOption;
     activeFilterOptions[parseInt(index)] = {
       filterOption: activeFilterOptions[parseInt(index)].filterOption,
       value: defaultValue,
@@ -607,7 +609,7 @@ class AdvancedFilter extends React.Component {
   };
 
   // Render relative date specific options
-  renderRelativeOptions = (current, index, value) => {
+  renderRelativeOptions = (current, index) => {
     return (
       <Form.Control
         as="select"
@@ -615,7 +617,7 @@ class AdvancedFilter extends React.Component {
         className="advanced-filter-relative-options py-0 my-0 mr-4"
         aria-label="Advanced Filter Relative Date Select Options"
         onChange={event => {
-          this.changeFilterRelativeOption(index, value, event.target.value);
+          this.changeFilterRelativeOption(index, event.target.value);
         }}>
         <option value="today">today</option>
         <option value="tomorrow">tomorrow</option>
@@ -1038,7 +1040,7 @@ class AdvancedFilter extends React.Component {
             )}
             {filterOption?.type === 'relative' && (
               <Form.Group className="form-group-inline py-0 my-0">
-                {this.renderRelativeOptions(relativeOption, index, value)}
+                {this.renderRelativeOptions(relativeOption, index)}
                 {relativeOption === 'custom' && (
                   <React.Fragment>
                     <Form.Control

--- a/app/javascript/tests/mocks/mockFilters.js
+++ b/app/javascript/tests/mocks/mockFilters.js
@@ -116,7 +116,7 @@ const mockFilterDefaultRelativeOption = {
   },
   numberOption: null,
   relativeOption: 'today',
-  value: null
+  value: 'today'
 }
 
 const mockFilterRelativeOption = {
@@ -131,7 +131,7 @@ const mockFilterRelativeOption = {
   },
   numberOption: null,
   relativeOption: 'yesterday',
-  value: null
+  value: 'yesterday'
 }
 
 const mockFilterDefaultCustomRelativeOption = {


### PR DESCRIPTION
# (Bugfix) How to Replicate
1. Open "Network" tab under Chrome dev tools
2. Open the advanced filter modal and create a new filter with any relative date (ex: "Latest Report (Relative Date)")
3. Select today, tomorrow, or, yesterday and click "Apply"
4. Notice that a 400 error is returned with the message: `"param is missing or the value is empty: value"`

# (Bugfix) Solution
The error is being thrown because `filter.require(:value)` is called when `filter[:value]` is not defined for these cases

# Important Changes
`app/controllers/user_filters_controller.rb`, `app/helpers/patient_query_helper.rb`
- Remove `filter.require(:value)` since it's already covered by `filter.require(:value)`

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
