### PR TITLE
SARAALERT-1307: Table row checkbox aria label updates

### DIFF
--- a/app/javascript/components/admin/AdminTable.js
+++ b/app/javascript/components/admin/AdminTable.js
@@ -69,7 +69,7 @@ class AdminTable extends React.Component {
     );
   }
 
-  getAriaLabel(rowData) {
+  getRowCheckboxAriaLabel(rowData) {
     return `User: ${rowData.email}`;
   }
 
@@ -720,7 +720,7 @@ class AdminTable extends React.Component {
           handleEdit={this.handleEditClick}
           handleEntriesChange={this.handleEntriesChange}
           handlePageUpdate={this.handlePageUpdate}
-          getAriaLabelText={this.getAriaLabel}
+          getRowCheckboxAriaLabel={this.getRowCheckboxAriaLabel}
           isSelectable={true}
           isEditable={true}
           isLoading={this.state.isLoading}

--- a/app/javascript/components/admin/AdminTable.js
+++ b/app/javascript/components/admin/AdminTable.js
@@ -69,6 +69,10 @@ class AdminTable extends React.Component {
     );
   }
 
+  getAriaLabel(rowData) {
+    return `User: ${rowData.email}`;
+  }
+
   componentDidMount() {
     // Update table data on initial mount.
     this.getTableData(this.state.query);
@@ -715,16 +719,16 @@ class AdminTable extends React.Component {
           handleSelect={this.handleSelect}
           handleEdit={this.handleEditClick}
           handleEntriesChange={this.handleEntriesChange}
+          handlePageUpdate={this.handlePageUpdate}
+          getAriaLabelText={this.getAriaLabel}
           isSelectable={true}
           isEditable={true}
           isLoading={this.state.isLoading}
           page={this.state.query.page}
-          handlePageUpdate={this.handlePageUpdate}
           selectedRows={this.state.table.selectedRows}
           selectAll={this.state.table.selectAll}
           entryOptions={this.state.entryOptions}
           entries={this.state.query.entries}
-          currentUser={this.props.current_user_email}
         />
         {Object.keys(this.state.jurisdiction_paths).length && (this.state.showEditUserModal || this.state.showAddUserModal) && (
           <UserModal
@@ -764,7 +768,6 @@ class AdminTable extends React.Component {
 AdminTable.propTypes = {
   authenticity_token: PropTypes.string,
   role_types: PropTypes.array,
-  current_user_email: PropTypes.string,
   is_usa_admin: PropTypes.bool,
 };
 

--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -125,7 +125,7 @@ class CustomTable extends React.Component {
           <input
             type="checkbox"
             disabled={this.props.disabledRows.includes(rowIndex)}
-            aria-label={`Select ${this.props.getAriaLabelText(rowData)}`}
+            aria-label={`Select ${this.props.getRowCheckboxAriaLabel(rowData)}`}
             checked={(this.props.selectAll && !this.props.disabledRows.includes(rowIndex)) || this.props.selectedRows.includes(rowIndex)}
             onChange={e => this.handleCheckboxChange(e, rowIndex)}></input>
         </span>
@@ -347,7 +347,7 @@ CustomTable.propTypes = {
   entryOptions: PropTypes.array,
   getRowClassName: PropTypes.func,
   getCustomTableClassName: PropTypes.func,
-  getAriaLabelText: PropTypes.func,
+  getRowCheckboxAriaLabel: PropTypes.func,
   orderBy: PropTypes.string,
   sortDirection: PropTypes.string,
 };

--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -105,7 +105,7 @@ class CustomTable extends React.Component {
           onChange={this.toggleSelectAll}
           disabled={this.props.disabledRows.length === this.props.rowData.length}
           checked={this.props.selectAll}
-          aria-label="Table Select All Rows"></input>
+          aria-label="Select All Rows"></input>
       </th>
     );
   };
@@ -125,7 +125,7 @@ class CustomTable extends React.Component {
           <input
             type="checkbox"
             disabled={this.props.disabledRows.includes(rowIndex)}
-            aria-label={`Table Select${rowData.name ? ` Monitoree: ${rowData.name}` : ''}${this.props.currentUser ? ` User: ${this.props.currentUser}` : ''}`}
+            aria-label={`Select ${this.props.getAriaLabelText(rowData)}`}
             checked={(this.props.selectAll && !this.props.disabledRows.includes(rowIndex)) || this.props.selectedRows.includes(rowIndex)}
             onChange={e => this.handleCheckboxChange(e, rowIndex)}></input>
         </span>
@@ -347,7 +347,7 @@ CustomTable.propTypes = {
   entryOptions: PropTypes.array,
   getRowClassName: PropTypes.func,
   getCustomTableClassName: PropTypes.func,
-  currentUser: PropTypes.string,
+  getAriaLabelText: PropTypes.func,
   orderBy: PropTypes.string,
   sortDirection: PropTypes.string,
 };

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -503,6 +503,10 @@ class PatientsTable extends React.Component {
     );
   };
 
+  getAriaLabel(rowData) {
+    return `Monitoree ${rowData.name}`;
+  }
+
   createEligibilityTooltip(data) {
     const reportEligibility = data.value;
     const rowData = data.rowData;
@@ -634,11 +638,12 @@ class PatientsTable extends React.Component {
                 handleTableUpdate={query => this.updateTable({ ...this.state.query, order: query.orderBy, page: query.page, direction: query.sortDirection })}
                 handleSelect={this.handleSelect}
                 handleEntriesChange={this.handleEntriesChange}
+                handlePageUpdate={this.handlePageUpdate}
+                getAriaLabelText={this.getAriaLabel}
                 isSelectable={true}
                 isEditable={false}
                 isLoading={this.state.loading}
                 page={this.state.query.page}
-                handlePageUpdate={this.handlePageUpdate}
                 selectedRows={this.state.selectedPatients}
                 selectAll={this.state.selectAll}
                 entryOptions={this.state.entryOptions}

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -503,7 +503,7 @@ class PatientsTable extends React.Component {
     );
   };
 
-  getAriaLabel(rowData) {
+  getRowCheckboxAriaLabel(rowData) {
     return `Monitoree ${rowData.name}`;
   }
 
@@ -639,7 +639,7 @@ class PatientsTable extends React.Component {
                 handleSelect={this.handleSelect}
                 handleEntriesChange={this.handleEntriesChange}
                 handlePageUpdate={this.handlePageUpdate}
-                getAriaLabelText={this.getAriaLabel}
+                getRowCheckboxAriaLabel={this.getRowCheckboxAriaLabel}
                 isSelectable={true}
                 isEditable={false}
                 isLoading={this.state.loading}

--- a/app/javascript/components/subject/household_actions/ApplyToHousehold.js
+++ b/app/javascript/components/subject/household_actions/ApplyToHousehold.js
@@ -293,6 +293,14 @@ class ApplyToHousehold extends React.Component {
     );
   };
 
+  /**
+   * Formats aria label for each table row checkbox.
+   * @param {Object} rowData - provided by CustomTable about the current row.
+   */
+  getAriaLabel(rowData) {
+    return `Monitoree ${rowData.last_name || ''}, ${rowData.first_name || ''} ${rowData.middle_name || ''}`;
+  }
+
   render() {
     return (
       <React.Fragment>
@@ -321,12 +329,13 @@ class ApplyToHousehold extends React.Component {
             rowData={this.state.table.rowData}
             totalRows={this.state.table.totalRows}
             handleTableUpdate={this.handleTableSort}
+            handleSelect={this.handleSelect}
+            getAriaLabelText={this.getAriaLabel}
             isSelectable={true}
             showPagination={false}
             checkboxColumnLocation={'left'}
             selectedRows={this.state.table.selectedRows}
             selectAll={this.state.table.selectAll}
-            handleSelect={this.handleSelect}
             disabledRows={this.state.table.disabledRows}
             disabledTooltipText={'You cannot update this record since it is not within your assigned jurisdiction'}
           />

--- a/app/javascript/components/subject/household_actions/ApplyToHousehold.js
+++ b/app/javascript/components/subject/household_actions/ApplyToHousehold.js
@@ -297,7 +297,7 @@ class ApplyToHousehold extends React.Component {
    * Formats aria label for each table row checkbox.
    * @param {Object} rowData - provided by CustomTable about the current row.
    */
-  getAriaLabel(rowData) {
+  getRowCheckboxAriaLabel(rowData) {
     return `Monitoree ${rowData.last_name || ''}, ${rowData.first_name || ''} ${rowData.middle_name || ''}`;
   }
 
@@ -330,7 +330,7 @@ class ApplyToHousehold extends React.Component {
             totalRows={this.state.table.totalRows}
             handleTableUpdate={this.handleTableSort}
             handleSelect={this.handleSelect}
-            getAriaLabelText={this.getAriaLabel}
+            getRowCheckboxAriaLabel={this.getRowCheckboxAriaLabel}
             isSelectable={true}
             showPagination={false}
             checkboxColumnLocation={'left'}

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -3,6 +3,5 @@
 <%= react_component('admin/AdminTable', {
                       role_types: Roles.all_assignable_role_values.reverse.map { |role| role.split('_').map(&:capitalize).join(' ') },
                       authenticity_token: form_authenticity_token,
-                      current_user_email: current_user.email,
                       is_usa_admin: current_user.can_send_admin_emails?
                     }) %>


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1307](https://tracker.codev.mitre.org/browse/SARAALERT-1307)

```
All aria labels for "Actions" checkboxes on the dashboard now begin with "select all", and then provide monitoree's name. However, only the very first top checkbox actually allows the user to "select all". Remove the "Select all" language from all action checkboxes but the first top one.
```

This ended up not being an issue with the individual row aria labels being in correct, however it is some how an issue with JAWS which reads the header checkbox aria label as well as the one from the row the user is on.  For now, updated the text in both the select all checkbox and the one in each row to make it easier for them to be read out loud.  Also refactored the individual row aria-label text to be passed in as a prop.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`CustomTable.js`
- Updated aria-label text
- Added support for an aria-label prop to customize each row

`AdminTable.js`, `PatientsTable.js`, `ApplyToHousehold.js`
- Added aria-label prop

`index.html.erb`
- Removed unused prop


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


**Reviewer 1:**

Username: @DPC15038 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] **N/A** The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] **N/A** If applicable, you have tested changes against a large database, and considered possible performance regressions


**Reviewer 2:**

Username: @tstrass  
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] **N/A** The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] **N/A** If applicable, you have tested changes against a large database, and considered possible performance regressions


**Reviewer 3:**

Username: @hackrm 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] **N/A** The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] **N/A** If applicable, you have tested changes against a large database, and considered possible performance regressions
