### PR TITLE
SARAALERT-727: Refine Duplicate Detection

### DIFF
--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -113,11 +113,7 @@ class ImportController < ApplicationController
           end
 
           # Checking for duplicates under current user's viewable patients is acceptable because custom jurisdictions must fall under hierarchy
-          patient[:duplicate_data] = current_user.viewable_patients.duplicate_data(patient[:first_name],
-                                                                                   patient[:last_name],
-                                                                                   patient[:sex],
-                                                                                   patient[:date_of_birth],
-                                                                                   patient[:user_defined_id_statelocal])
+          patient[:duplicate_data] = current_user.viewable_patients.duplicate_data_detection(patient)
         rescue ValidationError => e
           @errors << e&.message || "Unknown error on row #{row_ind}"
         rescue StandardError => e

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -101,11 +101,7 @@ class PatientsController < ApplicationController
 
     # Check for potential duplicate
     unless params[:bypass_duplicate]
-      duplicate_data = current_user.viewable_patients.duplicate_data(allowed_params[:first_name],
-                                                                     allowed_params[:last_name],
-                                                                     allowed_params[:sex],
-                                                                     allowed_params[:date_of_birth],
-                                                                     allowed_params[:user_defined_id_statelocal])
+      duplicate_data = current_user.viewable_patients.duplicate_data_detection(allowed_params)
 
       render(json: duplicate_data) && return if duplicate_data[:is_duplicate]
     end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -759,10 +759,9 @@ class Patient < ApplicationRecord
     fn_ln_sex_matches = 0
     fn_ln_dob_matches = 0
     fn_ln_matches = 0
-    potential_duplicates = where(first_name: first_name, last_name: last_name)
 
     # Determine which type of duplicate exists
-    potential_duplicates.pluck(*%i[sex date_of_birth]).each do |(s, dob)|
+    where(first_name: first_name, last_name: last_name).pluck(*%i[sex date_of_birth]).each do |(s, dob)|
       dob = dob&.strftime('%F')
       # If the sex isn't nil and doesn't match it is not a duplicate. Same for DoB.
       next if (sex.present? && s.present? && sex != s) || (date_of_birth.present? && dob.present? && date_of_birth != dob)

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -745,11 +745,15 @@ class Patient < ApplicationRecord
   # OR
   # - matching state/local id
   def self.duplicate_data(first_name, last_name, sex, date_of_birth, user_defined_id_statelocal)
-    # if first_name or last_name is null skip duplicate detection
-    return false if first_name.nil? || last_name.nil?
-
     # Track which matches have occurred
     duplicate_field_data = []
+
+    # check for a duplicate state/local id
+    dup_statelocal_id = where('user_defined_id_statelocal = ?', user_defined_id_statelocal&.to_s&.strip)
+    duplicate_field_data << { count: dup_statelocal_id.count, fields: ['State/Local ID'] } if dup_statelocal_id.present?
+
+    # if first_name or last_name is null skip duplicate detection
+    return { is_duplicate: duplicate_field_data.length.positive?, duplicate_field_data: duplicate_field_data } if first_name.nil? || last_name.nil?
 
     # Get fields that have matching values
     fn_ln_match = where('first_name = ?', first_name)
@@ -797,10 +801,6 @@ class Patient < ApplicationRecord
     end
     # put the remaining matches in
     duplicate_field_data << { count: remaining_matches, fields: ['First Name', 'Last Name'] } if remaining_matches.positive?
-
-    # check for a duplicate state/local id
-    dup_statelocal_id = where('user_defined_id_statelocal = ?', user_defined_id_statelocal&.to_s&.strip)
-    duplicate_field_data << { count: dup_statelocal_id.count, fields: ['State/Local ID'] } if dup_statelocal_id.present?
 
     { is_duplicate: duplicate_field_data.length.positive?, duplicate_field_data: duplicate_field_data }
   end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -759,9 +759,9 @@ class Patient < ApplicationRecord
     fn_ln_sex_matches = 0
     fn_ln_dob_matches = 0
     fn_ln_matches = 0
-    potential_duplicates = where(first_name: first_name, last_name: last_name)
     return { is_duplicate: duplicate_field_data.any?, duplicate_field_data: duplicate_field_data } if first_name.nil? || last_name.nil?
 
+    potential_duplicates = where(first_name: first_name, last_name: last_name)
     potential_duplicates_count = potential_duplicates.size
 
     # Remove any records that don't match.

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -762,15 +762,17 @@ class Patient < ApplicationRecord
     potential_duplicates = where(first_name: first_name, last_name: last_name)
 
     # Determine which type of duplicate exists
