### PR TITLE
SARAALERT-711: Symptomatic Dashboard Icon

### DIFF
--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -580,7 +580,8 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
       details[:reason_for_closure] = patient[:monitoring_reason] || '' if fields.include?(:reason_for_closure)
       details[:closed_at] = patient[:closed_at]&.rfc2822 || '' if fields.include?(:closed_at)
       details[:transferred_at] = patient[:latest_transfer_at]&.rfc2822 || '' if fields.include?(:transferred_at)
-      details[:latest_report] = patient[:latest_assessment_at]&.rfc2822 || '' if fields.include?(:latest_report)
+      latest_report = { timestamp: patient[:latest_assessment_at]&.rfc2822, symptomatic: patient.latest_assessment_symptomatic? }
+      details[:latest_report] = latest_report || '' if fields.include?(:latest_report)
       details[:status] = patient.status.to_s.gsub('_', ' ').sub('exposure ', '')&.sub('isolation ', '') if fields.include?(:status)
       details[:report_eligibility] = patient.report_eligibility if fields.include?(:report_eligibility)
       details[:is_hoh] = patient.head_of_household?

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -544,13 +544,13 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     patients = patients.select('patients.id, patients.first_name, patients.last_name, patients.user_defined_id_statelocal, patients.symptom_onset, '\
                                'patients.date_of_birth, patients.assigned_user, patients.exposure_risk_assessment, patients.monitoring_plan, '\
                                'patients.public_health_action, patients.monitoring_reason, patients.closed_at, patients.last_date_of_exposure, '\
-                               'patients.created_at, patients.updated_at, patients.latest_assessment_at, patients.latest_transfer_at, '\
-                               'patients.continuous_exposure, patients.head_of_household, patients.purged, patients.monitoring, patients.isolation, '\
-                               'patients.responder_id, patients.pause_notifications, patients.preferred_contact_method, '\
+                               'patients.created_at, patients.updated_at, patients.latest_assessment_at, patients.latest_assessment_symptomatic, '\
+                               'patients.latest_transfer_at, patients.continuous_exposure, patients.head_of_household, patients.purged, patients.monitoring, '\
+                               'patients.isolation, patients.responder_id, patients.pause_notifications, patients.preferred_contact_method, '\
                                'patients.last_assessment_reminder_sent, patients.preferred_contact_time, patients.extended_isolation, '\
                                'patients.latest_fever_or_fever_reducer_at, patients.latest_positive_lab_at, patients.negative_lab_count, '\
                                'patients.head_of_household, jurisdictions.name AS jurisdiction_name, jurisdictions.path AS jurisdiction_path, '\
-                               'jurisdictions.id AS jurisdiction_id', 'patients.latest_assessment_symptomatic')
+                               'jurisdictions.id AS jurisdiction_id')
 
     # execute query and get total count
     total = patients.total_entries

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -550,7 +550,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
                                'patients.last_assessment_reminder_sent, patients.preferred_contact_time, patients.extended_isolation, '\
                                'patients.latest_fever_or_fever_reducer_at, patients.latest_positive_lab_at, patients.negative_lab_count, '\
                                'patients.head_of_household, jurisdictions.name AS jurisdiction_name, jurisdictions.path AS jurisdiction_path, '\
-                               'jurisdictions.id AS jurisdiction_id')
+                               'jurisdictions.id AS jurisdiction_id', 'patients.latest_assessment_symptomatic')
 
     # execute query and get total count
     total = patients.total_entries
@@ -580,7 +580,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
       details[:reason_for_closure] = patient[:monitoring_reason] || '' if fields.include?(:reason_for_closure)
       details[:closed_at] = patient[:closed_at]&.rfc2822 || '' if fields.include?(:closed_at)
       details[:transferred_at] = patient[:latest_transfer_at]&.rfc2822 || '' if fields.include?(:transferred_at)
-      latest_report = { timestamp: patient[:latest_assessment_at]&.rfc2822, symptomatic: patient.latest_assessment_symptomatic? }
+      latest_report = { timestamp: patient[:latest_assessment_at]&.rfc2822, symptomatic: patient[:latest_assessment_symptomatic] }
       details[:latest_report] = latest_report || '' if fields.include?(:latest_report)
       details[:status] = patient.status.to_s.gsub('_', ' ').sub('exposure ', '')&.sub('isolation ', '') if fields.include?(:status)
       details[:report_eligibility] = patient.report_eligibility if fields.include?(:report_eligibility)

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -476,7 +476,7 @@ class PatientsTable extends React.Component {
   };
 
   formatTimestamp(data) {
-    const timestamp = data.value;
+    const timestamp = Object.prototype.hasOwnProperty.call(data, 'value') ? data.value : data;
     const ts = moment.tz(timestamp, 'UTC');
     return ts.isValid() ? ts.tz(moment.tz.guess()).format('MM/DD/YYYY HH:mm z') : '';
   }

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -18,6 +18,7 @@ import {
   Row,
 } from 'react-bootstrap';
 import { ToastContainer } from 'react-toastify';
