### PR TITLE
SARAALERT-1281 Assessments Job Performance

### DIFF
--- a/app/jobs/send_assessments_job.rb
+++ b/app/jobs/send_assessments_job.rb
@@ -5,15 +5,70 @@ class SendAssessmentsJob < ApplicationJob
   queue_as :mailers
 
   def perform(*_args)
-    eligible = Patient.reminder_eligible.count
-    sent = []
-    not_sent = []
-    Patient.reminder_eligible.find_each do |patient|
-      sent << { id: patient.id, method: patient.preferred_contact_method } if patient.send_assessment
-    rescue StandardError => e
-      not_sent << { id: patient.id, method: patient.preferred_contact_method, reason: e.message }
-      next
+    patient_ids = Patient.reminder_eligible.pluck(:id)
+    eligible = patient_ids.size
+
+    # Check what the max thread pool is for the DB since that is the limiting factor
+    # on how many threads can be used in the job. Subtracting 2 from the pool
+    # size to be on the safer side of exhausting the connection pool.
+    total_threads = [1, ActiveRecord::Base.connection_pool.stat[:size] - 2].max
+
+    # [1, x].max here avoids an exception when there are 0 eligible patients
+    slice_size = [1, patient_ids.size / total_threads].max
+
+    threads = patient_ids.each_slice(slice_size).map do |patient_batch|
+      Thread.new { perform_batch(patient_batch) }
     end
-    UserMailer.assessment_job_email(sent, not_sent, eligible).deliver_now
+    threads.each(&:join)
+    results = combine_batch_results(threads.map(&:value))
+    UserMailer.assessment_job_email(results[:sent], results[:not_sent], eligible).deliver_now
+  end
+
+  private
+
+  def perform_batch(patient_batch)
+    sent = Hash.new(0)
+    not_sent = []
+    Patient.select(
+      :id,
+      :email,
+      :preferred_contact_method,
+      :monitored_address_state,
+      :address_state,
+      :last_assessment_reminder_sent,
+      :preferred_contact_time,
+      :last_date_of_exposure,
+      :created_at,
+      :monitoring,
+      :isolation,
+      :continuous_exposure
+    ).where(id: patient_batch).find_in_batches(batch_size: 15_000) do |group|
+      group.each do |patient|
+        if patient.send_assessment
+          sent[:count] += 1
+          sent[patient.preferred_contact_method] += 1
+        end
+      rescue StandardError => e
+        not_sent << { id: patient.id, method: patient.preferred_contact_method, reason: e.message }
+      end
+    end
+    {
+      sent: sent,
+      not_sent: not_sent
+    }
+  end
+
+  def combine_batch_results(batch_results)
+    results = {
+      sent: Hash.new(0),
+      not_sent: []
+    }
+    batch_results.each do |batch_result|
+      batch_result[:sent].each do |key, value|
+        results[:sent][key] += value
+      end
+      results[:not_sent] += batch_result[:not_sent]
+    end
+    results
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -916,9 +916,6 @@ class Patient < ApplicationRecord
   # Send a daily assessment to this monitoree (if currently eligible). By setting send_now to true, an assessment
   # will be sent immediately without any consideration of the monitoree's preferred_contact_time.
   def send_assessment(send_now: false)
-    # Stop execution if in CI
-    return if Rails.env.test?
-
     # Return UNLESS:
     # - in exposure: NOT closed AND within monitoring period OR
     # - in isolation: NOT closed (as patients on RRR linelist should receive notifications) OR

--- a/app/views/user_mailer/assessment_job_email.html.erb
+++ b/app/views/user_mailer/assessment_job_email.html.erb
@@ -7,7 +7,7 @@
 <br />
   Total eligible for notifications at runtime: <%= @eligible %>
 <br />
-Sent during this job run: <b><%= @sent.count %></b>
+Sent during this job run: <b><%= @sent[:count] %></b>
 <br />
 Not sent during this job run (due to exceptions): <b><%= @not_sent.count %></b>
 <br />
@@ -15,10 +15,11 @@ Not sent during this job run (due to exceptions): <b><%= @not_sent.count %></b>
   Sent
 </h2>
 <br />