-    potential_duplicates.pluck(*%i[sex date_of_birth]).each do |p|
+    potential_duplicates.pluck(*%i[sex date_of_birth]).each do |(s, dob)|
+      dob = dob&.strftime('%F')
       # If the sex isn't nil and doesn't match it is not a duplicate. Same for DoB.
-      if (sex.present? && !p[0].nil? && sex != p[0]) || (date_of_birth.present? && !p[1].nil? && date_of_birth != p[1].strftime('%F'))
-      # this is not a duplicate
-      elsif sex.present? && sex == p[0] && date_of_birth.present? && !p[1].nil? && date_of_birth == p[1].strftime('%F')
+      next if (sex.present? && s.present? && sex != s) || (date_of_birth.present? && dob.present? && date_of_birth != dob)
+
+      # Check for duplicates
+      if sex.present? && sex == s && date_of_birth.present? && date_of_birth == dob
         fn_ln_sex_dob_matches += 1
-      elsif sex.present? && sex == p[0]
+      elsif sex.present? && sex == s
         fn_ln_sex_matches += 1
-      elsif date_of_birth.present? && !p[1].nil? && date_of_birth == p[1].strftime('%F')
+      elsif date_of_birth.present? && date_of_birth == dob
         fn_ln_dob_matches += 1
       else
         fn_ln_matches += 1

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -759,27 +759,14 @@ class Patient < ApplicationRecord
     fn_ln_sex_matches = 0
     fn_ln_dob_matches = 0
     fn_ln_matches = 0
-    return { is_duplicate: duplicate_field_data.any?, duplicate_field_data: duplicate_field_data } if first_name.nil? || last_name.nil?
-
     potential_duplicates = where(first_name: first_name, last_name: last_name)
-    potential_duplicates_count = potential_duplicates.size
-
-    # Remove any records that don't match.
-    if potential_duplicates.size.positive? && date_of_birth.present?
-      potential_duplicates.where.not(date_of_birth: nil).where.not('date_of_birth = ?', date_of_birth).destroy_all
-      potential_duplicates_count = potential_duplicates.size
-    end
-    if potential_duplicates.size.positive? && sex.present?
-      potential_duplicates.where.not(sex: nil).where.not('sex = ?', sex).destroy_all
-      potential_duplicates_count = potential_duplicates.size
-    end
-
-    # Return if we don't have any potential matches
-    return { is_duplicate: duplicate_field_data.any?, duplicate_field_data: duplicate_field_data } unless potential_duplicates_count.positive?
 
     # Determine which type of duplicate exists
     potential_duplicates.pluck(*%i[sex date_of_birth]).each do |p|
-      if sex.present? && sex == p[0] && date_of_birth.present? && !p[1].nil? && date_of_birth == p[1].strftime('%F')
+      # If the sex isn't nil and doesn't match it is not a duplicate. Same for DoB.
+      if (sex.present? && !p[0].nil? && sex != p[0]) || (date_of_birth.present? && !p[1].nil? && date_of_birth != p[1].strftime('%F'))
+      # this is not a duplicate
+      elsif sex.present? && sex == p[0] && date_of_birth.present? && !p[1].nil? && date_of_birth == p[1].strftime('%F')
         fn_ln_sex_dob_matches += 1
       elsif sex.present? && sex == p[0]
         fn_ln_sex_matches += 1

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -767,19 +767,19 @@ class Patient < ApplicationRecord
 
     # Determine which type of duplicate exists
     where(first_name: patient[:first_name], last_name: patient[:last_name])
-      .select('sex', "DATE_FORMAT(date_of_birth, '%Y-%m-%d') date_of_birth").each do |found|
+      .pluck(:sex, ActiveRecord::Base.sanitize_sql(Arel.sql('CAST(date_of_birth AS CHAR)'))).each do |(sex, dob)|
         # If the sex isn't nil and doesn't match it is not a duplicate. Same for DoB.
-        if (patient[:sex].present? && found.sex.present? && patient[:sex] != found.sex) ||
-           (date_of_birth.present? && found.date_of_birth.present? && date_of_birth != found.date_of_birth.to_s)
+        if (patient[:sex].present? && sex.present? && patient[:sex] != sex) ||
+           (date_of_birth.present? && dob.present? && date_of_birth != dob)
           next
         end
 
         # Check for duplicates
-        if patient[:sex].present? && patient[:sex] == found.sex && date_of_birth.present? && date_of_birth == found.date_of_birth.to_s
+        if patient[:sex].present? && patient[:sex] == sex && date_of_birth.present? && date_of_birth == dob
           fn_ln_sex_dob_matches += 1
-        elsif patient[:sex].present? && patient[:sex] == found.sex
+        elsif patient[:sex].present? && patient[:sex] == sex
           fn_ln_sex_matches += 1
