### PR TITLE
SARAALERT-475: Ability to hide locked users

### DIFF
--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -246,7 +246,7 @@ class CustomTable extends React.Component {
               })}
               {!this.props.rowData?.length && (
                 <tr>
-                  <td colSpan={this.props.columnData?.length + (this.props.isEditable ? 0 : 1) + (this.props.isSelectable ? 0 : 1)} className="text-center">
+                  <td colSpan={this.props.columnData?.length + (this.props.isEditable ? 1 : 0) + (this.props.isSelectable ? 1 : 0)} className="text-center">
                     No data available in table.
                   </td>
                 </tr>

--- a/test/system/roles/admin/dashboard/dashboard_verifier.rb
+++ b/test/system/roles/admin/dashboard/dashboard_verifier.rb
@@ -33,6 +33,7 @@ class AdminDashboardVerifier < ApplicationSystemTestCase
   end
 
   def verify_lock_status(email, locked)
+    find('#admin-table-all-filter-btn').click
     if locked
       assert page.has_content?('Locked'), @@system_test_utils.get_err_msg('User info', 'status', 'Locked')
       assert_not_nil User.where(email: email).first.locked_at, @@system_test_utils.get_err_msg('Lock user', 'locked_at', 'not nil')


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-475](https://tracker.codev.mitre.org/browse/SARAALERT-475)

Add switch/toggle above admin table to hide/show locked users. Default to only showing unlocked.

# (Feature) Demo/Screenshots
https://user-images.githubusercontent.com/35042815/111217843-63ca3f00-85ac-11eb-8812-1810a0228055.mov

# Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`admin_controller.rb`
- Added support to filter users by all/unlocked/locked

`AdminTable.js`
- Added all/unlocked/locked toggle buttons at the top of admin table for filtering

`CustomTable.js`
- Fixed bug where "No data to display" column wouldn't span the whole admin table

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

Please describe the tests needed to verify your changes. Provide instructions for reproducing these tests. List any relevant details for your test configuration.
