### PR TITLE
FIX: Export bug when only one field is selected

### DIFF
--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -369,6 +369,9 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
     # pluck selected fields
     records = assessments.pluck(*plucked_fields)
 
+    # ensure that records is always a 2d array
+    records = records.map { |record| [record] } if plucked_fields.size == 1
+
     # remove formula start for who_reported field
     (fields & %i[who_reported]).map { |field| fields.index(field) }
                                .each { |index| records.each { |values| values[index] = remove_formula_start(values[index]) } }
@@ -382,7 +385,13 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
     laboratories = laboratories.joins(:patient) if (fields & PATIENT_FIELD_TYPES[:alternative_identifiers]).any?
 
     # validate and pluck selected fields
-    laboratories.pluck(*(fields & LABORATORY_FIELD_NAMES.keys))
+    plucked_fields = fields & LABORATORY_FIELD_NAMES.keys
+    records = laboratories.pluck(*plucked_fields)
+
+    # ensure that records is always a 2d array
+    records = records.map { |record| [record] } if plucked_fields.size == 1
+
+    records
   end
 
   # Extract vaccine data values given relevant fields
@@ -391,7 +400,11 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
     vaccines = vaccines.joins(:patient) if (fields & PATIENT_FIELD_TYPES[:alternative_identifiers]).any?
 
     # validate and pluck selected fields
-    records = vaccines.pluck(*(fields & VACCINE_FIELD_NAMES.keys))
+    plucked_fields = fields & VACCINE_FIELD_NAMES.keys
+    records = vaccines.pluck(*plucked_fields)
+
+    # ensure that records is always a 2d array
+    records = records.map { |record| [record] } if plucked_fields.size == 1
 
     # remove formula start for 'notes' field
     (fields & %i[notes]).map { |field| fields.index(field) }
@@ -406,7 +419,11 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
     close_contacts = close_contacts.joins(:patient) if (fields & PATIENT_FIELD_TYPES[:alternative_identifiers]).any?
 
     # validate and pluck selected fields
-    records = close_contacts.pluck(*(fields & CLOSE_CONTACT_FIELD_NAMES.keys))
+    plucked_fields = fields & CLOSE_CONTACT_FIELD_NAMES.keys
+    records = close_contacts.pluck(*plucked_fields)
+
+    # ensure that records is always a 2d array
+    records = records.map { |record| [record] } if plucked_fields.size == 1
 
     # remove formula start for 'created_by' and 'comment' fields
     (fields & %i[first_name last_name email notes]).map { |field| fields.index(field) }
@@ -446,7 +463,12 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
     end
 
     # pluck selected fields
-    transfers.pluck(*plucked_fields)
+    records = transfers.pluck(*plucked_fields)
+
+    # ensure that records is always a 2d array
+    records = records.map { |record| [record] } if plucked_fields.size == 1
+
+    records
   end
 
   # Extract history data values given relevant fields
@@ -455,7 +477,11 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
     histories = histories.joins(:patient) if (fields & PATIENT_FIELD_TYPES[:alternative_identifiers]).any?
 
     # validate and pluck selected fields
-    records = histories.pluck(*(fields & HISTORY_FIELD_NAMES.keys))
+    plucked_fields = fields & HISTORY_FIELD_NAMES.keys
+    records = histories.pluck(*plucked_fields)
+
+    # ensure that records is always a 2d array
+    records = records.map { |record| [record] } if plucked_fields.size == 1
 
     # remove formula start for 'created_by' and 'comment' fields
     (fields & %i[created_by comment]).map { |field| fields.index(field) }

--- a/test/system/roles/public_health/dashboard/dashboard.rb
+++ b/test/system/roles/public_health/dashboard/dashboard.rb
@@ -69,10 +69,19 @@ class PublicHealthDashboard < ApplicationSystemTestCase
     # Choose which records to export
     choose "select-monitoree-records-#{settings[:records]}" if settings[:records].present?
 
-    # Choose which elements to export
+    # Expand trees for selection
     settings[:data]&.each_value do |data_type|
-      data_type[:selected]&.each do |label|
-        find('span', class: 'rct-title', text: label).click
+      data_type[:expanded]&.each do |label|
+        find('span', class: 'rct-title', text: label).first(:xpath, '..//..//button').click
+      end
+    end
+
+    # Choose which elements to export
+    settings[:data]&.each do |data_type, config|
+      # only find headers under data type section to avoid ambiguous matches (ex: Sara Alert ID)
+      section = find('span', class: 'rct-title', text: ImportExportConstants::CUSTOM_EXPORT_OPTIONS[data_type][:nodes][0][:label]).first(:xpath, '..//..//..')
+      config[:selected]&.each do |label|
+        section.find('span', class: 'rct-title', text: label).click
       end
     end
 

--- a/test/system/roles/public_health/public_health_custom_export_test.rb
+++ b/test/system/roles/public_health/public_health_custom_export_test.rb
@@ -350,4 +350,54 @@ class PublicHealthCustomExportTest < ApplicationSystemTestCase
     }
     @@public_health_test_helper.export_custom('state1_epi', settings)
   end
+
+  # ---- Test the same exports but with smaller batching so that the batching functionality can be tested ----
+
+  test 'export xlsx format with all monitorees with all data types with only some fields' do
+    settings = {
+      records: :all,
+      name: 'Excel export all',
+      format: :xlsx,
+      actions: %i[save export],
+      confirm: :start,
+      data: {
+        patients: {
+          selected: ['Monitoree Details'],
+          checked: all_custom_export_patient_fields,
+          query: {
+            workflow: 'all',
+            tab: 'all',
+            jurisdiction: 1,
+            scope: 'all',
+            user: nil,
+            search: '',
+            tz_offset: 300
+          }
+        },
+        assessments: {
+          expanded: ['Reports'],
+          selected: ['Sara Alert ID'],
+          checked: %i[patient_id]
+        },
+        laboratories: {
+          selected: ['Lab Results']
+        },
+        vaccines: {
+          expanded: ['Vaccinations'],
+          selected: ['Vaccination Created Date'],
+          checked: %i[created_at]
+        },
+        close_contacts: {
+          selected: ['Close Contacts']
+        },
+        transfers: {
+          selected: ['Transfers']
+        },
+        histories: {
+          selected: ['History']
+        }
+      }
+    }
+    @@public_health_test_helper.export_custom('state1_epi', settings)
+  end
 end

--- a/test/system_test_case.rb
+++ b/test/system_test_case.rb
@@ -4,6 +4,6 @@ require 'test_helper'
 require 'minitest/retry'
 
 class ActionDispatch::SystemTestCase
-  Minitest::Retry.use!
+  Minitest::Retry.use! if ENV['APP_IN_CI']
   fixtures :all
 end


### PR DESCRIPTION
# Description

These changes address a bug that is caused by ActiveRecord `pluck` returning inconsistent array dimensions if only 1 field is plucked (1D array) vs when multiple fields are plucked (2D array)

## (Feature) Demo/Screenshots
Insert demo video or photos for a new or updated feature or capability.

## (Bugfix) How to Replicate
Perform a custom export where only `updated_at` is the only selected field from `assessments` for export

## (Bugfix) Solution
Convert plucked records from 1D array to 2D array if only one field is plucked

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`import_export.js`
- Fix extract data methods


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] **N/A** This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] **N/A** If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] **N/A** Test fixtures updated and documented as necessary


@holmesie  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] N/A The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ngfreiter  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@Bialogs  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
