### PR TITLE
Error when including AssessmentsQueryHelper from the console

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -24,7 +24,7 @@ class AssessmentsController < ApplicationController
     assessments = search(assessments, search_text)
     assessments = sort(assessments, sort_order, sort_direction)
     assessments = paginate(assessments, entries, page)
-    assessments = format(assessments)
+    assessments = format_for_frontend(assessments)
 
     render json: assessments
   end

--- a/app/helpers/assessment_query_helper.rb
+++ b/app/helpers/assessment_query_helper.rb
@@ -68,7 +68,7 @@ module AssessmentQueryHelper
   end
 
   # Formats assessments to be displayed on the frontend.
-  def format(assessments)
+  def format_for_frontend(assessments)
     table_data = []
     symptoms = Assessment.get_unique_symptoms_for_assessments(assessments.pluck(:id))
 


### PR DESCRIPTION
# Description
No JIRA ticket associated

Change AssessmentsQueryHelper#format to #format_for_frontend so as not to conflict with Kernel#format when including AssessmentsQueryHelper from the console.

# (Bugfix) How to Replicate
drop into `rails c`

```
include AssessmentsQueryHelper
app/helpers/assessment_query_helper.rb:71:in `format': wrong number of arguments (given 2, expected 1) (ArgumentError)
```

# (Bugfix) Solution

Change the method name
