### PR TITLE
SARAALERT-1337: Prevent advanced filter from submitting empty date inputs

### DIFF
--- a/app/helpers/validation_helper.rb
+++ b/app/helpers/validation_helper.rb
@@ -111,7 +111,7 @@ module ValidationHelper # rubocop:todo Metrics/ModuleLength
 
   VALID_PATIENT_ENUMS = {
     gender_identity: ['Male (Identifies as male)', 'Female (Identifies as female)', 'Transgender Male (Female-to-Male [FTM])',
-                      'Transgender Female (Male-to-Female [MTF]', 'Genderqueer / gender nonconforming (neither exclusively male nor female)', 'Another',
+                      'Transgender Female (Male-to-Female [MTF])', 'Genderqueer / gender nonconforming (neither exclusively male nor female)', 'Another',
                       'Chose not to disclose'],
     sexual_orientation: ['Straight or Heterosexual', 'Lesbian, Gay, or Homosexual', 'Bisexual', 'Another', 'Choose not to disclose', 'Don’t know'],
     ethnicity: ['Not Hispanic or Latino', 'Hispanic or Latino', 'Unknown', 'Refused to Answer', nil, ''],

--- a/app/javascript/components/enrollment/steps/Identification.js
+++ b/app/javascript/components/enrollment/steps/Identification.js
@@ -314,6 +314,7 @@ class Identification extends React.Component {
                     onChange={date => this.handleDateChange('date_of_birth', date)}
                     placement="bottom"
                     isInvalid={!!this.state.errors['date_of_birth']}
+                    clearInvalid={true}
                     customClass="form-control-lg"
                     ariaLabel="Date of Birth Input"
                   />

--- a/app/javascript/components/enrollment/steps/Identification.js
+++ b/app/javascript/components/enrollment/steps/Identification.js
@@ -374,7 +374,7 @@ class Identification extends React.Component {
                     <option>Male (Identifies as male)</option>
                     <option>Female (Identifies as female)</option>
                     <option>Transgender Male (Female-to-Male [FTM])</option>
-                    <option>Transgender Female (Male-to-Female [MTF]</option>
+                    <option>Transgender Female (Male-to-Female [MTF])</option>
                     <option>Genderqueer / gender nonconforming (neither exclusively male nor female)</option>
                     <option>Another</option>
                     <option>Chose not to disclose</option>

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -409,7 +409,7 @@ class AdvancedFilter extends React.Component {
     if (value === 'within') {
       defaultValue = {
         start: moment()
-          .add(-72, 'hours')
+          .subtract(3, 'days')
           .format('YYYY-MM-DD'),
         end: moment().format('YYYY-MM-DD'),
       };
@@ -1049,6 +1049,7 @@ class AdvancedFilter extends React.Component {
                       maxDate={moment()
                         .add(2, 'years')
                         .format('YYYY-MM-DD')}
+                      required={true}
                     />
                   </div>
                 )}
@@ -1067,6 +1068,7 @@ class AdvancedFilter extends React.Component {
                         maxDate={moment()
                           .add(2, 'years')
                           .format('YYYY-MM-DD')}
+                        required={true}
                       />
                     </div>
                     <div className="text-center my-auto mx-4">
@@ -1085,6 +1087,7 @@ class AdvancedFilter extends React.Component {
                         maxDate={moment()
                           .add(2, 'years')
                           .format('YYYY-MM-DD')}
+                        required={true}
                       />
                     </div>
                   </React.Fragment>

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -1049,7 +1049,7 @@ class AdvancedFilter extends React.Component {
                       maxDate={moment()
                         .add(2, 'years')
                         .format('YYYY-MM-DD')}
-                      required={true}
+                      replaceBlank={true}
                     />
                   </div>
                 )}
@@ -1068,7 +1068,7 @@ class AdvancedFilter extends React.Component {
                         maxDate={moment()
                           .add(2, 'years')
                           .format('YYYY-MM-DD')}
-                        required={true}
+                        replaceBlank={true}
                       />
                     </div>
                     <div className="text-center my-auto mx-4">
@@ -1087,7 +1087,7 @@ class AdvancedFilter extends React.Component {
                         maxDate={moment()
                           .add(2, 'years')
                           .format('YYYY-MM-DD')}
-                        required={true}
+                        replaceBlank={true}
                       />
                     </div>
                   </React.Fragment>

--- a/app/javascript/components/util/DateInput.js
+++ b/app/javascript/components/util/DateInput.js
@@ -32,19 +32,15 @@ class DateInput extends React.Component {
    * Called when typing into the date input
    */
   handleRawChange = event => {
-    let value = event.target.value;
-    this.setState({ currentDate: value }, () => {
-      if (value) {
-        this.datePickerRef.current.setOpen(true);
-      }
-    });
+    this.datePickerRef.current.setOpen(true);
+    this.setState({ currentDate: event.target.value });
   };
 
   /**
    * Called when day is clicked in the datepicker
    */
   handleSelect = date => {
-    this.setState({ currentDate: date && moment(date).format('YYYY-MM-DD') });
+    this.setState({ currentDate: date });
   };
 
   /**
@@ -52,13 +48,14 @@ class DateInput extends React.Component {
    * This will happen when the user leaves the form input (i.e. clicks out of the datepicker)
    */
   handleOnBlur = () => {
+    const currentDate = this.state.currentDate && moment(this.state.currentDate).format('YYYY-MM-DD');
     // if date is not valid when clicking out of the date input
-    if (!this.dateIsValidAndNotEmpty(this.state.currentDate)) {
+    if (!this.dateIsValidAndNotEmpty(currentDate)) {
       // change back to the last valid date or today if the field should revert to the last valid date
       if (this.props.replaceBlank) {
         const date = this.state.lastValidDate || moment().format('YYYY-MM-DD');
         this.props.onChange(date);
-      // clear the date if field should be empty on invalid
+        // clear the date if field should be empty on invalid
       } else if (this.props.clearInvalid) {
         this.clearDate();
       }
@@ -66,12 +63,15 @@ class DateInput extends React.Component {
   };
 
   /**
-   * Returns false if date is null, undefined or invalid
+   * Returns false if date is null, undefined, invalid or falls outside the min/max date range
    * Returns true otherwise
    */
   dateIsValidAndNotEmpty = date => {
-    return !_.isNil(date) && moment(date, 'YYYY-MM-DD').isValid();
-  }
+    const isNotNull = !_.isNil(date);
+    const isValid = moment(date, 'YYYY-MM-DD').isValid();
+    const isInRange = moment(this.props.minDate).isBefore(date) && moment(this.props.maxDate).isAfter(date);
+    return isNotNull && isValid && isInRange;
+  };
 
   /**
    * Clears the selected date in parent component and closes the datepicker

--- a/app/javascript/components/util/DateInput.js
+++ b/app/javascript/components/util/DateInput.js
@@ -18,6 +18,7 @@ class DateInput extends React.Component {
 
   /**
    * Called only when date value is changed
+   * This happens both when a date is clicked in the datepicker AND when the user types a complete valid date
    */
   handleDateChange = date => {
     const momentDate = date && moment(date).format('YYYY-MM-DD');
@@ -30,6 +31,7 @@ class DateInput extends React.Component {
 
   /**
    * Called when typing into the date input
+   * This fires everytime a character is added or deleted in the input
    */
   handleRawChange = event => {
     this.datePickerRef.current.setOpen(true);
@@ -77,10 +79,9 @@ class DateInput extends React.Component {
    * Clears the selected date in parent component and closes the datepicker
    */
   clearDate = () => {
-    this.setState({ currentDate: null }, () => {
-      this.props.onChange(null);
-      this.datePickerRef.current.setOpen(false);
-    });
+    this.props.onChange(null);
+    this.datePickerRef.current.setOpen(false);
+    this.setState({ currentDate: null });
   };
 
   render() {

--- a/app/javascript/components/util/DateInput.js
+++ b/app/javascript/components/util/DateInput.js
@@ -30,11 +30,16 @@ class DateInput extends React.Component {
   };
 
   handleOnBlur = () => {
-    if (this.props.required) {
-      const date = this.state.lastValidDate || moment().format('YYYY-MM-DD');
-      this.props.onChange(date);
-    } else if (this.props.clearInvalid && !this.validDate(this.props.date)) {
-      this.clearDate();
+    // if date is not valid when clicking out of the date input
+    if (!this.validDate(this.props.date)) {
+      // change back to the last valid date or today if the field is required
+      if (this.props.required) {
+        const date = this.state.lastValidDate || moment().format('YYYY-MM-DD');
+        this.props.onChange(date);
+      // clear the date if field should be empty on invalid
+      } else if (this.props.clearInvalid) {
+        this.clearDate();
+      }
     }
   };
 


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1337](https://tracker.codev.mitre.org/browse/SARAALERT-1337)

The issue stems from the fact that you can apply a filter with the date field empty.  For “before” or “after,” that value would be null because it’s only one field so when you apply the filter it fails as a bad request (which is the intended behavior).  With “within,” there are “start” and “end” fields in the value so it gets past the check if the value is empty, causing that error to in the sentry error in the JIRA.

# (Bugfix) How to Replicate
1. Open the advanced filter modal and select a date field
2. Clear the date input and hit apply (notice there is an error)
3. Repeat step 1 but select "before" or "after" instead of "within"
4. Observe similar behavior

# (Bugfix) Solution
Prevent the user from submitting an empty date by reverting the date to the last valid date if they clear the date and click outside the field.

https://user-images.githubusercontent.com/35042815/109867350-62a42400-7c34-11eb-82a9-2d0490448ed6.mov

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`DateInput.js`
- Added `handleOnBlur` method that is resets the input to the last valid value if it is empty or invalid
- Added new prop `requireDate` that must be true for the `handleOnBlur` method to fire

`AdvancedFilter.js`
- Pass in `requireDate` flag to necessary `DateInput` components

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