-        elsif date_of_birth.present? && date_of_birth == found.date_of_birth.to_s
+        elsif date_of_birth.present? && date_of_birth == dob
           fn_ln_dob_matches += 1
         else
           fn_ln_matches += 1

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -775,11 +775,11 @@ class Patient < ApplicationRecord
         end
 
         # Check for duplicates
-        if patient[:sex].present? && patient[:sex] == found.sex && patient[:date_of_birth].present? && date_of_birth == found.date_of_birth.to_s
+        if patient[:sex].present? && patient[:sex] == found.sex && date_of_birth.present? && date_of_birth == found.date_of_birth.to_s
           fn_ln_sex_dob_matches += 1
         elsif patient[:sex].present? && patient[:sex] == found.sex
           fn_ln_sex_matches += 1
-        elsif patient[:date_of_birth].present? && patient[:date_of_birth] == found.date_of_birth.to_s
+        elsif date_of_birth.present? && date_of_birth == found.date_of_birth.to_s
           fn_ln_dob_matches += 1
         else
           fn_ln_matches += 1

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -763,6 +763,10 @@ class Patient < ApplicationRecord
     # Determine which type of duplicate exists
     where(first_name: first_name, last_name: last_name).pluck(*%i[sex date_of_birth]).each do |(s, dob)|
       dob = dob&.strftime('%F')
+
+      # The EPI-X format sends this as a Date while Exposure sends it as a string
+      date_of_birth = date_of_birth&.strftime('%F') if date_of_birth.instance_of?(Date)
+
       # If the sex isn't nil and doesn't match it is not a duplicate. Same for DoB.
       next if (sex.present? && s.present? && sex != s) || (date_of_birth.present? && dob.present? && date_of_birth != dob)
 

--- a/test/models/patient_duplicate_detection_test.rb
+++ b/test/models/patient_duplicate_detection_test.rb
@@ -24,7 +24,7 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   end
 
   test 'duplicate_data finds duplicate with input of FN LN Sex DoB ID' do
-    patient_dup = {first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: 'Male', user_defined_id_statelocal: 'asdf123'}
+    patient_dup = { first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: 'Male', user_defined_id_statelocal: 'asdf123' }
 
     duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
                                             patient_dup[:last_name],
@@ -58,7 +58,7 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   end
 
   test 'duplicate_data finds duplicate with input of FN LN DoB' do
-    patient_dup = {first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31'}
+    patient_dup = { first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31' }
 
     duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
                                             patient_dup[:last_name],
@@ -80,7 +80,7 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   end
 
   test 'duplicate_data finds duplicate with input of FN LN Sex' do
-    patient_dup = {first_name: 'Deckard', last_name: 'Cain', sex: 'Male'}
+    patient_dup = { first_name: 'Deckard', last_name: 'Cain', sex: 'Male' }
 
     duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
                                             patient_dup[:last_name],
@@ -102,7 +102,7 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   end
 
   test 'duplicate_data finds duplicate with input of FN LN' do
-    patient_dup = {first_name: 'Deckard', last_name: 'Cain'}
+    patient_dup = { first_name: 'Deckard', last_name: 'Cain' }
 
     duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
                                             patient_dup[:last_name],
@@ -120,7 +120,7 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   end
 
   test 'duplicate_data finds duplicate with input of FN ID' do
-    patient_dup = {first_name: 'Deckard', user_defined_id_statelocal: 'asdf123'}
+    patient_dup = { first_name: 'Deckard', user_defined_id_statelocal: 'asdf123' }
 
     duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
                                             patient_dup[:last_name],
@@ -138,7 +138,7 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   end
 
   test 'duplicate_data finds duplicate with input of LN ID' do
-    patient_dup = {last_name: 'Cain',  user_defined_id_statelocal: 'asdf123'}
+    patient_dup = { last_name: 'Cain', user_defined_id_statelocal: 'asdf123' }
 
     duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
                                             patient_dup[:last_name],
@@ -156,7 +156,7 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   end
 
   test 'duplicate_data finds duplicate with input of ID' do
-    patient_dup = {user_defined_id_statelocal: 'asdf123'}
+    patient_dup = { user_defined_id_statelocal: 'asdf123' }
 
     duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
                                             patient_dup[:last_name],
@@ -174,7 +174,7 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   end
 
   test 'duplicate_data does NOT find duplicate with input of FN LN Sex DoB ID' do
-    patient_dup = {first_name: 'Cain', last_name: 'Deckard', date_of_birth: '1996-12-31', sex: 'Male', user_defined_id_statelocal: '123abc'}
+    patient_dup = { first_name: 'Cain', last_name: 'Deckard', date_of_birth: '1996-12-31', sex: 'Male', user_defined_id_statelocal: '123abc' }
     duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
                                             patient_dup[:last_name],
                                             patient_dup[:sex],

--- a/test/models/patient_duplicate_detection_test.rb
+++ b/test/models/patient_duplicate_detection_test.rb
@@ -6,30 +6,30 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   def setup
     Patient.destroy_all
     create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: 'Male', user_defined_id_statelocal: 'asdf123')
-    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: nil)
-    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: 'Male')
-    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: nil)
-    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: 'Male')
-    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: nil)
-    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: nil)
-    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: nil)
-    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: nil)
-    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: nil)
-    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-30', sex: nil)
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31')
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', sex: 'Male')
+    create(:patient, first_name: 'Deckard', last_name: 'Cain')
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', sex: 'Male')
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31')
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31')
+    create(:patient, first_name: 'Deckard', last_name: 'Cain')
+    create(:patient, first_name: 'Deckard', last_name: 'Cain')
+    create(:patient, first_name: 'Deckard', last_name: 'Cain')
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-30')
     create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: 'Female')
     create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-30', sex: 'Male')
