### PR TITLE
SARAALERT-1255: Support Close Contacts in the API

### DIFF
--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -398,7 +398,7 @@ class Fhir::R4::ApiController < ActionController::API
     status_ok(bundle) && return
   end
 
-  # Return a FHIR Bundle containing a monitoree and all their assessments, labe results,
+  # Return a FHIR Bundle containing a monitoree and all their assessments, lab results,
   # and close contacts
   #
   # GET /fhir/r4/Patient/[:id]/$everything
@@ -457,7 +457,7 @@ class Fhir::R4::ApiController < ActionController::API
     resource = FHIR::CapabilityStatement.new(
       status: 'active',
       kind: 'instance',
-      date: DateTime.parse('2020-05-28').strftime('%FT%T%:z'),
+      date: DateTime.parse('2021-03-04').strftime('%FT%T%:z'),
       software: FHIR::CapabilityStatement::Software.new(
         name: 'Sara Alert',
         version: ADMIN_OPTIONS['version']
@@ -505,6 +505,21 @@ class Fhir::R4::ApiController < ActionController::API
               FHIR::CapabilityStatement::Rest::Resource::SearchParam.new(name: 'telecom', type: 'string'),
               FHIR::CapabilityStatement::Rest::Resource::SearchParam.new(name: 'email', type: 'string'),
               FHIR::CapabilityStatement::Rest::Resource::SearchParam.new(name: 'active', type: 'boolean'),
+              FHIR::CapabilityStatement::Rest::Resource::SearchParam.new(name: '_id', type: 'string'),
+              FHIR::CapabilityStatement::Rest::Resource::SearchParam.new(name: '_count', type: 'string')
+            ]
+          ),
+          FHIR::CapabilityStatement::Rest::Resource.new(
+            type: 'RelatedPerson',
+            interaction: [
+              FHIR::CapabilityStatement::Rest::Resource::Interaction.new(code: 'read'),
+              FHIR::CapabilityStatement::Rest::Resource::Interaction.new(code: 'update'),
+              FHIR::CapabilityStatement::Rest::Resource::Interaction.new(code: 'patch'),
+              FHIR::CapabilityStatement::Rest::Resource::Interaction.new(code: 'create'),
+              FHIR::CapabilityStatement::Rest::Resource::Interaction.new(code: 'search-type')
+            ],
+            searchParam: [
+              FHIR::CapabilityStatement::Rest::Resource::SearchParam.new(name: 'patient', type: 'reference'),
               FHIR::CapabilityStatement::Rest::Resource::SearchParam.new(name: '_id', type: 'string'),
               FHIR::CapabilityStatement::Rest::Resource::SearchParam.new(name: '_count', type: 'string')
             ]

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -11,17 +11,25 @@ class Fhir::R4::ApiController < ActionController::API
       :'user/Patient.write',
       :'user/Patient.*',
       :'system/Patient.write',
-      :'system/Patient.*'
+      :'system/Patient.*',
+      :'user/RelatedPerson.write',
+      :'user/RelatedPerson.*',
+      :'system/RelatedPerson.write',
+      :'system/RelatedPerson.*'
     )
   end
   before_action only: %i[show search] do
     doorkeeper_authorize!(
       :'user/Patient.read',
       :'user/Patient.*',
+      :'user/RelatedPerson.read',
+      :'user/RelatedPerson.*',
       :'user/Observation.read',
       :'user/QuestionnaireResponse.read',
       :'system/Patient.read',
       :'system/Patient.*',
+      :'system/RelatedPerson.read',
+      :'system/RelatedPerson.*',
       :'system/Observation.read',
       :'system/QuestionnaireResponse.read'
     )
@@ -31,7 +39,7 @@ class Fhir::R4::ApiController < ActionController::API
 
   # Return a resource given a type and an id.
   #
-  # Supports (reading): Patient, Observation, QuestionnaireResponse
+  # Supports (reading): Patient, Observation, QuestionnaireResponse, RelatedPerson
   #
   # GET /[:resource_type]/[:id]
   def show
@@ -62,6 +70,15 @@ class Fhir::R4::ApiController < ActionController::API
       )
 
       resource = get_assessment(params.permit(:id)[:id])
+    when 'relatedperson'
+      return if doorkeeper_authorize!(
+        :'user/RelatedPerson.read',
+        :'user/RelatedPerson.*',
+        :'system/RelatedPerson.read',
+        :'system/RelatedPerson.*'
+      )
+
+      resource = get_close_contact(params.permit(:id)[:id])
     else
       status_not_found && return
     end
@@ -754,6 +771,11 @@ class Fhir::R4::ApiController < ActionController::API
   # Get an assessment by id
   def get_assessment(id)
     Assessment.where(patient_id: accessible_patients).find_by(id: id)
+  end
+
+  # Get an CloseContact by id
+  def get_close_contact(id)
+    CloseContact.where(patient_id: accessible_patients).find_by(id: id)
   end
 
   # Construct a full url via a request and resource

--- a/app/helpers/fhir_helper.rb
+++ b/app/helpers/fhir_helper.rb
@@ -2,7 +2,6 @@
 
 # Helper module for FHIR translations
 module FhirHelper # rubocop:todo Metrics/ModuleLength
-  SARA_BASE_URL = 'http://saraalert.org'
   # Returns a representative FHIR::Patient for an instance of a Sara Alert Patient. Uses US Core
   # extensions for sex, race, and ethnicity.
   # https://www.hl7.org/fhir/us/core/StructureDefinition-us-core-patient.html
@@ -350,14 +349,14 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
 
   def to_bool_extension(value, extension_id)
     value.nil? ? nil : FHIR::Extension.new(
-      url: "#{SARA_BASE_URL}/StructureDefinition/#{extension_id}",
+      url: "http://saraalert.org/StructureDefinition/#{extension_id}",
       valueBoolean: value
     )
   end
 
   def to_date_extension(value, extension_id)
     value.nil? ? nil : FHIR::Extension.new(
-      url: "#{SARA_BASE_URL}/StructureDefinition/#{extension_id}",
+      url: "http://saraalert.org/StructureDefinition/#{extension_id}",
       valueDate: value
     )
   end
@@ -374,7 +373,7 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
 
   def to_string_extension(value, extension_id)
     value.nil? || value.empty? ? nil : FHIR::Extension.new(
-      url: "#{SARA_BASE_URL}/StructureDefinition/#{extension_id}",
+      url: "http://saraalert.org/StructureDefinition/#{extension_id}",
       valueString: value
     )
   end
@@ -385,14 +384,14 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
 
   def to_reference_extension(id, resource_type, extension_id)
     id.blank? ? nil : FHIR::Extension.new(
-      url: "#{SARA_BASE_URL}/StructureDefinition/#{extension_id}",
+      url: "http://saraalert.org/StructureDefinition/#{extension_id}",
       valueReference: FHIR::Reference.new(reference: "#{resource_type}/#{id}")
     )
   end
 
   def to_positive_integer_extension(value, extension_id)
     value.nil? ? nil : FHIR::Extension.new(
-      url: "#{SARA_BASE_URL}/StructureDefinition/#{extension_id}",
+      url: "http://saraalert.org/StructureDefinition/#{extension_id}",
       valuePositiveInt: value
     )
   end
@@ -403,7 +402,7 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
 
   def to_unsigned_integer_extension(value, extension_id)
     value.nil? ? nil : FHIR::Extension.new(
-      url: "#{SARA_BASE_URL}/StructureDefinition/#{extension_id}",
+      url: "http://saraalert.org/StructureDefinition/#{extension_id}",
       valueUnsignedInt: value
     )
   end
@@ -434,11 +433,11 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
   end
 
   def to_statelocal_identifier(statelocal_identifier)
-    FHIR::Identifier.new(value: statelocal_identifier, system: "#{SARA_BASE_URL}/SaraAlert/state-local-id") unless statelocal_identifier.blank?
+    FHIR::Identifier.new(value: statelocal_identifier, system: 'http://saraalert.org/SaraAlert/state-local-id') unless statelocal_identifier.blank?
   end
 
   def from_statelocal_id_extension(patient)
-    statelocal_id = patient&.identifier&.find { |i| i&.system == "#{SARA_BASE_URL}/SaraAlert/state-local-id" }
+    statelocal_id = patient&.identifier&.find { |i| i&.system == 'http://saraalert.org/SaraAlert/state-local-id' }
     statelocal_id&.value
   end
 
@@ -466,19 +465,19 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
         country: patient.foreign_address_country,
         state: patient.foreign_address_state,
         postalCode: patient.foreign_address_zip,
-        extension: [FHIR::Extension.new(url: "#{SARA_BASE_URL}/StructureDefinition/address-type", valueString: 'Foreign')]
+        extension: [FHIR::Extension.new(url: 'http://saraalert.org/StructureDefinition/address-type', valueString: 'Foreign')]
       ) : nil
     end
   end
 
   def from_address_by_type_extension(patient, address_type)
     address = patient&.address&.find do |a|
-      a.extension&.any? { |e| e.url == "#{SARA_BASE_URL}/StructureDefinition/address-type" && e.valueString == address_type }
+      a.extension&.any? { |e| e.url == 'http://saraalert.org/StructureDefinition/address-type' && e.valueString == address_type }
     end
 
     if address.nil? && address_type == 'USA'
       address = patient&.address&.find do |a|
-        a.extension&.all? { |e| e.url != "#{SARA_BASE_URL}/StructureDefinition/address-type" }
+        a.extension&.all? { |e| e.url != 'http://saraalert.org/StructureDefinition/address-type' }
       end
     end
 

--- a/app/helpers/fhir_helper.rb
+++ b/app/helpers/fhir_helper.rb
@@ -194,7 +194,7 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
       extension: [
         to_date_extension(close_contact.last_date_of_exposure, 'last-date-of-exposure'),
         to_positive_integer_extension(close_contact.assigned_user, 'assigned-user'),
-        to_positive_integer_extension(close_contact.contact_attempts, 'contact-attempts'),
+        to_unsigned_integer_extension(close_contact.contact_attempts, 'contact-attempts'),
         to_string_extension(close_contact.notes, 'notes'),
         to_reference_extension(close_contact.enrolled_id, 'Patient', 'enrolled-patient')
       ]
@@ -211,8 +211,7 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
       assigned_user: from_positive_integer_extension(related_person, 'assigned-user'),
       notes: from_string_extension(related_person, 'notes'),
       patient_id: related_person&.patient&.reference&.match(%r{^Patient/(\d+)$}).to_a[1],
-      contact_attempts: from_positive_integer_extension(related_person, 'contact-attempts'),
-      enrolled_id: from_reference_extension(related_person, 'enrolled-patient')&.reference&.match(%r{^Patient/(\d+)$}).to_a[1]
+      contact_attempts: from_unsigned_integer_extension(related_person, 'contact-attempts') || 0
     }
   end
 
@@ -391,10 +390,6 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
     )
   end
 
-  def from_reference_extension(element, extension_id)
-    element&.extension&.select { |e| e.url.include?(extension_id) }&.first&.valueReference
-  end
-
   def to_positive_integer_extension(value, extension_id)
     value.nil? ? nil : FHIR::Extension.new(
       url: "#{SARA_BASE_URL}/StructureDefinition/#{extension_id}",
@@ -404,6 +399,17 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
 
   def from_positive_integer_extension(element, extension_id)
     element&.extension&.select { |e| e.url.include?(extension_id) }&.first&.valuePositiveInt
+  end
+
+  def to_unsigned_integer_extension(value, extension_id)
+    value.nil? ? nil : FHIR::Extension.new(
+      url: "#{SARA_BASE_URL}/StructureDefinition/#{extension_id}",
+      valueUnsignedInt: value
+    )
+  end
+
+  def from_unsigned_integer_extension(element, extension_id)
+    element&.extension&.select { |e| e.url.include?(extension_id) }&.first&.valueUnsignedInt
   end
 
   # Convert from FHIR extension for Full Assigned Jurisdiction Path.

--- a/app/helpers/validation_helper.rb
+++ b/app/helpers/validation_helper.rb
@@ -238,12 +238,12 @@ module ValidationHelper # rubocop:todo Metrics/ModuleLength
       # NOTE: If the value is a date, the typecast value may not correspond to original user input, so get value_before_type_cast
       unless attribute == :base
         value = VALIDATION[attribute][:checks].include?(:date) ? resource.public_send("#{attribute}_before_type_cast") : resource[attribute]
-        msg_header = (value ? "Value '#{value}' for " : '') + "'#{VALIDATION[attribute][:label]}' "
+        msg_header = (value ? "Value '#{value}' for " : '') + "'#{VALIDATION[attribute][:label]}'"
       end
       errors.each do |error_message|
         # Exclude the actual value in logging to avoid PII/PHI
         Rails.logger.info "Validation Error on: #{attribute}"
-        messages << "#{msg_header}#{error_message}"
+        messages << "#{msg_header} #{error_message}".strip
       end
     end
   end

--- a/app/helpers/validation_helper.rb
+++ b/app/helpers/validation_helper.rb
@@ -205,7 +205,8 @@ module ValidationHelper # rubocop:todo Metrics/ModuleLength
     report: { label: 'Lab Report Date', checks: [:date] },
     result: { label: 'Result', checks: [:enum] },
     assigned_user: { label: 'Assigned User', checks: [] },
-    continuous_exposure: { label: 'Continuous Exposure', checks: [:bool] }
+    continuous_exposure: { label: 'Continuous Exposure', checks: [:bool] },
+    patient_id: { label: 'Patient ID', checks: [] }
   }.freeze
 
   # Validates if a given date value is between (inclusive) two dates.
@@ -235,7 +236,7 @@ module ValidationHelper # rubocop:todo Metrics/ModuleLength
 
       # NOTE: If the value is a date, the typecast value may not correspond to original user input, so get value_before_type_cast
       value = VALIDATION[attribute][:checks].include?(:date) ? resource.public_send("#{attribute}_before_type_cast") : resource[attribute]
-      msg_header = (value ? " Value '#{value}' for " : '') + "'#{VALIDATION[attribute][:label]}'"
+      msg_header = (value ? "Value '#{value}' for " : '') + "'#{VALIDATION[attribute][:label]}'"
       errors.each do |error_message|
         # Exclude the actual value in logging to avoid PII/PHI
         Rails.logger.info "Validation Error on: #{attribute}"

--- a/app/helpers/validation_helper.rb
+++ b/app/helpers/validation_helper.rb
@@ -207,7 +207,7 @@ module ValidationHelper # rubocop:todo Metrics/ModuleLength
     assigned_user: { label: 'Assigned User', checks: [] },
     continuous_exposure: { label: 'Continuous Exposure', checks: [:bool] },
     patient_id: { label: 'Patient ID', checks: [] },
-    enrolled_id: { label: 'Enrolled ID', checks: [] }
+    contact_attempts: { label: 'Contact Attempts', checks: [] }
   }.freeze
 
   # Validates if a given date value is between (inclusive) two dates.

--- a/app/helpers/validation_helper.rb
+++ b/app/helpers/validation_helper.rb
@@ -206,7 +206,8 @@ module ValidationHelper # rubocop:todo Metrics/ModuleLength
     result: { label: 'Result', checks: [:enum] },
     assigned_user: { label: 'Assigned User', checks: [] },
     continuous_exposure: { label: 'Continuous Exposure', checks: [:bool] },
-    patient_id: { label: 'Patient ID', checks: [] }
+    patient_id: { label: 'Patient ID', checks: [] },
+    enrolled_id: { label: 'Enrolled ID', checks: [] }
   }.freeze
 
   # Validates if a given date value is between (inclusive) two dates.

--- a/app/models/close_contact.rb
+++ b/app/models/close_contact.rb
@@ -4,6 +4,34 @@
 class CloseContact < ApplicationRecord
   include Utils
   include ExcelSanitizer
+  include FhirHelper
 
   belongs_to :patient, touch: true
+
+  def custom_details(fields, patient_identifiers)
+    close_contact_details = {}
+    close_contact_details[:id] = id || '' if fields.include?(:id)
+    close_contact_details[:patient_id] = patient_id || '' if fields.include?(:patient_id)
+    close_contact_details[:user_defined_id_statelocal] = patient_identifiers[:user_defined_id_statelocal]
+    close_contact_details[:user_defined_id_cdc] = patient_identifiers[:user_defined_id_cdc]
+    close_contact_details[:user_defined_id_nndss] = patient_identifiers[:user_defined_id_nndss]
+    close_contact_details[:first_name] = remove_formula_start(first_name) || '' if fields.include?(:first_name)
+    close_contact_details[:last_name] = remove_formula_start(last_name) || '' if fields.include?(:last_name)
+    close_contact_details[:primary_telephone] = format_phone_number(primary_telephone) || '' if fields.include?(:primary_telephone)
+    close_contact_details[:email] = remove_formula_start(email) || '' if fields.include?(:email)
+    close_contact_details[:contact_attempts] = contact_attempts || '' if fields.include?(:contact_attempts)
+    close_contact_details[:last_date_of_exposure] = last_date_of_exposure || '' if fields.include?(:last_date_of_exposure)
+    close_contact_details[:assigned_user] = assigned_user || '' if fields.include?(:assigned_user)
+    close_contact_details[:notes] = remove_formula_start(notes) || '' if fields.include?(:notes)
+    close_contact_details[:enrolled_id] = enrolled_id || '' if fields.include?(:enrolled_id)
+    close_contact_details[:created_at] = created_at || '' if fields.include?(:created_at)
+    close_contact_details[:updated_at] = updated_at || '' if fields.include?(:updated_at)
+    close_contact_details
+  end
+
+  # Returns a representative FHIR::RelatedPerson for an instance of a Sara Alert Close Contact.
+  # https://www.hl7.org/fhir/relatedperson.html
+  def as_fhir
+    close_contact_as_fhir(self)
+  end
 end

--- a/app/models/close_contact.rb
+++ b/app/models/close_contact.rb
@@ -13,6 +13,10 @@ class CloseContact < ApplicationRecord
                                                       greater_than: 0,
                                                       less_than_or_equal_to: 999_999,
                                                       message: 'is not valid, acceptable values are numbers between 1-999999' }
+  validates :contact_attempts, on: :api, numericality: { only_integer: true,
+                                                         allow_nil: true,
+                                                         greater_than_or_equal_to: 0,
+                                                         message: 'is not valid, acceptable values are integers greater than or equal to 0' }
   validates :last_date_of_exposure, on: :api, date: true
   validates_with CompleteCloseContactValidator, on: :api
 

--- a/app/models/close_contact.rb
+++ b/app/models/close_contact.rb
@@ -6,6 +6,16 @@ class CloseContact < ApplicationRecord
   include ExcelSanitizer
   include FhirHelper
 
+  validates :primary_telephone, on: :api, phone_number: true
+  validates :email, on: :api, email: true
+  validates :assigned_user, on: :api, numericality: { only_integer: true,
+                                                      allow_nil: true,
+                                                      greater_than: 0,
+                                                      less_than_or_equal_to: 999_999,
+                                                      message: 'is not valid, acceptable values are numbers between 1-999999' }
+  validates :last_date_of_exposure, on: :api, date: true
+  validates_with CompleteCloseContactValidator, on: :api
+
   belongs_to :patient, touch: true
 
   def custom_details(fields, patient_identifiers)

