### PR TITLE
API Documentation Updates for 1.24.0

### DIFF
--- a/docs/api/api-coming-soon.md
+++ b/docs/api/api-coming-soon.md
@@ -7,10 +7,10 @@ nav_order: 2
 
 **Below you will find a list of ongoing work that affects the Sara Alert™ API. This page will be updated regularly. If you have any questions on the information here, please email them to our API Help Desk, saraalert-interop@mitre.org. For past release notes, please see [API Release Notes](api-release-notes).**
 
-## Planned for 1.24\*:
+## Planned for 1.25\*:
 
 - Improved validation error messaging: validation messages will more clearly indicate what value caused the validation error, and where that value is in the JSON document
-- Support for Continuous Exposure
+- Support for Close Contacts 
 
 ---
 

--- a/docs/api/api-release-notes.md
+++ b/docs/api/api-release-notes.md
@@ -5,6 +5,10 @@ parent: API
 nav_order: 1
 ---
 
+# 1.24.0
+* Support for Continuous Exposure
+
+***
 # 1.23.0
 * Support for Foreign Address (read/write)
 


### PR DESCRIPTION
# Description
Jira Ticket: N/A

This updates the API documentation to be accurate with respect to 1.24.0.

# Important Changes
`docs/api-coming-soon.md`
* Update to indicate things coming in 1.25.0

`docs/api-release-notes.md`
* Update to indicate what was released in 1.24.0

# Note
I think it makes sense for us to start doing these updates the second the candidate branch gets merged, for some reason in my head I had been thinking we had to wait until the version was actually released, but that isn't right, we just have to wait on the release before we actually push to `gh-pages`. 
