### PR TITLE
Remove require for mocha/Test::Unit since we are not using Test::Unit

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,6 @@ SimpleCov.start('saraalert')
 require_relative '../config/environment'
 require 'rails/test_help'
 require 'rack/test'
-require 'mocha/test_unit'
 require 'mocha/minitest'
 require 'fakeredis/minitest'
 require 'sidekiq/testing'


### PR DESCRIPTION
Removes deprecation warning when running tests:
```
Mocha deprecation warning at /Users/kfagan/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bootsnap-1.7.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require': Test::Unit must be loaded *before* `require 'mocha/test_unit'`.
```

We are not using test unit. We are using minitest. https://guides.rubyonrails.org/testing.html#available-assertions