### PR TITLE
Advanced filter delete saved filter bugfix

### DIFF
--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -525,17 +525,18 @@ class AdvancedFilter extends React.Component {
         if (this.props.updateStickySettings) {
           localStorage.removeItem(`SaraFilter`);
         }
-        this.setState({
-          show: false,
-          applied: false,
-          activeFilter: null,
-          activeFilterOptions: null,
-          savedFilters: [
-            ...self.state.savedFilters.filter(filter => {
-              return filter.id != id;
-            }),
-          ],
-        });
+        this.setState(
+          {
+            savedFilters: [
+              ...self.state.savedFilters.filter(filter => {
+                return filter.id != id;
+              }),
+            ],
+          },
+          () => {
+            this.clear();
+          }
+        );
       });
   };
 


### PR DESCRIPTION
# Description

Ensure the advanced filter modal is fully reset reset after deleting a saved filter.

## (Bugfix) Solution

To recreate:
1. Delete any saved advanced filter
2. Click the "Advanced Filter" button to re-open the modal
3. Click the plus sign and an error fires blanking out the page
