### PR TITLE
SARAALERT-1145: SymptomsAssessment input validation & IntegerSymptom support

### DIFF
--- a/app/javascript/components/assessment/steps/SymptomsAssessment.js
+++ b/app/javascript/components/assessment/steps/SymptomsAssessment.js
@@ -32,6 +32,16 @@ class SymptomsAssessment extends React.Component {
     this.handleChange(event, value);
   };
 
+  handleIntChange = event => {
+    const validInputs = ['', '-'];
+    if (
+      validInputs.includes(event?.target?.value) ||
+      (!event?.target?.value.includes('.') && event?.target?.value && !isNaN(event.target.value) && !isNaN(parseInt(event.target.value)))
+    ) {
+      this.handleChange(event, event.target.value);
+    }
+  };
+
   handleFloatChange = event => {
     const validInputs = ['', '.', '-', '-.'];
     if (validInputs.includes(event?.target?.value) || (event?.target?.value && !isNaN(event.target.value) && !isNaN(parseFloat(event.target.value)))) {
@@ -104,13 +114,19 @@ class SymptomsAssessment extends React.Component {
     }
   };
 
-  // Converts all FloatSymptoms to be floating point values and nulls out any non-floating point values provided
+  // Converts all FloatSymptoms and IntergerSymptoms to numerical values and nulls out any non-numerical values provided (such as '-', '.', and '-.')
   formatedReportState = () => {
     let reportState = this.state.reportState;
     for (const key in this.state.reportState['symptoms']) {
       if (parseInt(key) && reportState['symptoms'][parseInt(key)].type == 'FloatSymptom') {
         if (!isNaN(parseFloat(reportState['symptoms'][parseInt(key)].value))) {
           reportState['symptoms'][parseInt(key)].value = parseFloat(reportState['symptoms'][parseInt(key)].value);
+        } else {
+          reportState['symptoms'][parseInt(key)].value = null;
+        }
+      } else if (parseInt(key) && reportState['symptoms'][parseInt(key)].type == 'IntegerSymptom') {
+        if (!isNaN(parseInt(reportState['symptoms'][parseInt(key)].value))) {
+          reportState['symptoms'][parseInt(key)].value = parseInt(reportState['symptoms'][parseInt(key)].value);
         } else {
           reportState['symptoms'][parseInt(key)].value = null;
         }
@@ -166,6 +182,22 @@ class SymptomsAssessment extends React.Component {
     );
   };
 
+  integerSymptom = symp => {
+    const key = `key_${symp.name}${this.props.idPre ? '_idpre' + this.props.idPre : ''}`;
+    const id = `${symp.name}${this.props.idPre ? '_idpre' + this.props.idPre : ''}`;
+    return (
+      <Form.Row className="pt-3" key={key}>
+        <Form.Label className="nav-input-label" key={key + '_label'} htmlFor={id}>
+          <b>{this.props.translations[this.props.lang]['symptoms'][symp.name]['name']}</b>{' '}
+          {this.props.translations[this.props.lang]['symptoms'][symp.name]['notes']
+            ? ' ' + this.props.translations[this.props.lang]['symptoms'][symp.name]['notes']
+            : ''}
+        </Form.Label>
+        <Form.Control size="lg" id={id} key={key + '_control'} className="form-square" value={symp.value || ''} maxLength="9" onChange={this.handleIntChange} />
+      </Form.Row>
+    );
+  };
+
   floatSymptom = symp => {
     const key = `key_${symp.name}${this.props.idPre ? '_idpre' + this.props.idPre : ''}`;
     const id = `${symp.name}${this.props.idPre ? '_idpre' + this.props.idPre : ''}`;
@@ -210,6 +242,11 @@ class SymptomsAssessment extends React.Component {
                 })
                 .map(symp => this.boolSymptom(symp))}
               {this.noSymptom()}
+              {this.state.reportState.symptoms
+                .filter(x => {
+                  return x.type === 'IntegerSymptom';
+                })
+                .map(symp => this.integerSymptom(symp))}
               {this.state.reportState.symptoms
                 .filter(x => {
                   return x.type === 'FloatSymptom';

--- a/app/javascript/components/assessment/steps/SymptomsAssessment.js
+++ b/app/javascript/components/assessment/steps/SymptomsAssessment.js
@@ -33,15 +33,8 @@ class SymptomsAssessment extends React.Component {
   };
 
   handleFloatChange = event => {
-    if (
-      event?.target?.value === '' ||
-      event?.target?.value === '.' ||
-      (event?.target?.value && !isNaN(event.target.value) && !isNaN(parseFloat(event.target.value)))
-    ) {
-      // To prevent the user from just submitting a period character
-      if (event.target.value === '.') {
-        event.target.value = '0.';
-      }
+    const validInputs = ['', '.', '-', '-.'];
+    if (validInputs.includes(event?.target?.value) || (event?.target?.value && !isNaN(event.target.value) && !isNaN(parseFloat(event.target.value)))) {
       this.handleChange(event, event.target.value);
     }
   };
@@ -111,13 +104,16 @@ class SymptomsAssessment extends React.Component {
     }
   };
 
-  // Converts all FloatSymptoms to be floating point values
-  // Specifically needed for the case of input "0." so an error doesn't occurr on submission
+  // Converts all FloatSymptoms to be floating point values and nulls out any non-floating point values provided
   formatedReportState = () => {
     let reportState = this.state.reportState;
     for (const key in this.state.reportState['symptoms']) {
-      if (parseInt(key) && reportState['symptoms'][parseInt(key)].type == 'FloatSymptom' && !isNaN(parseFloat(reportState['symptoms'][parseInt(key)].value))) {
-        reportState['symptoms'][parseInt(key)].value = parseFloat(reportState['symptoms'][parseInt(key)].value);
+      if (parseInt(key) && reportState['symptoms'][parseInt(key)].type == 'FloatSymptom') {
+        if (!isNaN(parseFloat(reportState['symptoms'][parseInt(key)].value))) {
+          reportState['symptoms'][parseInt(key)].value = parseFloat(reportState['symptoms'][parseInt(key)].value);
+        } else {
+          reportState['symptoms'][parseInt(key)].value = null;
+        }
       }
     }
     return reportState;

--- a/app/javascript/components/assessment/steps/SymptomsAssessment.js
+++ b/app/javascript/components/assessment/steps/SymptomsAssessment.js
@@ -34,9 +34,15 @@ class SymptomsAssessment extends React.Component {
 
   handleIntChange = event => {
     const validInputs = ['', '-'];
+    const value = event?.target?.value;
+    // Ensure (1) the value is defined or an empty string && meets the condintions of (2) or (3)
+    //        (2.a) the value is a number & the user is prevented from inputting non-numerical characters after inputting a number (ex. '43test')
+    //        (2.b) the value can be parsed as an integer
+    //        (2.c) the user is prevented from inputting '.' characters (since parseInt() would allow that as an input)
+    //        (3) if the value is not a valid number, check if it is an acceptable character input
     if (
-      validInputs.includes(event?.target?.value) ||
-      (!event?.target?.value.includes('.') && event?.target?.value && !isNaN(event.target.value) && !isNaN(parseInt(event.target.value)))
+      (value || value === '') &&
+      ((!isNaN(event.target.value) && !isNaN(parseInt(event.target.value)) && !event?.target?.value.includes('.')) || validInputs.includes(value))
     ) {
       this.handleChange(event, event.target.value);
     }
@@ -44,7 +50,12 @@ class SymptomsAssessment extends React.Component {
 
   handleFloatChange = event => {
     const validInputs = ['', '.', '-', '-.'];
-    if (validInputs.includes(event?.target?.value) || (event?.target?.value && !isNaN(event.target.value) && !isNaN(parseFloat(event.target.value)))) {
+    const value = event?.target?.value;
+    // Ensure (1) the value is defined or an empty string && meets the condintions of (2) or (3)
+    //        (2.a) the value is a number & the user is prevented from inputting non-numerical characters after inputting a number (ex. '4.3test')
+    //        (2.b) the value can be parsed as an float
+    //        (3) if the value is not a valid number, check if it is an acceptable character input
+    if ((value || value === '') && ((!isNaN(event.target.value) && !isNaN(parseFloat(event.target.value))) || validInputs.includes(value))) {
       this.handleChange(event, event.target.value);
     }
   };
@@ -98,7 +109,7 @@ class SymptomsAssessment extends React.Component {
   };
 
   handleSubmit = async () => {
-    const reportState = this.formatedReportState();
+    const reportState = this.formattedReportState();
     if (this.fieldIsEmptyOrNew(this.props.assessment)) {
       this.props.submit(reportState);
     } else {
@@ -114,21 +125,18 @@ class SymptomsAssessment extends React.Component {
     }
   };
 
-  // Converts all FloatSymptoms and IntergerSymptoms to numerical values and nulls out any non-numerical values provided (such as '-', '.', and '-.')
-  formatedReportState = () => {
+  // Converts all FloatSymptoms and IntegerSymptoms to numerical values and nulls out any non-numerical values provided (such as '-', '.', and '-.')
+  formattedReportState = () => {
     let reportState = this.state.reportState;
     for (const key in this.state.reportState['symptoms']) {
-      if (parseInt(key) && reportState['symptoms'][parseInt(key)].type == 'FloatSymptom') {
-        if (!isNaN(parseFloat(reportState['symptoms'][parseInt(key)].value))) {
-          reportState['symptoms'][parseInt(key)].value = parseFloat(reportState['symptoms'][parseInt(key)].value);
-        } else {
-          reportState['symptoms'][parseInt(key)].value = null;
-        }
-      } else if (parseInt(key) && reportState['symptoms'][parseInt(key)].type == 'IntegerSymptom') {
-        if (!isNaN(parseInt(reportState['symptoms'][parseInt(key)].value))) {
-          reportState['symptoms'][parseInt(key)].value = parseInt(reportState['symptoms'][parseInt(key)].value);
-        } else {
-          reportState['symptoms'][parseInt(key)].value = null;
+      if (parseInt(key)) {
+        let symptom = reportState['symptoms'][parseInt(key)];
+        if (symptom.type === 'FloatSymptom' && !isNaN(parseFloat(symptom.value))) {
+          symptom.value = parseFloat(symptom.value);
+        } else if (symptom.type === 'IntegerSymptom' && !isNaN(parseInt(symptom.value))) {
+          symptom.value = parseInt(symptom.value);
+        } else if (symptom.type === 'IntegerSymptom' || symptom.type === 'FloatSymptom') {
+          symptom.value = null;
         }
       }
     }
@@ -186,19 +194,27 @@ class SymptomsAssessment extends React.Component {
     const key = `key_${symp.name}${this.props.idPre ? '_idpre' + this.props.idPre : ''}`;
     const id = `${symp.name}${this.props.idPre ? '_idpre' + this.props.idPre : ''}`;
     return (
-      <Form.Row className="pt-3" key={key}>
-        <Form.Label className="nav-input-label" key={key + '_label'} htmlFor={id}>
-          <b>{this.props.translations[this.props.lang]['symptoms'][symp.name]['name']}</b>{' '}
-          {this.props.translations[this.props.lang]['symptoms'][symp.name]['notes']
-            ? ' ' + this.props.translations[this.props.lang]['symptoms'][symp.name]['notes']
-            : ''}
-        </Form.Label>
-        <Form.Control size="lg" id={id} key={key + '_control'} className="form-square" value={symp.value || ''} maxLength="9" onChange={this.handleIntChange} />
-      </Form.Row>
+      <Form.Control size="lg" id={id} key={key + '_control'} className="form-square" value={symp.value || ''} maxLength="9" onChange={this.handleIntChange} />
     );
   };
 
   floatSymptom = symp => {
+    const key = `key_${symp.name}${this.props.idPre ? '_idpre' + this.props.idPre : ''}`;
+    const id = `${symp.name}${this.props.idPre ? '_idpre' + this.props.idPre : ''}`;
+    return (
+      <Form.Control
+        size="lg"
+        id={id}
+        key={key + '_control'}
+        className="form-square"
+        value={symp.value || ''}
+        maxLength="35"
+        onChange={this.handleFloatChange}
+      />
+    );
+  };
+
+  intOrFloatSymptom = symp => {
     const key = `key_${symp.name}${this.props.idPre ? '_idpre' + this.props.idPre : ''}`;
     const id = `${symp.name}${this.props.idPre ? '_idpre' + this.props.idPre : ''}`;
     return (
@@ -209,7 +225,8 @@ class SymptomsAssessment extends React.Component {
             ? ' ' + this.props.translations[this.props.lang]['symptoms'][symp.name]['notes']
             : ''}
         </Form.Label>
-        <Form.Control size="lg" id={id} key={key + '_control'} className="form-square" value={symp.value || ''} maxlength="35" onChange={this.handleFloatChange} />
+        {symp.type === 'IntegerSymptom' && this.integerSymptom(symp)}
+        {symp.type === 'FloatSymptom' && this.floatSymptom(symp)}
       </Form.Row>
     );
   };
@@ -246,12 +263,12 @@ class SymptomsAssessment extends React.Component {
                 .filter(x => {
                   return x.type === 'IntegerSymptom';
                 })
-                .map(symp => this.integerSymptom(symp))}
+                .map(symp => this.intOrFloatSymptom(symp))}
               {this.state.reportState.symptoms
                 .filter(x => {
                   return x.type === 'FloatSymptom';
                 })
-                .map(symp => this.floatSymptom(symp))}
+                .map(symp => this.intOrFloatSymptom(symp))}
             </Form.Group>
           </Form.Row>
           <Form.Row className="pt-4">

--- a/app/javascript/tests/assessment/steps/SymptomsAssessment.test.js
+++ b/app/javascript/tests/assessment/steps/SymptomsAssessment.test.js
@@ -26,7 +26,7 @@ describe('SymptomsAssessment', () => {
     expect(wrapper.find(Card.Body).find(Form.Row).at(0).text()).toEqual(mockTranslations['en']['web']['bool-title']);
     expect(wrapper.find(Card.Body).find(Form.Group).exists()).toBeTruthy();
     expect(wrapper.find(Card.Body).find(Form.Check).length).toEqual(17);
-    expect(wrapper.find(Card.Body).find(Form.Control).length).toEqual(1);
+    expect(wrapper.find(Card.Body).find(Form.Control).length).toEqual(2);
     expect(wrapper.find(Card.Body).find(Button).exists()).toBeTruthy();
     expect(wrapper.find(Card.Body).find(Button).text()).toEqual(mockTranslations['en']['web']['submit']);
   });
@@ -38,7 +38,10 @@ describe('SymptomsAssessment', () => {
       expect(cb.prop('checked')).toBeFalsy();
       expect(cb.prop('disabled')).toBeFalsy();
     });
-    expect(wrapper.find(Form.Control).prop('value')).toEqual('');
+    const formControls = wrapper.find(Form.Control);
+    formControls.forEach(fc => {
+      expect(fc.prop('value')).toEqual('');
+    });
   });
 
   it('Properly renders checked bool symptoms when editing a report', () => {
@@ -50,17 +53,22 @@ describe('SymptomsAssessment', () => {
     });
     expect(wrapper.find(Form.Check).at(16).prop('checked')).toBeFalsy();
     expect(wrapper.find(Form.Check).at(16).prop('disabled')).toBeTruthy();
-    expect(wrapper.find(Form.Control).prop('value')).toEqual('');
+    const formControls = wrapper.find(Form.Control);
+    formControls.forEach(fc => {
+      expect(fc.prop('value')).toEqual('');
+    });
   });
 
-  it('Properly renders float symptom values when editing a report', () => {
+  it('Properly renders float & integer symptom values when editing a report', () => {
     const wrapper = getWrapper(mockAssessment2, mockSymptoms2, '777');
     const checkboxes = wrapper.find(Form.Check);
     checkboxes.forEach(cb => {
       expect(cb.prop('checked')).toBeFalsy();
       expect(cb.prop('disabled')).toBeFalsy();
     });
-    expect(wrapper.find(Form.Control).prop('value')).toEqual(1);
+    const formControls = wrapper.find(Form.Control);
+    expect(formControls.at(0).prop('value')).toEqual(5);
+    expect(formControls.at(1).prop('value')).toEqual(1);
   });
 
   it('Clicking "I am not experiencing any symptoms" disables all bool symptom checkboxes', () => {
@@ -80,7 +88,7 @@ describe('SymptomsAssessment', () => {
   it('Clicking any bool symptom disables the "I am not experiencing any symptoms" checkbox', () => {
     const wrapper = getWrapper({}, mockNewSymptoms, 'new');
     const checkbox = wrapper.find(Form.Check).at(0);
-    checkbox.simulate('change', { target: { id: checkbox.prop('id'), value: true } });
+    checkbox.simulate('change', { target: { id: checkbox.prop('id'), checked: true } });
     wrapper.find(Form.Check).forEach(cb => {
       if (checkbox.prop('id') === cb.prop('id')) {
         expect(cb.prop('checked')).toBeTruthy();
@@ -111,7 +119,7 @@ describe('SymptomsAssessment', () => {
     const wrapper = getWrapper({}, mockNewSymptoms, 'new');
     const checkbox = wrapper.find(Form.Check).at(0);
     const checkboxId = checkbox.prop('id');
-    checkbox.simulate('change', { target: { id: checkboxId, value: true } });
+    checkbox.simulate('change', { target: { id: checkboxId, checked: true } });
     expect(wrapper.state('noSymptomsCheckbox')).toBeFalsy();
     expect(wrapper.state('selectedBoolSymptomCount')).toEqual(1);
     wrapper.state('reportState').symptoms.forEach(symp => {
@@ -140,7 +148,7 @@ describe('SymptomsAssessment', () => {
     const navigateSpy = jest.spyOn(wrapper.instance(), 'navigate');
     const handleSubmitSpy = jest.spyOn(wrapper.instance(), 'handleSubmit');
     const checkbox = wrapper.find(Form.Check).at(7);
-    checkbox.simulate('change', { target: { id: checkbox.prop('id'), value: true } });
+    checkbox.simulate('change', { target: { id: checkbox.prop('id'), checked: true } });
 
     expect(navigateSpy).toHaveBeenCalledTimes(0);
     expect(handleSubmitSpy).toHaveBeenCalledTimes(0);

--- a/app/javascript/tests/mocks/mockAssessments.js
+++ b/app/javascript/tests/mocks/mockAssessments.js
@@ -23,6 +23,7 @@ const mockAssessment1 = {
     difficulty_breathing: true,
     fatigue: true,
     fever: true,
+    general_health: null,
     headache: false,
     muscle_pain: false,
     nausea_or_vomiting: false,
@@ -34,6 +35,7 @@ const mockAssessment1 = {
     sore_throat: true,
     used_a_fever_reducer: false
   },
+  general_health: '',
   pulse_ox: '',
   repeated_shaking_with_chills: 'No',
   shortness_of_breath: 'No',
@@ -68,6 +70,7 @@ const mockAssessment2 = {
     difficulty_breathing: false,
     fatigue: false,
     fever: false,
+    general_health: false,
     headache: false,
     muscle_pain: false,
     nausea_or_vomiting: false,
@@ -79,6 +82,7 @@ const mockAssessment2 = {
     sore_throat: false,
     used_a_fever_reducer: false
   },
+  general_health: 5,
   pulse_ox: 1,
   repeated_shaking_with_chills: 'No',
   shortness_of_breath: 'No',

--- a/app/javascript/tests/mocks/mockSymptoms.js
+++ b/app/javascript/tests/mocks/mockSymptoms.js
@@ -287,6 +287,23 @@ const mockNewSymptoms = [
     type: 'FloatSymptom',
     updated_at: null,
     value: null
+  },
+  {
+    bool_value: null,
+    condition_id: 915,
+    created_at: null,
+    float_value: null,
+    group: 1,
+    id: null,
+    int_value: null,
+    label: 'General Health',
+    name: 'general_health',
+    notes: null,
+    required: true,
+    threshold_operator: 'Greater Than',
+    type: 'IntegerSymptom',
+    updated_at: null,
+    value: null
   }
 ];
 
@@ -577,6 +594,23 @@ const mockSymptoms1 = [
     required: true,
     threshold_operator: 'Less Than',
     type: 'FloatSymptom',
+    updated_at: '2020-12-23T15:12:53.000Z',
+    value: null
+  },
+  {
+    bool_value: null,
+    condition_id: 915,
+    created_at: '2020-12-23T15:12:53.000Z',
+    float_value: null,
+    group: 1,
+    id: 22985,
+    int_value: null,
+    label: 'General Health',
+    name: 'general_health',
+    notes: null,
+    required: true,
+    threshold_operator: 'Greater Than',
+    type: 'IntegerSymptom',
     updated_at: '2020-12-23T15:12:53.000Z',
     value: null
   }
@@ -871,6 +905,23 @@ const mockSymptoms2 = [
     type: 'FloatSymptom',
     updated_at: '2020-12-22T08:57:53.000Z',
     value: 1
+  },
+  {
+    bool_value: null,
+    condition_id: 915,
+    created_at: '2020-12-22T08:57:53.000Z',
+    float_value: null,
+    group: 1,
+    id: 22985,
+    int_value: 5,
+    label: 'General Health',
+    name: 'general_health',
+    notes: null,
+    required: true,
+    threshold_operator: 'Greater Than',
+    type: 'IntegerSymptom',
+    updated_at: '2020-12-22T08:57:53.000Z',
+    value: 5
   }
 ];
 

--- a/app/javascript/tests/mocks/mockTranslations.js
+++ b/app/javascript/tests/mocks/mockTranslations.js
@@ -265,8 +265,8 @@ const mockTranslations = {
         'notes': ''
       },
       'general_health': {
-        'name': 'General Health',
-        'notes': 'How are you feeling on a scale of 1 (feeling great) to 10 (feeling very sickly)?'
+        'name': 'Salud general',
+        'notes': '¿Cómo se siente en una escala del 1 (sentirse bien) al 10 (sentirse muy enfermo)?'
       }
     },
     'threshold-op': {
@@ -439,8 +439,8 @@ const mockTranslations = {
         'notes': ''
       },
       'general_health': {
-        'name': 'General Health',
-        'notes': 'How are you feeling on a scale of 1 (feeling great) to 10 (feeling very sickly)?'
+        'name': 'Salud general',
+        'notes': '¿Cómo se siente en una escala del 1 (sentirse bien) al 10 (sentirse muy enfermo)?'
       }
     },
     'threshold-op': {
@@ -613,8 +613,8 @@ const mockTranslations = {
         'notes': ''
       },
       'general_health': {
-        'name': 'General Health',
-        'notes': 'How are you feeling on a scale of 1 (feeling great) to 10 (feeling very sickly)?'
+        'name': 'Santé générale',
+        'notes': 'Comment vous sentez-vous sur une échelle de 1 (se sentir bien) à 10 (se sentir très malade)?'
       }
     },
     'threshold_op': {
@@ -787,8 +787,8 @@ const mockTranslations = {
         'notes': ''
       },
       'general_health': {
-        'name': 'General Health',
-        'notes': 'How are you feeling on a scale of 1 (feeling great) to 10 (feeling very sickly)?'
+        'name': 'Caafimaadka guud',
+        'notes': 'Sidee kuula muuqataa miisaanka 1 (dareen weyn) ilaa 10 (aad dareemaysid jirro aad u daran)?'
       }
     },
     'threshold-op': {

--- a/app/javascript/tests/mocks/mockTranslations.js
+++ b/app/javascript/tests/mocks/mockTranslations.js
@@ -89,6 +89,10 @@ const mockTranslations = {
       'congestion_or_runny_nose': {
         'name': 'Congestion or Runny Nose',
         'notes': ''
+      },
+      'general_health': {
+        'name': 'General Health',
+        'notes': 'How are you feeling on a scale of 1 (feeling great) to 10 (feeling very sickly)?'
       }
     },
     'threshold-op': {
@@ -259,6 +263,10 @@ const mockTranslations = {
       'congestion_or_runny_nose': {
         'name': 'Congestión nasal o un exceso de moco en la nariz',
         'notes': ''
+      },
+      'general_health': {
+        'name': 'General Health',
+        'notes': 'How are you feeling on a scale of 1 (feeling great) to 10 (feeling very sickly)?'
       }
     },
     'threshold-op': {
@@ -429,6 +437,10 @@ const mockTranslations = {
       'congestion_or_runny_nose': {
         'name': 'Congestión nasal o un exceso de moco en la nariz',
         'notes': ''
+      },
+      'general_health': {
+        'name': 'General Health',
+        'notes': 'How are you feeling on a scale of 1 (feeling great) to 10 (feeling very sickly)?'
       }
     },
     'threshold-op': {
@@ -599,6 +611,10 @@ const mockTranslations = {
       'congestion_or_runny_nose': {
         'name': 'Congestion nasale ou nez qui coule',
         'notes': ''
+      },
+      'general_health': {
+        'name': 'General Health',
+        'notes': 'How are you feeling on a scale of 1 (feeling great) to 10 (feeling very sickly)?'
       }
     },
     'threshold_op': {
@@ -769,6 +785,10 @@ const mockTranslations = {
       'congestion_or_runny_nose': {
         'name': 'San xidhan ama duuf leh',
         'notes': ''
+      },
+      'general_health': {
+        'name': 'General Health',
+        'notes': 'How are you feeling on a scale of 1 (feeling great) to 10 (feeling very sickly)?'
       }
     },
     'threshold-op': {


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1145](https://tracker.codev.mitre.org/browse/SARAALERT-1145)

Certain browsers allowed users to input non-numerical values into `FloatSymptom` input fields which caused errors at times. This PR addresses that issue as well as two other issues that were identified while testing the original reported bug: 
- `IntegerSymptom`s did not render in the `SymptomsAssessment` component when present
- Inputs over a certain value would cause errors.

# Screenshot
`IntegerSymptom`s now display properly in the `SymptomsAssessment` component:

![image](https://user-images.githubusercontent.com/42656458/108560032-21258780-72ca-11eb-931a-c692d9ee7a8e.png)


# Bugfix - How to Replicate
**Bug 1**: `FloatSymptom` inputs accepted non-numerical inputs (all browsers except Chrome) and at times caused errors (specifically for Internet Explorer).

1. While in Internet Explorer, navigate to a monitoree's profile that has a `SymptomAssessment` with a `FloatSymptom`.
2. Click on "+ Add New Report" to open up a new assessment.
3. Input an invalid entry such as "6%" and submit the Symptom Assessment.
4. Observe that an error occurs after a short time.

**Bug 2**: `IntegerSymptom`s (when present) do not render in the `SymptomsAssessment`

1. (Ensure you have an `IntegerSymptom` configured for at least one of your available jurisdictions - see instructions in Testing section on how to configure if needed)
2. Navigate to a monitoree's profile that has a `SymptomAssessment` that should have a `IntegerSymptom`.
3. Click on "+ Add New Report" to open up a new assessment.
4. Observe that the `IntegerSymtom` is not displayed.
5. (To confirm that the `IntegerSymptom` should be in that assessment, submit that assessment and observe in the Reports table that a column should be displayed for the `IntegerSymptom` that wasn't displayed in the assessment.

**Bug 3**: Providing a `FloatSymptom` input over a certain value causes an error (any browser)

1. Navigate to a monitoree's profile that has a `SymptomAssessment` with a `FloatSymptom`.
2. Click on "+ Add New Report" to open up a new assessment.
3. Input the following value into the `FloatSymptom` input: `9999999999999999999999999999999999999999`
4. Observe that an error occurs after a short time.

# Bugfix - Solution
**Bug 1**: `FloatSymptom` inputs accepted non-numerical inputs (all browsers except Chrome) and at times caused errors (specifically for Internet Explorer).

The various browsers handle `type='number'` in different ways and the `handleChange()` method was not robust enough to prevent the user from inputting non-numerical values. Various handle change methods were created for float, integer & boolean symptoms to ensure more robust validation was in place to prevent the user from inputting erroneous inputs. And due to issues with how Firefox passed the inputted value to the `handleChange()` method, the `type='number'` property was removed. To handle the special cases of `.`, `-`, & `-.` characters being inputted, on submission, validation is done to null the values out if such inputs are detected so as not to trigger an error. 

**Bug 2**: `IntegerSymptom`s (when present) do not render in the `SymptomsAssessment`

The `SymptomsAssessment` component did not support the rendering of `IntergerSymptoms`. The component was updated to check and properly render `IntergerSymptoms` when any were present in the list of symptoms to display. Validation was also included similar to the validation for `FloatSymptoms`. 

**Bug 3**: Providing a `FloatSymptom` input over a certain value causes an error (any browser)

Providing an input over a certain value would cause an error to occur on the backend. So the user/monitoree will now be limited in the value they can input through an enforced `maxLength` property on the input (set to 35 for `FloatSymptoms` and 9 for `IntergerSymptoms`).  

# Important Changes

`app/javascript/components/assessment/steps/SymptomsAssessment.js`
- Each different symptom type now has their own change method for validating user input
- Formatting is done on the submitted `FloatSymptom`s and `IntegerSymptoms` to ensure an invalid input does not cause an error.
- Logic included to handle the rendering of `IntegerSymptoms`
- The `type='number'` property was removed due an issue in Firefox (if a user inputted an invalid entry such as "6tk", Firefox would pass in an empty string to the change method) 

`app/javascript/tests/assessment/steps/SymptomsAssessment.test.js`
- Tests were updated to address the new `IntegerSymptom` that was included in the mock files. 

`app/javascript/tests/mocks/mockAssessments.js`
`app/javascript/tests/mocks/mockSymptoms.js`
`app/javascript/tests/mocks/mockTranslations.js`
- Mocks for an `IntergerSymptom` were included for testing purposes



# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [x] Firefox
* [x] Safari
* [x] IE11
* [x] Edge

**Note** - Please perform these tests in all the browsers listed above.

`FloatSymptom` Tests:

- [x] Attempt to type in any non-floating point input. Observe the input field prevents the user from providing such input. The only allowed inputs are any valid positive or negative floating point number, `.`, `-`, and `-.`
- [x] Type in each of the following inputs into the `FloatSymptom` field and submit the assessment:  `.`, `-`, and `-.`. Observe that the new assessment displayed in the Reports table displayes the `FloatSymptom` value for that symptom as blank.
- [x] Type in any valid floating point value into the `FloatSymptom` field and submit (such as `0.22`, `.12`, `1.23`, `-0.1`, `-1`, `-1.`, `-.12`). Observe that the new assessment displayed in the Reports table displayes the `FloatSymptom` value for that symptom as expected.
- [x] Attempt to input `9999999999999999999999999999999999999999` (which is 40 characters long) into the `FloatSymptom` field. Observe that the input only accepts up to 35 characters. Click submit and observe that no error occurs and the new assessment displayed in the Reports table displayes the `FloatSymptom` value for that symptom as expected.

`IntegerSymptom` Tests:

**See section at bottom for configuring an `IntegerSymptom`

- [x] Attempt to type in any non-integer input. Observe the input field prevents the user from providing such input. The only allowed inputs are any valid positive or negative integers and  `-`.
- [x] Type in the following input into the `IntegerSymptom` field and submit the assessment:  `-`. Observe that the new assessment displayed in the Reports table displayes the `IntegerSymptom` value for that symptom as blank.
- [x] Type in any valid floating point value into the `IntegerSymptom` field and submit (such as `12` & `-12`). Observe that the new assessment displayed in the Reports table displayes the `IntegerSymptom` value for that symptom as expected.
- [x] Attempt to input `9999999999` (which is 10 characters long) into the `IntegerSymptom` field. Observe that the input only accepts up to 9 characters. Click submit and observe that no error occurs and the new assessment displayed in the Reports table displayes the `IntegerSymptom` value for that symptom as expected.

Adding a `IntegerSymptom` to your local Sara Alert instance:

1. (optional) Save a copy of your current database elsewhere if you would like to use it again. 
2. Go to [this line](https://github.com/SaraAlert/SaraAlert/blob/master/config/sara/jurisdictions.yml#L121) of your local `jurisdiction.yml` file and input the following right under that `FloatSymptom`:
```
'Integer Symp':
                    value: 10
                    threshold_operator: 'Less Than'
                    type: 'IntegerSymptom'
                    required: true
```
3. Go to [this line](https://github.com/SaraAlert/SaraAlert/blob/master/config/locales/en.yml#L36) of your local `en.yml` file and input the following right under that `FloatSymptom`:
```
integer-symp:
        name: 'Integer Symp'
        notes: ''
```
4. Run the following on your command line: `bundle exec rake admin:import_or_update_jurisdictions`
5. Now all monitorees in State 1 would be expected to have the "Integer Symp" display in their symptom assessments.

When you are done testing and would like to remove the Integer Symp, you can do one of the 3 following options: 

1. If you saved a copy of your database before adding the Integer Symp, drop your current database and use your previous one. 
2. Revert the changes you made to your local `jurisdiction.yml`and `en.yml` files.

OR

1. Drop your current database.
2. Revert the changes you made to your local `jurisdiction.yml`and `en.yml` files and run the following commands to re-initiatize your database (based on the Sara Alert README): 

- `rails db:create`
- `rails db:schema:load`
- `bundle exec rake admin:import_or_update_jurisdictions`
- `bundle exec rake demo:setup demo:populate` (optional)

OR 

1. **Revert the changes you made to your local `jurisdiction.yml`and `en.yml` files and run the following commands to remove the Integer Symp from State 1 assessments: `bundle exec rake admin:import_or_update_jurisdictions`

**If you decide to do this method, please note that all assessments that were previously submitted with Integer Symp will still be displayed in a monitoree's Reports table and if you attempt to edit any of those prior assessments, the Reports table will crash. 
