### PR TITLE
SARAALERT-1300 negated non-bool symptom value

### DIFF
--- a/app/models/float_symptom.rb
+++ b/app/models/float_symptom.rb
@@ -14,10 +14,6 @@ class FloatSymptom < Symptom
     self.float_value = value
   end
 
-  def negate
-    self.float_value = 0.0
-  end
-
   def as_json(options = {})
     super(options).merge({
                            value: float_value

--- a/app/models/integer_symptom.rb
+++ b/app/models/integer_symptom.rb
@@ -14,10 +14,6 @@ class IntegerSymptom < Symptom
     self.int_value = value
   end
 
-  def negate
-    self.int_value = 0
-  end
-
   def as_json(options = {})
     super(options).merge({
                            value: int_value

--- a/app/models/symptom.rb
+++ b/app/models/symptom.rb
@@ -54,6 +54,10 @@ class Symptom < ApplicationRecord
     end
   end
 
+  def negate
+    raise 'negation for this symptom type is not supported'
+  end
+
   private
 
   def update_patient_linelist_after_save

--- a/app/models/threshold_condition.rb
+++ b/app/models/threshold_condition.rb
@@ -17,6 +17,12 @@ class ThresholdCondition < Condition
   # manual follow-up.
   def clone_symptoms_negate_bool_values
     new_symptoms = symptoms.to_a.deep_dup
-    new_symptoms.each(&:negate)
+    new_symptoms.each do |symptom|
+      if symptom.type == 'BoolSymptom'
+        symptom.negate
+      else
+        symptom.value = nil
+      end
+    end
   end
 end

--- a/test/jobs/consume_assessments_job_test.rb
+++ b/test/jobs/consume_assessments_job_test.rb
@@ -88,17 +88,15 @@ class ConsumeAssessmentsJobTest < ActiveJob::TestCase
     end
 
     # Bypass latest assessment check
-    # This test will highlight a known bug in negating a Bool or Int symptom.
-    # To be fixed once PO team approves UI changes that are brought along with fixing the issue.
-    # @patient.update(assessments: [])
+    @patient.update(assessments: [])
 
-    # assert_difference '@patient.assessments.count', 1 do
-    #   @redis.publish('reports', @assessment_generator.generic_assessment(symptomatic: false))
-    #   ConsumeAssessmentsJob.perform_now
-    #   @patient.reload
-    #   assert_not @patient.assessments.first.symptomatic
-    #   assert_equal 'Monitoree', @patient.assessments.first.who_reported
-    # end
+    assert_difference '@patient.assessments.count', 1 do
+      @redis_queue.push @assessment_generator.generic_assessment(symptomatic: false)
+      ConsumeAssessmentsJob.perform_now
+      @patient.reload
+      assert_not @patient.assessments.first.symptomatic
+      assert_equal 'Monitoree', @patient.assessments.first.who_reported
+    end
   end
 
   test 'consume generic assessment with dependents' do

--- a/test/models/threshold_condition_test.rb
+++ b/test/models/threshold_condition_test.rb
@@ -34,7 +34,7 @@ class ThresholdConditionTest < ActiveSupport::TestCase
       if symptom.type == 'BoolSymptom'
         assert_not_equal(threshold_condition.symptoms[idx].value, symptom.value)
       else
-        assert_equal(0, symptom.value)
+        assert_equal(nil, symptom.value)
       end
       assert_equal(threshold_condition.symptoms[idx].name, symptom.name)
       assert_equal(threshold_condition.symptoms[idx].label, symptom.label)

--- a/test/models/threshold_condition_test.rb
+++ b/test/models/threshold_condition_test.rb
@@ -34,7 +34,7 @@ class ThresholdConditionTest < ActiveSupport::TestCase
       if symptom.type == 'BoolSymptom'
         assert_not_equal(threshold_condition.symptoms[idx].value, symptom.value)
       else
-        assert_equal(nil, symptom.value)
+        assert_nil(symptom.value)
       end
       assert_equal(threshold_condition.symptoms[idx].name, symptom.name)
       assert_equal(threshold_condition.symptoms[idx].label, symptom.label)


### PR DESCRIPTION
When assigning a reviewer, tag their GitHub username in the reviewer checklist section below.


# Description
Jira Ticket: SARAALERT-1300

Write out a concise summary of this pull request and what it addresses.
When a non-symptomatic SMS/Voice report comes through, the int/float symptoms are set to 0 instead of nil. This PR makes sure that int/float symptoms values are set to nil for non-symptomatic SMS/Voice assessments.

## (Bugfix) How to Replicate
In report mode, submit a non-symptomatic assessment for a patient in a jurisdiction that has an int/float symptom eg: any of the State1 jurisdictions in the sample jurisdictions.yml included in the repo.

`{"response_status": "success_sms","experiencing_symptoms":"No","patient_submission_token": "TYptUSsGmj","threshold_hash":"854613cf6657d5ebfef5babcc3eb0f1a465ac723859d4df0d1cdcd5ff321d165"}`


See that the report that was generated has a int/float symptom value of 0.

## (Bugfix) Solution
Insert description for the solution this PR implements to address the bug.

Repeat the steps above and see that the int/float symptom within the newly created report does not contain a value.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced. NA
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary NA


@hackrm:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] **N/A** If applicable, you have tested changes against a large database, and considered possible performance regressions


@ngfreiter 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
