### PR TITLE
Revert lab results button text

### DIFF
--- a/app/javascript/components/laboratory/Laboratory.js
+++ b/app/javascript/components/laboratory/Laboratory.js
@@ -166,7 +166,7 @@ class Laboratory extends React.Component {
         {!this.props.lab.id && (
           <Button onClick={this.toggleModal}>
             <i className="fas fa-plus fa-fw"></i>
-            <span className="ml-2">Add New Close Contact</span>
+            <span className="ml-2">Add New Lab Result</span>
           </Button>
         )}
         {this.props.lab.id && (


### PR DESCRIPTION
# Description

Fixed copy paste error where the `Add New Lab Result` button actually says `Add New Close Contact`

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
