### PR TITLE
SARAALERT-1398: Force tests to run in UTC

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -62,4 +62,6 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  config.time_zone = 'UTC'
 end

--- a/test/db/database_test.rb
+++ b/test/db/database_test.rb
@@ -30,6 +30,7 @@ class DatabaseTest < ActiveSupport::TestCase
         ruby_offset = time_zone_offset_for_state(state)[0..2].to_i
         assert_equal ruby_offset, db_offset
       end
+      Timecop.return
     end
   end
 

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -2721,6 +2721,7 @@ class PatientTest < ActiveSupport::TestCase
     Timecop.freeze((Time.now.utc).change(hour: 23)) do
       assert_nil Patient.within_preferred_contact_time.find_by(id: patient.id)
     end
+    Timecop.return
   end
 
   test 'within_preferred_contact_time scope' do
@@ -2830,6 +2831,7 @@ class PatientTest < ActiveSupport::TestCase
         assert_nil Patient.within_preferred_contact_time.find_by(id: patient.id)
       end
     end
+    Timecop.return
   end
 
   test 'has_not_reported_recently scope' do


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1398

Our GitHub actions runners are running in UTC. We have run into a few scenarios where tests will pass in a developer's local timezone, but then fail on the runner. This ticket is for changing the `config/environments/test.rb` file to force use of the 'UTC' time zone when running tests.

This PR also incorporates some `Timecop.return` calls that should have been written previously.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`config/environments/test.rb`
- Force use of 'UTC' timezone

`database_test.rb`, `patient_notification_eligibility_test.rb`, `patient_test.rb`
- added missing `Timecop.return` statements


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@Bialogs  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