-ID, Method
+Method, Count
 <br />
-<% @sent.each do |s| %>
-  <%= s[:id] %>, <%= s[:method] %>
+<% @sent.each do |method, count| %>
+  <% next if method == :count %>
+  <%= method %>, <%= count %>
   <br />
 <% end %>
 <br />

--- a/app/views/user_mailer/assessment_job_email.html.erb
+++ b/app/views/user_mailer/assessment_job_email.html.erb
@@ -7,19 +7,18 @@
 <br />
   Total eligible for notifications at runtime: <%= @eligible %>
 <br />
-Sent during this job run: <b><%= @sent[:count] %></b>
+Sent during this job run: <b><%= @sent.size %></b>
 <br />
-Not sent during this job run (due to exceptions): <b><%= @not_sent.count %></b>
+Not sent during this job run (due to exceptions): <b><%= @not_sent.size %></b>
 <br />
 <h2>
   Sent
 </h2>
 <br />
-Method, Count
+ID, Method
 <br />
-<% @sent.each do |method, count| %>
-  <% next if method == :count %>
-  <%= method %>, <%= count %>
+<% @sent.each do |s| %>
+  <%= s[:id] %>, <%= s[:method] %>
   <br />
 <% end %>
 <br />

--- a/performance/benchmarks/send_assessments_job_benchmark.rb
+++ b/performance/benchmarks/send_assessments_job_benchmark.rb
@@ -3,10 +3,10 @@
 require_relative '../../config/environment'
 require_relative '../benchmark'
 
-# Time Threshold: 10 minutes
+# Time Threshold: 260 seconds
 benchmark(
   name: 'SendAssessmentsJob',
-  time_threshold: 10 * 60,
+  time_threshold: 260,
   setup: proc { Timecop.travel(Time.now.utc.change(hour: 21)) },
   teardown: proc { Timecop.return }
 ) { SendAssessmentsJob.perform_now }

--- a/performance/benchmarks/send_assessments_job_benchmark.rb
+++ b/performance/benchmarks/send_assessments_job_benchmark.rb
@@ -4,12 +4,9 @@ require_relative '../../config/environment'
 require_relative '../benchmark'
 
 # Time Threshold: 10 minutes
-# NOTE: Using Timecop here appears to cause this job in GitHub actions to
-#       hang indefinitely.
-#       Timecop commands are:
-#           setup: proc { Timecop.travel(Time.now.utc.change(hour: 18)) },
-#           teardown: proc { Timecop.return }
 benchmark(
   name: 'SendAssessmentsJob',
-  time_threshold: 10 * 60
+  time_threshold: 10 * 60,
+  setup: proc { Timecop.travel(Time.now.utc.change(hour: 21)) },
+  teardown: proc { Timecop.return }
 ) { SendAssessmentsJob.perform_now }

--- a/test/jobs/send_assessments_job_test.rb
+++ b/test/jobs/send_assessments_job_test.rb
@@ -26,10 +26,48 @@ class SendAssessmentsJobTest < ActiveSupport::TestCase
     assert_includes(email_body, 'Not sent during this job run (due to exceptions): 0')
   end
 