-    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: 'Female')
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', sex: 'Female')
     create(:patient, first_name: 'Deckar', last_name: 'Cain', date_of_birth: '1996-12-31', sex: 'Male')
     create(:patient, first_name: 'Deckard', last_name: 'Cai', date_of_birth: '1996-12-31', sex: 'Male')
   end
 
   test 'duplicate_data finds duplicate with input of FN LN Sex DoB ID' do
-    patient_dup = Patient.new(first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: 'Male', user_defined_id_statelocal: 'asdf123')
+    patient_dup = {first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: 'Male', user_defined_id_statelocal: 'asdf123'}
 
     duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
                                             patient_dup[:last_name],
                                             patient_dup[:sex],
-                                            patient_dup[:date_of_birth]&.strftime('%F'),
+                                            patient_dup[:date_of_birth],
                                             patient_dup[:user_defined_id_statelocal])
 
     assert duplicate_data[:is_duplicate]
@@ -58,12 +58,12 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   end
 
   test 'duplicate_data finds duplicate with input of FN LN DoB' do
-    patient_dup = Patient.new(first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: nil, user_defined_id_statelocal: nil)
+    patient_dup = {first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31'}
 
     duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
                                             patient_dup[:last_name],
                                             patient_dup[:sex],
-                                            patient_dup[:date_of_birth]&.strftime('%F'),
+                                            patient_dup[:date_of_birth],
                                             patient_dup[:user_defined_id_statelocal])
 
     assert duplicate_data[:is_duplicate]
@@ -80,12 +80,12 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   end
 
   test 'duplicate_data finds duplicate with input of FN LN Sex' do
-    patient_dup = Patient.new(first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: 'Male', user_defined_id_statelocal: nil)
+    patient_dup = {first_name: 'Deckard', last_name: 'Cain', sex: 'Male'}
 
     duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
                                             patient_dup[:last_name],
                                             patient_dup[:sex],
-                                            patient_dup[:date_of_birth]&.strftime('%F'),
+                                            patient_dup[:date_of_birth],
                                             patient_dup[:user_defined_id_statelocal])
 
     assert duplicate_data[:is_duplicate]
@@ -102,12 +102,12 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   end
 
   test 'duplicate_data finds duplicate with input of FN LN' do
-    patient_dup = Patient.new(first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: nil, user_defined_id_statelocal: nil)
+    patient_dup = {first_name: 'Deckard', last_name: 'Cain'}
 
     duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
                                             patient_dup[:last_name],
                                             patient_dup[:sex],
-                                            patient_dup[:date_of_birth]&.strftime('%F'),
+                                            patient_dup[:date_of_birth],
                                             patient_dup[:user_defined_id_statelocal])
 
     assert duplicate_data[:is_duplicate]
@@ -120,12 +120,12 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   end
 
   test 'duplicate_data finds duplicate with input of FN ID' do
-    patient_dup = Patient.new(first_name: 'Deckard', last_name: nil, date_of_birth: nil, sex: nil, user_defined_id_statelocal: 'asdf123')
+    patient_dup = {first_name: 'Deckard', user_defined_id_statelocal: 'asdf123'}
 
     duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
                                             patient_dup[:last_name],
                                             patient_dup[:sex],
-                                            patient_dup[:date_of_birth]&.strftime('%F'),
+                                            patient_dup[:date_of_birth],
                                             patient_dup[:user_defined_id_statelocal])
 
     assert duplicate_data[:is_duplicate]
@@ -138,12 +138,12 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   end
 
   test 'duplicate_data finds duplicate with input of LN ID' do
-    patient_dup = Patient.new(first_name: nil, last_name: 'Cain', date_of_birth: nil, sex: nil, user_defined_id_statelocal: 'asdf123')
+    patient_dup = {last_name: 'Cain',  user_defined_id_statelocal: 'asdf123'}
 
     duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
                                             patient_dup[:last_name],
                                             patient_dup[:sex],
