### PR TITLE
SARAALERT-1359: Adds Counties to Counties.yml

### DIFF
--- a/lib/assets/counties.yml
+++ b/lib/assets/counties.yml
@@ -185,7 +185,7 @@ Arkansas:
   - White
   - Woodruff
   - Yell
-  
+
 California:
   - Alameda
   - Alpine
@@ -321,7 +321,7 @@ Connecticut:
   - New London
   - Tolland
   - Windham
-  
+
 Delaware:
   - Kent
   - New Castle
@@ -1137,7 +1137,7 @@ Kentucky:
   - Whitley
   - Wolfe
   - Woodford
-  
+
 Louisiana:
   - Acadia Parish
   - Allen Parish
@@ -2101,7 +2101,7 @@ North Dakota:
   - Wells
   - Williams
 
-Ohio: 
+Ohio:
   - Adams
   - Allen
   - Ashland
@@ -2376,6 +2376,13 @@ Pennsylvania:
   - Westmoreland
   - Wyoming
   - York
+
+Rhode Island:
+  - Bristol
+  - Kent
+  - Newport
+  - Providence
+  - Washington
 
 South Carolina:
   - Abbeville


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1359

The state of Rhode Island had been left out of Counties.yml. This is a tiny change, but they should be added for consistency's sake. This only impacts `demo.rake`