+  test 'send assessments job with StandardError exceptions' do
+    # https://relishapp.com/rspec/rspec-mocks/docs/working-with-legacy-code/any-instance
+    # https://relishapp.com/rspec/rspec-mocks/docs/configuring-responses/raising-an-error
+    allow_any_instance_of(Patient).to receive(:send_assessment).and_raise('Testing send_assessments_job')
+
+    # Patients that should be sent assessments
+    # But will not be sent since we are forcing an exception
+    eligible_patients = [
+      { isolation: true },
+      { preferred_contact_method: 'SMS Texted Weblink', continuous_exposure: true },
+      { preferred_contact_method: 'Telephone call', last_date_of_exposure: nil, created_at: default_days_ago(5) },
+      { preferred_contact_method: 'SMS Text-message', last_date_of_exposure: default_days_ago(5), created_at: default_days_ago(5) },
+      { last_date_of_exposure: default_days_ago(11), created_at: default_days_ago(20) }
+    ].map do |eligible_params|
+      create(
+        :patient,
+        {
+          email: 'example@example.com',
+          preferred_contact_method: 'E-mailed Web Link',
+          preferred_contact_time: 'Morning',
+          last_date_of_exposure: 1.day.ago,
+          submission_token: SecureRandom.urlsafe_base64[0, 10]
+        }.merge(eligible_params)
+      )
+    end
+
+    email = SendAssessmentsJob.perform_now
+    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+
+    assert_includes(email_body, "Total eligible for notifications at runtime: #{eligible_patients.size}")
+    assert_includes(email_body, 'Sent during this job run: 0')
+    assert_includes(email_body, "Not sent during this job run (due to exceptions): #{eligible_patients.size}")
+
+    eligible_patients.each do |patient|
+      assert_includes(email_body, "#{patient.id}, #{patient.preferred_contact_method}, Testing send_assessments_job")
+    end
+  end
+
   test 'send assessments job to various patient configurations' do
     # Patients that should NOT be sent assessments or be counted in
     # any of the counts found in the summary email
-    [
+    ineligible_patients = [
       { purged: true },
       { pause_notifications: true },
       { preferred_contact_method: 'Unknown' },
@@ -38,7 +76,7 @@ class SendAssessmentsJobTest < ActiveSupport::TestCase
       { preferred_contact_method: nil },
       { monitoring: false },
       { last_assessment_reminder_sent: Time.now }
-    ].each do |ineligible_params|
+    ].map do |ineligible_params|
       create(
         :patient,
         {
@@ -102,5 +140,14 @@ class SendAssessmentsJobTest < ActiveSupport::TestCase
     assert_includes(email_body, "Total eligible for notifications at runtime: #{eligible_patients.size + scope_not_sent.size}")
     assert_includes(email_body, "Sent during this job run: #{eligible_patients.size}")
     assert_includes(email_body, 'Not sent during this job run (due to exceptions): 0')
+    eligible_patients.each do |patient|
+      assert_includes(email_body, "#{patient.id}, #{patient.preferred_contact_method}")
+    end
+    scope_not_sent.each do |patient|
+      assert_not_includes(email_body, "#{patient.id}, #{patient.preferred_contact_method}")
+    end
+    ineligible_patients.each do |patient|
+      assert_not_includes(email_body, "#{patient.id}, #{patient.preferred_contact_method}")
+    end
   end
 end

--- a/test/jobs/send_assessments_job_test.rb
+++ b/test/jobs/send_assessments_job_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'test_case'
+
+class SendAssessmentsJobTest < ActiveSupport::TestCase
+  def setup
+    Timecop.freeze(Time.now.in_time_zone('Eastern Time (US & Canada)').change(hour: 10).utc)
+    Patient.delete_all
+    ADMIN_OPTIONS['job_run_email'] = 'test@test.com'
+    ActionMailer::Base.deliveries.clear
+  end
+
+  def teardown; end
+
+  def default_days_ago(days)
+    (Time.now.in_time_zone('Eastern Time (US & Canada)') - days.days)
+  end
+
+  test 'send assessments job to zero patients' do
+    email = SendAssessmentsJob.perform_now
+    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    assert_includes(email_body, 'Total eligible for notifications at runtime: 0')
+    assert_includes(email_body, 'Sent during this job run: 0')
+    assert_includes(email_body, 'Not sent during this job run (due to exceptions): 0')
+  end
+
+  test 'send assessments job to various patient configurations' do
+    # Patients that should NOT be sent assessments or be counted in
+    # any of the counts found in the summary email
+    [
+      { purged: true },
+      { pause_notifications: true },
+      { preferred_contact_method: 'Unknown' },
+      { preferred_contact_method: 'Opt-out' },
+      { preferred_contact_method: '' },
+      { preferred_contact_method: nil },
+      { monitoring: false },
+      { last_assessment_reminder_sent: Time.now }
+    ].each do |ineligible_params|
+      create(
+        :patient,
+        {
+          email: 'example@example.com',
+          preferred_contact_method: 'E-mailed Web Link',
+          preferred_contact_time: 'Morning',
+          last_date_of_exposure: 1.day.ago,
+          submission_token: SecureRandom.urlsafe_base64[0, 10]
+        }.merge(ineligible_params)
+      )
+    end
+
+    # Patients that are expected to be returned by the scope but are not
+    # expected to be sent assessments
+    # (due to any logic in the Patient#send_assessment method)
+    #
+    # NOTE: Expect to need to move items from this list to the ineligible list
+    #       above as logic is pulled out of send_assessment and into reminder_eligible
+    scope_not_sent = [
+      { last_date_of_exposure: nil, created_at: 50.days.ago },
+      { last_date_of_exposure: 50.days.ago, created_at: 50.days.ago },
+      { latest_assessment_at: Time.now },
+      { preferred_contact_time: 'Evening' }
+    ].map do |ineligible_params|
+      create(
+        :patient,
+        {
+          email: 'example@example.com',
+          preferred_contact_method: 'E-mailed Web Link',
+          preferred_contact_time: 'Morning',
+          last_date_of_exposure: 1.day.ago,
+          submission_token: SecureRandom.urlsafe_base64[0, 10]
+        }.merge(ineligible_params)
+      )
+    end
+
+    # Patients that should be sent assessments
+    eligible_patients = [
+      { isolation: true },
+      { preferred_contact_method: 'SMS Texted Weblink', continuous_exposure: true },
+      { preferred_contact_method: 'Telephone call', last_date_of_exposure: nil, created_at: default_days_ago(5) },
+      { preferred_contact_method: 'SMS Text-message', last_date_of_exposure: default_days_ago(5), created_at: default_days_ago(5) },
+      { last_date_of_exposure: default_days_ago(11), created_at: default_days_ago(20) }
+    ].map do |eligible_params|
+      create(
+        :patient,
+        {
+          email: 'example@example.com',
+          preferred_contact_method: 'E-mailed Web Link',
+          preferred_contact_time: 'Morning',
+          last_date_of_exposure: 1.day.ago,
+          submission_token: SecureRandom.urlsafe_base64[0, 10]
+        }.merge(eligible_params)
+      )
+    end
+
+    email = SendAssessmentsJob.perform_now
+    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+
+    assert_not ActionMailer::Base.deliveries.empty?
+    assert_includes(email_body, "Total eligible for notifications at runtime: #{eligible_patients.size + scope_not_sent.size}")
+    assert_includes(email_body, "Sent during this job run: #{eligible_patients.size}")
+    assert_includes(email_body, 'Not sent during this job run (due to exceptions): 0')
+  end
+end


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1281

1) Improve the performance of the `send_assessments_job`
2) Write a test file for the `send_assessments_job`