--- a/app/models/concerns/complete_close_contact_validator.rb
+++ b/app/models/concerns/complete_close_contact_validator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Validates that at least one of several attributes is present
+class CompleteCloseContactValidator < ActiveModel::Validator
+  def validate(record)
+    record.errors.add(:base, "At least one of 'First Name' or 'Last Name' must be specified") if record.first_name.blank? && record.last_name.blank?
+    record.errors.add(:base, "At least one of 'Primary Telephone' or 'Email' must be specified") if record.primary_telephone.blank? && record.email.blank?
+  end
+end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -231,11 +231,17 @@ Doorkeeper.configure do
     'user/Patient.read',
     'user/Patient.write',
     'user/Patient.*',
+    'user/RelatedPerson.read',
+    'user/RelatedPerson.write',
+    'user/RelatedPerson.*',
     'user/Observation.read',
     'user/QuestionnaireResponse.read',
     'system/Patient.read',
     'system/Patient.write',
     'system/Patient.*',
+    'system/RelatedPerson.read',
+    'system/RelatedPerson.write',
+    'system/RelatedPerson.*',
     'system/Observation.read',
     'system/QuestionnaireResponse.read'
   )

--- a/docs/api/api-specification.md
+++ b/docs/api/api-specification.md
@@ -28,6 +28,7 @@ Because the Sara Alert API follows the FHIR specification, there is a mapping be
 | Monitoree                 | [Patient](https://hl7.org/fhir/R4/patient.html)|
 | Monitoree Lab Result      | [Observation](https://hl7.org/fhir/R4/observation.html)|
 | Monitoree Daily Report    | [QuestionnaireResponse](https://www.hl7.org/fhir/questionnaireresponse.html)|
+| Monitoree Close Contact   | [RelatedPerson](https://www.hl7.org/fhir/relatedperson.html)|
 
 <a name="supported-scopes"/>
 
@@ -39,6 +40,9 @@ For applications following the [SMART-on-FHIR App Launch Framework "Standalone L
 * `user/Patient.*`, (for both read and write access to this resource)
 * `user/Observation.read`,
 * `user/QuestionnaireResponse.read`,
+* `user/RelatedPerson.read`,
+* `user/RelatedPerson.write`,
+* `user/RelatedPerson.*`
 
 For applications following the [SMART on FHIR Backend Services Workflow](#backend-services), these are the available scopes:
 
@@ -47,6 +51,9 @@ For applications following the [SMART on FHIR Backend Services Workflow](#backen
 * `system/Patient.*`, (for both read and write access to this resource)
 * `system/Observation.read`,
 * `system/QuestionnaireResponse.read`,
+* `system/RelatedPerson.read`,
+* `system/RelatedPerson.write`,
+* `system/RelatedPerson.*`
 
 Please note a given application and request for access token can have have multiple scopes, which must be space-separated. For example:
 ```
@@ -70,11 +77,11 @@ A capability statement is available at `[base]/metadata`:
 ```json
 {
   "status": "active",
-  "date": "2020-05-28T00:00:00+00:00",
+  "date": "2021-03-04T00:00:00+00:00",
   "kind": "instance",
   "software": {
     "name": "Sara Alert",
-    "version": "v1.4.1"
+    "version": "v1.25.0"
   },
   "implementation": {
     "description": "Sara Alert API"
@@ -119,7 +126,7 @@ A capability statement is available at `[base]/metadata`:
                 "code": "SMART-on-FHIR"
               }
             ],
-            "text": "OAuth2 using SMART-on-FHIR profile (see http://docs.smarthealthit.org"
+            "text": "OAuth2 using SMART-on-FHIR profile (see http://docs.smarthealthit.org)"
           }
         ]
       },
@@ -163,6 +170,40 @@ A capability statement is available at `[base]/metadata`:
             {
               "name": "active",
               "type": "boolean"
+            },
+            {
+              "name": "_id",
+              "type": "string"
+            },
+            {
+              "name": "_count",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "type": "RelatedPerson",
+          "interaction": [
+            {
+              "code": "read"
+            },
+            {
+              "code": "update"
+            },
+            {
+              "code": "patch"
+            },
+            {
+              "code": "create"
+            },
+            {
+              "code": "search-type"
+            }
+          ],
+          "searchParam": [
+            {
+              "name": "patient",
+              "type": "reference"
             },
             {
               "name": "_id",
@@ -266,7 +307,7 @@ A Well Known statement is also available at `/.well-known/smart-configuration` o
 
 ## Reading
 
-The API supports reading monitorees, monitoree lab results, and monitoree daily reports.
+The API supports reading monitorees, monitoree lab results, monitoree daily reports, and monitoree close contacts.
 
 <a name="read-get-pat"/>
 
@@ -549,6 +590,59 @@ Get a monitoree daily report via an id, e.g.:
   </div>
 </details>
 
+<a name="read-get-related"/>
+
+### GET `[base]/RelatedPerson/[:id]`
+
+Get a monitoree close contact via an id, e.g.:
+
+<details>
+  <summary>Click to expand JSON snippet</summary>
+  <div markdown="1">
+
+```json
+{
+  "id": 950,
+  "meta": {
+    "lastUpdated": "2021-01-31T18:23:16+00:00"
+  },
+  "extension": [
+    {
+      "url": "http://saraalert.org/StructureDefinition/contact-attempts",
+      "valuePositiveInt": 5
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/notes",
+      "valueString": "Parsing the panel won't do anything, we need to program the optical ib array!"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/222"
+  },
+  "name": [
+    {
+      "family": "Pollich97",
+      "given": ["Nam32"]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "+15555550104",
+      "rank": 1
+    },
+    {
+      "system": "email",
+      "value": "1845823000fake@example.com",
+      "rank": 1
+    }
+  ],
+  "resourceType": "RelatedPerson"
+}
+```
+  </div>
+</details>
+
 
 <a name="read-get-all"/>
 
@@ -809,197 +903,6 @@ Use this route to retrieve a FHIR Bundle containing the monitoree, all their lab
 ## Creating
 
 The API supports creating new monitorees.
-
-### Extensions
-
-<a name="create-ext"/>
-
-Along with supporting the US Core extensions for [race](https://www.hl7.org/fhir/us/core/StructureDefinition-us-core-race.html), [ethnicity](https://www.hl7.org/fhir/us/core/StructureDefinition-us-core-ethnicity.html), and [birthsex](https://www.hl7.org/fhir/us/core/StructureDefinition-us-core-birthsex.html), Sara Alert includes additional extensions for attributes specific to the Sara Alert workflows.
-
-Use `http://saraalert.org/StructureDefinition/preferred-contact-method` to specify the monitoree's Sara Alert preferred contact method (options are: `E-mailed Web Link`, `SMS Texted Weblink`, `Telephone call`, `SMS Text-message`, `Opt-out`, and `Unknown`).
-
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/preferred-contact-method",
-  "valueString": "E-mailed Web Link"
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/preferred-contact-time` to specify the monitoree's Sara Alert preferred contact time (options are: `Morning`, `Afternoon`, and `Evening`).
-
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/preferred-contact-time",
-  "valueString": "Morning"
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/symptom-onset-date` to specify when the monitoree's first symptoms appeared for use in the Sara Alert isolation workflow.
-
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/symptom-onset-date",
-  "valueDate": "2020-05-23"
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/last-exposure-date` to specify when the monitoree's last exposure occurred for use in the Sara Alert exposure workflow.
-
-
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/last-exposure-date",
-  "valueDate": "2020-05-18"
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/isolation` to specify if the monitoree should be in the isolation workflow (omitting this extension defaults this value to false, leaving the monitoree in the exposure workflow).
-
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/isolation",
-  "valueBoolean": false
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path` to specify the monitoree's assigned jurisdiction.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path",
-  "valueString": "USA, State 1"
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/monitoring-plan` to specify the monitoree's Sara Alert monitoring plan (options are: `None`, `Daily active monitoring`, `Self-monitoring with public health supervision`, `Self-monitoring with delegated supervision`, and `Self-observation`).
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/monitoring-plan",
-  "valueString": "Daily active monitoring"
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/assigned-user` to specify the monitoree's assigned user.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/assigned-user",
-  "valuePositiveInt": 123
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/additional-planned-travel-start-date` to specify when the monitoree is planning to begin their travel.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-start-date",
-  "valueDate": "2020-06-15"
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/port-of-origin` to specify the port that the monitoree traveled from.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/port-of-origin",
-  "valueString": "MSP Airport"
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/date-of-departure` to specify when the monitoree departed from the port of origin.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/date-of-departure",
-  "valueDate": "2020-05-25"
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/flight-or-vessel-number` to specify the plane, train, ship, or other vessel that the monitoree used to travel to their destination.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/flight-or-vessel-number",
-  "valueString": "QQ1234"
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/flight-or-vessel-carrier` to specify the carrier, operating company, or provider of the flight or vessel.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/flight-or-vessel-carrier",
-  "valueString": "QQ Airways"
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/date-of-arrival` to specify when the monitoree
-entered the United States after travel.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/date-of-arrival",
-  "valueDate": "2020-05-28"
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/exposure-notes` to specify additional notes about the monitoree's exposure history or case information history.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/exposure-notes",
-  "valueString": "Sample exposure notes."
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/travel-related-notes` to specify additional notes
-about the monitoree’s travel history.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/travel-related-notes",
-  "valueString": "Sample travel notes."
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/additional-planned-travel-notes` to specify additional notes about the monitoree's planned travel.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-notes",
-  "valueString": "Sample planned travel notes."
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/phone-type` to specify the type of phone attached to the primary or secondary phone number (options are: `Smartphone`, `Plain Cell`, and `Landline`). Note that this extension should be placed on the first element in the `Patient.telecom` array to specify the monitoree's primary phone type, and the second element in the `Patient.telecom` array to specify the monitoree's secondary phone type.
-```json
-"telecom": [
-  {
-    "system": "phone",
-    "value": "(333) 333-3333",
-    "rank": 1,
-    "extension": {
-      "url": "http://saraalert.org/StructureDefinition/phone-type",
-      "valueString": "Smartphone"
-    }
-  }
-]
-```
-
-Use `http://saraalert.org/StructureDefinition/address-type` to specify the type of an address (options are: `USA` and `Foreign`). Note that this extension should be placed on an element in the `Patient.address` array. If this extension is not present on an address in the `Patient.address` array, the address is assumed to be a `USA` address.
-```json
-"address": [
-  {
-    "extension": [
-      {
-        "url": "http://saraalert.org/StructureDefinition/address-type",
-        "valueString": "Foreign"
-      }
-    ],
-    "line": ["24961 Linnie Inlet", "Apt. 497"],
-    "city": "Ottawa",
-    "state": "Ontario",
-    "country": "Canada",
-    "postalCode": "192387"
-  },
-  {
-    "line": ["35047 Van Light"],
-    "city": "New Tambra",
-    "state": "Mississippi",
-    "district": "Summer Square",
-    "postalCode": "05657",
-  }
-]
-```
 
 ### POST `[base]/Patient`
 
@@ -1262,6 +1165,296 @@ On success, the server will return the newly created resource with an id. This i
 ```
   </div>
 </details>
+
+#### Patient Extensions
+
+<a name="create-pat-ext"/>
+
+Along with supporting the US Core extensions for [race](https://www.hl7.org/fhir/us/core/StructureDefinition-us-core-race.html), [ethnicity](https://www.hl7.org/fhir/us/core/StructureDefinition-us-core-ethnicity.html), and [birthsex](https://www.hl7.org/fhir/us/core/StructureDefinition-us-core-birthsex.html), Sara Alert includes additional extensions for attributes specific to the Sara Alert workflows.
+
+Use `http://saraalert.org/StructureDefinition/preferred-contact-method` to specify the monitoree's Sara Alert preferred contact method (options are: `E-mailed Web Link`, `SMS Texted Weblink`, `Telephone call`, `SMS Text-message`, `Opt-out`, and `Unknown`).
+
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/preferred-contact-method",
+  "valueString": "E-mailed Web Link"
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/preferred-contact-time` to specify the monitoree's Sara Alert preferred contact time (options are: `Morning`, `Afternoon`, and `Evening`).
+
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/preferred-contact-time",
+  "valueString": "Morning"
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/symptom-onset-date` to specify when the monitoree's first symptoms appeared for use in the Sara Alert isolation workflow.
+
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/symptom-onset-date",
+  "valueDate": "2020-05-23"
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/last-exposure-date` to specify when the monitoree's last exposure occurred for use in the Sara Alert exposure workflow.
+
+
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/last-exposure-date",
+  "valueDate": "2020-05-18"
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/isolation` to specify if the monitoree should be in the isolation workflow (omitting this extension defaults this value to false, leaving the monitoree in the exposure workflow).
+
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/isolation",
+  "valueBoolean": false
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path` to specify the monitoree's assigned jurisdiction.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path",
+  "valueString": "USA, State 1"
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/monitoring-plan` to specify the monitoree's Sara Alert monitoring plan (options are: `None`, `Daily active monitoring`, `Self-monitoring with public health supervision`, `Self-monitoring with delegated supervision`, and `Self-observation`).
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/monitoring-plan",
+  "valueString": "Daily active monitoring"
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/assigned-user` to specify the monitoree's assigned user.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/assigned-user",
+  "valuePositiveInt": 123
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/additional-planned-travel-start-date` to specify when the monitoree is planning to begin their travel.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-start-date",
+  "valueDate": "2020-06-15"
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/port-of-origin` to specify the port that the monitoree traveled from.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/port-of-origin",
+  "valueString": "MSP Airport"
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/date-of-departure` to specify when the monitoree departed from the port of origin.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/date-of-departure",
+  "valueDate": "2020-05-25"
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/flight-or-vessel-number` to specify the plane, train, ship, or other vessel that the monitoree used to travel to their destination.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/flight-or-vessel-number",
+  "valueString": "QQ1234"
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/flight-or-vessel-carrier` to specify the carrier, operating company, or provider of the flight or vessel.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/flight-or-vessel-carrier",
+  "valueString": "QQ Airways"
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/date-of-arrival` to specify when the monitoree
+entered the United States after travel.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/date-of-arrival",
+  "valueDate": "2020-05-28"
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/exposure-notes` to specify additional notes about the monitoree's exposure history or case information history.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/exposure-notes",
+  "valueString": "Sample exposure notes."
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/travel-related-notes` to specify additional notes
+about the monitoree’s travel history.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/travel-related-notes",
+  "valueString": "Sample travel notes."
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/additional-planned-travel-notes` to specify additional notes about the monitoree's planned travel.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-notes",
+  "valueString": "Sample planned travel notes."
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/phone-type` to specify the type of phone attached to the primary or secondary phone number (options are: `Smartphone`, `Plain Cell`, and `Landline`). Note that this extension should be placed on the first element in the `Patient.telecom` array to specify the monitoree's primary phone type, and the second element in the `Patient.telecom` array to specify the monitoree's secondary phone type.
+```json
+"telecom": [
+  {
+    "system": "phone",
+    "value": "(333) 333-3333",
+    "rank": 1,
+    "extension": {
+      "url": "http://saraalert.org/StructureDefinition/phone-type",
+      "valueString": "Smartphone"
+    }
+  }
+]
+```
+
+Use `http://saraalert.org/StructureDefinition/address-type` to specify the type of an address (options are: `USA` and `Foreign`). Note that this extension should be placed on an element in the `Patient.address` array. If this extension is not present on an address in the `Patient.address` array, the address is assumed to be a `USA` address.
+```json
+"address": [
+  {
+    "extension": [
+      {
+        "url": "http://saraalert.org/StructureDefinition/address-type",
+        "valueString": "Foreign"
+      }
+    ],
+    "line": ["24961 Linnie Inlet", "Apt. 497"],
+    "city": "Ottawa",
+    "state": "Ontario",
+    "country": "Canada",
+    "postalCode": "192387"
+  },
+  {
+    "line": ["35047 Van Light"],
+    "city": "New Tambra",
+    "state": "Mississippi",
+    "district": "Summer Square",
+    "postalCode": "05657",
+  }
+]
+```
+
+### POST `[base]/RelatedPerson`
+
+<a name="create-post-related"/>
+
+To create a new monitoree close contact, simply POST a FHIR RelatedPerson resource.
+
+**Request Body:**
+<details>
+  <summary>Click to expand JSON snippet</summary>
+  <div markdown="1">
+
+```json
+{
+  "extension": [
+    {
+      "url": "http://saraalert.org/StructureDefinition/contact-attempts",
+      "valuePositiveInt": 5
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/notes",
+      "valueString": "Parsing the panel won't do anything, we need to program the optical ib array!"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/222"
+  },
+  "name": [
+    {
+      "family": "Pollich97",
+      "given": ["Nam32"]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "+15555550104",
+      "rank": 1
+    },
+    {
+      "system": "email",
+      "value": "1845823000fake@example.com",
+      "rank": 1
+    }
+  ],
+  "resourceType": "RelatedPerson"
+}
+```
+  </div>
+</details>
+
+#### RelatedPerson Extensions
+
+<a name="create-related-ext"/>
+
+Sara Alert includes additional extensions for attributes specific to a monitoree close contact.
+
+
+Use `http://saraalert.org/StructureDefinition/last-date-of-exposure` to specify when the close contact's last exposure occurred.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/last-date-of-exposure",
+  "valueDate": "2020-05-18"
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/assigned-user` to specify the close contacts's assigned user.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/assigned-user",
+  "valuePositiveInt": 123
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/notes` to specify additional notes about the close contacts's case.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/notes",
+  "valueString": "Sample notes."
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/contact-attempts` to specify the number of attempts made to contact the close contact.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/contact-attempts",
+  "valuePositiveInt": 2
+}
+```
+
+Use `http://saraalert.org/StructureDefinition/enrolled-patient` to reference the full Patient resource that corresponds to the close contact, if such a Patient exists.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/enrolled-patient",
+  "valueReference": {
+    "reference": "Patient/567"
+  }
+}
+```
 
 
 <a name="update"/>
@@ -1533,6 +1726,54 @@ On success, the server will update the existing resource given the id.
   </div>
 </details>
 
+<a name="update-put-related"/>
+
+### PUT `[base]/RelatedPerson/[:id]`
+
+**Request Body:**
+<details>
+  <summary>Click to expand JSON snippet</summary>
+  <div markdown="1">
+
+```json
+{
+  "extension": [
+    {
+      "url": "http://saraalert.org/StructureDefinition/contact-attempts",
+      "valuePositiveInt": 5
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/notes",
+      "valueString": "Parsing the panel won't do anything, we need to program the optical ib array!"
+    }
+  ],
+  "patient": {
+    "reference": "Patient/222"
+  },
+  "name": [
+    {
+      "family": "Pollich97",
+      "given": ["Nam32"]
+    }
+  ],
+  "telecom": [
+    {
+      "system": "phone",
+      "value": "+15555550104",
+      "rank": 1
+    },
+    {
+      "system": "email",
+      "value": "1845823000fake@example.com",
+      "rank": 1
+    }
+  ],
+  "resourceType": "RelatedPerson"
+}
+```
+  </div>
+</details>
+
 <a name="update-patch-pat"/>
 
 ### PATCH `[base]/Patient/[:id]`
@@ -1676,6 +1917,32 @@ On success, the server will update the attributes indicated by the request.
   ],
   "resourceType": "Patient"
 }
+```
+  </div>
+</details>
+
+<a name="update-patch-related"/>
+
+### PATCH `[base]/RelatedPerson/[:id]`
+
+**NOTE:** See the [Patient PATCH documentation](#update-patch-pat) for a more complete explanation of PATCH.
+
+**Request Headers:**
+```
+Content-Type: application/json-patch+json
+```
+
+**Request Body:**
+
+
+<details>
+  <summary>Click to expand JSON snippet</summary>
+  <div markdown="1">
+
+```json
+[
+  { "op": "remove", "path": "/name/0/family" },
+]
 ```
   </div>
 </details>
@@ -2062,6 +2329,74 @@ GET `[base]/Observation?subject=Patient/[:id]`
   </div>
 </details>
 
+### GET `[base]/RelatedPerson?patient=Patient/[:id]`
+
+You can also use search to find Monitoree close contacts by using the `patient` parameter.
+
+<a name="search-related-patient"/>
+
+GET `[base]/RelatedPerson?patient=Patient/[:id]`
+
+<details>
+  <summary>Click to expand JSON snippet</summary>
+  <div markdown="1">
+
+```json
+{
+  "id": "f37cc7ac-3543-4ded-8902-841d0076a9bd",
+  "meta": {
+    "lastUpdated": "2021-03-04T17:04:29-05:00"
+  },
+  "type": "searchset",
+  "total": 1,
+  "entry": [
+    {
+      "fullUrl": "http://localhost:3000/fhir/r4/RelatedPerson/950",
+      "resource": {
+        "id": 950,
+        "meta": {
+          "lastUpdated": "2021-01-31T18:23:16+00:00"
+        },
+        "extension": [
+          {
+            "url": "http://saraalert.org/StructureDefinition/contact-attempts",
+            "valuePositiveInt": 5
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/notes",
+            "valueString": "Parsing the panel won't do anything, we need to program the optical ib array!"
+          }
+        ],
+        "patient": {
+          "reference": "Patient/222"
+        },
+        "name": [
+          {
+            "family": "Pollich97",
+            "given": ["Nam32"]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+15555550104",
+            "rank": 1
+          },
+          {
+            "system": "email",
+            "value": "1845823000fake@example.com",
+            "rank": 1
+          }
+        ],
+        "resourceType": "RelatedPerson"
+      }
+    }
+  ],
+  "resourceType": "Bundle"
+}
+```
+  </div>
+</details>
 ### GET `[base]/Patient`
 
 By not specifying any search parameters, you can request all resources of the specified type.

--- a/docs/api/api-specification.md
+++ b/docs/api/api-specification.md
@@ -609,7 +609,7 @@ Get a monitoree close contact via an id, e.g.:
   "extension": [
     {
       "url": "http://saraalert.org/StructureDefinition/contact-attempts",
-      "valuePositiveInt": 5
+      "valueUnsignedInt": 5
     },
     {
       "url": "http://saraalert.org/StructureDefinition/notes",
@@ -1361,7 +1361,7 @@ Use `http://saraalert.org/StructureDefinition/address-type` to specify the type 
 
 <a name="create-post-related"/>
 
-To create a new monitoree close contact, simply POST a FHIR RelatedPerson resource.
+To create a new monitoree close contact, simply POST a FHIR RelatedPerson resource that references the monitoree.
 
 **Request Body:**
 <details>
@@ -1373,7 +1373,7 @@ To create a new monitoree close contact, simply POST a FHIR RelatedPerson resour
   "extension": [
     {
       "url": "http://saraalert.org/StructureDefinition/contact-attempts",
-      "valuePositiveInt": 5
+      "valueUnsignedInt": 5
     },
     {
       "url": "http://saraalert.org/StructureDefinition/notes",
@@ -1442,11 +1442,11 @@ Use `http://saraalert.org/StructureDefinition/contact-attempts` to specify the n
 ```json
 {
   "url": "http://saraalert.org/StructureDefinition/contact-attempts",
-  "valuePositiveInt": 2
+  "valueUnsignedInt": 2
 }
 ```
 
-Use `http://saraalert.org/StructureDefinition/enrolled-patient` to reference the full Patient resource that corresponds to the close contact, if such a Patient exists.
+The `http://saraalert.org/StructureDefinition/enrolled-patient` extension is used to reference the full Patient resource that corresponds to the close contact, if such a Patient exists. Note that this extension is read-only. This field may only be updated by manually enrolling a new Patient for this close contact via the user interface.
 ```json
 {
   "url": "http://saraalert.org/StructureDefinition/enrolled-patient",
@@ -1740,7 +1740,7 @@ On success, the server will update the existing resource given the id.
   "extension": [
     {
       "url": "http://saraalert.org/StructureDefinition/contact-attempts",
-      "valuePositiveInt": 5
+      "valueUnsignedInt": 5
     },
     {
       "url": "http://saraalert.org/StructureDefinition/notes",
@@ -2360,7 +2360,7 @@ GET `[base]/RelatedPerson?patient=Patient/[:id]`
         "extension": [
           {
             "url": "http://saraalert.org/StructureDefinition/contact-attempts",
-            "valuePositiveInt": 5
+            "valueUnsignedInt": 5
           },
           {
             "url": "http://saraalert.org/StructureDefinition/notes",

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -29,18 +29,28 @@ As indicated in the previous section, the API follows SMART on FHIR API standard
 
 The API exists to allow other software systems to **read** and **write** Sara Alert data. Reading can mean either requesting specific data, e.g. "give me Monitoree X's information", or it can mean searching data, e.g. "give me the Monitoree with the e-mail address jane@example<span></span>.com". Writing data can mean putting new data into the system, e.g. "enroll this person as a new Monitoree", or it can mean updating existing data, e.g. "change this Monitoree's preferred reporting method to Opt-Out".
 
-The examples above are in terms of Monitorees, but the API also supports Symptom Reports and Lab Results. However, these entities are currently only supported for reading data.
+The examples above are in terms of Monitorees, but the API also supports reading and writing of Close Contacts, and reading of Symptom Reports and Lab Results
 
 ### For Monitorees
 **A client can read and write the following data elements:**<br>Workflow, First Name, Middle Name, Last Name, Date of Birth, Sex, White, Black or African American, American Indian or Alaskan Native, Asian, Native Hawaiian or Other Pacific Islander, Ethnicity, Primary Language, Interpretation Requirement, Address 1, Address 2, Town/City, State, Zip, Country, Address 1 (Foreign), Address 2 (Foreign), Address 3 (Foreign), Town/City (Foreign), State/Province (Foreign), Postal Code (Foreign), Country (Foreign), Preferred Reporting Method, Preferred Contact Time, Primary Telephone Number, Secondary Telephone Number, E-mail Address, Last Date of Exposure, Symptom Onset Date, Monitoring Status, Assigned Jurisdiction, Monitoring Plan, Assigned User, Additional Planned Travel Start Date, Additional Planned Travel Notes, Port of Origin, Date of Departure, Flight or Vessel Number, Flight or Vessel Carrier, Date of Arrival, Travel Related Notes, Exposure Notes, Primary Telephone Type, Secondary Telephone Type, State/Local ID
-**A client can search by the following data elements:** First Name, Last Name, Primary Telephone Number, E-mail Address, Monitoring Status
+
+**A client can search by the following data elements:**<br>First Name, Last Name, Primary Telephone Number, E-mail Address, Monitoring Status
+
+### For Close Contacts
+**A client can read and write the following data elements:**<br>First Name, Last Name, Primary Telephone, Email, Notes, Enrolled ID, Contact Attempts, Last Date of Exposure, Assigned User, Patient ID
+
+**A client can search by the following data elements:**<br>ID, Patient ID
 
 ### For Symptom Reports
 **A client can read the following data elements:**<br>Name, Answer
 
+**A client can search by the following data elements:**<br>ID, Patient ID
+
 
 ### For Lab Results
 **A client can read the following data elements:**<br>Report Date, Result
+
+**A client can search by the following data elements:**<br>ID, Patient ID
 
 # Tentative Roadmap
 **DISCLAIMER**: This roadmap is **tentative**, meaning we are not making any promises. Future work is subject to change at all times; we can and will modify and prioritize future work based on user needs as they arise.

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -7,12 +7,57 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
   fixtures :all
 
   setup do
+    setup_patients
     setup_user_applications
     setup_system_applications
     # Suppress logging calls originating from:
     # https://github.com/fhir-crucible/fhir_models/blob/v4.1.0/lib/fhir_models/bootstrap/json.rb
     logger_double = double('logger_double', debug: nil, info: nil, warning: nil, error: nil)
     FHIR.logger = logger_double
+  end
+
+  # Sets up FHIR patients used for testing
+  def setup_patients
+    Patient.find_by(id: 1).update!(
+      assigned_user: '1234',
+      exposure_notes: 'exposure notes',
+      travel_related_notes: 'travel notes',
+      additional_planned_travel_related_notes: 'additional travel notes'
+    )
+    @patient_1 = Patient.find_by(id: 1).as_fhir
+
+    # Update Patient 2 before created FHIR resource from it
+    Patient.find_by(id: 2).update!(
+      preferred_contact_method: 'SMS Texted Weblink',
+      preferred_contact_time: 'Afternoon',
+      symptom_onset: 3.days.ago,
+      isolation: true,
+      primary_telephone: '+15555559999',
+      jurisdiction_id: 4,
+      monitoring_plan: 'Daily active monitoring',
+      assigned_user: '2345',
+      additional_planned_travel_start_date: 5.days.from_now,
+      port_of_origin: 'Tortuga',
+      date_of_departure: 2.days.ago,
+      flight_or_vessel_number: 'XYZ123',
+      flight_or_vessel_carrier: 'FunAirlines',
+      date_of_arrival: 2.days.from_now,
+      exposure_notes: 'exposure notes',
+      travel_related_notes: 'travel related notes',
+      additional_planned_travel_related_notes: 'additional travel related notes',
+      primary_telephone_type: 'Plain Cell',
+      secondary_telephone_type: 'Landline',
+      black_or_african_american: true,
+      asian: true,
+      continuous_exposure: true,
+      last_date_of_exposure: nil
+    )
+    @patient_2 = Patient.find_by(id: 2).as_fhir
+
+    # Update Patient 2 number to guarantee unique phone number
+    Patient.find_by(id: 2).update!(
+      primary_telephone: '+15555559998'
+    )
   end
 
   # Sets up applications registered for user flow

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -3,14 +3,12 @@
 require 'test_helper'
 require 'rspec/mocks/minitest_integration'
 
-# rubocop:disable Metrics/ClassLength
 class ApiControllerTest < ActionDispatch::IntegrationTest
   fixtures :all
 
   setup do
     setup_user_applications
     setup_system_applications
-    setup_patients
     # Suppress logging calls originating from:
     # https://github.com/fhir-crucible/fhir_models/blob/v4.1.0/lib/fhir_models/bootstrap/json.rb
     logger_double = double('logger_double', debug: nil, info: nil, warning: nil, error: nil)
@@ -30,11 +28,25 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       scopes: 'user/Patient.*'
     )
 
+    # Create OAuth applications
+    @user_everything_app = OauthApplication.create(
+      name: 'user-test-patient-rw',
+      redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
+      scopes: 'system/Patient.* system/QuestionnaireResponse.read system/Observation.read system/RelatedPerson.*'
+    )
+
     # Create access tokens
     @user_patient_token_rw = Doorkeeper::AccessToken.create(
       resource_owner_id: @user.id,
       application: @user_patient_read_write_app,
       scopes: 'user/Patient.*'
+    )
+
+    # Create access tokens
+    @user_everything_token = Doorkeeper::AccessToken.create(
+      resource_owner_id: @user.id,
+      application: @user_everything_app,
+      scopes: 'system/Patient.* system/QuestionnaireResponse.read system/Observation.read system/RelatedPerson.*'
     )
   end
 
@@ -120,7 +132,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     @system_everything_app = OauthApplication.create(
       name: 'system-test-everything',
       redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
-      scopes: 'system/Patient.* system/QuestionnaireResponse.read system/Observation.read',
+      scopes: 'system/Patient.* system/QuestionnaireResponse.read system/Observation.read system/RelatedPerson.*',
       jurisdiction_id: 2,
       user_id: shadow_user.id
     )
@@ -160,51 +172,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     )
     @system_everything_token = Doorkeeper::AccessToken.create(
       application: @system_everything_app,
-      scopes: 'system/Patient.* system/QuestionnaireResponse.read system/Observation.read'
-    )
-  end
-
-  # Sets up FHIR patients used for testing
-  def setup_patients
-    Patient.find_by(id: 1).update!(
-      assigned_user: '1234',
-      exposure_notes: 'exposure notes',
-      travel_related_notes: 'travel notes',
-      additional_planned_travel_related_notes: 'additional travel notes'
-    )
-    @patient_1 = Patient.find_by(id: 1).as_fhir
-
-    # Update Patient 2 before created FHIR resource from it
-    Patient.find_by(id: 2).update!(
-      preferred_contact_method: 'SMS Texted Weblink',
-      preferred_contact_time: 'Afternoon',
-      symptom_onset: 3.days.ago,
-      isolation: true,
-      primary_telephone: '+15555559999',
-      jurisdiction_id: 4,
-      monitoring_plan: 'Daily active monitoring',
-      assigned_user: '2345',
-      additional_planned_travel_start_date: 5.days.from_now,
-      port_of_origin: 'Tortuga',
-      date_of_departure: 2.days.ago,
-      flight_or_vessel_number: 'XYZ123',
-      flight_or_vessel_carrier: 'FunAirlines',
-      date_of_arrival: 2.days.from_now,
-      exposure_notes: 'exposure notes',
-      travel_related_notes: 'travel related notes',
-      additional_planned_travel_related_notes: 'additional travel related notes',
-      primary_telephone_type: 'Plain Cell',
-      secondary_telephone_type: 'Landline',
-      black_or_african_american: true,
-      asian: true,
-      continuous_exposure: true,
-      last_date_of_exposure: nil
-    )
-    @patient_2 = Patient.find_by(id: 2).as_fhir
-
-    # Update Patient 2 number to guarantee unique phone number
-    Patient.find_by(id: 2).update!(
-      primary_telephone: '+15555559998'
+      scopes: 'system/Patient.* system/QuestionnaireResponse.read system/Observation.read system/RelatedPerson.*'
     )
   end
 
@@ -441,80 +409,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_acceptable
   end
 
-  test 'should get patient via show' do
-    patient_id = 1
-    patient = Patient.find_by(id: patient_id)
-    resource_path = "/fhir/r4/Patient/#{patient_id}"
-    get(
-      resource_path,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 1, json_response['id']
-    assert_equal 'Patient', json_response['resourceType']
-    assert_equal 3, json_response['telecom'].count
-    assert_equal 'Boehm62', json_response['name'].first['family']
-    assert_equal 'Telephone call', json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-method' }.first['valueString']
-    assert_equal 'Morning', json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-time' }.first['valueString']
-    assert_equal 45.days.ago.strftime('%Y-%m-%d'), json_response['extension'].filter { |e| e['url'].include? 'last-date-of-exposure' }.first['valueDate']
-    assert_equal 5.days.ago.strftime('%Y-%m-%d'), json_response['extension'].filter { |e| e['url'].include? 'symptom-onset-date' }.first['valueDate']
-    assert_not json_response['extension'].filter { |e| e['url'].include? 'isolation' }.first['valueBoolean']
-    assert_equal resource_path, json_response['contained'].first['target'].first['reference']
-    assert_equal Patient.find_by(id: patient_id).creator_id, json_response['contained'].first['agent'].first['who']['identifier']['value']
-    assert_equal Patient.find_by(id: patient_id).creator.email, json_response['contained'].first['agent'].first['who']['display']
-    assert_equal patient.primary_telephone_type, fhir_ext_str(json_response['telecom'].first, 'phone-type')
-    assert_equal patient.secondary_telephone_type, fhir_ext_str(json_response['telecom'].second, 'phone-type')
-    assert_equal patient.monitoring_plan, fhir_ext_str(json_response, 'monitoring-plan')
-    assert_equal patient.assigned_user, fhir_ext_pos_int(json_response, 'assigned-user')
-    assert_equal patient.additional_planned_travel_start_date.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'additional-planned-travel-start-date')
-    assert_equal patient.port_of_origin, fhir_ext_str(json_response, 'port-of-origin')
-    assert_equal patient.date_of_departure.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'date-of-departure')
-    assert_equal patient.flight_or_vessel_number, fhir_ext_str(json_response, 'flight-or-vessel-number')
-    assert_equal patient.flight_or_vessel_carrier, fhir_ext_str(json_response, 'flight-or-vessel-carrier')
-    assert_equal patient.date_of_arrival.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'date-of-arrival')
-    assert_equal patient.exposure_notes, fhir_ext_str(json_response, 'exposure-notes')
-    assert_equal patient.travel_related_notes, fhir_ext_str(json_response, 'travel-related-notes')
-    assert_equal patient.additional_planned_travel_related_notes, fhir_ext_str(json_response, 'additional-planned-travel-notes')
-    assert_equal patient.user_defined_id_statelocal, json_response['identifier'].find { |i| i['system'].include? 'state-local-id' }['value']
-  end
-
-  test 'should get patient via show using _format parameter' do
-    get(
-      '/fhir/r4/Patient/1?' + { _format: 'application/fhir+json' }.to_param,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}" }
-    )
-    assert_response :ok
-  end
-
-  test 'should get observation via show' do
-    get(
-      '/fhir/r4/Observation/1001',
-      headers: { 'Authorization': "Bearer #{@system_observation_token_r.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 1001, json_response['id']
-    assert_equal 'Observation', json_response['resourceType']
-    assert_equal 'Patient/1', json_response['subject']['reference']
-    assert_equal 'positive', json_response['valueString']
-  end
-
-  test 'should get QuestionnaireResponse via show' do
-    get(
-      '/fhir/r4/QuestionnaireResponse/1001',
-      headers: { 'Authorization': "Bearer #{@system_response_token_r.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 1001, json_response['id']
-    assert_equal 'QuestionnaireResponse', json_response['resourceType']
-    assert_equal 'Patient/1', json_response['subject']['reference']
-    assert_not json_response['item'].find(text: 'fever').first['answer'].first['valueBoolean']
-    assert_not json_response['item'].find(text: 'cough').first['answer'].first['valueBoolean']
-    assert_not json_response['item'].find(text: 'difficulty-breathing').first['answer'].first['valueBoolean']
-  end
-
   test 'should be 404 via show when requesting unsupported resource' do
     get(
       '/fhir/r4/FooBar/1',
@@ -529,125 +423,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
     )
     assert_response :forbidden
-  end
-
-  test 'SYSTEM FLOW: patients within exact jurisdiction should be accessible' do
-    # Same jurisdiction
-    get(
-      '/fhir/r4/Patient/1',
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 1, json_response['id']
-  end
-
-  test 'SYSTEM FLOW: patients within subjurisdictions should be accessible' do
-    # Update jurisdiction to be subjurisdiction
-    Patient.find_by(id: 1).update!(jurisdiction_id: 4)
-    get(
-      '/fhir/r4/Patient/1',
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 1, json_response['id']
-  end
-
-  test 'SYSTEM FLOW: patients outside of jurisdiction should NOT be accessible' do
-    # Update jurisdiction to be out of scope
-    Patient.find_by(id: 1).update!(jurisdiction_id: 1)
-    get(
-      '/fhir/r4/Patient/1',
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :forbidden
-  end
-
-  test 'USER FLOW: analysts should not have any access to patients' do
-    @user = User.find_by(email: 'analyst_all@example.com')
-    @user.update!(api_enabled: true)
-    @user_patient_token_rw = Doorkeeper::AccessToken.create(
-      resource_owner_id: @user.id,
-      application: @user_patient_read_write_app,
-      scopes: 'user/Patient.*'
-    )
-    get(
-      '/fhir/r4/Patient/1',
-      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :forbidden
-  end
-
-  test 'USER FLOW: enrollers should only have access to enrolled patients' do
-    # Created patient should be okay
-    @user = User.find_by(email: 'state1_enroller@example.com')
-    @user.update!(api_enabled: true, jurisdiction_id: 2)
-    @user_patient_token_rw = Doorkeeper::AccessToken.create(
-      resource_owner_id: @user.id,
-      application: @user_patient_read_write_app,
-      scopes: 'user/Patient.*'
-    )
-    Patient.find_by(id: 1).update!(creator_id: @user[:id])
-
-    get(
-      '/fhir/r4/Patient/1',
-      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 1, json_response['id']
-
-    # Not created patient should be forbidden okay
-    get(
-      '/fhir/r4/Patient/2',
-      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :forbidden
-  end
-
-  test 'USER FLOW: epis should have access to all patients within jurisdiction' do
-    @user = User.find_by(email: 'state1_epi@example.com')
-    @user.update!(api_enabled: true, jurisdiction_id: 2)
-    @user_patient_token_rw = Doorkeeper::AccessToken.create(resource_owner_id: @user.id, application: @user_patient_read_write_app, scopes: 'user/Patient.*')
-
-    get(
-      '/fhir/r4/Patient/1',
-      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 1, json_response['id']
-
-    get(
-      '/fhir/r4/Patient/2',
-      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 2, json_response['id']
-  end
-
-  test 'USER FLOW: epi enrollers should have access to all patients within jurisdiction' do
-    @user = User.find_by(email: 'state1_epi_enroller@example.com')
-    @user.update!(api_enabled: true, jurisdiction_id: 2)
-    @user_patient_token_rw = Doorkeeper::AccessToken.create(resource_owner_id: @user.id, application: @user_patient_read_write_app, scopes: 'user/Patient.*')
-
-    get(
-      '/fhir/r4/Patient/1',
-      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 1, json_response['id']
-
-    get(
-      '/fhir/r4/Patient/2',
-      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 2, json_response['id']
   end
 
   test 'USER FLOW: should be 403 forbidden when user does not have api access enabled via show' do
@@ -669,98 +444,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
   test 'should be unauthorized via create' do
     post '/fhir/r4/Patient'
     assert_response :unauthorized
-  end
-
-  test 'SYSTEM FLOW: should create Patient via create' do
-    patient = Patient.find_by(id: 1)
-    post(
-      '/fhir/r4/Patient',
-      params: @patient_1.to_json,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :created
-    json_response = JSON.parse(response.body)
-    id = json_response['id']
-    p = Patient.find_by(id: id)
-    assert_not p.nil?
-    h = History.where(patient_id: id)
-    assert_not h.first.nil?
-    assert_equal 1, h.count
-    assert_equal 'Patient', json_response['resourceType']
-    assert_equal 3, json_response['telecom'].count
-    assert_equal 'Boehm62', json_response['name'].first['family']
-    assert response.headers['Location'].ends_with?(json_response['id'].to_s)
-    assert_equal 'USA, State 1',
-                 json_response['extension'].find { |e| e['url'] == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }['valueString']
-    assert_equal "/fhir/r4/Patient/#{id}", json_response['contained'].first['target'].first['reference']
-    assert_equal @system_patient_read_write_app.uid, json_response['contained'].first['agent'].first['who']['identifier']['value']
-    assert_equal @system_patient_read_write_app.name, json_response['contained'].first['agent'].first['who']['display']
-    assert_equal patient.primary_telephone_type, fhir_ext_str(json_response['telecom'].first, 'phone-type')
-    assert_equal patient.secondary_telephone_type, fhir_ext_str(json_response['telecom'].second, 'phone-type')
-    assert_equal patient.monitoring_plan, fhir_ext_str(json_response, 'monitoring-plan')
-    assert_equal patient.assigned_user, fhir_ext_pos_int(json_response, 'assigned-user')
-    assert_equal patient.additional_planned_travel_start_date.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'additional-planned-travel-start-date')
-    assert_equal patient.port_of_origin, fhir_ext_str(json_response, 'port-of-origin')
-    assert_equal patient.date_of_departure.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'date-of-departure')
-    assert_equal patient.flight_or_vessel_number, fhir_ext_str(json_response, 'flight-or-vessel-number')
-    assert_equal patient.flight_or_vessel_carrier, fhir_ext_str(json_response, 'flight-or-vessel-carrier')
-    assert_equal patient.date_of_arrival.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'date-of-arrival')
-    assert_equal patient.exposure_notes, fhir_ext_str(json_response, 'exposure-notes')
-    assert_equal patient.travel_related_notes, fhir_ext_str(json_response, 'travel-related-notes')
-    assert_equal patient.additional_planned_travel_related_notes, fhir_ext_str(json_response, 'additional-planned-travel-notes')
-    assert_equal patient.user_defined_id_statelocal, json_response['identifier'].find { |i| i['system'].include? 'state-local-id' }['value']
-  end
-
-  test 'USER FLOW: should create Patient via create' do
-    patient = Patient.find_by(id: 1)
-    post(
-      '/fhir/r4/Patient', params: @patient_1.to_json,
-                          headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :created
-    json_response = JSON.parse(response.body)
-    id = json_response['id']
-    p = Patient.find_by(id: id)
-    assert_not p.nil?
-    h = History.where(patient_id: id)
-    assert_not h.first.nil?
-    assert_equal 1, h.count
-    assert_equal 'state1_epi@example.com', h.first.created_by
-    assert_equal 'Patient', json_response['resourceType']
-    assert_equal 3, json_response['telecom'].count
-    assert_equal 'Boehm62', json_response['name'].first['family']
-    assert response.headers['Location'].ends_with?(json_response['id'].to_s)
-    assert_equal 'USA, State 1',
-                 json_response['extension'].find { |e| e['url'] == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }['valueString']
-    assert_equal "/fhir/r4/Patient/#{id}", json_response['contained'].first['target'].first['reference']
-    assert_equal Patient.find_by(id: id).creator_id, json_response['contained'].first['agent'].first['who']['identifier']['value']
-    assert_equal Patient.find_by(id: id).creator.email, json_response['contained'].first['agent'].first['who']['display']
-    assert_equal patient.primary_telephone_type, fhir_ext_str(json_response['telecom'].first, 'phone-type')
-    assert_equal patient.secondary_telephone_type, fhir_ext_str(json_response['telecom'].second, 'phone-type')
-    assert_equal patient.monitoring_plan, fhir_ext_str(json_response, 'monitoring-plan')
-    assert_equal patient.assigned_user, fhir_ext_pos_int(json_response, 'assigned-user')
-    assert_equal patient.additional_planned_travel_start_date.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'additional-planned-travel-start-date')
-    assert_equal patient.port_of_origin, fhir_ext_str(json_response, 'port-of-origin')
-    assert_equal patient.date_of_departure.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'date-of-departure')
-    assert_equal patient.flight_or_vessel_number, fhir_ext_str(json_response, 'flight-or-vessel-number')
-    assert_equal patient.flight_or_vessel_carrier, fhir_ext_str(json_response, 'flight-or-vessel-carrier')
-    assert_equal patient.date_of_arrival.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'date-of-arrival')
-    assert_equal patient.exposure_notes, fhir_ext_str(json_response, 'exposure-notes')
-    assert_equal patient.travel_related_notes, fhir_ext_str(json_response, 'travel-related-notes')
-    assert_equal patient.additional_planned_travel_related_notes, fhir_ext_str(json_response, 'additional-planned-travel-notes')
-  end
-
-  test 'should calculate Patient age via create' do
-    post(
-      '/fhir/r4/Patient',
-      params: @patient_1.to_json,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-
-    assert_response :created
-    json_response = JSON.parse(response.body)
-    patient = Patient.find(json_response['id'])
-    assert_equal 25, patient.age
   end
 
   test 'should be 415 when bad content type header via create' do
@@ -830,339 +513,11 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  test 'should be unprocessable entity via create with validation errors' do
-    post(
-      '/fhir/r4/Patient',
-      params: IO.read(file_fixture('fhir_invalid_patient.json')),
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :unprocessable_entity
-    json_response = JSON.parse(response.body)
-    errors = json_response['issue'].map { |i| i['diagnostics'] }
-
-    msg = 'Expected validation error on '
-    assert_equal 18, errors.length
-    assert(errors.any?(/Invalid.*Monitoring Plan/), msg + 'Monitoring Plan')
-    assert(errors.any?(/Old York.*State/), msg + 'State')
-    assert(errors.any?(/0000.*Ethnicity/), msg + 'Ethnicity')
-    assert(errors.any?(/High noon.*Preferred Contact Time/), msg + 'Preferred Contact Time')
-    assert(errors.any?(/On FHIR.*Sex/), msg + 'Sex')
-    assert(errors.any?(/Dumbphone.*Telephone Type/), msg + 'Phone Type')
-    assert(errors.any?(/123.*Primary Telephone/), msg + 'Primary Telephone')
-    assert(errors.any?(/Date of Birth/), msg + 'Date of Birth')
-    assert(errors.any?(/Last Date of Exposure/), msg + 'Last Date of Exposure')
-    assert(errors.any?(/1492.*Symptom Onset/), msg + 'Symptom Onset')
-    assert(errors.any?(/1776.*Additional Planned Travel Start Date/), msg + 'Additional Planned Travel Start Date')
-    assert(errors.any?(/2020-01-32.*Date of Departure/), msg + 'Date of Departure')
-    assert(errors.any?(/9999-99-99.*Date of Arrival/), msg + 'Date of Arrival')
-    assert(errors.any?(/Last Name/), msg + 'Last Name')
-    assert(errors.any?(/10000.*Assigned User/), msg + 'Assigned User')
-    assert(errors.any?(/Email.*Primary Contact Method/), msg + 'Email')
-  end
-
-  test 'should group Patients in households with matching phone numbers' do
-    post(
-      '/fhir/r4/Patient',
-      params: @patient_1.to_json,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :created
-    json_response = JSON.parse(response.body)
-    # Should be a dependent in the same household as patient with ID 1, who is now the HoH
-    assert_equal 1, Patient.find_by(id: json_response['id']).responder_id
-  end
-
-  test 'should group Patients in households with matching emails' do
-    Patient.find_by(id: 1).update!(preferred_contact_method: 'E-mailed Web Link')
-    @patient_1 = Patient.find_by(id: 1).as_fhir
-    post(
-      '/fhir/r4/Patient',
-      params: @patient_1.to_json,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :created
-    json_response = JSON.parse(response.body)
-    # Should be a dependent in the same household as patient with ID 1, who is now the HoH
-    assert_equal 1, Patient.find_by(id: json_response['id']).responder_id
-  end
-
-  test 'should make Patient a self reporter if no matching number or email' do
-    post(
-      '/fhir/r4/Patient',
-      params: @patient_2.to_json,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :created
-    json_response = JSON.parse(response.body)
-    # Should be their own reporter since they have a unique phone number and email
-    assert_equal json_response['id'], Patient.find_by(id: json_response['id']).responder_id
-  end
-
   #----- update tests -----
 
   test 'should be unauthorized via update' do
     get '/fhir/r4/Patient/1'
     assert_response :unauthorized
-  end
-
-  test 'should update Patient via update' do
-    patient_id = 1
-    patient = Patient.find_by(id: 2)
-    resource_path = "/fhir/r4/Patient/#{patient_id}"
-    put(
-      resource_path,
-      params: @patient_2.to_json,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 1, json_response['id']
-    p = Patient.find_by(id: 1)
-    assert_not p.nil?
-    assert p.black_or_african_american
-    assert p.asian
-    assert_equal 'Patient', json_response['resourceType']
-    assert_equal 'Kirlin44', json_response['name'].first['family']
-    assert_equal 'SMS Texted Weblink', json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-method' }.first['valueString']
-    assert_equal 'Afternoon', json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-time' }.first['valueString']
-    assert json_response['extension'].filter { |e| e['url'].include? 'continuous-exposure' }.first['valueBoolean']
-    assert_equal 3.days.ago.strftime('%Y-%m-%d'), json_response['extension'].filter { |e| e['url'].include? 'symptom-onset-date' }.first['valueDate']
-    assert p.user_defined_symptom_onset
-    assert json_response['extension'].filter { |e| e['url'].include? 'isolation' }.first['valueBoolean']
-    assert_equal 'USA, State 1, County 1',
-                 json_response['extension'].find { |e| e['url'] == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }['valueString']
-    assert_equal resource_path, json_response['contained'].first['target'].first['reference']
-    assert_equal Patient.find_by(id: patient_id).creator_id, json_response['contained'].first['agent'].first['who']['identifier']['value']
-    assert_equal Patient.find_by(id: patient_id).creator.email, json_response['contained'].first['agent'].first['who']['display']
-    assert_equal patient.primary_telephone_type, fhir_ext_str(json_response['telecom'].first, 'phone-type')
-    assert_equal patient.secondary_telephone_type, fhir_ext_str(json_response['telecom'].second, 'phone-type')
-    assert_equal patient.monitoring_plan, fhir_ext_str(json_response, 'monitoring-plan')
-    assert_equal patient.assigned_user, fhir_ext_pos_int(json_response, 'assigned-user')
-    assert_equal patient.additional_planned_travel_start_date.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'additional-planned-travel-start-date')
-    assert_equal patient.port_of_origin, fhir_ext_str(json_response, 'port-of-origin')
-    assert_equal patient.date_of_departure.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'date-of-departure')
-    assert_equal patient.flight_or_vessel_number, fhir_ext_str(json_response, 'flight-or-vessel-number')
-    assert_equal patient.flight_or_vessel_carrier, fhir_ext_str(json_response, 'flight-or-vessel-carrier')
-    assert_equal patient.date_of_arrival.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'date-of-arrival')
-    assert_equal patient.exposure_notes, fhir_ext_str(json_response, 'exposure-notes')
-    assert_equal patient.travel_related_notes, fhir_ext_str(json_response, 'travel-related-notes')
-    assert_equal patient.additional_planned_travel_related_notes, fhir_ext_str(json_response, 'additional-planned-travel-notes')
-    assert_equal patient.user_defined_id_statelocal, json_response['identifier'].find { |i| i['system'].include? 'state-local-id' }['value']
-  end
-
-  test 'should create "Record Edit" and not "Monitoring Change" History item when updating patient with record edit' do
-    patient = @patient_2
-    patient.identifier = [FHIR::Identifier.new(system: 'http://saraalert.org/SaraAlert/state-local-id', value: '123')]
-    resource_path = "/fhir/r4/Patient/#{patient.id}"
-    histories = History.where(patient: patient.id)
-    record_edit_count = histories.where(history_type: 'Record Edit')&.count || 0
-    monitoring_change_count = histories.where(history_type: 'Monitoring Change')&.count || 0
-    put(
-      resource_path,
-      params: patient.to_json,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :ok
-    histories = History.where(patient: patient.id)
-    assert_equal(record_edit_count + 1, histories.where(history_type: 'Record Edit').count)
-    assert_equal(monitoring_change_count, histories.where(history_type: 'Monitoring Change').count)
-    assert_match(/Changes were.*User defined id statelocal \("EX-904188" to "123"\)/, histories.find_by(history_type: 'Record Edit').comment)
-  end
-
-  test 'should create "Monitoring Change" History item when updating patient with monitoring change' do
-    patient = @patient_2
-    resource_path = "/fhir/r4/Patient/#{patient.id}"
-    histories = History.where(patient: patient.id)
-    monitoring_change_count = histories.where(history_type: 'Monitoring Change').count
-    patch = [
-      { 'op': 'replace', 'path': '/active', 'value': 'false' }
-    ]
-    patch(
-      resource_path,
-      params: patch.to_json,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/json-patch+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal false, json_response['active']
-    histories = History.where(patient: patient.id)
-    assert_equal(monitoring_change_count + 2, histories.where(history_type: 'Monitoring Change').count)
-    assert_match(/Continuous Exposure/, histories.find_by(created_by: 'Sara Alert System').comment)
-    assert_match(/"Monitoring" to "Not Monitoring"/, histories.find_by(history_type: 'Monitoring Change').comment)
-  end
-
-  test 'should update Patient via update and set omitted fields to nil ' do
-    # Possible update request that omits all fields that can be updated except for the "active" field.
-    patient_update = {
-      'id' => @patient_2.id,
-      'birthDate' => @patient_2.birthDate,
-      'name' => @patient_2.name,
-      'address' => @patient_2.address,
-      'extension' => @patient_1.extension.find { |e| e.url.include? 'last-date-of-exposure' },
-      'active' => false,
-      'resourceType' => 'Patient'
-    }
-
-    put(
-      '/fhir/r4/Patient/1',
-      params: patient_update.to_json,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 1, json_response['id']
-    p = Patient.find_by(id: 1)
-
-    assert_not p.nil?
-    assert_equal 'Patient', json_response['resourceType']
-    assert_equal([], json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-method' })
-    assert_equal([], json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-time' })
-    assert_equal([], json_response['extension'].filter { |e| e['url'].include? 'symptom-onset-date' })
-    assert_equal false, json_response['active']
-  end
-
-  test 'should properly close Patient record via update' do
-    # Possible update request that omits many fields but sets active to false
-    patient_update = {
-      'id' => @patient_2.id,
-      'birthDate' => @patient_2.birthDate,
-      'name' => @patient_2.name,
-      'address' => @patient_2.address,
-      'extension' => @patient_1.extension.find { |e| e.url.include? 'last-date-of-exposure' },
-      'active' => false,
-      'resourceType' => 'Patient',
-      'telecom' => [
-        {
-          "system": 'email',
-          "value": '2966977816fake@example.com',
-          "rank": 1
-        }
-      ]
-    }
-
-    put(
-      '/fhir/r4/Patient/1',
-      params: patient_update.to_json,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 1, json_response['id']
-    p = Patient.find_by(id: 1)
-
-    assert_not p.nil?
-
-    # Record should be closed
-    assert_not json_response['active']
-    assert_not p.monitoring
-
-    # Closed at date should have been set to today
-    assert_equal DateTime.now.to_date, p.closed_at&.to_date
-  end
-
-  test 'should differentiate USA and Foreign addresses in update' do
-    @patient_1.address << FHIR::Address.new(line: ['123 First Ave', 'Unit 22', 'Sector B'], city: 'Northland', state: 'Quebec', postalCode: '77658-0950',
-                                            country: 'Canada')
-    @patient_1.address[1].extension << FHIR::Extension.new(url: 'http://saraalert.org/StructureDefinition/address-type', valueString: 'Foreign')
-
-    put(
-      '/fhir/r4/Patient/1',
-      params: @patient_1.to_json,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-
-    assert_response :ok
-    patient = Patient.find_by(id: 1)
-    json_response = JSON.parse(response.body)
-    # Test that the address was saved as expected
-    assert_equal @patient_1.address[0].line[0], patient.address_line_1
-    assert_equal @patient_1.address[0].city, patient.address_city
-    assert_equal @patient_1.address[0].state, patient.address_state
-    assert_equal @patient_1.address[0].postalCode, patient.address_zip
-    assert_equal @patient_1.address[0].district, patient.address_county
-    # Test that the foreign address was saved as expected
-    assert_equal @patient_1.address[1].line[0], patient.foreign_address_line_1
-    assert_equal @patient_1.address[1].line[1], patient.foreign_address_line_2
-    assert_equal @patient_1.address[1].line[2], patient.foreign_address_line_3
-    assert_equal @patient_1.address[1].city, patient.foreign_address_city
-    assert_equal @patient_1.address[1].state, patient.foreign_address_state
-    assert_equal @patient_1.address[1].postalCode, patient.foreign_address_zip
-    assert_equal @patient_1.address[1].country, patient.foreign_address_country
-
-    # Test that the response is as expected
-    assert_equal JSON.parse(@patient_1.address.to_json), json_response['address']
-  end
-
-  test 'should update address fields from an explicit USA address' do
-    @patient_1.address = [FHIR::Address.new(line: ['123 First Ave', 'Unit 22'], city: 'Southland', state: 'Vermont', postalCode: '77658-0950',
-                                            district: 'Middletown')]
-    @patient_1.address[0].extension << FHIR::Extension.new(url: 'http://saraalert.org/StructureDefinition/address-type', valueString: 'USA')
-
-    put(
-      '/fhir/r4/Patient/1',
-      params: @patient_1.to_json,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-
-    assert_response :ok
-    patient = Patient.find_by(id: 1)
-    json_response = JSON.parse(response.body)
-    # Test that the address was saved as expected
-    assert_equal @patient_1.address[0].line[0], patient.address_line_1
-    assert_equal @patient_1.address[0].city, patient.address_city
-    assert_equal @patient_1.address[0].state, patient.address_state
-    assert_equal @patient_1.address[0].postalCode, patient.address_zip
-    assert_equal @patient_1.address[0].district, patient.address_county
-
-    # Test that the foreign address was not saved
-    assert_nil patient.foreign_address_line_1
-    assert_nil patient.foreign_address_line_2
-    assert_nil patient.foreign_address_line_3
-    assert_nil patient.foreign_address_city
-    assert_nil patient.foreign_address_state
-    assert_nil patient.foreign_address_zip
-    assert_nil patient.foreign_address_country
-
-    # Test that the response is as expected
-    assert_equal @patient_1.address[0].line, json_response['address'][0]['line']
-    assert_equal @patient_1.address[0].city, json_response['address'][0]['city']
-    assert_equal @patient_1.address[0].state, json_response['address'][0]['state']
-    assert_equal @patient_1.address[0].postalCode, json_response['address'][0]['postalCode']
-  end
-
-  test 'should ignore unknown address types in update' do
-    @patient_1.address << FHIR::Address.new(line: ['123 First Ave', 'Unit 22', 'Sector B'], city: 'Northland', state: 'Quebec', postalCode: '77658-0950',
-                                            country: 'Canada')
-    @patient_1.address[1].extension << FHIR::Extension.new(url: 'http://saraalert.org/StructureDefinition/address-type', valueString: 'mysterious')
-
-    put(
-      '/fhir/r4/Patient/1',
-      params: @patient_1.to_json,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-
-    assert_response :ok
-    patient = Patient.find_by(id: 1)
-    json_response = JSON.parse(response.body)
-    # Test that the foreign address was not saved
-    assert_nil patient.foreign_address_line_1
-    assert_nil patient.foreign_address_line_2
-    assert_nil patient.foreign_address_line_3
-    assert_nil patient.foreign_address_city
-    assert_nil patient.foreign_address_state
-    assert_nil patient.foreign_address_zip
-    assert_nil patient.foreign_address_country
-
-    # Test that the address was saved as expected
-    assert_equal @patient_1.address[0].line[0], patient.address_line_1
-    assert_equal @patient_1.address[0].city, patient.address_city
-    assert_equal @patient_1.address[0].state, patient.address_state
-    assert_equal @patient_1.address[0].postalCode, patient.address_zip
-    assert_equal @patient_1.address[0].district, patient.address_county
-
-    # Test that the response is as expected
-    assert_equal JSON.parse(@patient_1.address[0].to_json), json_response['address'][0]
-    assert_nil json_response['address'][1]
   end
 
   test 'should be bad request via update due to invalid JSON' do
@@ -1223,36 +578,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  test 'should be unprocessable entity via update with validation errors' do
-    put(
-      '/fhir/r4/Patient/1',
-      params: IO.read(file_fixture('fhir_invalid_patient.json')),
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :unprocessable_entity
-    json_response = JSON.parse(response.body)
-    errors = json_response['issue'].map { |i| i['diagnostics'] }
-
-    msg = 'Expected validation error on '
-    assert_equal 18, errors.length
-    assert(errors.any?(/Invalid.*Monitoring Plan/), msg + 'Monitoring Plan')
-    assert(errors.any?(/Old York.*State/), msg + 'State')
-    assert(errors.any?(/0000.*Ethnicity/), msg + 'Ethnicity')
-    assert(errors.any?(/High noon.*Preferred Contact Time/), msg + 'Preferred Contact Time')
-    assert(errors.any?(/On FHIR.*Sex/), msg + 'Sex')
-    assert(errors.any?(/Dumbphone.*Telephone Type/), msg + 'Phone Type')
-    assert(errors.any?(/123.*Primary Telephone/), msg + 'Primary Telephone')
-    assert(errors.any?(/Date of Birth/), msg + 'Date of Birth')
-    assert(errors.any?(/Last Date of Exposure/), msg + 'Last Date of Exposure')
-    assert(errors.any?(/1492.*Symptom Onset/), msg + 'Symptom Onset')
-    assert(errors.any?(/1776.*Additional Planned Travel Start Date/), msg + 'Additional Planned Travel Start Date')
-    assert(errors.any?(/2020-01-32.*Date of Departure/), msg + 'Date of Departure')
-    assert(errors.any?(/9999-99-99.*Date of Arrival/), msg + 'Date of Arrival')
-    assert(errors.any?(/Last Name/), msg + 'Last Name')
-    assert(errors.any?(/10000.*Assigned User/), msg + 'Assigned User')
-    assert(errors.any?(/Email.*Primary Contact Method/), msg + 'Email')
-  end
-
   test 'should be forbidden via update' do
     put(
       '/fhir/r4/Patient/9',
@@ -1260,83 +585,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
     )
     assert_response :forbidden
-  end
-
-  test 'SYSTEM FLOW: should allow jurisdiction transfers when jurisdiction exists' do
-    @patient_1.extension.find { |e| e.url == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }.valueString = 'USA, State 2'
-    put(
-      '/fhir/r4/Patient/1',
-      params: @patient_1.to_json,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :success
-    json_response = JSON.parse(response.body)
-    assert_equal 'USA, State 2', json_response['extension'].filter { |e| e['url'].include? 'full-assigned-jurisdiction-path' }.first['valueString']
-    t = Transfer.find_by(patient_id: @patient_1.id)
-    assert_equal Jurisdiction.find_by(path: 'USA, State 1').id, t.from_jurisdiction_id
-    assert_equal Jurisdiction.find_by(path: 'USA, State 2').id, t.to_jurisdiction_id
-    assert_equal @system_patient_read_write_app.user_id, t.who_id
-  end
-
-  test 'USER FLOW: should allow jurisdiction transfers when jurisdiction exists' do
-    @patient_1.extension.find { |e| e.url == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }.valueString = 'USA, State 2'
-    put(
-      '/fhir/r4/Patient/1',
-      params: @patient_1.to_json,
-      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :success
-    json_response = JSON.parse(response.body)
-    assert_equal 'USA, State 2', json_response['extension'].filter { |e| e['url'].include? 'full-assigned-jurisdiction-path' }.first['valueString']
-    t = Transfer.find_by(patient_id: @patient_1.id)
-    assert_equal Jurisdiction.find_by(path: 'USA, State 1').id, t.from_jurisdiction_id
-    assert_equal Jurisdiction.find_by(path: 'USA, State 2').id, t.to_jurisdiction_id
-    assert_equal @user.id, t.who_id
-  end
-
-  test 'SYSTEM FLOW: should be unprocessable entity via update with invalid jurisdiction path' do
-    @patient_1.extension.find { |e| e.url == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }.valueString = 'USA'
-    put(
-      '/fhir/r4/Patient/1',
-      params: @patient_1.to_json,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :unprocessable_entity
-    json_response = JSON.parse(response.body)
-    assert_equal 1, json_response['issue'].length
-    assert(json_response['issue'][0]['diagnostics'].include?('Jurisdiction does not exist'))
-  end
-
-  test 'USER FLOW: should be unprocessable entity via update with invalid jurisdiction path' do
-    @patient_1.extension.find { |e| e.url == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }.valueString = 'USA'
-    put(
-      '/fhir/r4/Patient/1',
-      params: @patient_1.to_json,
-      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :unprocessable_entity
-    json_response = JSON.parse(response.body)
-    assert_equal 1, json_response['issue'].length
-    assert(json_response['issue'][0]['diagnostics'].include?('Jurisdiction does not exist'))
-  end
-
-  test 'should update Patient via patch update' do
-    patch = [
-      { 'op': 'remove', 'path': '/communication/0/language' },
-      { 'op': 'add', 'path': '/address/0/line/-', 'value': 'Unit 123' },
-      { 'op': 'replace', 'path': '/name/0/family', 'value': 'Foo' }
-    ]
-    patch(
-      '/fhir/r4/Patient/1',
-      params: patch.to_json,
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/json-patch+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 1, json_response['id']
-    assert_nil json_response['communication']
-    assert_equal 'Unit 123', json_response['address'][0]['line'][1]
-    assert_equal 'Foo', json_response['name'][0]['family']
   end
 
   test 'should be bad request when patch update is invalid' do
@@ -1375,175 +623,12 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
-  test 'should find Observations for a Patient via search' do
-    get(
-      '/fhir/r4/Observation?subject=Patient/1',
-      headers: { 'Authorization': "Bearer #{@system_observation_token_r.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 'Bundle', json_response['resourceType']
-    assert_equal 'Observation', json_response['entry'].first['resource']['resourceType']
-  end
-
-  test 'should find QuestionnaireResponses for a Patient via search' do
-    get(
-      '/fhir/r4/QuestionnaireResponse?subject=Patient/1',
-      headers: { 'Authorization': "Bearer #{@system_response_token_r.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 'Bundle', json_response['resourceType']
-    assert_equal 'QuestionnaireResponse', json_response['entry'].first['resource']['resourceType']
-  end
-
-  test 'should find no Observations for an invalid Patient via search' do
-    get(
-      '/fhir/r4/Observation?subject=Patient/blah',
-      headers: { 'Authorization': "Bearer #{@system_observation_token_r.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 'Bundle', json_response['resourceType']
-    assert_equal 0, json_response['total']
-  end
-
-  test 'should find no QuestionnaireResponses for an invalid Patient via search' do
-    get(
-      '/fhir/r4/QuestionnaireResponse?subject=Patient/blah',
-      headers: { 'Authorization': "Bearer #{@system_response_token_r.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 'Bundle', json_response['resourceType']
-    assert_equal 0, json_response['total']
-  end
-
-  test 'should find Patient via search by _id' do
-    get(
-      '/fhir/r4/Patient?_id=1',
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 'Bundle', json_response['resourceType']
-    assert_equal 1, json_response['total']
-    assert_equal 1, json_response['entry'].first['resource']['id']
-  end
-
-  test 'should find Patient via search on existing family' do
-    get(
-      '/fhir/r4/Patient?family=Kirlin44',
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 'Bundle', json_response['resourceType']
-    assert_equal 1, json_response['total']
-    assert_equal 2, json_response['entry'].first['resource']['id']
-  end
-
-  test 'should find no Patients via search on non-existing family' do
-    get(
-      '/fhir/r4/Patient?family=foo',
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 'Bundle', json_response['resourceType']
-    assert_equal 0, json_response['total']
-  end
-
-  test 'should find Patient via search on given' do
-    get(
-      '/fhir/r4/Patient?given=Chris32',
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 'Bundle', json_response['resourceType']
-    assert_equal 1, json_response['total']
-    assert_equal 2, json_response['entry'].first['resource']['id']
-  end
-
-  test 'should find Patient via search on telecom' do
-    get(
-      '/fhir/r4/Patient?telecom=5555550111',
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 'Bundle', json_response['resourceType']
-    assert_equal 1, json_response['total']
-    assert_equal 1, json_response['entry'].first['resource']['id']
-  end
-
-  test 'should find Patient via search on email' do
-    get(
-      '/fhir/r4/Patient?email=grazyna%40example.com',
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 'Bundle', json_response['resourceType']
-    assert_equal 1, json_response['total']
-    assert_equal 2, json_response['entry'].first['resource']['id']
-  end
-
-  test 'should get Bundle via search without params' do
-    get(
-      '/fhir/r4/Patient',
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 'Bundle', json_response['resourceType']
-    json_response['entry'].each do |entry|
-      assert(entry['fullUrl'].include?('Patient') ||
-              entry['fullUrl'].include?('Observation') ||
-              entry['fullUrl'].include?('QuestionnaireResponse'))
-    end
-  end
-
   test 'should be 404 via search when requesting unsupported resource' do
     get(
       '/fhir/r4/FooBar?email=grazyna%40example.com',
       headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
     )
     assert_response :not_found
-  end
-
-  test 'should get patients with default count via search' do
-    get(
-      '/fhir/r4/Patient',
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 'Bundle', json_response['resourceType']
-    assert_equal 'http://www.example.com/fhir/r4/Patient?page=2', json_response['link'][0]['url']
-  end
-
-  test 'should get patients with count as 100 via search' do
-    get(
-      '/fhir/r4/Patient?_count=100',
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 'Bundle', json_response['resourceType']
-    assert_nil json_response['link']
-  end
-
-  test 'should only get summary with count as 0 via search' do
-    get(
-      '/fhir/r4/Patient?_count=0',
-      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
-    )
-    assert_response :ok
-    json_response = JSON.parse(response.body)
-    assert_equal 'Bundle', json_response['resourceType']
-    assert_nil json_response['link']
   end
 
   #----- all tests -----
@@ -1634,4 +719,3 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     ext && ext['valuePositiveInt']
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -684,6 +684,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get Bundle via all' do
+    patient = Patient.find_by_id(1)
     get(
       '/fhir/r4/Patient/1/$everything',
       headers: { 'Authorization': "Bearer #{@system_everything_token.token}", 'Accept': 'application/fhir+json' }
@@ -691,10 +692,11 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     json_response = JSON.parse(response.body)
     assert_equal 'Bundle', json_response['resourceType']
-    assert_equal 5, json_response['total']
+    assert_equal patient.assessments.length + patient.laboratories.length + patient.close_contacts.length + 1, json_response['total']
     assert_equal 1, json_response['entry'].filter { |e| e['resource']['resourceType'] == 'Patient' }.count
-    assert_equal 2, json_response['entry'].filter { |e| e['resource']['resourceType'] == 'QuestionnaireResponse' }.count
-    assert_equal 2, json_response['entry'].filter { |e| e['resource']['resourceType'] == 'Observation' }.count
+    assert_equal patient.assessments.length, json_response['entry'].filter { |e| e['resource']['resourceType'] == 'QuestionnaireResponse' }.count
+    assert_equal patient.laboratories.length, json_response['entry'].filter { |e| e['resource']['resourceType'] == 'Observation' }.count
+    assert_equal patient.close_contacts.length, json_response['entry'].filter { |e| e['resource']['resourceType'] == 'RelatedPerson' }.count
     assert_equal 'Patient/1', json_response['entry'].filter { |e| e['resource']['resourceType'] == 'Observation' }.first['resource']['subject']['reference']
     assert_equal 1, json_response['entry'].first['resource']['id']
   end

--- a/test/controllers/fhir/r4/observation_test.rb
+++ b/test/controllers/fhir/r4/observation_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rspec/mocks/minitest_integration'
+require 'controllers/fhir/r4/api_controller_test'
+
+class ApiControllerTest < ActionDispatch::IntegrationTest
+  #----- show tests -----
+
+  test 'should get Observation via show' do
+    get(
+      '/fhir/r4/Observation/1001',
+      headers: { 'Authorization': "Bearer #{@system_observation_token_r.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 1001, json_response['id']
+    assert_equal 'Observation', json_response['resourceType']
+    assert_equal 'Patient/1', json_response['subject']['reference']
+    assert_equal 'positive', json_response['valueString']
+  end
+
+  #----- search tests -----
+
+  test 'should find Observations for a Patient via search' do
+    get(
+      '/fhir/r4/Observation?subject=Patient/1',
+      headers: { 'Authorization': "Bearer #{@system_observation_token_r.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 'Bundle', json_response['resourceType']
+    assert_equal 'Observation', json_response['entry'].first['resource']['resourceType']
+  end
+
+  test 'should find no Observations for an invalid Patient via search' do
+    get(
+      '/fhir/r4/Observation?subject=Patient/blah',
+      headers: { 'Authorization': "Bearer #{@system_observation_token_r.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 'Bundle', json_response['resourceType']
+    assert_equal 0, json_response['total']
+  end
+end

--- a/test/controllers/fhir/r4/patient_test.rb
+++ b/test/controllers/fhir/r4/patient_test.rb
@@ -4,56 +4,7 @@ require 'test_helper'
 require 'rspec/mocks/minitest_integration'
 require 'controllers/fhir/r4/api_controller_test'
 
-# rubocop:disable Metrics/ClassLength
 class ApiControllerTest < ActionDispatch::IntegrationTest
-  setup do
-    setup_patients
-  end
-
-  # Sets up FHIR patients used for testing
-  def setup_patients
-    Patient.find_by(id: 1).update!(
-      assigned_user: '1234',
-      exposure_notes: 'exposure notes',
-      travel_related_notes: 'travel notes',
-      additional_planned_travel_related_notes: 'additional travel notes'
-    )
-    @patient_1 = Patient.find_by(id: 1).as_fhir
-
-    # Update Patient 2 before created FHIR resource from it
-    Patient.find_by(id: 2).update!(
-      preferred_contact_method: 'SMS Texted Weblink',
-      preferred_contact_time: 'Afternoon',
-      symptom_onset: 3.days.ago,
-      isolation: true,
-      primary_telephone: '+15555559999',
-      jurisdiction_id: 4,
-      monitoring_plan: 'Daily active monitoring',
-      assigned_user: '2345',
-      additional_planned_travel_start_date: 5.days.from_now,
-      port_of_origin: 'Tortuga',
-      date_of_departure: 2.days.ago,
-      flight_or_vessel_number: 'XYZ123',
-      flight_or_vessel_carrier: 'FunAirlines',
-      date_of_arrival: 2.days.from_now,
-      exposure_notes: 'exposure notes',
-      travel_related_notes: 'travel related notes',
-      additional_planned_travel_related_notes: 'additional travel related notes',
-      primary_telephone_type: 'Plain Cell',
-      secondary_telephone_type: 'Landline',
-      black_or_african_american: true,
-      asian: true,
-      continuous_exposure: true,
-      last_date_of_exposure: nil
-    )
-    @patient_2 = Patient.find_by(id: 2).as_fhir
-
-    # Update Patient 2 number to guarantee unique phone number
-    Patient.find_by(id: 2).update!(
-      primary_telephone: '+15555559998'
-    )
-  end
-
   #----- show tests -----
 
   test 'should get patient via show' do
@@ -871,4 +822,3 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_nil json_response['link']
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/test/controllers/fhir/r4/patient_test.rb
+++ b/test/controllers/fhir/r4/patient_test.rb
@@ -1,0 +1,874 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rspec/mocks/minitest_integration'
+require 'controllers/fhir/r4/api_controller_test'
+
+# rubocop:disable Metrics/ClassLength
+class ApiControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    setup_patients
+  end
+
+  # Sets up FHIR patients used for testing
+  def setup_patients
+    Patient.find_by(id: 1).update!(
+      assigned_user: '1234',
+      exposure_notes: 'exposure notes',
+      travel_related_notes: 'travel notes',
+      additional_planned_travel_related_notes: 'additional travel notes'
+    )
+    @patient_1 = Patient.find_by(id: 1).as_fhir
+
+    # Update Patient 2 before created FHIR resource from it
+    Patient.find_by(id: 2).update!(
+      preferred_contact_method: 'SMS Texted Weblink',
+      preferred_contact_time: 'Afternoon',
+      symptom_onset: 3.days.ago,
+      isolation: true,
+      primary_telephone: '+15555559999',
+      jurisdiction_id: 4,
+      monitoring_plan: 'Daily active monitoring',
+      assigned_user: '2345',
+      additional_planned_travel_start_date: 5.days.from_now,
+      port_of_origin: 'Tortuga',
+      date_of_departure: 2.days.ago,
+      flight_or_vessel_number: 'XYZ123',
+      flight_or_vessel_carrier: 'FunAirlines',
+      date_of_arrival: 2.days.from_now,
+      exposure_notes: 'exposure notes',
+      travel_related_notes: 'travel related notes',
+      additional_planned_travel_related_notes: 'additional travel related notes',
+      primary_telephone_type: 'Plain Cell',
+      secondary_telephone_type: 'Landline',
+      black_or_african_american: true,
+      asian: true,
+      continuous_exposure: true,
+      last_date_of_exposure: nil
+    )
+    @patient_2 = Patient.find_by(id: 2).as_fhir
+
+    # Update Patient 2 number to guarantee unique phone number
+    Patient.find_by(id: 2).update!(
+      primary_telephone: '+15555559998'
+    )
+  end
+
+  #----- show tests -----
+
+  test 'should get patient via show' do
+    patient_id = 1
+    patient = Patient.find_by(id: patient_id)
+    resource_path = "/fhir/r4/Patient/#{patient_id}"
+    get(
+      resource_path,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 1, json_response['id']
+    assert_equal 'Patient', json_response['resourceType']
+    assert_equal 3, json_response['telecom'].count
+    assert_equal 'Boehm62', json_response['name'].first['family']
+    assert_equal 'Telephone call', json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-method' }.first['valueString']
+    assert_equal 'Morning', json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-time' }.first['valueString']
+    assert_equal 45.days.ago.strftime('%Y-%m-%d'), json_response['extension'].filter { |e| e['url'].include? 'last-date-of-exposure' }.first['valueDate']
+    assert_equal 5.days.ago.strftime('%Y-%m-%d'), json_response['extension'].filter { |e| e['url'].include? 'symptom-onset-date' }.first['valueDate']
+    assert_not json_response['extension'].filter { |e| e['url'].include? 'isolation' }.first['valueBoolean']
+    assert_equal resource_path, json_response['contained'].first['target'].first['reference']
+    assert_equal Patient.find_by(id: patient_id).creator_id, json_response['contained'].first['agent'].first['who']['identifier']['value']
+    assert_equal Patient.find_by(id: patient_id).creator.email, json_response['contained'].first['agent'].first['who']['display']
+    assert_equal patient.primary_telephone_type, fhir_ext_str(json_response['telecom'].first, 'phone-type')
+    assert_equal patient.secondary_telephone_type, fhir_ext_str(json_response['telecom'].second, 'phone-type')
+    assert_equal patient.monitoring_plan, fhir_ext_str(json_response, 'monitoring-plan')
+    assert_equal patient.assigned_user, fhir_ext_pos_int(json_response, 'assigned-user')
+    assert_equal patient.additional_planned_travel_start_date.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'additional-planned-travel-start-date')
+    assert_equal patient.port_of_origin, fhir_ext_str(json_response, 'port-of-origin')
+    assert_equal patient.date_of_departure.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'date-of-departure')
+    assert_equal patient.flight_or_vessel_number, fhir_ext_str(json_response, 'flight-or-vessel-number')
+    assert_equal patient.flight_or_vessel_carrier, fhir_ext_str(json_response, 'flight-or-vessel-carrier')
+    assert_equal patient.date_of_arrival.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'date-of-arrival')
+    assert_equal patient.exposure_notes, fhir_ext_str(json_response, 'exposure-notes')
+    assert_equal patient.travel_related_notes, fhir_ext_str(json_response, 'travel-related-notes')
+    assert_equal patient.additional_planned_travel_related_notes, fhir_ext_str(json_response, 'additional-planned-travel-notes')
+    assert_equal patient.user_defined_id_statelocal, json_response['identifier'].find { |i| i['system'].include? 'state-local-id' }['value']
+  end
+
+  test 'should get patient via show using _format parameter' do
+    get(
+      '/fhir/r4/Patient/1?' + { _format: 'application/fhir+json' }.to_param,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}" }
+    )
+    assert_response :ok
+  end
+
+  test 'SYSTEM FLOW: patients within exact jurisdiction should be accessible' do
+    # Same jurisdiction
+    get(
+      '/fhir/r4/Patient/1',
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 1, json_response['id']
+  end
+
+  test 'SYSTEM FLOW: patients within subjurisdictions should be accessible' do
+    # Update jurisdiction to be subjurisdiction
+    Patient.find_by(id: 1).update!(jurisdiction_id: 4)
+    get(
+      '/fhir/r4/Patient/1',
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 1, json_response['id']
+  end
+
+  test 'SYSTEM FLOW: patients outside of jurisdiction should NOT be accessible' do
+    # Update jurisdiction to be out of scope
+    Patient.find_by(id: 1).update!(jurisdiction_id: 1)
+    get(
+      '/fhir/r4/Patient/1',
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :forbidden
+  end
+
+  test 'USER FLOW: analysts should not have any access to patients' do
+    @user = User.find_by(email: 'analyst_all@example.com')
+    @user.update!(api_enabled: true)
+    @user_patient_token_rw = Doorkeeper::AccessToken.create(
+      resource_owner_id: @user.id,
+      application: @user_patient_read_write_app,
+      scopes: 'user/Patient.*'
+    )
+    get(
+      '/fhir/r4/Patient/1',
+      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :forbidden
+  end
+
+  test 'USER FLOW: enrollers should only have access to enrolled patients' do
+    # Created patient should be okay
+    @user = User.find_by(email: 'state1_enroller@example.com')
+    @user.update!(api_enabled: true, jurisdiction_id: 2)
+    @user_patient_token_rw = Doorkeeper::AccessToken.create(
+      resource_owner_id: @user.id,
+      application: @user_patient_read_write_app,
+      scopes: 'user/Patient.*'
+    )
+    Patient.find_by(id: 1).update!(creator_id: @user[:id])
+
+    get(
+      '/fhir/r4/Patient/1',
+      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 1, json_response['id']
+
+    # Not created patient should be forbidden okay
+    get(
+      '/fhir/r4/Patient/2',
+      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :forbidden
+  end
+
+  test 'USER FLOW: epis should have access to all patients within jurisdiction' do
+    @user = User.find_by(email: 'state1_epi@example.com')
+    @user.update!(api_enabled: true, jurisdiction_id: 2)
+    @user_patient_token_rw = Doorkeeper::AccessToken.create(resource_owner_id: @user.id, application: @user_patient_read_write_app, scopes: 'user/Patient.*')
+
+    get(
+      '/fhir/r4/Patient/1',
+      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 1, json_response['id']
+
+    get(
+      '/fhir/r4/Patient/2',
+      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 2, json_response['id']
+  end
+
+  test 'USER FLOW: epi enrollers should have access to all patients within jurisdiction' do
+    @user = User.find_by(email: 'state1_epi_enroller@example.com')
+    @user.update!(api_enabled: true, jurisdiction_id: 2)
+    @user_patient_token_rw = Doorkeeper::AccessToken.create(resource_owner_id: @user.id, application: @user_patient_read_write_app, scopes: 'user/Patient.*')
+
+    get(
+      '/fhir/r4/Patient/1',
+      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 1, json_response['id']
+
+    get(
+      '/fhir/r4/Patient/2',
+      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 2, json_response['id']
+  end
+
+  #----- create tests -----
+  test 'SYSTEM FLOW: should create Patient via create' do
+    patient = Patient.find_by(id: 1)
+    post(
+      '/fhir/r4/Patient',
+      params: @patient_1.to_json,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :created
+    json_response = JSON.parse(response.body)
+    id = json_response['id']
+    p = Patient.find_by(id: id)
+    assert_not p.nil?
+    h = History.where(patient_id: id)
+    assert_not h.first.nil?
+    assert_equal 1, h.count
+    assert_equal 'Patient', json_response['resourceType']
+    assert_equal 3, json_response['telecom'].count
+    assert_equal 'Boehm62', json_response['name'].first['family']
+    assert response.headers['Location'].ends_with?(json_response['id'].to_s)
+    assert_equal 'USA, State 1',
+                 json_response['extension'].find { |e| e['url'] == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }['valueString']
+    assert_equal "/fhir/r4/Patient/#{id}", json_response['contained'].first['target'].first['reference']
+    assert_equal @system_patient_read_write_app.uid, json_response['contained'].first['agent'].first['who']['identifier']['value']
+    assert_equal @system_patient_read_write_app.name, json_response['contained'].first['agent'].first['who']['display']
+    assert_equal patient.primary_telephone_type, fhir_ext_str(json_response['telecom'].first, 'phone-type')
+    assert_equal patient.secondary_telephone_type, fhir_ext_str(json_response['telecom'].second, 'phone-type')
+    assert_equal patient.monitoring_plan, fhir_ext_str(json_response, 'monitoring-plan')
+    assert_equal patient.assigned_user, fhir_ext_pos_int(json_response, 'assigned-user')
+    assert_equal patient.additional_planned_travel_start_date.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'additional-planned-travel-start-date')
+    assert_equal patient.port_of_origin, fhir_ext_str(json_response, 'port-of-origin')
+    assert_equal patient.date_of_departure.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'date-of-departure')
+    assert_equal patient.flight_or_vessel_number, fhir_ext_str(json_response, 'flight-or-vessel-number')
+    assert_equal patient.flight_or_vessel_carrier, fhir_ext_str(json_response, 'flight-or-vessel-carrier')
+    assert_equal patient.date_of_arrival.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'date-of-arrival')
+    assert_equal patient.exposure_notes, fhir_ext_str(json_response, 'exposure-notes')
+    assert_equal patient.travel_related_notes, fhir_ext_str(json_response, 'travel-related-notes')
+    assert_equal patient.additional_planned_travel_related_notes, fhir_ext_str(json_response, 'additional-planned-travel-notes')
+    assert_equal patient.user_defined_id_statelocal, json_response['identifier'].find { |i| i['system'].include? 'state-local-id' }['value']
+  end
+
+  test 'USER FLOW: should create Patient via create' do
+    patient = Patient.find_by(id: 1)
+    post(
+      '/fhir/r4/Patient', params: @patient_1.to_json,
+                          headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :created
+    json_response = JSON.parse(response.body)
+    id = json_response['id']
+    p = Patient.find_by(id: id)
+    assert_not p.nil?
+    h = History.where(patient_id: id)
+    assert_not h.first.nil?
+    assert_equal 1, h.count
+    assert_equal 'state1_epi@example.com', h.first.created_by
+    assert_equal 'Patient', json_response['resourceType']
+    assert_equal 3, json_response['telecom'].count
+    assert_equal 'Boehm62', json_response['name'].first['family']
+    assert response.headers['Location'].ends_with?(json_response['id'].to_s)
+    assert_equal 'USA, State 1',
+                 json_response['extension'].find { |e| e['url'] == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }['valueString']
+    assert_equal "/fhir/r4/Patient/#{id}", json_response['contained'].first['target'].first['reference']
+    assert_equal Patient.find_by(id: id).creator_id, json_response['contained'].first['agent'].first['who']['identifier']['value']
+    assert_equal Patient.find_by(id: id).creator.email, json_response['contained'].first['agent'].first['who']['display']
+    assert_equal patient.primary_telephone_type, fhir_ext_str(json_response['telecom'].first, 'phone-type')
+    assert_equal patient.secondary_telephone_type, fhir_ext_str(json_response['telecom'].second, 'phone-type')
+    assert_equal patient.monitoring_plan, fhir_ext_str(json_response, 'monitoring-plan')
+    assert_equal patient.assigned_user, fhir_ext_pos_int(json_response, 'assigned-user')
+    assert_equal patient.additional_planned_travel_start_date.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'additional-planned-travel-start-date')
+    assert_equal patient.port_of_origin, fhir_ext_str(json_response, 'port-of-origin')
+    assert_equal patient.date_of_departure.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'date-of-departure')
+    assert_equal patient.flight_or_vessel_number, fhir_ext_str(json_response, 'flight-or-vessel-number')
+    assert_equal patient.flight_or_vessel_carrier, fhir_ext_str(json_response, 'flight-or-vessel-carrier')
+    assert_equal patient.date_of_arrival.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'date-of-arrival')
+    assert_equal patient.exposure_notes, fhir_ext_str(json_response, 'exposure-notes')
+    assert_equal patient.travel_related_notes, fhir_ext_str(json_response, 'travel-related-notes')
+    assert_equal patient.additional_planned_travel_related_notes, fhir_ext_str(json_response, 'additional-planned-travel-notes')
+  end
+
+  test 'should calculate Patient age via create' do
+    post(
+      '/fhir/r4/Patient',
+      params: @patient_1.to_json,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+
+    assert_response :created
+    json_response = JSON.parse(response.body)
+    patient = Patient.find(json_response['id'])
+    assert_equal 25, patient.age
+  end
+
+  test 'should be unprocessable entity via create with validation errors' do
+    post(
+      '/fhir/r4/Patient',
+      params: IO.read(file_fixture('fhir_invalid_patient.json')),
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :unprocessable_entity
+    json_response = JSON.parse(response.body)
+    errors = json_response['issue'].map { |i| i['diagnostics'] }
+
+    msg = 'Expected validation error on '
+    assert_equal 18, errors.length
+    assert(errors.any?(/Invalid.*Monitoring Plan/), msg + 'Monitoring Plan')
+    assert(errors.any?(/Old York.*State/), msg + 'State')
+    assert(errors.any?(/0000.*Ethnicity/), msg + 'Ethnicity')
+    assert(errors.any?(/High noon.*Preferred Contact Time/), msg + 'Preferred Contact Time')
+    assert(errors.any?(/On FHIR.*Sex/), msg + 'Sex')
+    assert(errors.any?(/Dumbphone.*Telephone Type/), msg + 'Phone Type')
+    assert(errors.any?(/123.*Primary Telephone/), msg + 'Primary Telephone')
+    assert(errors.any?(/Date of Birth/), msg + 'Date of Birth')
+    assert(errors.any?(/Last Date of Exposure/), msg + 'Last Date of Exposure')
+    assert(errors.any?(/1492.*Symptom Onset/), msg + 'Symptom Onset')
+    assert(errors.any?(/1776.*Additional Planned Travel Start Date/), msg + 'Additional Planned Travel Start Date')
+    assert(errors.any?(/2020-01-32.*Date of Departure/), msg + 'Date of Departure')
+    assert(errors.any?(/9999-99-99.*Date of Arrival/), msg + 'Date of Arrival')
+    assert(errors.any?(/Last Name/), msg + 'Last Name')
+    assert(errors.any?(/10000.*Assigned User/), msg + 'Assigned User')
+    assert(errors.any?(/Email.*Primary Contact Method/), msg + 'Email')
+  end
+
+  test 'should group Patients in households with matching phone numbers' do
+    post(
+      '/fhir/r4/Patient',
+      params: @patient_1.to_json,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :created
+    json_response = JSON.parse(response.body)
+    # Should be a dependent in the same household as patient with ID 1, who is now the HoH
+    assert_equal 1, Patient.find_by(id: json_response['id']).responder_id
+  end
+
+  test 'should group Patients in households with matching emails' do
+    Patient.find_by(id: 1).update!(preferred_contact_method: 'E-mailed Web Link')
+    @patient_1 = Patient.find_by(id: 1).as_fhir
+    post(
+      '/fhir/r4/Patient',
+      params: @patient_1.to_json,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :created
+    json_response = JSON.parse(response.body)
+    # Should be a dependent in the same household as patient with ID 1, who is now the HoH
+    assert_equal 1, Patient.find_by(id: json_response['id']).responder_id
+  end
+
+  test 'should make Patient a self reporter if no matching number or email' do
+    post(
+      '/fhir/r4/Patient',
+      params: @patient_2.to_json,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :created
+    json_response = JSON.parse(response.body)
+    # Should be their own reporter since they have a unique phone number and email
+    assert_equal json_response['id'], Patient.find_by(id: json_response['id']).responder_id
+  end
+
+  #----- update tests -----
+
+  test 'should update Patient via update' do
+    patient_id = 1
+    patient = Patient.find_by(id: 2)
+    resource_path = "/fhir/r4/Patient/#{patient_id}"
+    put(
+      resource_path,
+      params: @patient_2.to_json,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 1, json_response['id']
+    p = Patient.find_by(id: 1)
+    assert_not p.nil?
+    assert p.black_or_african_american
+    assert p.asian
+    assert_equal 'Patient', json_response['resourceType']
+    assert_equal 'Kirlin44', json_response['name'].first['family']
+    assert_equal 'SMS Texted Weblink', json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-method' }.first['valueString']
+    assert_equal 'Afternoon', json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-time' }.first['valueString']
+    assert json_response['extension'].filter { |e| e['url'].include? 'continuous-exposure' }.first['valueBoolean']
+    assert_equal 3.days.ago.strftime('%Y-%m-%d'), json_response['extension'].filter { |e| e['url'].include? 'symptom-onset-date' }.first['valueDate']
+    assert p.user_defined_symptom_onset
+    assert json_response['extension'].filter { |e| e['url'].include? 'isolation' }.first['valueBoolean']
+    assert_equal 'USA, State 1, County 1',
+                 json_response['extension'].find { |e| e['url'] == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }['valueString']
+    assert_equal resource_path, json_response['contained'].first['target'].first['reference']
+    assert_equal Patient.find_by(id: patient_id).creator_id, json_response['contained'].first['agent'].first['who']['identifier']['value']
+    assert_equal Patient.find_by(id: patient_id).creator.email, json_response['contained'].first['agent'].first['who']['display']
+    assert_equal patient.primary_telephone_type, fhir_ext_str(json_response['telecom'].first, 'phone-type')
+    assert_equal patient.secondary_telephone_type, fhir_ext_str(json_response['telecom'].second, 'phone-type')
+    assert_equal patient.monitoring_plan, fhir_ext_str(json_response, 'monitoring-plan')
+    assert_equal patient.assigned_user, fhir_ext_pos_int(json_response, 'assigned-user')
+    assert_equal patient.additional_planned_travel_start_date.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'additional-planned-travel-start-date')
+    assert_equal patient.port_of_origin, fhir_ext_str(json_response, 'port-of-origin')
+    assert_equal patient.date_of_departure.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'date-of-departure')
+    assert_equal patient.flight_or_vessel_number, fhir_ext_str(json_response, 'flight-or-vessel-number')
+    assert_equal patient.flight_or_vessel_carrier, fhir_ext_str(json_response, 'flight-or-vessel-carrier')
+    assert_equal patient.date_of_arrival.strftime('%Y-%m-%d'), fhir_ext_date(json_response, 'date-of-arrival')
+    assert_equal patient.exposure_notes, fhir_ext_str(json_response, 'exposure-notes')
+    assert_equal patient.travel_related_notes, fhir_ext_str(json_response, 'travel-related-notes')
+    assert_equal patient.additional_planned_travel_related_notes, fhir_ext_str(json_response, 'additional-planned-travel-notes')
+    assert_equal patient.user_defined_id_statelocal, json_response['identifier'].find { |i| i['system'].include? 'state-local-id' }['value']
+  end
+
+  test 'should create "Record Edit" and not "Monitoring Change" History item when updating patient with record edit' do
+    patient = @patient_2
+    patient.identifier = [FHIR::Identifier.new(system: 'http://saraalert.org/SaraAlert/state-local-id', value: '123')]
+    resource_path = "/fhir/r4/Patient/#{patient.id}"
+    histories = History.where(patient: patient.id)
+    record_edit_count = histories.where(history_type: 'Record Edit')&.count || 0
+    monitoring_change_count = histories.where(history_type: 'Monitoring Change')&.count || 0
+    put(
+      resource_path,
+      params: patient.to_json,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :ok
+    histories = History.where(patient: patient.id)
+    assert_equal(record_edit_count + 1, histories.where(history_type: 'Record Edit').count)
+    assert_equal(monitoring_change_count, histories.where(history_type: 'Monitoring Change').count)
+    assert_match(/Changes were.*User defined id statelocal \("EX-904188" to "123"\)/, histories.find_by(history_type: 'Record Edit').comment)
+  end
+
+  test 'should create "Monitoring Change" History item when updating patient with monitoring change' do
+    patient = @patient_2
+    resource_path = "/fhir/r4/Patient/#{patient.id}"
+    histories = History.where(patient: patient.id)
+    monitoring_change_count = histories.where(history_type: 'Monitoring Change').count
+    patch = [
+      { 'op': 'replace', 'path': '/active', 'value': 'false' }
+    ]
+    patch(
+      resource_path,
+      params: patch.to_json,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/json-patch+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal false, json_response['active']
+    histories = History.where(patient: patient.id)
+    assert_equal(monitoring_change_count + 2, histories.where(history_type: 'Monitoring Change').count)
+    assert_match(/Continuous Exposure/, histories.find_by(created_by: 'Sara Alert System').comment)
+    assert_match(/"Monitoring" to "Not Monitoring"/, histories.find_by(history_type: 'Monitoring Change').comment)
+  end
+
+  test 'should update Patient via update and set omitted fields to nil ' do
+    # Possible update request that omits all fields that can be updated except for the "active" field.
+    patient_update = {
+      'id' => @patient_2.id,
+      'birthDate' => @patient_2.birthDate,
+      'name' => @patient_2.name,
+      'address' => @patient_2.address,
+      'extension' => @patient_1.extension.find { |e| e.url.include? 'last-date-of-exposure' },
+      'active' => false,
+      'resourceType' => 'Patient'
+    }
+
+    put(
+      '/fhir/r4/Patient/1',
+      params: patient_update.to_json,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 1, json_response['id']
+    p = Patient.find_by(id: 1)
+
+    assert_not p.nil?
+    assert_equal 'Patient', json_response['resourceType']
+    assert_equal([], json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-method' })
+    assert_equal([], json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-time' })
+    assert_equal([], json_response['extension'].filter { |e| e['url'].include? 'symptom-onset-date' })
+    assert_equal false, json_response['active']
+  end
+
+  test 'should properly close Patient record via update' do
+    # Possible update request that omits many fields but sets active to false
+    patient_update = {
+      'id' => @patient_2.id,
+      'birthDate' => @patient_2.birthDate,
+      'name' => @patient_2.name,
+      'address' => @patient_2.address,
+      'extension' => @patient_1.extension.find { |e| e.url.include? 'last-date-of-exposure' },
+      'active' => false,
+      'resourceType' => 'Patient',
+      'telecom' => [
+        {
+          "system": 'email',
+          "value": '2966977816fake@example.com',
+          "rank": 1
+        }
+      ]
+    }
+
+    put(
+      '/fhir/r4/Patient/1',
+      params: patient_update.to_json,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 1, json_response['id']
+    p = Patient.find_by(id: 1)
+
+    assert_not p.nil?
+
+    # Record should be closed
+    assert_not json_response['active']
+    assert_not p.monitoring
+
+    # Closed at date should have been set to today
+    assert_equal DateTime.now.to_date, p.closed_at&.to_date
+  end
+
+  test 'should differentiate USA and Foreign addresses in update' do
+    @patient_1.address << FHIR::Address.new(line: ['123 First Ave', 'Unit 22', 'Sector B'], city: 'Northland', state: 'Quebec', postalCode: '77658-0950',
+                                            country: 'Canada')
+    @patient_1.address[1].extension << FHIR::Extension.new(url: 'http://saraalert.org/StructureDefinition/address-type', valueString: 'Foreign')
+
+    put(
+      '/fhir/r4/Patient/1',
+      params: @patient_1.to_json,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+
+    assert_response :ok
+    patient = Patient.find_by(id: 1)
+    json_response = JSON.parse(response.body)
+    # Test that the address was saved as expected
+    assert_equal @patient_1.address[0].line[0], patient.address_line_1
+    assert_equal @patient_1.address[0].city, patient.address_city
+    assert_equal @patient_1.address[0].state, patient.address_state
+    assert_equal @patient_1.address[0].postalCode, patient.address_zip
+    assert_equal @patient_1.address[0].district, patient.address_county
+    # Test that the foreign address was saved as expected
+    assert_equal @patient_1.address[1].line[0], patient.foreign_address_line_1
+    assert_equal @patient_1.address[1].line[1], patient.foreign_address_line_2
+    assert_equal @patient_1.address[1].line[2], patient.foreign_address_line_3
+    assert_equal @patient_1.address[1].city, patient.foreign_address_city
+    assert_equal @patient_1.address[1].state, patient.foreign_address_state
+    assert_equal @patient_1.address[1].postalCode, patient.foreign_address_zip
+    assert_equal @patient_1.address[1].country, patient.foreign_address_country
+
+    # Test that the response is as expected
+    assert_equal JSON.parse(@patient_1.address.to_json), json_response['address']
+  end
+
+  test 'should update address fields from an explicit USA address' do
+    @patient_1.address = [FHIR::Address.new(line: ['123 First Ave', 'Unit 22'], city: 'Southland', state: 'Vermont', postalCode: '77658-0950',
+                                            district: 'Middletown')]
+    @patient_1.address[0].extension << FHIR::Extension.new(url: 'http://saraalert.org/StructureDefinition/address-type', valueString: 'USA')
+
+    put(
+      '/fhir/r4/Patient/1',
+      params: @patient_1.to_json,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+
+    assert_response :ok
+    patient = Patient.find_by(id: 1)
+    json_response = JSON.parse(response.body)
+    # Test that the address was saved as expected
+    assert_equal @patient_1.address[0].line[0], patient.address_line_1
+    assert_equal @patient_1.address[0].city, patient.address_city
+    assert_equal @patient_1.address[0].state, patient.address_state
+    assert_equal @patient_1.address[0].postalCode, patient.address_zip
+    assert_equal @patient_1.address[0].district, patient.address_county
+
+    # Test that the foreign address was not saved
+    assert_nil patient.foreign_address_line_1
+    assert_nil patient.foreign_address_line_2
+    assert_nil patient.foreign_address_line_3
+    assert_nil patient.foreign_address_city
+    assert_nil patient.foreign_address_state
+    assert_nil patient.foreign_address_zip
+    assert_nil patient.foreign_address_country
+
+    # Test that the response is as expected
+    assert_equal @patient_1.address[0].line, json_response['address'][0]['line']
+    assert_equal @patient_1.address[0].city, json_response['address'][0]['city']
+    assert_equal @patient_1.address[0].state, json_response['address'][0]['state']
+    assert_equal @patient_1.address[0].postalCode, json_response['address'][0]['postalCode']
+  end
+
+  test 'should ignore unknown address types in update' do
+    @patient_1.address << FHIR::Address.new(line: ['123 First Ave', 'Unit 22', 'Sector B'], city: 'Northland', state: 'Quebec', postalCode: '77658-0950',
+                                            country: 'Canada')
+    @patient_1.address[1].extension << FHIR::Extension.new(url: 'http://saraalert.org/StructureDefinition/address-type', valueString: 'mysterious')
+
+    put(
+      '/fhir/r4/Patient/1',
+      params: @patient_1.to_json,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+
+    assert_response :ok
+    patient = Patient.find_by(id: 1)
+    json_response = JSON.parse(response.body)
+    # Test that the foreign address was not saved
+    assert_nil patient.foreign_address_line_1
+    assert_nil patient.foreign_address_line_2
+    assert_nil patient.foreign_address_line_3
+    assert_nil patient.foreign_address_city
+    assert_nil patient.foreign_address_state
+    assert_nil patient.foreign_address_zip
+    assert_nil patient.foreign_address_country
+
+    # Test that the address was saved as expected
+    assert_equal @patient_1.address[0].line[0], patient.address_line_1
+    assert_equal @patient_1.address[0].city, patient.address_city
+    assert_equal @patient_1.address[0].state, patient.address_state
+    assert_equal @patient_1.address[0].postalCode, patient.address_zip
+    assert_equal @patient_1.address[0].district, patient.address_county
+
+    # Test that the response is as expected
+    assert_equal JSON.parse(@patient_1.address[0].to_json), json_response['address'][0]
+    assert_nil json_response['address'][1]
+  end
+
+  test 'should be unprocessable entity via update with validation errors' do
+    put(
+      '/fhir/r4/Patient/1',
+      params: IO.read(file_fixture('fhir_invalid_patient.json')),
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :unprocessable_entity
+    json_response = JSON.parse(response.body)
+    errors = json_response['issue'].map { |i| i['diagnostics'] }
+
+    msg = 'Expected validation error on '
+    assert_equal 18, errors.length
+    assert(errors.any?(/Invalid.*Monitoring Plan/), msg + 'Monitoring Plan')
+    assert(errors.any?(/Old York.*State/), msg + 'State')
+    assert(errors.any?(/0000.*Ethnicity/), msg + 'Ethnicity')
+    assert(errors.any?(/High noon.*Preferred Contact Time/), msg + 'Preferred Contact Time')
+    assert(errors.any?(/On FHIR.*Sex/), msg + 'Sex')
+    assert(errors.any?(/Dumbphone.*Telephone Type/), msg + 'Phone Type')
+    assert(errors.any?(/123.*Primary Telephone/), msg + 'Primary Telephone')
+    assert(errors.any?(/Date of Birth/), msg + 'Date of Birth')
+    assert(errors.any?(/Last Date of Exposure/), msg + 'Last Date of Exposure')
+    assert(errors.any?(/1492.*Symptom Onset/), msg + 'Symptom Onset')
+    assert(errors.any?(/1776.*Additional Planned Travel Start Date/), msg + 'Additional Planned Travel Start Date')
+    assert(errors.any?(/2020-01-32.*Date of Departure/), msg + 'Date of Departure')
+    assert(errors.any?(/9999-99-99.*Date of Arrival/), msg + 'Date of Arrival')
+    assert(errors.any?(/Last Name/), msg + 'Last Name')
+    assert(errors.any?(/10000.*Assigned User/), msg + 'Assigned User')
+    assert(errors.any?(/Email.*Primary Contact Method/), msg + 'Email')
+  end
+
+  test 'SYSTEM FLOW: should allow jurisdiction transfers when jurisdiction exists' do
+    @patient_1.extension.find { |e| e.url == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }.valueString = 'USA, State 2'
+    put(
+      '/fhir/r4/Patient/1',
+      params: @patient_1.to_json,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :success
+    json_response = JSON.parse(response.body)
+    assert_equal 'USA, State 2', json_response['extension'].filter { |e| e['url'].include? 'full-assigned-jurisdiction-path' }.first['valueString']
+    t = Transfer.find_by(patient_id: @patient_1.id)
+    assert_equal Jurisdiction.find_by(path: 'USA, State 1').id, t.from_jurisdiction_id
+    assert_equal Jurisdiction.find_by(path: 'USA, State 2').id, t.to_jurisdiction_id
+    assert_equal @system_patient_read_write_app.user_id, t.who_id
+  end
+
+  test 'USER FLOW: should allow jurisdiction transfers when jurisdiction exists' do
+    @patient_1.extension.find { |e| e.url == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }.valueString = 'USA, State 2'
+    put(
+      '/fhir/r4/Patient/1',
+      params: @patient_1.to_json,
+      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :success
+    json_response = JSON.parse(response.body)
+    assert_equal 'USA, State 2', json_response['extension'].filter { |e| e['url'].include? 'full-assigned-jurisdiction-path' }.first['valueString']
+    t = Transfer.find_by(patient_id: @patient_1.id)
+    assert_equal Jurisdiction.find_by(path: 'USA, State 1').id, t.from_jurisdiction_id
+    assert_equal Jurisdiction.find_by(path: 'USA, State 2').id, t.to_jurisdiction_id
+    assert_equal @user.id, t.who_id
+  end
+
+  test 'SYSTEM FLOW: should be unprocessable entity via update with invalid jurisdiction path' do
+    @patient_1.extension.find { |e| e.url == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }.valueString = 'USA'
+    put(
+      '/fhir/r4/Patient/1',
+      params: @patient_1.to_json,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :unprocessable_entity
+    json_response = JSON.parse(response.body)
+    assert_equal 1, json_response['issue'].length
+    assert(json_response['issue'][0]['diagnostics'].include?('Jurisdiction does not exist'))
+  end
+
+  test 'USER FLOW: should be unprocessable entity via update with invalid jurisdiction path' do
+    @patient_1.extension.find { |e| e.url == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }.valueString = 'USA'
+    put(
+      '/fhir/r4/Patient/1',
+      params: @patient_1.to_json,
+      headers: { 'Authorization': "Bearer #{@user_patient_token_rw.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :unprocessable_entity
+    json_response = JSON.parse(response.body)
+    assert_equal 1, json_response['issue'].length
+    assert(json_response['issue'][0]['diagnostics'].include?('Jurisdiction does not exist'))
+  end
+
+  test 'should update Patient via patch update' do
+    patch = [
+      { 'op': 'remove', 'path': '/communication/0/language' },
+      { 'op': 'add', 'path': '/address/0/line/-', 'value': 'Unit 123' },
+      { 'op': 'replace', 'path': '/name/0/family', 'value': 'Foo' }
+    ]
+    patch(
+      '/fhir/r4/Patient/1',
+      params: patch.to_json,
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Content-Type': 'application/json-patch+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 1, json_response['id']
+    assert_nil json_response['communication']
+    assert_equal 'Unit 123', json_response['address'][0]['line'][1]
+    assert_equal 'Foo', json_response['name'][0]['family']
+  end
+
+  #----- search tests -----
+  test 'should find Patient via search by _id' do
+    get(
+      '/fhir/r4/Patient?_id=1',
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 'Bundle', json_response['resourceType']
+    assert_equal 1, json_response['total']
+    assert_equal 1, json_response['entry'].first['resource']['id']
+  end
+
+  test 'should find Patient via search on existing family' do
+    get(
+      '/fhir/r4/Patient?family=Kirlin44',
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 'Bundle', json_response['resourceType']
+    assert_equal 1, json_response['total']
+    assert_equal 2, json_response['entry'].first['resource']['id']
+  end
+
+  test 'should find no Patients via search on non-existing family' do
+    get(
+      '/fhir/r4/Patient?family=foo',
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 'Bundle', json_response['resourceType']
+    assert_equal 0, json_response['total']
+  end
+
+  test 'should find Patient via search on given' do
+    get(
+      '/fhir/r4/Patient?given=Chris32',
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 'Bundle', json_response['resourceType']
+    assert_equal 1, json_response['total']
+    assert_equal 2, json_response['entry'].first['resource']['id']
+  end
+
+  test 'should find Patient via search on telecom' do
+    get(
+      '/fhir/r4/Patient?telecom=5555550111',
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 'Bundle', json_response['resourceType']
+    assert_equal 1, json_response['total']
+    assert_equal 1, json_response['entry'].first['resource']['id']
+  end
+
+  test 'should find Patient via search on email' do
+    get(
+      '/fhir/r4/Patient?email=grazyna%40example.com',
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 'Bundle', json_response['resourceType']
+    assert_equal 1, json_response['total']
+    assert_equal 2, json_response['entry'].first['resource']['id']
+  end
+
+  test 'should get patients with default count via search' do
+    get(
+      '/fhir/r4/Patient',
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 'Bundle', json_response['resourceType']
+    assert_equal 'http://www.example.com/fhir/r4/Patient?page=2', json_response['link'][0]['url']
+  end
+
+  test 'should get patients with count as 100 via search' do
+    get(
+      '/fhir/r4/Patient?_count=100',
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 'Bundle', json_response['resourceType']
+    assert_nil json_response['link']
+  end
+
+  test 'should get Bundle via search without params' do
+    get(
+      '/fhir/r4/Patient',
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 'Bundle', json_response['resourceType']
+    json_response['entry'].each do |entry|
+      assert(entry['fullUrl'].include?('Patient') ||
+              entry['fullUrl'].include?('Observation') ||
+              entry['fullUrl'].include?('QuestionnaireResponse'))
+    end
+  end
+
+  test 'should only get summary with count as 0 via search' do
+    get(
+      '/fhir/r4/Patient?_count=0',
+      headers: { 'Authorization': "Bearer #{@system_patient_token_rw.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 'Bundle', json_response['resourceType']
+    assert_nil json_response['link']
+  end
+end
+# rubocop:enable Metrics/ClassLength

--- a/test/controllers/fhir/r4/patient_test.rb
+++ b/test/controllers/fhir/r4/patient_test.rb
@@ -227,7 +227,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     h = History.where(patient_id: id)
     assert_not h.first.nil?
     assert_equal 1, h.count
-    assert_equal 'state1_epi@example.com', h.first.created_by
+    assert_equal 'state1_epi@example.com (API)', h.first.created_by
     assert_equal 'Patient', json_response['resourceType']
     assert_equal 3, json_response['telecom'].count
     assert_equal 'Boehm62', json_response['name'].first['family']

--- a/test/controllers/fhir/r4/questionnaire_response.rb
+++ b/test/controllers/fhir/r4/questionnaire_response.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rspec/mocks/minitest_integration'
+require 'controllers/fhir/r4/api_controller_test'
+
+class ApiControllerTest < ActionDispatch::IntegrationTest
+  #----- show tests -----
+
+  test 'should get QuestionnaireResponse via show' do
+    get(
+      '/fhir/r4/QuestionnaireResponse/1001',
+      headers: { 'Authorization': "Bearer #{@system_response_token_r.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 1001, json_response['id']
+    assert_equal 'QuestionnaireResponse', json_response['resourceType']
+    assert_equal 'Patient/1', json_response['subject']['reference']
+    assert_not json_response['item'].find(text: 'fever').first['answer'].first['valueBoolean']
+    assert_not json_response['item'].find(text: 'cough').first['answer'].first['valueBoolean']
+    assert_not json_response['item'].find(text: 'difficulty-breathing').first['answer'].first['valueBoolean']
+  end
+
+  #----- search tests -----
+
+  test 'should find QuestionnaireResponses for a Patient via search' do
+    get(
+      '/fhir/r4/QuestionnaireResponse?subject=Patient/1',
+      headers: { 'Authorization': "Bearer #{@system_response_token_r.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 'Bundle', json_response['resourceType']
+    assert_equal 'QuestionnaireResponse', json_response['entry'].first['resource']['resourceType']
+  end
+
+  test 'should find no QuestionnaireResponses for an invalid Patient via search' do
+    get(
+      '/fhir/r4/QuestionnaireResponse?subject=Patient/blah',
+      headers: { 'Authorization': "Bearer #{@system_response_token_r.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    json_response = JSON.parse(response.body)
+    assert_equal 'Bundle', json_response['resourceType']
+    assert_equal 0, json_response['total']
+  end
+end

--- a/test/controllers/fhir/r4/related_person_test.rb
+++ b/test/controllers/fhir/r4/related_person_test.rb
@@ -70,6 +70,11 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
 
     # Verify that the JSON response matches the original as FHIR
     assert_equal JSON.parse(@close_contact_1.as_fhir.to_json), json_response.except('id')
+
+    histories = History.where(patient: created_cc.patient_id)
+    assert_equal(1, histories.count)
+    assert_equal 'system-test-everything (API)', histories.first.created_by
+    assert_match(/close contact added.*API/, histories.first.comment)
   end
 
   test 'SYSTEM FLOW: should be unprocessable entity via create with invalid Patient reference' do
@@ -131,6 +136,11 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     # Verify that updated fields are updated
     assert_equal 'Some new notes', updated_cc.notes
     assert_equal 'FarContact1', updated_cc.first_name
+
+    histories = History.where(patient: updated_cc.patient_id)
+    assert_equal(1, histories.count)
+    assert_equal 'system-test-everything (API)', histories.first.created_by
+    assert_match(/Close contact edited.*API/, histories.first.comment)
   end
 
   test 'should update RelatedPerson via patch update' do

--- a/test/controllers/fhir/r4/related_person_test.rb
+++ b/test/controllers/fhir/r4/related_person_test.rb
@@ -20,7 +20,9 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       last_date_of_exposure: 20.days.ago,
       assigned_user: 8,
       notes: 'Only the educated are free.',
-      enrolled_id: 3
+      enrolled_id: 3,
+      updated_at: 33.days.ago,
+      created_at: 33.days.ago
     )
   end
   #----- show tests -----
@@ -71,7 +73,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     end
 
     # Verify that the JSON response matches the original as FHIR
-    assert_equal JSON.parse(@close_contact_1.as_fhir.to_json), json_response.except('id')
+    assert_equal JSON.parse(@close_contact_1.as_fhir.to_json).except('meta'), json_response.except('id', 'meta')
 
     histories = History.where(patient: created_cc.patient_id)
     assert_equal(1, histories.count)

--- a/test/controllers/fhir/r4/related_person_test.rb
+++ b/test/controllers/fhir/r4/related_person_test.rb
@@ -20,7 +20,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       last_date_of_exposure: 20.days.ago,
       assigned_user: 8,
       notes: 'Only the educated are free.',
-      enrolled_id: 3,
       updated_at: 33.days.ago,
       created_at: 33.days.ago
     )
@@ -67,8 +66,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
        contact_attempts
        last_date_of_exposure
        assigned_user
-       notes
-       enrolled_id].each do |field|
+       notes].each do |field|
       assert_equal @close_contact_1[field], created_cc[field]
     end
 
@@ -109,36 +107,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal 1, errors.length
     assert_match(/0.*Patient ID.*API user/, errors[0])
-  end
-
-  test 'SYSTEM FLOW: should be unprocessable entity via create with invalid enrolled Patient reference' do
-    @close_contact_1.enrolled_id = 0
-    post(
-      '/fhir/r4/RelatedPerson',
-      params: @close_contact_1.as_fhir.to_json,
-      headers: { 'Authorization': "Bearer #{@system_everything_token.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :unprocessable_entity
-    json_response = JSON.parse(response.body)
-    errors = json_response['issue'].map { |i| i['diagnostics'] }
-
-    assert_equal 1, errors.length
-    assert_match(/0.*Enrolled ID.*client application/, errors[0])
-  end
-
-  test 'USER FLOW: should be unprocessable entity via create with invalid enrolled Patient reference' do
-    @close_contact_1.enrolled_id = 0
-    post(
-      '/fhir/r4/RelatedPerson',
-      params: @close_contact_1.as_fhir.to_json,
-      headers: { 'Authorization': "Bearer #{@user_everything_token.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :unprocessable_entity
-    json_response = JSON.parse(response.body)
-    errors = json_response['issue'].map { |i| i['diagnostics'] }
-
-    assert_equal 1, errors.length
-    assert_match(/0.*Enrolled ID.*API user/, errors[0])
   end
 
   test 'should be unprocessable entity via RelatedPerson create with validation errors' do
@@ -182,46 +150,13 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
        email
        contact_attempts
        last_date_of_exposure
-       assigned_user
-       enrolled_id].each do |field|
+       assigned_user].each do |field|
       assert_equal original_cc[field], updated_cc[field]
     end
 
     # Verify that updated fields are updated
     assert_equal 'Some new notes', updated_cc.notes
     assert_equal 'FarContact1', updated_cc.first_name
-
-    histories = History.where(patient: updated_cc.patient_id)
-    assert_equal(1, histories.count)
-    assert_equal 'system-test-everything (API)', histories.first.created_by
-    assert_match(/Close contact edited.*API/, histories.first.comment)
-  end
-
-  test 'should allow nil enrolled_id when updating RelatedPerson via update' do
-    cc = CloseContact.find_by_id(1)
-    original_cc = cc.dup
-    cc.enrolled_id = nil
-    put(
-      '/fhir/r4/RelatedPerson/1',
-      params: cc.as_fhir.to_json,
-      headers: { 'Authorization': "Bearer #{@system_everything_token.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :ok
-    updated_cc = CloseContact.find_by_id(1)
-
-    # Verify that the created Close Contact matches the original outside of updated fields
-    %i[patient_id
-       last_name
-       primary_telephone
-       email
-       contact_attempts
-       last_date_of_exposure
-       assigned_user].each do |field|
-      assert_equal original_cc[field], updated_cc[field]
-    end
-
-    # Verify that updated fields are updated
-    assert_nil updated_cc.enrolled_id
 
     histories = History.where(patient: updated_cc.patient_id)
     assert_equal(1, histories.count)
@@ -287,36 +222,6 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal 1, errors.length
     assert_match(/0.*Patient ID.*API user/, errors[0])
-  end
-
-  test 'SYSTEM FLOW: should be unprocessable entity via update with invalid enrolled Patient reference' do
-    @close_contact_1.enrolled_id = 0
-    put(
-      '/fhir/r4/RelatedPerson/1',
-      params: @close_contact_1.as_fhir.to_json,
-      headers: { 'Authorization': "Bearer #{@system_everything_token.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :unprocessable_entity
-    json_response = JSON.parse(response.body)
-    errors = json_response['issue'].map { |i| i['diagnostics'] }
-
-    assert_equal 1, errors.length
-    assert_match(/0.*Enrolled ID.*client application/, errors[0])
-  end
-
-  test 'USER FLOW: should be unprocessable entity via update with invalid enrolled Patient reference' do
-    @close_contact_1.enrolled_id = 0
-    put(
-      '/fhir/r4/RelatedPerson/1',
-      params: @close_contact_1.as_fhir.to_json,
-      headers: { 'Authorization': "Bearer #{@user_everything_token.token}", 'Content-Type': 'application/fhir+json' }
-    )
-    assert_response :unprocessable_entity
-    json_response = JSON.parse(response.body)
-    errors = json_response['issue'].map { |i| i['diagnostics'] }
-
-    assert_equal 1, errors.length
-    assert_match(/0.*Enrolled ID.*API user/, errors[0])
   end
 
   test 'should be unprocessable entity via RelatedPerson update with validation errors' do

--- a/test/controllers/fhir/r4/related_person_test.rb
+++ b/test/controllers/fhir/r4/related_person_test.rb
@@ -22,6 +22,25 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       notes: 'Only the educated are free.'
     )
   end
+  #----- show tests -----
+
+  test 'should get RelatedPerson via show' do
+    get(
+      '/fhir/r4/RelatedPerson/1',
+      headers: { 'Authorization': "Bearer #{@system_everything_token.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :ok
+    assert_equal JSON.parse(CloseContact.find_by_id(1).as_fhir.to_json), JSON.parse(response.body)
+  end
+
+  test 'should be forbidden via show for inaccessible RelatedPerson' do
+    get(
+      '/fhir/r4/RelatedPerson/2',
+      headers: { 'Authorization': "Bearer #{@system_everything_token.token}", 'Accept': 'application/fhir+json' }
+    )
+    assert_response :forbidden
+    # assert_equal JSON.parse(CloseContact.find_by_id(1).as_fhir.to_json), JSON.parse(response.body)
+  end
 
   test 'should create RelatedPerson via create' do
     post(

--- a/test/controllers/fhir/r4/related_person_test.rb
+++ b/test/controllers/fhir/r4/related_person_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'rspec/mocks/minitest_integration'
+require 'controllers/fhir/r4/api_controller_test'
+
+class ApiControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    setup_close_contacts
+  end
+
+  def setup_close_contacts
+    @close_contact_1 = CloseContact.new(
+      patient_id: 1,
+      first_name: 'Domingo54',
+      last_name: 'Boehm62',
+      primary_telephone: '+15555550111',
+      email: 'jeremy@example.com',
+      contact_attempts: 3,
+      last_date_of_exposure: 20.days.ago,
+      assigned_user: 8,
+      notes: 'Only the educated are free.'
+    )
+  end
+
+  test 'should create RelatedPerson via create' do
+    post(
+      '/fhir/r4/RelatedPerson',
+      params: @close_contact_1.as_fhir.to_json,
+      headers: { 'Authorization': "Bearer #{@system_everything_token.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :created
+    json_response = JSON.parse(response.body)
+    id = json_response['id']
+    created_cc = CloseContact.find_by(id: id)
+    assert_not created_cc.nil?
+
+    # Verify that the created Close Contact matches the original
+    %i[patient_id
+       first_name
+       last_name
+       primary_telephone
+       email
+       contact_attempts
+       last_date_of_exposure
+       assigned_user
+       notes].each do |field|
+      assert_equal @close_contact_1[field], created_cc[field]
+    end
+
+    # Verify that the JSON response matches the original as FHIR
+    assert_equal JSON.parse(@close_contact_1.as_fhir.to_json), json_response.except('id')
+  end
+
+  test 'SYSTEM FLOW: should be unprocessable entity via create with invalid Patient reference' do
+    @close_contact_1.patient_id = 0
+    post(
+      '/fhir/r4/RelatedPerson',
+      params: @close_contact_1.as_fhir.to_json,
+      headers: { 'Authorization': "Bearer #{@system_everything_token.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :unprocessable_entity
+    json_response = JSON.parse(response.body)
+    errors = json_response['issue'].map { |i| i['diagnostics'] }
+
+    assert_equal 1, errors.length
+    assert_match(/0.*Patient ID.*client application/, errors[0])
+  end
+
+  test 'USER FLOW: should be unprocessable entity via create with invalid Patient reference' do
+    @close_contact_1.patient_id = 0
+    post(
+      '/fhir/r4/RelatedPerson',
+      params: @close_contact_1.as_fhir.to_json,
+      headers: { 'Authorization': "Bearer #{@user_everything_token.token}", 'Content-Type': 'application/fhir+json' }
+    )
+    assert_response :unprocessable_entity
+    json_response = JSON.parse(response.body)
+    errors = json_response['issue'].map { |i| i['diagnostics'] }
+
+    assert_equal 1, errors.length
+    assert_match(/0.*Patient ID.*API user/, errors[0])
+  end
+end

--- a/test/fixtures/close_contacts.yml
+++ b/test/fixtures/close_contacts.yml
@@ -11,6 +11,7 @@ close_contact_1:
   notes: 'Close and contacted'
   assigned_user: 1
   patient_id: 1
+  enrolled_id: 2
 close_contact_2:
   id: 2
   created_at: <%= 33.days.ago %>

--- a/test/fixtures/close_contacts.yml
+++ b/test/fixtures/close_contacts.yml
@@ -1,0 +1,25 @@
+close_contact_1:
+  id: 1
+  created_at: <%= 35.days.ago %>
+  updated_at: <%= 35.days.ago %>
+  first_name: 'Close1'
+  last_name: 'Contact1'
+  primary_telephone: '+15555550111'
+  email: 'jeremy@example.com'
+  last_date_of_exposure: <%= 45.days.ago %>
+  contact_attempts: 3
+  notes: 'Close and contacted'
+  assigned_user: 1
+  patient_id: 1
+close_contact_2:
+  id: 2
+  created_at: <%= 33.days.ago %>
+  updated_at: <%= 33.days.ago %>
+  first_name: 'Close2'
+  last_name: 'Contact2'
+  primary_telephone: '+15555550111'
+  email: 'jeremy@example.com'
+  last_date_of_exposure: <%= 35.days.ago %>
+  contact_attempts: 0
+  assigned_user: 1
+  patient_id: 0

--- a/test/models/close_contact_test.rb
+++ b/test/models/close_contact_test.rb
@@ -7,6 +7,21 @@ class CloseContactTest < ActiveSupport::TestCase
 
   def teardown; end
 
+  def valid_cc
+    CloseContact.new(
+      patient_id: 1,
+      first_name: 'Domingo54',
+      last_name: 'Boehm62',
+      primary_telephone: '+15555550111',
+      email: 'jeremy@example.com',
+      contact_attempts: 3,
+      last_date_of_exposure: 20.days.ago,
+      assigned_user: 8,
+      notes: 'Only the educated are free.',
+      enrolled_id: 3
+    )
+  end
+
   test 'update patient updated_at upon close_contact create, update, and delete' do
     patient = create(:patient)
 
@@ -27,5 +42,91 @@ class CloseContactTest < ActiveSupport::TestCase
     ActiveRecord::Base.record_timestamps = true
     close_contact.destroy
     assert_in_delta patient.updated_at, Time.now.utc, 1
+  end
+
+  test 'validates primary phone is a possible phone number in api context' do
+    cc = valid_cc
+
+    cc.primary_telephone = '+15555555555'
+    assert cc.valid?(:api)
+
+    cc.primary_telephone = '+1 555 555 5555'
+    assert cc.valid?(:api)
+
+    cc.primary_telephone = ''
+    assert cc.valid?(:api)
+
+    cc.primary_telephone = nil
+    assert cc.valid?(:api)
+
+    cc.primary_telephone = '+1 123 456 7890'
+    assert_not cc.valid?(:api)
+
+    cc.primary_telephone = '123'
+    assert_not cc.valid?(:api)
+    assert cc.valid?
+  end
+
+  test 'validates email is a valid email address in api and import context' do
+    cc = valid_cc
+
+    cc.email = 'foo@bar.com'
+    assert cc.valid?(:api)
+
+    cc.email = ''
+    assert cc.valid?(:api)
+
+    cc.email = nil
+    assert cc.valid?(:api)
+
+    cc.email = 'not@an@email.com'
+    assert_not cc.valid?(:api)
+    assert cc.valid?
+  end
+
+  test 'validates assigned user is valid in api context' do
+    cc = valid_cc
+
+    cc.assigned_user = 1
+    assert cc.valid?(:api)
+
+    cc.assigned_user = 999_999
+    assert cc.valid?(:api)
+
+    cc.assigned_user = nil
+    assert cc.valid?(:api)
+
+    cc.assigned_user = 0
+    assert_not cc.valid?(:api)
+    assert cc.valid?
+  end
+
+  test 'validates last_date_of_exposure is a valid date in api context' do
+    cc = valid_cc
+
+    cc.last_date_of_exposure = 25.years.ago
+    assert cc.valid?(:api)
+
+    cc.last_date_of_exposure = '01-15-2000'
+    assert_not cc.valid?(:api)
+
+    cc.last_date_of_exposure = '2000-13-13'
+    assert_not cc.valid?(:api)
+    assert cc.valid?
+  end
+
+  test 'validates a complete close contact is present in api context' do
+    cc = valid_cc
+
+    cc.first_name = nil
+    cc.last_name = nil
+    assert_not cc.valid?(:api)
+    assert cc.valid?
+
+    cc = valid_cc
+    cc.primary_telephone = nil
+    cc.email = nil
+    assert_not cc.valid?(:api)
+    assert cc.valid?
   end
 end

--- a/test/models/close_contact_test.rb
+++ b/test/models/close_contact_test.rb
@@ -101,6 +101,23 @@ class CloseContactTest < ActiveSupport::TestCase
     assert cc.valid?
   end
 
+  test 'validates contact_attempts is valid in api context' do
+    cc = valid_cc
+
+    cc.contact_attempts = 0
+    assert cc.valid?(:api)
+
+    cc.contact_attempts = 1
+    assert cc.valid?(:api)
+
+    cc.contact_attempts = nil
+    assert cc.valid?(:api)
+
+    cc.contact_attempts = -1
+    assert_not cc.valid?(:api)
+    assert cc.valid?
+  end
+
   test 'validates last_date_of_exposure is a valid date in api context' do
     cc = valid_cc
 


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1255](https://tracker.codev.mitre.org/browse/SARAALERT-1255)

This PR adds support for Close Contacts in the API. The Close Contacts are represented using a FHIR [RelatedPerson](https://www.hl7.org/fhir/relatedperson.html) resource. The API can be used to write and to read close contacts.

# Important Changes
`api_controller.rb`
- Support a GET endpoint for RelatedPerson in the `show` method
- Support a PUT endpoint for RelatedPerson in the `update` method
- Support a POST endpoint for RelatedPerson in the `create` method
- Support searching of RelatedPersons in the `search` method
- Modify the `all` method so that it includes RelatedPersons

`fhir_helper.rb`
- Add a `close_contact_as_fhir` function for going from a ruby `CloseContact` to a FHIR RelatedPerson
- Add a `close_contact_from_fhir` function for going from a FHIR RelatedPerson to a ruby `CloseContact`

`close_contact.rb`
- Add validation in the `:api` context for `primary_telephone`, `email`, `assigned_user`, `last_date_of_exposure`, and for the requirement that at least one name and one contact method are specified on a Close Contact

`api_controller_test.rb`
- Split this file into `observation_test.rb`, `patient_test.rb`, `questionnaire_response_test.rb` and `related_person_test.rb` (this final file contains new tests) since the `api_controller_test.rb` file was getting long, and only going to get longer with the addition of RelatedPerson tests. Each individual file should contain the tests specific to that type of resource, while the `api_controller_test.rb` should test shared logic, things like showing a 404 when someone tries to get an unsupported resource.

`close_contact_test.rb`
- Added tests for the validation added in this PR

`docs/*`
- Added documentation for the RelatedPerson resource type to our existing API documentation

# Testing
All of the possible endpoints should be tested, so test:
* GET `[base]/RelatedPerson/[id]`
* PUT `[base]/RelatedPerson/[id]`
* PATCH `[base]/RelatedPerson/[id]`
* POST `[base]/RelatedPerson`
* GET `[base]/RelatedPerson?patient=Patient/[id]` (searching)
* POST `[base]/RelatedPerson/_search?patient=Patient/[id]` (also searching)
* GET `[base]/Patient/[id]/$everything` (make sure RelatedPersons appear in the resulting Bundle if the Patient has Close Contacts)

When writing a Close Contact via the API it is important also to test that:
* A RelatedPerson must have a `RelatedPerson.patient.reference` element that points towards a Patient resource that is accessible to the creator. The reference has the format `Patient/[id]`. If you create a Close Contact pointing to a specific Patient, you can then check that Patient in the API and the Close Contact and corresponding History item should appear.
* A RelatedPerson can have a `enrolled-patient` extension, which references the Patient that resulted from enrolling the Close Contact. If this reference exists, it must point towards a Patient that is accessible to the user, or you should see a 422.
* Email, primary telephone, last date of exposure, and assigned user must be valid (same validation as a Patient) or you get a 422.
* One of first name or last name must be present, and one of email or primary telephone must be present. This matches a restriction recently introduced in the UI.
* You cannot access Close Contacts which are not on Patients that are accessible to the current user.
* Of course it is also good to double check that any changes you make to a Close Contact via the API do show up if you look at that Close Contact in the UI.

# Notes
* Here is an [example RelatedPerson](https://gist.github.com/ngfreiter/2512895678c327101d2c2511727f7eb2) if you want one for testing creating and updating.
*  Don't worry, the PR isn't nearly as big as it seems since most of those changes are from the refactoring of the tests, and the updates to the documentation.
