### PR TITLE
Monitoring status LDE household update bug

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -453,7 +453,7 @@ class PatientsController < ApplicationController
     # NOTE: This is a possible option when changing monitoring status of HoH in isolation.
     if params.permit(:apply_to_household_cm_exp_only)[:apply_to_household_cm_exp_only] && params[:apply_to_household_cm_exp_only_date].present?
       # Only update dependents (not including the HoH) in exposure with continuous exposure is turned on
-      (current_user.get_patient(patient.responder_id)&.dependents_exclude_self&.where(continuous_exposure: true, isolation: false) || []).uniq.each do |member|
+      (current_user.get_patient(patient.responder_id)&.household&.where(continuous_exposure: true, isolation: false) || []).uniq.each do |member|
         History.monitoring_change(patient: member, created_by: 'Sara Alert System', comment: "User updated Monitoring Status for another member in this
         monitoree's household and chose to update Last Date of Exposure for household members so System changed Last Date of Exposure from
         #{member[:last_date_of_exposure] ? member[:last_date_of_exposure].to_date.strftime('%m/%d/%Y') : 'blank'} to

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -449,10 +449,10 @@ class PatientsController < ApplicationController
     patient = current_user.get_patient(params.permit(:id)[:id])
     redirect_to(root_url) && return if patient.nil?
 
-    # Update LDE for patient and group members only in the exposure workflow with continuous exposure on
-    # NOTE: This is a possible option when changing monitoring status of HoH in isolation.
+    # Update LDE for patient and household members only in the exposure workflow with continuous exposure on
+    # NOTE: This is a possible option when changing monitoring status of HoH or dependent in isolation
     if params.permit(:apply_to_household_cm_exp_only)[:apply_to_household_cm_exp_only] && params[:apply_to_household_cm_exp_only_date].present?
-      # Only update dependents (not including the HoH) in exposure with continuous exposure is turned on
+      # Only update household members in the exposure workflow with continuous exposure is turned on
       (current_user.get_patient(patient.responder_id)&.household&.where(continuous_exposure: true, isolation: false) || []).uniq.each do |member|
         History.monitoring_change(patient: member, created_by: 'Sara Alert System', comment: "User updated Monitoring Status for another member in this
         monitoree's household and chose to update Last Date of Exposure for household members so System changed Last Date of Exposure from


### PR DESCRIPTION
# Description

With the apply to household refactor, household dependents can now see the apply to household radio buttons.  With this, if a dependent is in the isolation workflow, they can now update the LDE if there are any other household members (including the HoH) that are CE in the exposure workflow.  This fixes a bug where if you select to update the LDE, the HoH was not being updated with the new LDE and turning off CE.

Fix: https://user-images.githubusercontent.com/35042815/111374689-c6d2d900-8673-11eb-8a06-f1d50da3d7cd.mov