-                                            patient_dup[:date_of_birth]&.strftime('%F'),
+                                            patient_dup[:date_of_birth],
                                             patient_dup[:user_defined_id_statelocal])
 
     assert duplicate_data[:is_duplicate]
@@ -156,12 +156,12 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   end
 
   test 'duplicate_data finds duplicate with input of ID' do
-    patient_dup = Patient.new(first_name: nil, last_name: nil, date_of_birth: nil, sex: nil, user_defined_id_statelocal: 'asdf123')
+    patient_dup = {user_defined_id_statelocal: 'asdf123'}
 
     duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
                                             patient_dup[:last_name],
                                             patient_dup[:sex],
-                                            patient_dup[:date_of_birth]&.strftime('%F'),
+                                            patient_dup[:date_of_birth],
                                             patient_dup[:user_defined_id_statelocal])
 
     assert duplicate_data[:is_duplicate]
@@ -174,11 +174,11 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   end
 
   test 'duplicate_data does NOT find duplicate with input of FN LN Sex DoB ID' do
-    patient_dup = Patient.new(first_name: 'Cain', last_name: 'Deckard', date_of_birth: '1996-12-31', sex: 'Male', user_defined_id_statelocal: '123abc')
+    patient_dup = {first_name: 'Cain', last_name: 'Deckard', date_of_birth: '1996-12-31', sex: 'Male', user_defined_id_statelocal: '123abc'}
     duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
                                             patient_dup[:last_name],
                                             patient_dup[:sex],
-                                            patient_dup[:date_of_birth]&.strftime('%F'),
+                                            patient_dup[:date_of_birth],
                                             patient_dup[:user_defined_id_statelocal])
 
     assert_not duplicate_data[:is_duplicate]

