### PR TITLE
SARAALERT-1381: Update "isolation asymptomatic non test based” recovery definition

### DIFF
--- a/app/helpers/patient_details_helper.rb
+++ b/app/helpers/patient_details_helper.rb
@@ -16,7 +16,7 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
       return :exposure_non_reporting
     end
 
-    return :isolation_asymp_non_test_based if !latest_assessment_at.nil? && !latest_positive_lab_at.nil? && latest_positive_lab_at < 10.days.ago &&
+    return :isolation_asymp_non_test_based if !latest_assessment_at.nil? && !first_positive_lab_at.nil? && first_positive_lab_at < 10.days.ago &&
                                               symptom_onset.nil? && (!extended_isolation || extended_isolation < Date.today)
     return :isolation_symp_non_test_based if (latest_fever_or_fever_reducer_at.nil? || latest_fever_or_fever_reducer_at < 24.hours.ago) &&
                                              !symptom_onset.nil? && symptom_onset <= 10.days.ago && (!extended_isolation || extended_isolation < Date.today)

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -563,7 +563,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
                                'patients.latest_transfer_at, patients.continuous_exposure, patients.head_of_household, patients.purged, patients.monitoring, '\
                                'patients.isolation, patients.responder_id, patients.pause_notifications, patients.preferred_contact_method, '\
                                'patients.last_assessment_reminder_sent, patients.preferred_contact_time, patients.extended_isolation, '\
-                               'patients.latest_fever_or_fever_reducer_at, patients.latest_positive_lab_at, patients.negative_lab_count, '\
+                               'patients.latest_fever_or_fever_reducer_at, patients.first_positive_lab_at, patients.negative_lab_count, '\
                                'patients.head_of_household, jurisdictions.name AS jurisdiction_name, jurisdictions.path AS jurisdiction_path, '\
                                'jurisdictions.id AS jurisdiction_id')
 

