### PR TITLE
SARAALERT-916: Google Translate Bug Fix

### DIFF
--- a/app/javascript/components/assessment/steps/SymptomsAssessment.js
+++ b/app/javascript/components/assessment/steps/SymptomsAssessment.js
@@ -197,7 +197,8 @@ class SymptomsAssessment extends React.Component {
                   <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
                 </React.Fragment>
               )}
-              {this.props.translations[this.props.lang]['web']['submit']}
+              {/* The following <span> tags cannot be removed. They prevent Google Translate from confusing the react node-tree when translated */}
+              <span>{this.props.translations[this.props.lang]['web']['submit']}</span>
             </Button>
           </Form.Row>
         </Card.Body>


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-916

This PR fixes an issue with Google Translate causing a bug on the Assessment page (when users submitted their daily assessment). If the user was using Google Translate to translate their page, React would get confused when they attempted to submit it. Because Google Translate changes parts of the DOM, React was unable to locate things it was looking for in its node-tree. This PR wraps the necessary text in a `<span>`. This works to solve the problem as those text nodes with `<span>` can still be referenced by React, as they will stay in the DOM tree even though their contents are replaced with `<font>` tags (from Google Translate).

I will note that, despite the bug not rendering the correct "You submitted your assessment correctly!" page, the assessments *were* being submitted correctly. That means that this PR only fixes a UI bug, and not a functionality bug.

# (Bugfix) How to Replicate
Navigate to a patient assessment page
`http://localhost:3000/r/<submission_token>/<jurisdiction.unique_identifier>/<language>/<intials_age>`
and attempt to translate the language using google translate. You will see that upon submission, errors are thrown in the console.

# (Bugfix) Solution
Check out this PR, and attempt the same thing. You will not see any errors, as the "Submission Successful" page is displayed  correctly.


# Important Changes


`app/javascript/components/assessment/steps/SymptomsAssessment.js`
- Wraps the Button Text in a `<span>` tag

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11