--- a/test/models/patient_duplicate_detection_test.rb
+++ b/test/models/patient_duplicate_detection_test.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require 'test_case'
+
+class PatientDuplicateDetectionTest < ActiveSupport::TestCase
+  def setup
+    Patient.destroy_all
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: 'Male', user_defined_id_statelocal: 'asdf123')
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: nil)
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: 'Male')
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: nil)
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: 'Male')
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: nil)
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: nil)
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: nil)
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: nil)
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: nil)
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-30', sex: nil)
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: 'Female')
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-30', sex: 'Male')
+    create(:patient, first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: 'Female')
+    create(:patient, first_name: 'Deckar', last_name: 'Cain', date_of_birth: '1996-12-31', sex: 'Male')
+    create(:patient, first_name: 'Deckard', last_name: 'Cai', date_of_birth: '1996-12-31', sex: 'Male')
+  end
+
+  test 'duplicate_data finds duplicate with input of FN LN Sex DoB ID' do
+    patient_dup = Patient.new(first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: 'Male', user_defined_id_statelocal: 'asdf123')
+
+    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
+                                            patient_dup[:last_name],
+                                            patient_dup[:sex],
+                                            patient_dup[:date_of_birth]&.strftime('%F'),
+                                            patient_dup[:user_defined_id_statelocal])
+
+    assert duplicate_data[:is_duplicate]
+    assert_equal(duplicate_data[:duplicate_field_data], [
+                   {
+                     count: 1,
+                     fields: ['State/Local ID']
+                   },
+                   {
+                     count: 1,
+                     fields: ['First Name', 'Last Name', 'Sex', 'Date of Birth']
+                   },
+                   {
+                     count: 2,
+                     fields: ['First Name', 'Last Name', 'Sex']
+                   },
+                   {
+                     count: 3,
+                     fields: ['First Name', 'Last Name', 'Date of Birth']
+                   },
+                   {
+                     count: 4,
+                     fields: ['First Name', 'Last Name']
+                   }
+                 ])
+  end
+
+  test 'duplicate_data finds duplicate with input of FN LN DoB' do
+    patient_dup = Patient.new(first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: nil, user_defined_id_statelocal: nil)
+
+    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
+                                            patient_dup[:last_name],
+                                            patient_dup[:sex],
+                                            patient_dup[:date_of_birth]&.strftime('%F'),
+                                            patient_dup[:user_defined_id_statelocal])
+
+    assert duplicate_data[:is_duplicate]
+    assert_equal(duplicate_data[:duplicate_field_data], [
+                   {
+                     count: 5,
+                     fields: ['First Name', 'Last Name', 'Date of Birth']
+                   },
+                   {
+                     count: 7,
+                     fields: ['First Name', 'Last Name']
+                   }
+                 ])
+  end
+
+  test 'duplicate_data finds duplicate with input of FN LN Sex' do
+    patient_dup = Patient.new(first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: 'Male', user_defined_id_statelocal: nil)
+
+    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
+                                            patient_dup[:last_name],
+                                            patient_dup[:sex],
+                                            patient_dup[:date_of_birth]&.strftime('%F'),
+                                            patient_dup[:user_defined_id_statelocal])
+
+    assert duplicate_data[:is_duplicate]
+    assert_equal(duplicate_data[:duplicate_field_data], [
+                   {
+                     count: 4,
+                     fields: ['First Name', 'Last Name', 'Sex']
+                   },
+                   {
+                     count: 8,
+                     fields: ['First Name', 'Last Name']
+                   }
+                 ])
+  end
+
+  test 'duplicate_data finds duplicate with input of FN LN' do
+    patient_dup = Patient.new(first_name: 'Deckard', last_name: 'Cain', date_of_birth: nil, sex: nil, user_defined_id_statelocal: nil)
+
+    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
+                                            patient_dup[:last_name],
+                                            patient_dup[:sex],
+                                            patient_dup[:date_of_birth]&.strftime('%F'),
+                                            patient_dup[:user_defined_id_statelocal])
+
+    assert duplicate_data[:is_duplicate]
+    assert_equal(duplicate_data[:duplicate_field_data], [
+                   {
+                     count: 14,
+                     fields: ['First Name', 'Last Name']
+                   }
+                 ])
+  end
+
+  test 'duplicate_data finds duplicate with input of FN ID' do
+    patient_dup = Patient.new(first_name: 'Deckard', last_name: nil, date_of_birth: nil, sex: nil, user_defined_id_statelocal: 'asdf123')
+
+    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
+                                            patient_dup[:last_name],
+                                            patient_dup[:sex],
+                                            patient_dup[:date_of_birth]&.strftime('%F'),
+                                            patient_dup[:user_defined_id_statelocal])
+
+    assert duplicate_data[:is_duplicate]
+    assert_equal(duplicate_data[:duplicate_field_data], [
+                   {
+                     count: 1,
+                     fields: ['State/Local ID']
+                   }
+                 ])
+  end
+
+  test 'duplicate_data finds duplicate with input of LN ID' do
+    patient_dup = Patient.new(first_name: nil, last_name: 'Cain', date_of_birth: nil, sex: nil, user_defined_id_statelocal: 'asdf123')
+
+    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
+                                            patient_dup[:last_name],
+                                            patient_dup[:sex],
+                                            patient_dup[:date_of_birth]&.strftime('%F'),
+                                            patient_dup[:user_defined_id_statelocal])
+
+    assert duplicate_data[:is_duplicate]
+    assert_equal(duplicate_data[:duplicate_field_data], [
+                   {
+                     count: 1,
+                     fields: ['State/Local ID']
+                   }
+                 ])
+  end
+
+  test 'duplicate_data finds duplicate with input of ID' do
+    patient_dup = Patient.new(first_name: nil, last_name: nil, date_of_birth: nil, sex: nil, user_defined_id_statelocal: 'asdf123')
+
+    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
+                                            patient_dup[:last_name],
+                                            patient_dup[:sex],
+                                            patient_dup[:date_of_birth]&.strftime('%F'),
+                                            patient_dup[:user_defined_id_statelocal])
+
+    assert duplicate_data[:is_duplicate]
+    assert_equal(duplicate_data[:duplicate_field_data], [
+                   {
+                     count: 1,
+                     fields: ['State/Local ID']
+                   }
+                 ])
+  end
+
+  test 'duplicate_data does NOT find duplicate with input of FN LN Sex DoB ID' do
+    patient_dup = Patient.new(first_name: 'Cain', last_name: 'Deckard', date_of_birth: '1996-12-31', sex: 'Male', user_defined_id_statelocal: '123abc')
+    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
+                                            patient_dup[:last_name],
+                                            patient_dup[:sex],
+                                            patient_dup[:date_of_birth]&.strftime('%F'),
+                                            patient_dup[:user_defined_id_statelocal])
+
+    assert_not duplicate_data[:is_duplicate]
+    assert_equal(duplicate_data[:duplicate_field_data], [])
+  end
+end