# (Improvement) Evidence
I ran 5 jobs in GitHub Actions for this PR to compare with the results from the `send_assessments_job_benchmark` in the 1.27.0 branch.

## 1.27.0 Results
<img width="332" alt="Screen Shot 2021-03-31 at 8 14 40 AM" src="https://user-images.githubusercontent.com/24628687/113158569-2515c500-91f9-11eb-8cae-7c74fd0bc59e.png">

## SA-1281/assessmentsJobPerf Results (Around 1400 UTC)
<img width="332" alt="Screen Shot 2021-03-31 at 8 21 19 AM" src="https://user-images.githubusercontent.com/24628687/113159733-15e34700-91fa-11eb-9721-b465cdec1a33.png">

## SA-1281/assessmentsJobPerf Results (Forced to run @ 2100 UTC)
<img width="333" alt="Screen Shot 2021-03-31 at 11 00 30 AM" src="https://user-images.githubusercontent.com/24628687/113182595-5057de80-9210-11eb-8c88-84b5633dbd07.png">


# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`send_assessments_job.rb`
- Made performance improvements to job (threading, find_in_batches, select specific fields)
- Now collects summary data for sent items, but still keeps all data for exceptions

`assessment_job_email.html.erb`
- Now expects summary data for the sent area

`send_assessments_job_test.rb`
- New test file for job

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@Bialogs  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions

