### PR TITLE
SARAALERT-1383: Form Control Lag Fix

### DIFF
--- a/app/javascript/packs/stylesheets/bootstrap.scss
+++ b/app/javascript/packs/stylesheets/bootstrap.scss
@@ -92,6 +92,7 @@ body {
 
 .form-control {
   border-radius: 0 !important;
+  transition: none !important;
 }
 
 .form-group-inline {


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1383

There is a new issue on Chromium based browsers where the Form-Control elements we use behave in a laggy manner. They are slow and very unresponsive. The exact cause of this is not entirely understood. However, I have figured out a fix. Removing the bootstrap `.form-control` `transition` styling prevents the issue from appearing.

# Testing
This fix was tested on the following browsers:
* [x] Chrome
* [x] Firefox
* [x] Safari
* [ ] IE11
