### PR TITLE
(Bugfix) Buttons above Admin Table Unclickable in Safari

### DIFF
--- a/app/javascript/components/admin/AdminTable.js
+++ b/app/javascript/components/admin/AdminTable.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, DropdownButton, Dropdown, InputGroup, Form, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { Button, DropdownButton, Dropdown, InputGroup, Form, OverlayTrigger, Tooltip, Row, Col } from 'react-bootstrap';
 import 'react-toastify/dist/ReactToastify.css';
 import UserModal from './UserModal';
 import EmailModal from './EmailModal';
@@ -602,8 +602,8 @@ class AdminTable extends React.Component {
     return (
       <div className="mx-2">
         <h1 className="sr-only">Admin Dashboard</h1>
-        <div className="d-flex justify-content-between mb-2">
-          <div className="mb-1">
+        <Row className="mb-2">
+          <Col className="mb-1">
             <Button className="mr-1" size="md" onClick={this.handleAddUserClick}>
               <i className="fas fa-plus-circle"></i>
               &nbsp;Add User
@@ -619,8 +619,8 @@ class AdminTable extends React.Component {
               </Button>
             )}
             {this.state.csvData.length > 0 ? <CSVLink data={this.state.csvData} filename={'sara-accounts.csv'} ref={this.csvLink} /> : undefined}
-          </div>
-          <div>
+          </Col>
+          <Col lg={5}>
             <InputGroup size="md">
               <InputGroup.Prepend>
                 <OverlayTrigger overlay={<Tooltip>Search by id, email, or jurisdiction.</Tooltip>}>
@@ -659,8 +659,8 @@ class AdminTable extends React.Component {
                 </Dropdown.Item>
               </DropdownButton>
             </InputGroup>
-          </div>
-        </div>
+          </Col>
+        </Row>
         <CustomTable
           columnData={this.state.table.colData}
           rowData={this.state.table.rowData}


### PR DESCRIPTION
# Description
Fixes a bug only in 1.25.0 introduced when a CSS class that was previously only applied to the Reports table, was changed to apply generally to the CustomTable (since other implementations such as the VaccinesTable needed it). See descriptions below for how to replicate and a description of the solution.

# (Bugfix) How to Replicate
1. Run `1.25.0` locally and open in Safari.
2. Navigate to the Admin Panel and try to click any of the three buttons above the table - notice they are unclickable.

# (Bugfix) Solution
- There was previously an issue where tables that had buttons that spawned dropdowns (such as the `ReportsTable`) would have those dropdowns cut-off by the `CustomTable` because overflow-y was not specified. Turns out, in the css spec when you have overflow-x on an element set to auto/scroll, then overflow-y gets also automatically set to auto even if you want it to be hidden or visible. See here for discussion/description and further links to docs: https://stackoverflow.com/a/6433475
- To address this, the `custom-table `class was applied to the `CustomTable` which essentially "fakes" enough space for the dropdown to not get cut off.
- This worked in all cases EXCEPT in Safari when the elements above the table (which were covered by this fake margin - see screenshot below) were not placed with `position: relative`. This bug only showed up on the `AdminTable` because these buttons were not in  Bootstrap Row/Col as they are everywhere else. 
<img width="1205" alt="Screen Shot 2021-03-12 at 1 18 47 PM" src="https://user-images.githubusercontent.com/11698457/110986893-43944900-833c-11eb-9670-166c993cf636.png">

- Solution was to put these buttons in a Row/Col to address the issue but also to be more consistent across the application. 

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [x] Firefox
* [x] Safari
* [x] Edge
* [ ] IE11 - currently unable to test due to other bug with monitoree page on IE that we are investigating.

I tested in almost all browsers (except IE11 - see above note) - but please in addition to verifying the buttons now work, please also verify that when the Reports table (or Vaccines table) only has 1 record, the Actions button does not get cut off like this (as that was the original bug the custom CSS class was fixing).
![Screen Shot 2021-03-12 at 10 23 43 AM](https://user-images.githubusercontent.com/11698457/110977016-a0d5cd80-832f-11eb-9429-e2e2d0507de3.png)