--- a/app/javascript/tests/mocks/mockPatients.js
+++ b/app/javascript/tests/mocks/mockPatients.js
@@ -67,7 +67,7 @@ const blankMockPatient = {
   latest_assessment_at: null,
   latest_assessment_symptomatic: null,
   latest_fever_or_fever_reducer_at: null,
-  latest_positive_lab_at: null,
+  first_positive_lab_at: null,
   latest_transfer_at: null,
   latest_transfer_from: null,
   linelist: {
@@ -209,7 +209,7 @@ const mockPatient1 = {
   latest_assessment_at: '2020-09-15T20:59:36.000Z',
   latest_assessment_symptomatic: null,
   latest_fever_or_fever_reducer_at: null,
-  latest_positive_lab_at: null,
+  first_positive_lab_at: null,
   latest_transfer_at: null,
   latest_transfer_from: null,
   linelist: {
@@ -350,7 +350,7 @@ const mockPatient2 = {
   latest_assessment_at: '2020-09-15T20:59:36.000Z',
   latest_assessment_symptomatic: null,
   latest_fever_or_fever_reducer_at: null,
-  latest_positive_lab_at: null,
+  first_positive_lab_at: null,
   latest_transfer_at: null,
   latest_transfer_from: null,
   linelist: {
@@ -492,7 +492,7 @@ const mockPatient3 = {
   latest_assessment_at: '2020-09-15T20:59:36.000Z',
   latest_assessment_symptomatic: null,
   latest_fever_or_fever_reducer_at: null,
-  latest_positive_lab_at: null,
+  first_positive_lab_at: null,
   latest_transfer_at: null,
   latest_transfer_from: null,
   linelist: {
@@ -634,7 +634,7 @@ const mockPatient4 = {
   latest_assessment_at: '2020-09-15T20:59:36.000Z',
   latest_assessment_symptomatic: null,
   latest_fever_or_fever_reducer_at: null,
-  latest_positive_lab_at: null,
+  first_positive_lab_at: null,
   latest_transfer_at: null,
   latest_transfer_from: null,
   linelist: {
@@ -776,7 +776,7 @@ const mockPatient5 = {
   latest_assessment_at: '2020-09-18T20:59:36.000Z',
   latest_assessment_symptomatic: null,
   latest_fever_or_fever_reducer_at: null,
-  latest_positive_lab_at: null,
+  first_positive_lab_at: null,
   latest_transfer_at: null,
   latest_transfer_from: null,
   linelist: {

--- a/app/models/laboratory.rb
+++ b/app/models/laboratory.rb
@@ -54,14 +54,14 @@ class Laboratory < ApplicationRecord
 
   def update_patient_linelist_after_save
     patient.update(
-      latest_positive_lab_at: patient.laboratories.where(result: 'positive').maximum(:specimen_collection),
+      first_positive_lab_at: patient.laboratories.where(result: 'positive').minimum(:specimen_collection),
       negative_lab_count: patient.laboratories.where(result: 'negative').size
     )
   end
 
   def update_patient_linelist_before_destroy
     patient.update(
-      latest_positive_lab_at: patient.laboratories.where.not(id: id).where(result: 'positive').maximum(:specimen_collection),
+      first_positive_lab_at: patient.laboratories.where.not(id: id).where(result: 'positive').minimum(:specimen_collection),
       negative_lab_count: patient.laboratories.where.not(id: id).where(result: 'negative').size
     )
   end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -456,7 +456,7 @@ class Patient < ApplicationRecord
       .where(isolation: true)
       .where(symptom_onset: nil)
       .where.not(latest_assessment_at: nil)
-      .where('latest_positive_lab_at < ?', 10.days.ago)
+      .where('first_positive_lab_at < ?', 10.days.ago)
       .where('extended_isolation IS NULL OR extended_isolation < ?', Date.today)
   }
 

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -34,7 +34,7 @@ Rails.application.config.filter_parameters += %i[password first_name middle_name
                                                  was_in_health_care_facility_with_known_cases
                                                  was_in_health_care_facility_with_known_cases_facility_name
                                                  exposure_notes symptom_onset continuous_exposure latest_assessment_at latest_assessment_symptomatic
-                                                 latest_fever_or_fever_reducer_at latest_positive_lab_at
+                                                 latest_fever_or_fever_reducer_at first_positive_lab_at
                                                  negative_lab_count gender_identity sexual_orientation
                                                  extended_isolation isolation dob status user_defined_id_statelocal
                                                  user_defined_id_cdc user_defined_id_nndss]

--- a/db/migrate/20210317233414_replace_latest_positive_lab_with_first_positive_lab_on_patients.rb
+++ b/db/migrate/20210317233414_replace_latest_positive_lab_with_first_positive_lab_on_patients.rb
@@ -1,0 +1,38 @@
+# This migration was created to address the issue that our isolation asymptomatic non test based definition was previously using the latest positive lab rather
+# than the first positive lab as outlined by the CDC (https://www.cdc.gov/coronavirus/2019-ncov/hcp/disposition-in-home-patients.html). Since the latest
+# positive lab is no longer a field used for anything, we've decided to replace the field entirely with first positive lab.
+class ReplaceLatestPositiveLabWithFirstPositiveLabOnPatients < ActiveRecord::Migration[6.1]
+  def up
+    add_column :patients, :first_positive_lab_at, :date, index: true
+    remove_column :patients, :latest_positive_lab_at
+
+    # populate :first_positive_lab_at
+    execute <<-SQL.squish
+      UPDATE patients
+      INNER JOIN (
+        SELECT patient_id, MIN(specimen_collection) AS first_positive_lab_at
+        FROM laboratories
+        WHERE result = 'positive'
+        GROUP BY patient_id
+      ) t ON patients.id = t.patient_id
+      SET patients.first_positive_lab_at = t.first_positive_lab_at
+    SQL
+  end
+
+  def down
+    add_column :patients, :latest_positive_lab_at, :date, index: true
+    remove_column :patients, :first_positive_lab_at
+
+    # populate :latest_positive_lab_at
+    execute <<-SQL.squish
+      UPDATE patients
+      INNER JOIN (
+        SELECT patient_id, MAX(specimen_collection) AS latest_positive_lab_at
+        FROM laboratories
+        WHERE result = 'positive'
+        GROUP BY patient_id
+      ) t ON patients.id = t.patient_id
+      SET patients.latest_positive_lab_at = t.latest_positive_lab_at
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_15_134120) do
+ActiveRecord::Schema.define(version: 2021_03_17_233414) do
 
   create_table "analytics", charset: "utf8", force: :cascade do |t|
     t.integer "jurisdiction_id"
@@ -387,7 +387,6 @@ ActiveRecord::Schema.define(version: 2021_03_15_134120) do
     t.boolean "continuous_exposure", default: false
     t.datetime "latest_assessment_at"
     t.datetime "latest_fever_or_fever_reducer_at"
-    t.date "latest_positive_lab_at"
     t.integer "negative_lab_count", default: 0
     t.datetime "latest_transfer_at"
     t.integer "latest_transfer_from"
@@ -401,6 +400,7 @@ ActiveRecord::Schema.define(version: 2021_03_15_134120) do
     t.boolean "race_unknown"
     t.boolean "race_refused_to_answer"
     t.boolean "latest_assessment_symptomatic", default: false
+    t.date "first_positive_lab_at"
     t.index ["assigned_user"], name: "index_patients_on_assigned_user"
     t.index ["creator_id"], name: "index_patients_on_creator_id"
     t.index ["date_of_birth"], name: "index_patients_on_date_of_birth"

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -917,16 +917,16 @@ desc 'Backup the database'
       SET patients.latest_fever_or_fever_reducer_at = t.latest_fever_or_fever_reducer_at
     SQL
 
-    # populate :latest_positive_lab_at
+    # populate :first_positive_lab_at
     ActiveRecord::Base.connection.execute <<-SQL.squish
       UPDATE patients
       INNER JOIN (
-        SELECT patient_id, MAX(specimen_collection) AS latest_positive_lab_at
+        SELECT patient_id, MIN(specimen_collection) AS first_positive_lab_at
         FROM laboratories
         WHERE result = 'positive'
         GROUP BY patient_id
       ) t ON patients.id = t.patient_id
-      SET patients.latest_positive_lab_at = t.latest_positive_lab_at
+      SET patients.first_positive_lab_at = t.first_positive_lab_at
     SQL
 
     # populate :negative_lab_count

--- a/test/fixtures/patients.yml
+++ b/test/fixtures/patients.yml
@@ -51,7 +51,7 @@ patient_1:
   travel_to_affected_country_or_area: true
   symptom_onset: <%= 5.days.ago %>
   latest_assessment_at: <%= 36.days.ago %>
-  latest_positive_lab_at: <%= 5.days.ago %>
+  first_positive_lab_at: <%= 5.days.ago %>
   negative_lab_count: 1
 patient_2:
   id: 2
@@ -1331,7 +1331,7 @@ patient_66:
   primary_telephone_type: 'Plain Cell'
   preferred_contact_method: 'Telephone call'
   last_date_of_exposure: <%= 5.days.ago %>
-  latest_positive_lab_at: <%= 20.days.ago %>
+  first_positive_lab_at: <%= 20.days.ago %>
   latest_assessment_at: <%= 2.days.ago %>
 patient_67:
   id: 67
@@ -1355,7 +1355,7 @@ patient_67:
   primary_telephone_type: 'Plain Cell'
   preferred_contact_method: 'Telephone call'
   last_date_of_exposure: <%= 5.days.ago %>
-  latest_positive_lab_at: <%= 20.days.ago %>
+  first_positive_lab_at: <%= 20.days.ago %>
   latest_assessment_at: <%= 2.days.ago %>
 patient_68:
   id: 68
@@ -1379,5 +1379,5 @@ patient_68:
   primary_telephone_type: 'Plain Cell'
   preferred_contact_method: 'Telephone call'
   last_date_of_exposure: <%= 5.days.ago %>
-  latest_positive_lab_at: <%= 20.days.ago %>
+  first_positive_lab_at: <%= 20.days.ago %>
   latest_assessment_at: <%= 2.days.ago %>

--- a/test/jobs/purge_job_test.rb
+++ b/test/jobs/purge_job_test.rb
@@ -114,7 +114,7 @@ class PurgeJobTest < ActiveSupport::TestCase
                                exposure_notes: 'a', isolation: false, closed_at: 1.month.ago, source_of_report_specify: 'a',
                                pause_notifications: false, symptom_onset: 1.month.ago, case_status: 'Suspect', assigned_user: 1,
                                latest_assessment_at: 1.month.ago, latest_assessment_symptomatic: false, latest_fever_or_fever_reducer_at: 1.month.ago,
-                               latest_positive_lab_at: 1.month.ago, negative_lab_count: 0, latest_transfer_at: 1.month.ago,
+                               first_positive_lab_at: 1.month.ago, negative_lab_count: 0, latest_transfer_at: 1.month.ago,
                                latest_transfer_from: 1, gender_identity: 'a', sexual_orientation: 'a', user_defined_symptom_onset: false)
     patient.update(close_contacts: [create(:close_contact, patient: patient)])
     patient.update(laboratories: [create(:laboratory, patient: patient)])

--- a/test/models/laboratory_test.rb
+++ b/test/models/laboratory_test.rb
@@ -76,39 +76,39 @@ class LaboratoryTest < ActiveSupport::TestCase
 
     # Create laboratory 1 as indeterminate
     laboratory_1 = create(:laboratory, patient: patient, result: 'indeterminate')
-    assert_nil patient.latest_positive_lab_at
+    assert_nil patient.first_positive_lab_at
     assert patient.negative_lab_count.zero?
 
     # Update assessment 1 to be negative
     laboratory_1.update(result: 'negative')
-    assert_nil patient.latest_positive_lab_at
+    assert_nil patient.first_positive_lab_at
     assert_equal 1, patient.negative_lab_count
 
     # Update assessment 1 to be positive
     timestamp_1 = 4.days.ago
     laboratory_1.update(result: 'positive', specimen_collection: timestamp_1)
-    assert_equal timestamp_1.to_date, patient.latest_positive_lab_at
+    assert_equal timestamp_1.to_date, patient.first_positive_lab_at
     assert patient.negative_lab_count.zero?
 
     # Create laboratory 2 as negative
     timestamp_2 = 2.days.ago
     laboratory_2 = create(:laboratory, patient: patient, result: 'negative', specimen_collection: timestamp_2)
-    assert_equal timestamp_1.to_date, patient.latest_positive_lab_at
+    assert_equal timestamp_1.to_date, patient.first_positive_lab_at
     assert_equal 1, patient.negative_lab_count
 
     # Update laboratory 1 back to negative
     laboratory_1.update(result: 'negative')
-    assert_nil patient.latest_positive_lab_at
+    assert_nil patient.first_positive_lab_at
     assert_equal 2, patient.negative_lab_count
 
     # Destory laboratory 1
     laboratory_1.destroy
-    assert_nil patient.latest_positive_lab_at
+    assert_nil patient.first_positive_lab_at
     assert_equal 1, patient.negative_lab_count
 
     # Destory laboratory 2
     laboratory_2.destroy!
-    assert_nil patient.latest_positive_lab_at
+    assert_nil patient.first_positive_lab_at
     assert patient.negative_lab_count.zero?
     assert_empty patient.laboratories
   end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1381](https://tracker.codev.mitre.org/browse/SARAALERT-1381)

For our “isolation asymptomatic non test based” recovery definition (code here), we’re currently using “latest positive lab” instead of “first positive lab”, which seems to be incorrect based on the [cdc guidelines](https://www.cdc.gov/coronavirus/2019-ncov/hcp/disposition-in-home-patients.html).

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/models/patient.rb`
- Update recovery definition logic

`db/migrate/20210310170556_replace_latest_positive_lab_with_first_positive_lab_on_patients.rb`
- Migration to replace and populate field

`db/migrate`
- Replace `latest_positive_lab_at` with `first_positive_lab_at`

`test/models/patient_test.rb`
- Update test to reflect recovery definition change

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Although manual testing can be done by following these steps, the unit tests in `patient_test.rb` are more thorough.

Before checking out this branch:
1. Enroll a case in isolation
2. Add a non-symptomatic assessment
3. Add 2 positive labs, 1 with a specimen collection date more than 10 days ago and one that's less than 10 days ago
4. Notice that the case has a status of `reporting`

Check out the branch and run the migration:
1. Go back to that case's page and verify that the status is `requires review (asymptomatic non test based)`