### PR TITLE
SARAALERT-975: Blocked Number Advanced Filter

### DIFF
--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -252,6 +252,12 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
         patients = patients.where(monitoring: filter[:value].present? ? true : [nil, false])
       when 'preferred-contact-method'
         patients = patients.where(preferred_contact_method: filter[:value].blank? ? [nil, ''] : filter[:value])
+      when 'sms-blocked'
+        patients = if filter[:value]
+                     patients.where(primary_telephone: BlockedNumber.pluck(:phone_number))
+                   else
+                     patients.where.not(primary_telephone: BlockedNumber.pluck(:phone_number))
+                   end
       when 'hoh'
         patients = if filter[:value]
                      patients.where('patients.id = patients.responder_id')

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -220,6 +220,15 @@ class AdvancedFilter extends React.Component {
             'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom ' +
             'Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.',
         },
+        {
+          name: 'sms-blocked',
+          title: 'SMS Blocked (Boolean)',
+          description: 'Monitorees that have blocked SMS communications with Sara Alert',
+          type: 'boolean',
+          tooltip:
+            `This filter will return monitorees that have texted “STOP” in response to a Sara Alert text message and ` +
+            `cannot receive messages through SMS Preferred Reporting Methods until they text "START"`,
+        },
       ],
       savedFilters: [],
       activeFilter: null,

--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -147,7 +147,8 @@ const TOOLTIP_TEXT = {
   blockedSMS: (
     <div>
       The owner of this phone number has texted &quot;STOP&quot; in response to a Sara Alert text message. This means that this phone number cannot receive text
-      messages from Sara Alert and should not be assigned SMS Preferred Reporting Methods unless the user replies &quot;START&quot; to a Sara Alert message.
+      messages from Sara Alert and should not be assigned SMS Preferred Reporting Methods unless the <i>monitoree</i> replies &quot;START&quot; to a Sara Alert
+      message.
     </div>
   ),
 


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-975](https://tracker.codev.mitre.org/browse/SARAALERT-975)

This Pull Request adds the ability to filter by Blocked Numbers in the Advanced Filter. Jurisdictions wanted this ability, as it lets them know who they need to follow up, through other means.

## Screenshots
<img width="407" alt="image" src="https://user-images.githubusercontent.com/17532163/111473154-1e6b5600-8701-11eb-954b-e8c297d3204f.png">


## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/helpers/patient_query_helper.rb`
- Adds the back-end logic for including Blocked Numbers in the Advanced Filter

`app/javascript/components/public_health/query/AdvancedFilter.js`
- Adds the front-end logic for including Blocked Numbers in the Advanced Filter

`app/javascript/components/util/InfoTooltip.js`
- Updates some terminology (per Product Owner Team feedback)


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary

**Reviewers:**

@mayerm94: 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x]  N/A If applicable, you have tested changes against a large database, and considered possible performance regressions


@sgober: 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] **N/A** If applicable, you have tested changes against a large database, and considered possible performance regressions


@timwongj 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] **N/A** If applicable, you have tested changes against a large database, and considered possible performance regressions