+import ReactTooltip from 'react-tooltip';
 
 import axios from 'axios';
 import moment from 'moment-timezone';
@@ -60,7 +61,7 @@ class PatientsTable extends React.Component {
           { field: 'reason_for_closure', label: 'Reason for Closure', isSortable: true, tooltip: null },
           { field: 'closed_at', label: 'Closed At', isSortable: true, tooltip: null, filter: this.formatTimestamp },
           { field: 'transferred_at', label: 'Transferred At', isSortable: true, tooltip: null, filter: this.formatTimestamp },
-          { field: 'latest_report', label: 'Latest Report', isSortable: true, tooltip: null, filter: this.formatTimestamp },
+          { field: 'latest_report', label: 'Latest Report', isSortable: true, tooltip: null, filter: this.formatLatestReport },
           { field: 'status', label: 'Status', isSortable: false, tooltip: null },
           { field: 'report_eligibility', label: '', isSortable: false, tooltip: null, filter: this.createEligibilityTooltip, icon: 'far fa-comment' },
         ],
@@ -492,6 +493,31 @@ class PatientsTable extends React.Component {
     }
     return moment(endOfMonitoring, 'YYYY-MM-DD').format('MM/DD/YYYY');
   }
+
+  formatLatestReport = data => {
+    const rowData = data.rowData;
+    return (
+      <Row>
+        <Col xs="1">
+          {rowData.latest_report.symptomatic && (
+            <span data-for={`${rowData.id.toString()}-symptomatic-icon`} data-tip="">
+              <i className="fas fa-exclamation-triangle red-icon"></i>
+              <ReactTooltip
+                id={`${rowData.id.toString()}-symptomatic-icon`}
+                multiline={true}
+                place="right"
+                type="dark"
+                effect="solid"
+                className="tooltip-container">
+                <span>Monitoree&apos;s latest report was symptomatic</span>
+              </ReactTooltip>
+            </span>
+          )}
+        </Col>
+        <Col>{rowData.latest_report.timestamp && this.formatTimestamp(rowData.latest_report.timestamp)}</Col>
+      </Row>
+    );
+  };
 
   createEligibilityTooltip(data) {
     const reportEligibility = data.value;

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -502,13 +502,7 @@ class PatientsTable extends React.Component {
           {rowData.latest_report.symptomatic && (
             <span data-for={`${rowData.id.toString()}-symptomatic-icon`} data-tip="">
               <i className="fas fa-exclamation-triangle red-icon"></i>
-              <ReactTooltip
-                id={`${rowData.id.toString()}-symptomatic-icon`}
-                multiline={true}
-                place="right"
-                type="dark"
-                effect="solid"
-                className="tooltip-container">
+              <ReactTooltip id={`${rowData.id.toString()}-symptomatic-icon`} multiline={false} place="right" type="dark" effect="solid">
                 <span>Monitoree&apos;s latest report was symptomatic</span>
               </ReactTooltip>
             </span>

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -503,7 +503,7 @@ class PatientsTable extends React.Component {
             <span data-for={`${rowData.id.toString()}-symptomatic-icon`} data-tip="">
               <i className="fas fa-exclamation-triangle red-icon"></i>
               <ReactTooltip id={`${rowData.id.toString()}-symptomatic-icon`} multiline={false} place="left" type="dark" effect="solid">
-                <span>Monitoree&apos;s latest report was symptomatic</span>
+                <span>{`Monitoree's latest report was symptomatic`}</span>
               </ReactTooltip>
             </span>
           )}

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -502,7 +502,7 @@ class PatientsTable extends React.Component {
           {rowData.latest_report.symptomatic && (
             <span data-for={`${rowData.id.toString()}-symptomatic-icon`} data-tip="">
               <i className="fas fa-exclamation-triangle red-icon"></i>
-              <ReactTooltip id={`${rowData.id.toString()}-symptomatic-icon`} multiline={false} place="right" type="dark" effect="solid">
+              <ReactTooltip id={`${rowData.id.toString()}-symptomatic-icon`} multiline={false} place="left" type="dark" effect="solid">
                 <span>Monitoree&apos;s latest report was symptomatic</span>
               </ReactTooltip>
             </span>

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -497,8 +497,8 @@ class PatientsTable extends React.Component {
   formatLatestReport = data => {
     const rowData = data.rowData;
     return (
-      <Row>
-        <Col xs="1">
+      <Row className="pl-1">
+        <Col xs="1" className="align-self-center">
           {rowData.latest_report.symptomatic && (
             <span data-for={`${rowData.id.toString()}-symptomatic-icon`} data-tip="">
               <i className="fas fa-exclamation-triangle red-icon"></i>

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -501,7 +501,7 @@ class PatientsTable extends React.Component {
         <Col xs="1" className="align-self-center">
           {rowData.latest_report.symptomatic && (
             <span data-for={`${rowData.id.toString()}-symptomatic-icon`} data-tip="">
-              <i className="fas fa-exclamation-triangle red-icon"></i>
+              <i className="fas fa-exclamation-triangle symptomatic-icon"></i>
               <ReactTooltip id={`${rowData.id.toString()}-symptomatic-icon`} multiline={false} place="left" type="dark" effect="solid">
                 <span>{`Monitoree's latest report was symptomatic`}</span>
               </ReactTooltip>

--- a/app/javascript/packs/stylesheets/application.scss
+++ b/app/javascript/packs/stylesheets/application.scss
@@ -15,3 +15,4 @@
 @import 'advanced_filter';
 @import 'devise_authy';
 @import 'monitoree_details';
+@import 'patient';

--- a/app/javascript/packs/stylesheets/bootstrap.scss
+++ b/app/javascript/packs/stylesheets/bootstrap.scss
@@ -283,8 +283,3 @@ select.form-control {
 .wrap {
   word-break: break-all;
 }
-
-
-.red-icon {
-  color: red;
-}

--- a/app/javascript/packs/stylesheets/bootstrap.scss
+++ b/app/javascript/packs/stylesheets/bootstrap.scss
@@ -285,3 +285,6 @@ select.form-control {
 }
 
 
+.red-icon {
+  color: red;
+}

--- a/app/javascript/packs/stylesheets/patient.scss
+++ b/app/javascript/packs/stylesheets/patient.scss
@@ -1,0 +1,3 @@
+.red-icon {
+  color: red;
+}

--- a/app/javascript/packs/stylesheets/patient.scss
+++ b/app/javascript/packs/stylesheets/patient.scss
@@ -1,3 +1,3 @@
-.red-icon {
-  color: red;
+.symptomatic-icon {
+  color: #CE2717;
 }

--- a/app/javascript/packs/stylesheets/patient.scss
+++ b/app/javascript/packs/stylesheets/patient.scss
@@ -1,3 +1,3 @@
 .symptomatic-icon {
-  color: #CE2717;
+  color: red;
 }

--- a/app/javascript/tests/mocks/mockPatients.js
+++ b/app/javascript/tests/mocks/mockPatients.js
@@ -65,6 +65,7 @@ const blankMockPatient = {
   last_date_of_exposure: null,
   last_name: null,
   latest_assessment_at: null,
+  latest_assessment_symptomatic: null,
   latest_fever_or_fever_reducer_at: null,
   latest_positive_lab_at: null,
   latest_transfer_at: null,
@@ -206,6 +207,7 @@ const mockPatient1 = {
   last_date_of_exposure: '2020-09-13',
   last_name: 'Mouse',
   latest_assessment_at: '2020-09-15T20:59:36.000Z',
+  latest_assessment_symptomatic: null,
   latest_fever_or_fever_reducer_at: null,
   latest_positive_lab_at: null,
   latest_transfer_at: null,
@@ -230,7 +232,7 @@ const mockPatient1 = {
     status: 'reporting',
     transferred_at: '',
     transferred_from: '',
-    transferred_to: ''
+    transferred_to: '',
   },
   member_of_a_common_exposure_cohort: true,
   member_of_a_common_exposure_cohort_type: 'Dark Two-Face',
@@ -278,8 +280,8 @@ const mockPatient1 = {
   user_defined_symptom_onset: null,
   was_in_health_care_facility_with_known_cases: false,
   was_in_health_care_facility_with_known_cases_facility_name: null,
-  white: null
-}
+  white: null,
+};
 
 const mockPatient2 = {
   additional_planned_travel_destination: 'Kokomo',
@@ -346,6 +348,7 @@ const mockPatient2 = {
   last_date_of_exposure: '2020-09-13',
   last_name: 'Mouse',
   latest_assessment_at: '2020-09-15T20:59:36.000Z',
+  latest_assessment_symptomatic: null,
   latest_fever_or_fever_reducer_at: null,
   latest_positive_lab_at: null,
   latest_transfer_at: null,
@@ -370,7 +373,7 @@ const mockPatient2 = {
     status: 'reporting',
     transferred_at: '',
     transferred_from: '',
-    transferred_to: ''
+    transferred_to: '',
   },
   member_of_a_common_exposure_cohort: true,
   member_of_a_common_exposure_cohort_type: 'Dark Two-Face',
@@ -419,8 +422,8 @@ const mockPatient2 = {
   user_defined_symptom_onset: null,
   was_in_health_care_facility_with_known_cases: true,
   was_in_health_care_facility_with_known_cases_facility_name: 'ABC Care',
-  white: null
-}
+  white: null,
+};
 
 const mockPatient3 = {
   additional_planned_travel_destination: 'Kokomo',
@@ -487,6 +490,7 @@ const mockPatient3 = {
   last_date_of_exposure: '2020-09-13',
   last_name: 'Duck',
   latest_assessment_at: '2020-09-15T20:59:36.000Z',
+  latest_assessment_symptomatic: null,
   latest_fever_or_fever_reducer_at: null,
   latest_positive_lab_at: null,
   latest_transfer_at: null,
@@ -511,7 +515,7 @@ const mockPatient3 = {
     status: 'reporting',
     transferred_at: '',
     transferred_from: '',
-    transferred_to: ''
+    transferred_to: '',
   },
   member_of_a_common_exposure_cohort: true,
   member_of_a_common_exposure_cohort_type: 'Dark Two-Face',
@@ -560,8 +564,8 @@ const mockPatient3 = {
   user_defined_symptom_onset: null,
   was_in_health_care_facility_with_known_cases: true,
   was_in_health_care_facility_with_known_cases_facility_name: 'ABC Care',
-  white: null
-}
+  white: null,
+};
 
 const mockPatient4 = {
   additional_planned_travel_destination: 'Kokomo',
@@ -628,6 +632,7 @@ const mockPatient4 = {
   last_date_of_exposure: '2020-09-13',
   last_name: 'Dawg',
   latest_assessment_at: '2020-09-15T20:59:36.000Z',
+  latest_assessment_symptomatic: null,
   latest_fever_or_fever_reducer_at: null,
   latest_positive_lab_at: null,
   latest_transfer_at: null,
@@ -652,7 +657,7 @@ const mockPatient4 = {
     status: 'reporting',
     transferred_at: '',
     transferred_from: '',
-    transferred_to: ''
+    transferred_to: '',
   },
   member_of_a_common_exposure_cohort: true,
   member_of_a_common_exposure_cohort_type: 'Dark Two-Face',
@@ -701,8 +706,8 @@ const mockPatient4 = {
   user_defined_symptom_onset: null,
   was_in_health_care_facility_with_known_cases: true,
   was_in_health_care_facility_with_known_cases_facility_name: 'ABC Care',
-  white: null
-}
+  white: null,
+};
 
 const mockPatient5 = {
   additional_planned_travel_destination: 'Kokomo',
@@ -769,6 +774,7 @@ const mockPatient5 = {
   last_date_of_exposure: null,
   last_name: 'Dastardly',
   latest_assessment_at: '2020-09-18T20:59:36.000Z',
+  latest_assessment_symptomatic: null,
   latest_fever_or_fever_reducer_at: null,
   latest_positive_lab_at: null,
   latest_transfer_at: null,
@@ -793,7 +799,7 @@ const mockPatient5 = {
     status: 'reporting',
     transferred_at: '',
     transferred_from: '',
-    transferred_to: ''
+    transferred_to: '',
   },
   member_of_a_common_exposure_cohort: null,
   member_of_a_common_exposure_cohort_type: null,
@@ -842,8 +848,8 @@ const mockPatient5 = {
   user_defined_symptom_onset: null,
   was_in_health_care_facility_with_known_cases: null,
   was_in_health_care_facility_with_known_cases_facility_name: null,
-  white: null
-  }
+  white: null,
+};
 
 export {
   blankMockPatient,

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -155,9 +155,12 @@ class Assessment < ApplicationRecord
   private
 
   def update_patient_linelist_after_save
+    latest_assessment = patient.assessments.order(:created_at).last
+
     if patient.user_defined_symptom_onset.present? && !patient.symptom_onset.nil?
       patient.update(
-        latest_assessment_at: patient.assessments.maximum(:created_at)
+        latest_assessment_at: latest_assessment&.created_at,
+        latest_assessment_symptomatic: latest_assessment&.symptomatic
       )
     else
       new_symptom_onset = patient.assessments.where(symptomatic: true).minimum(:created_at)&.to_date
@@ -175,17 +178,21 @@ class Assessment < ApplicationRecord
         History.monitoring_change(patient: patient, created_by: 'Sara Alert System', comment: comment)
       end
       patient.update(
-        latest_assessment_at: patient.assessments.maximum(:created_at),
+        latest_assessment_at: latest_assessment&.created_at,
+        latest_assessment_symptomatic: latest_assessment&.symptomatic,
         symptom_onset: new_symptom_onset
       )
     end
   end
 
   def update_patient_linelist_after_destroy
+    latest_assessment = patient.assessments.where.not(id: id).order(:created_at).last
+
     # latest fever or fever reducer at only needs to be updated upon deletion as it is updated in the symptom model upon symptom creation
     if patient.user_defined_symptom_onset.present? && !patient.symptom_onset.nil?
       patient.update(
-        latest_assessment_at: patient.assessments.where.not(id: id).maximum(:created_at)&.to_date,
+        latest_assessment_at: latest_assessment&.created_at,
+        latest_assessment_symptomatic: latest_assessment&.symptomatic,
         latest_fever_or_fever_reducer_at: patient.assessments
                                                  .where.not(id: id)
                                                  .where_assoc_exists(:reported_condition, &:fever_or_fever_reducer)
@@ -199,7 +206,8 @@ class Assessment < ApplicationRecord
       end
       patient.update(
         symptom_onset: new_symptom_onset,
-        latest_assessment_at: patient.assessments.where.not(id: id).maximum(:created_at),
+        latest_assessment_at: latest_assessment&.created_at,
+        latest_assessment_symptomatic: latest_assessment&.symptomatic,
         latest_fever_or_fever_reducer_at: patient.assessments
                                                  .where.not(id: id)
                                                  .where_assoc_exists(:reported_condition, &:fever_or_fever_reducer)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1332,5 +1332,14 @@ class Patient < ApplicationRecord
               end
     History.monitoring_change(patient: self, created_by: 'Sara Alert System', comment: comment)
   end
+
+  # Determine if the most recent assessment was symptomatic
+  def latest_assessment_symptomatic?
+    if !latest_assessment.nil?
+      latest_assessment.symptomatic
+    else
+      false
+    end
+  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1332,14 +1332,5 @@ class Patient < ApplicationRecord
               end
     History.monitoring_change(patient: self, created_by: 'Sara Alert System', comment: comment)
   end
-
-  # Determine if the most recent assessment was symptomatic
-  def latest_assessment_symptomatic?
-    if !latest_assessment.nil?
-      latest_assessment.symptomatic
-    else
-      false
-    end
-  end
 end
 # rubocop:enable Metrics/ClassLength

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -33,7 +33,7 @@ Rails.application.config.filter_parameters += %i[password first_name middle_name
                                                  healthcare_personnel_facility_name crew_on_passenger_or_cargo_flight
                                                  was_in_health_care_facility_with_known_cases
                                                  was_in_health_care_facility_with_known_cases_facility_name
-                                                 exposure_notes symptom_onset continuous_exposure latest_assessment_at
+                                                 exposure_notes symptom_onset continuous_exposure latest_assessment_at latest_assessment_symptomatic
                                                  latest_fever_or_fever_reducer_at latest_positive_lab_at
                                                  negative_lab_count gender_identity sexual_orientation
                                                  extended_isolation isolation dob status user_defined_id_statelocal

--- a/db/migrate/20210315134120_add_latest_assessment_symptomatic_to_patients.rb
+++ b/db/migrate/20210315134120_add_latest_assessment_symptomatic_to_patients.rb
@@ -1,0 +1,21 @@
+class AddLatestAssessmentSymptomaticToPatients < ActiveRecord::Migration[6.1]
+  def up
+    add_column :patients, :latest_assessment_symptomatic, :boolean, default: false
+
+    # populate :latest_assessment_symptomatic
+    execute <<-SQL.squish
+      UPDATE patients
+      INNER JOIN (
+        SELECT patient_id, MAX(created_at)
+        FROM assessments
+        WHERE symptomatic = TRUE
+        GROUP BY patient_id
+      ) t ON patients.id = t.patient_id
+      SET patients.latest_assessment_symptomatic = TRUE
+    SQL
+  end
+
+  def down
+    remove_column :patients, :latest_assessment_symptomatic, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_04_191950) do
+ActiveRecord::Schema.define(version: 2021_03_15_134120) do
 
   create_table "analytics", charset: "utf8", force: :cascade do |t|
     t.integer "jurisdiction_id"
@@ -387,7 +387,6 @@ ActiveRecord::Schema.define(version: 2021_02_04_191950) do
     t.boolean "continuous_exposure", default: false
     t.datetime "latest_assessment_at"
     t.datetime "latest_fever_or_fever_reducer_at"
-    t.date "latest_positive_lab_at"
     t.integer "negative_lab_count", default: 0
     t.datetime "latest_transfer_at"
     t.integer "latest_transfer_from"
@@ -400,6 +399,8 @@ ActiveRecord::Schema.define(version: 2021_02_04_191950) do
     t.boolean "race_other"
     t.boolean "race_unknown"
     t.boolean "race_refused_to_answer"
+    t.date "latest_positive_lab_at"
+    t.boolean "latest_assessment_symptomatic", default: false
     t.index ["assigned_user"], name: "index_patients_on_assigned_user"
     t.index ["creator_id"], name: "index_patients_on_creator_id"
     t.index ["date_of_birth"], name: "index_patients_on_date_of_birth"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -387,6 +387,7 @@ ActiveRecord::Schema.define(version: 2021_03_15_134120) do
     t.boolean "continuous_exposure", default: false
     t.datetime "latest_assessment_at"
     t.datetime "latest_fever_or_fever_reducer_at"
+    t.date "latest_positive_lab_at"
     t.integer "negative_lab_count", default: 0
     t.datetime "latest_transfer_at"
     t.integer "latest_transfer_from"
@@ -399,7 +400,6 @@ ActiveRecord::Schema.define(version: 2021_03_15_134120) do
     t.boolean "race_other"
     t.boolean "race_unknown"
     t.boolean "race_refused_to_answer"
-    t.date "latest_positive_lab_at"
     t.boolean "latest_assessment_symptomatic", default: false
     t.index ["assigned_user"], name: "index_patients_on_assigned_user"
     t.index ["creator_id"], name: "index_patients_on_creator_id"

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -884,6 +884,18 @@ desc 'Backup the database'
       SET patients.latest_assessment_at = t.latest_assessment_at
     SQL
 
+    # populate :latest_assessment_symptomatic
+    ActiveRecord::Base.connection.execute <<-SQL.squish
+      UPDATE patients
+      INNER JOIN (
+        SELECT patient_id, MAX(created_at)
+        FROM assessments
+        WHERE symptomatic = TRUE
+        GROUP BY patient_id
+      ) t ON patients.id = t.patient_id
+      SET patients.latest_assessment_symptomatic = TRUE
+    SQL
+
     # populate :latest_fever_or_fever_reducer_at
     ActiveRecord::Base.connection.execute <<-SQL.squish
       UPDATE patients

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -887,12 +887,19 @@ desc 'Backup the database'
     # populate :latest_assessment_symptomatic
     ActiveRecord::Base.connection.execute <<-SQL.squish
       UPDATE patients
-      INNER JOIN (
-        SELECT patient_id, MAX(created_at)
+      JOIN (
+        SELECT assessments.patient_id
         FROM assessments
-        WHERE symptomatic = TRUE
-        GROUP BY patient_id
-      ) t ON patients.id = t.patient_id
+        JOIN (
+          SELECT patient_id, MAX(created_at) AS latest_assessment_at
+          FROM assessments
+          GROUP BY patient_id
+        ) latest_assessments
+        ON assessments.patient_id = latest_assessments.patient_id
+        AND assessments.created_at = latest_assessments.latest_assessment_at
+        WHERE assessments.symptomatic = TRUE
+      ) latest_symptomatic_assessments
+      ON patients.id = latest_symptomatic_assessments.patient_id
       SET patients.latest_assessment_symptomatic = TRUE
     SQL
 

--- a/test/jobs/purge_job_test.rb
+++ b/test/jobs/purge_job_test.rb
@@ -113,7 +113,7 @@ class PurgeJobTest < ActiveSupport::TestCase
                                was_in_health_care_facility_with_known_cases: false, was_in_health_care_facility_with_known_cases_facility_name: 'a',
                                exposure_notes: 'a', isolation: false, closed_at: 1.month.ago, source_of_report_specify: 'a',
                                pause_notifications: false, symptom_onset: 1.month.ago, case_status: 'Suspect', assigned_user: 1,
-                               latest_assessment_at: 1.month.ago, latest_fever_or_fever_reducer_at: 1.month.ago,
+                               latest_assessment_at: 1.month.ago, latest_assessment_symptomatic: false, latest_fever_or_fever_reducer_at: 1.month.ago,
                                latest_positive_lab_at: 1.month.ago, negative_lab_count: 0, latest_transfer_at: 1.month.ago,
                                latest_transfer_from: 1, gender_identity: 'a', sexual_orientation: 'a', user_defined_symptom_onset: false)
     patient.update(close_contacts: [create(:close_contact, patient: patient)])

--- a/test/models/assessment_test.rb
+++ b/test/models/assessment_test.rb
@@ -38,6 +38,7 @@ class AssessmentTest < ActiveSupport::TestCase
     assessment_1 = create(:assessment, patient: patient, symptomatic: false, created_at: timestamp_1)
     assert_nil patient.symptom_onset
     assert_in_delta timestamp_1, patient.latest_assessment_at, 1
+    assert_equal false, patient.latest_assessment_symptomatic
     assert_nil patient.latest_fever_or_fever_reducer_at
 
     # Update assessment 1 to be symptomatic
@@ -45,6 +46,7 @@ class AssessmentTest < ActiveSupport::TestCase
     assessment_1.update(symptomatic: true, created_at: timestamp_1)
     assert_equal timestamp_1.to_date, patient.symptom_onset
     assert_in_delta timestamp_1, patient.latest_assessment_at, 1
+    assert_equal true, patient.latest_assessment_symptomatic
     assert_nil patient.latest_fever_or_fever_reducer_at
 
     # Create assessment 2 as symptomatic
@@ -54,6 +56,7 @@ class AssessmentTest < ActiveSupport::TestCase
     symptom_2 = create(:symptom, condition_id: reported_condition_2.id, type: 'BoolSymptom', name: 'fever', bool_value: false)
     assert_equal timestamp_2.to_date, patient.symptom_onset
     assert_in_delta timestamp_1, patient.latest_assessment_at, 1
+    assert_equal true, patient.latest_assessment_symptomatic
     assert_nil patient.latest_fever_or_fever_reducer_at
 
     # Update assessment 2 to include fever
@@ -71,12 +74,14 @@ class AssessmentTest < ActiveSupport::TestCase
     assessment_3 = create(:assessment, patient: patient, symptomatic: true, created_at: timestamp_3)
     assert_equal timestamp_3.to_date, patient.symptom_onset
     assert_in_delta timestamp_1, patient.latest_assessment_at, 1
+    assert_equal true, patient.latest_assessment_symptomatic
     assert_nil patient.latest_fever_or_fever_reducer_at
 
     # Update assessment 3 to be asymptomatic
     assessment_3.update(symptomatic: false)
     assert_equal timestamp_2.to_date, patient.symptom_onset
     assert_in_delta timestamp_1, patient.latest_assessment_at, 1
+    assert_equal true, patient.latest_assessment_symptomatic
     assert_nil patient.latest_fever_or_fever_reducer_at
 
     # Manually update symptom onset
@@ -88,12 +93,14 @@ class AssessmentTest < ActiveSupport::TestCase
     assessment_3.update(symptomatic: true, created_at: timestamp_3)
     assert_equal symptom_onset_timestamp.to_date, patient.symptom_onset
     assert_in_delta timestamp_1, patient.latest_assessment_at, 1
+    assert_equal true, patient.latest_assessment_symptomatic
     assert_nil patient.latest_fever_or_fever_reducer_at
 
     # Update assessment 3 to be asymptomatic
     assessment_3.update(symptomatic: false)
     assert_equal symptom_onset_timestamp.to_date, patient.symptom_onset
     assert_in_delta timestamp_1, patient.latest_assessment_at, 1
+    assert_equal true, patient.latest_assessment_symptomatic
     assert_nil patient.latest_fever_or_fever_reducer_at
 
     # Turn off manual symptom onset override
@@ -104,12 +111,14 @@ class AssessmentTest < ActiveSupport::TestCase
     assessment_3.update(symptomatic: true, created_at: timestamp_3)
     assert_equal timestamp_3.to_date, patient.symptom_onset
     assert_in_delta timestamp_1, patient.latest_assessment_at, 1
+    assert_equal true, patient.latest_assessment_symptomatic
     assert_nil patient.latest_fever_or_fever_reducer_at
 
     # Update assessment 3 to be asymptomatic
     assessment_3.update(symptomatic: false)
     assert_equal timestamp_2.to_date, patient.symptom_onset
     assert_in_delta timestamp_1, patient.latest_assessment_at, 1
+    assert_equal true, patient.latest_assessment_symptomatic
     assert_nil patient.latest_fever_or_fever_reducer_at
 
     # Destroy assessment 3
@@ -123,12 +132,19 @@ class AssessmentTest < ActiveSupport::TestCase
     assessment_2.update(created_at: timestamp_2)
     assert_equal timestamp_1.to_date, patient.symptom_onset
     assert_in_delta timestamp_2, patient.latest_assessment_at, 1
+    assert_equal true, patient.latest_assessment_symptomatic
     assert_nil patient.latest_fever_or_fever_reducer_at
 
+    # Update assessment 2 symptomatic
+    assessment_2.update(symptomatic: false)
+    assert_equal false, patient.latest_assessment_symptomatic
+    assessment_2.update(symptomatic: true)
+
     # Update assessment 1 to be asymptomatic
-    assessment_1.update!(symptomatic: false)
+    assessment_1.update(symptomatic: false)
     assert_equal timestamp_2.to_date, patient.symptom_onset
     assert_in_delta timestamp_2, patient.latest_assessment_at, 1
+    assert_equal true, patient.latest_assessment_symptomatic
     assert_nil patient.latest_fever_or_fever_reducer_at
 
     # Destroy assessment 2
@@ -138,9 +154,10 @@ class AssessmentTest < ActiveSupport::TestCase
     assert_nil patient.latest_fever_or_fever_reducer_at
 
     # Update assessment 1 to be symptomatic
-    assessment_1.update!(symptomatic: true)
+    assessment_1.update(symptomatic: true)
     assert_equal timestamp_1.to_date, patient.symptom_onset
     assert_in_delta timestamp_1, patient.latest_assessment_at, 1
+    assert_equal true, patient.latest_assessment_symptomatic
     assert_nil patient.latest_fever_or_fever_reducer_at
 
     # Create assessment 4 with fever
@@ -150,6 +167,7 @@ class AssessmentTest < ActiveSupport::TestCase
     symptom_4 = create(:symptom, condition_id: reported_condition_4.id, type: 'BoolSymptom', name: 'fever', bool_value: true)
     assert_equal timestamp_1.to_date, patient.symptom_onset
     assert_in_delta timestamp_4, patient.latest_assessment_at, 1
+    assert_equal true, patient.latest_assessment_symptomatic
     patient.reload.latest_fever_or_fever_reducer_at
     assert_in_delta timestamp_4, patient.latest_fever_or_fever_reducer_at, 1
 
@@ -163,6 +181,7 @@ class AssessmentTest < ActiveSupport::TestCase
     assessment_4.destroy
     assert_nil patient.symptom_onset
     assert_nil patient.latest_assessment_at
+    assert_nil patient.latest_assessment_symptomatic
     assert_nil patient.latest_fever_or_fever_reducer_at
     assert_empty patient.assessments
   end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -795,6 +795,7 @@ class PatientTest < ActiveSupport::TestCase
     assert patient = create(:patient)
     assert_nil patient.symptom_onset
     assert_nil patient.latest_assessment_at
+    assert_nil patient.latest_assessment_symptomatic
     assert_nil patient.latest_fever_or_fever_reducer_at
     assert_empty patient.assessments
     assert_nil patient.latest_positive_lab_at


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-711](https://tracker.codev.mitre.org/browse/SARAALERT-711)

Display if a monitoree's latest report was symptomatic through an icon on the Patients dashboard.

# Demo/Screenshots
![image](https://user-images.githubusercontent.com/42656458/110540299-5288ba80-80f4-11eb-9935-84ad8eccc8f5.png)


# Important Changes

`app/helpers/patient_query_helper.rb`
- Include symptomatic flag as a part of the Latest Report data element

`app/javascript/components/public_health/PatientsTable.js`
- New format method for the Latest Report column to handle displaying the symptomatic icon

`app/javascript/packs/stylesheets/bootstrap.scss`
- New style class for symptomatic icon

`app/models/patient.rb`
- Method to determine if a monitoree's latest assessment was symptomatic & not reviewed

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [ ] Chrome
* [x] Firefox
* [ ] Safari
* [ ] IE11

- [ ] In the patients table, verify that the symptomatic icon appears in the Latest Report cells for applicable monitorees. Pick some monitorees in the dashboard & verify if they should or shouldn't have the symptomatic icon displayed in the dashbaord.
- [ ] Hover over the symptomatic icon and verify a tooltip appears.
- [ ] Verify that the symptomatic icon only can appear for monitorees in the following line lists: Exposure-Symptomatic, Exposure-PUI, Exposure-AllMonitorees, Isolation-RRR, Isolation-NonReporting, Isolation-Reporting, & Isolation-AllCases.