--- a/test/models/patient_duplicate_detection_test.rb
+++ b/test/models/patient_duplicate_detection_test.rb
@@ -26,11 +26,7 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   test 'duplicate_data finds duplicate with input of FN LN Sex DoB ID' do
     patient_dup = { first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31', sex: 'Male', user_defined_id_statelocal: 'asdf123' }
 
-    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
-                                            patient_dup[:last_name],
-                                            patient_dup[:sex],
-                                            patient_dup[:date_of_birth],
-                                            patient_dup[:user_defined_id_statelocal])
+    duplicate_data = Patient.duplicate_data_detection(patient_dup)
 
     assert duplicate_data[:is_duplicate]
     assert_equal(duplicate_data[:duplicate_field_data], [
@@ -60,11 +56,7 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   test 'duplicate_data finds duplicate with input of FN LN DoB' do
     patient_dup = { first_name: 'Deckard', last_name: 'Cain', date_of_birth: '1996-12-31' }
 
-    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
-                                            patient_dup[:last_name],
-                                            patient_dup[:sex],
-                                            patient_dup[:date_of_birth],
-                                            patient_dup[:user_defined_id_statelocal])
+    duplicate_data = Patient.duplicate_data_detection(patient_dup)
 
     assert duplicate_data[:is_duplicate]
     assert_equal(duplicate_data[:duplicate_field_data], [
@@ -82,11 +74,7 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   test 'duplicate_data finds duplicate with input of FN LN Sex' do
     patient_dup = { first_name: 'Deckard', last_name: 'Cain', sex: 'Male' }
 
-    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
-                                            patient_dup[:last_name],
-                                            patient_dup[:sex],
-                                            patient_dup[:date_of_birth],
-                                            patient_dup[:user_defined_id_statelocal])
+    duplicate_data = Patient.duplicate_data_detection(patient_dup)
 
     assert duplicate_data[:is_duplicate]
     assert_equal(duplicate_data[:duplicate_field_data], [
@@ -104,11 +92,7 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   test 'duplicate_data finds duplicate with input of FN LN' do
     patient_dup = { first_name: 'Deckard', last_name: 'Cain' }
 
-    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
-                                            patient_dup[:last_name],
-                                            patient_dup[:sex],
-                                            patient_dup[:date_of_birth],
-                                            patient_dup[:user_defined_id_statelocal])
+    duplicate_data = Patient.duplicate_data_detection(patient_dup)
 
     assert duplicate_data[:is_duplicate]
     assert_equal(duplicate_data[:duplicate_field_data], [
@@ -122,11 +106,7 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   test 'duplicate_data finds duplicate with input of FN ID' do
     patient_dup = { first_name: 'Deckard', user_defined_id_statelocal: 'asdf123' }
 
-    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
-                                            patient_dup[:last_name],
-                                            patient_dup[:sex],
-                                            patient_dup[:date_of_birth],
-                                            patient_dup[:user_defined_id_statelocal])
+    duplicate_data = Patient.duplicate_data_detection(patient_dup)
 
     assert duplicate_data[:is_duplicate]
     assert_equal(duplicate_data[:duplicate_field_data], [
@@ -140,11 +120,7 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   test 'duplicate_data finds duplicate with input of LN ID' do
     patient_dup = { last_name: 'Cain', user_defined_id_statelocal: 'asdf123' }
 
-    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
-                                            patient_dup[:last_name],
-                                            patient_dup[:sex],
-                                            patient_dup[:date_of_birth],
-                                            patient_dup[:user_defined_id_statelocal])
+    duplicate_data = Patient.duplicate_data_detection(patient_dup)
 
     assert duplicate_data[:is_duplicate]
     assert_equal(duplicate_data[:duplicate_field_data], [
@@ -158,11 +134,21 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
   test 'duplicate_data finds duplicate with input of ID' do
     patient_dup = { user_defined_id_statelocal: 'asdf123' }
 
-    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
-                                            patient_dup[:last_name],
-                                            patient_dup[:sex],
-                                            patient_dup[:date_of_birth],
-                                            patient_dup[:user_defined_id_statelocal])
+    duplicate_data = Patient.duplicate_data_detection(patient_dup)
+
+    assert duplicate_data[:is_duplicate]
+    assert_equal(duplicate_data[:duplicate_field_data], [
+                   {
+                     count: 1,
+                     fields: ['State/Local ID']
+                   }
+                 ])
+  end
+
+  test 'duplicate_data finds duplicate with input of ID with extra spaces' do
+    patient_dup = { user_defined_id_statelocal: ' asdf123 ' }
+
+    duplicate_data = Patient.duplicate_data_detection(patient_dup)
 
     assert duplicate_data[:is_duplicate]
     assert_equal(duplicate_data[:duplicate_field_data], [
@@ -175,11 +161,7 @@ class PatientDuplicateDetectionTest < ActiveSupport::TestCase
 
   test 'duplicate_data does NOT find duplicate with input of FN LN Sex DoB ID' do
     patient_dup = { first_name: 'Cain', last_name: 'Deckard', date_of_birth: '1996-12-31', sex: 'Male', user_defined_id_statelocal: '123abc' }
-    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
-                                            patient_dup[:last_name],
-                                            patient_dup[:sex],
-                                            patient_dup[:date_of_birth],
-                                            patient_dup[:user_defined_id_statelocal])
+    duplicate_data = Patient.duplicate_data_detection(patient_dup)
 
     assert_not duplicate_data[:is_duplicate]
     assert_equal(duplicate_data[:duplicate_field_data], [])

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -1321,68 +1321,6 @@ class PatientTest < ActiveSupport::TestCase
     assert patient.address_timezone_offset == formatted_tz_offset(Time.now.in_time_zone('Guam').utc_offset / 60 / 60)
   end
 
-  test 'duplicate_data finds duplicate that matches all criteria' do
-    patient_dup = Patient.first
-    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
-                                            patient_dup[:last_name],
-                                            patient_dup[:sex],
-                                            patient_dup[:date_of_birth],
-                                            patient_dup[:user_defined_id_statelocal])
-
-    assert duplicate_data[:is_duplicate]
-    assert_equal(duplicate_data[:duplicate_field_data], [
-                   {
-                     count: 1,
-                     fields: ['First Name', 'Last Name', 'Sex', 'Date of Birth']
-                   },
-                   {
-                     count: 1,
-                     fields: ['State/Local ID']
-                   }
-                 ])
-  end
-
-  test 'duplicate_data finds duplicate that matches basic info fields' do
-    patient_dup = Patient.first
-    duplicate_data = Patient.duplicate_data(patient_dup[:first_name],
-                                            patient_dup[:last_name],
-                                            patient_dup[:sex],
-                                            patient_dup[:date_of_birth],
-                                            'test state/local ID')
-
-    assert duplicate_data[:is_duplicate]
-    assert_equal(duplicate_data[:duplicate_field_data], [{
-                   count: 1,
-                   fields: ['First Name', 'Last Name', 'Sex', 'Date of Birth']
-                 }])
-  end
-
-  test 'duplicate_data finds duplicate that matches state/local id' do
-    patient_dup = Patient.first
-    duplicate_data = Patient.duplicate_data('test first name',
-                                            'test last name',
-                                            'test sex',
-                                            Time.now,
-                                            patient_dup[:user_defined_id_statelocal])
-
-    assert duplicate_data[:is_duplicate]
-    assert_equal(duplicate_data[:duplicate_field_data], [{
-                   count: 1,
-                   fields: ['State/Local ID']
-                 }])
-  end
-
-  test 'duplicate_data correctly finds no duplicates' do
-    duplicate_data = Patient.duplicate_data('test first name',
-                                            'test last name',
-                                            'test sex',
-                                            Time.now,
-                                            'test state/local ID')
-
-    assert !duplicate_data[:is_duplicate]
-    assert_equal(duplicate_data[:duplicate_field_data], [])
-  end
-
   def verify_patient_status(patient, status)
     patients = Patient.where(id: patient.id)
 


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-727](https://tracker.codev.mitre.org/browse/SARAALERT-727)

This ticket addresses the duplicate detection logic when importing patients. Originally First Name, Last Name, Date of Birth, and Sex or State/Local ID had to match. Now First Name and Last Name or State/Local ID have to match. DoB and Sex will be checked for additional logging information but are now optional.

# Solution
In the image below we use as much information as we can while displaying the duplicate messages but all of them are considered duplicates
![image](https://user-images.githubusercontent.com/7842704/111210018-19909000-85a3-11eb-995a-64643e204b97.png)

# Testing
This fix was tested on the following browsers (submitter must check all those that apply):
* [x] Chrome
* [ ] Firefox
* [ ] Safari
* [ ] IE11

First import all of the patients here 
[import_cain.xlsx](https://github.com/SaraAlert/SaraAlert/files/6172601/import_cain.xlsx)

Then import these to test for the detections
[test_duplicate_detection.xlsx](https://github.com/SaraAlert/SaraAlert/files/6166995/test_duplicate_detection.xlsx)


The results should be as follows - #. info about import: output results ->
1. no missing fields:   1 all, 2 FN LN S, 3 FN LN DOB, 4 FN LN, 1 STATE/LOCAL ID
2. no sex or ID:  0 all, 0 FN LN S, 5 FN LN DOB, 7 FN LN, 0 STATE/LOCAL ID
3. no DoB or ID:  0 all, 4 FN LN S, 0 FN LN DOB, 8 FN LN, 0 STATE/LOCAL ID
4. no sex or DoB:  0 all, 0 FN LN S, 0 FN LN DOB, 14 FN LN, 1 STATE/LOCAL ID
5. no FN, sex or DoB:  1 STATE/LOCAL ID
6. no LN, sex or DoB:  1 STATE/LOCAL ID
7. no FN, LN sex or DoB:  1 STATE/LOCAL ID
8. different FN, LN: no duplicates

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


**Reviewer 1:**

Username @timwongj  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] **N/A** If applicable, you have tested changes against a large database, and considered possible performance regressions


**Reviewer 2:**

Username:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


**Reviewer 3:**

Username: @Bialogs 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions