### PR TITLE
Window.BASE_PATH fixes

### DIFF
--- a/app/javascript/components/admin/AdminTable.js
+++ b/app/javascript/components/admin/AdminTable.js
@@ -109,7 +109,7 @@ class AdminTable extends React.Component {
   axiosAdminPostRequest = (path, data, handleSuccess, handleError) => {
     axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
     axios
-      .post('/admin/' + path, data)
+      .post(window.BASE_PATH + '/admin/' + path, data)
       .then(handleSuccess)
       .catch(handleError);
   };
@@ -130,7 +130,7 @@ class AdminTable extends React.Component {
 
     this.setState({ cancelToken, isLoading }, () => {
       axios
-        .get('/admin/' + path, {
+        .get(window.BASE_PATH + '/admin/' + path, {
           params: params,
           cancelToken: this.state.cancelToken.token,
         })
@@ -154,7 +154,7 @@ class AdminTable extends React.Component {
    * Gets the jurisdictions path options via an axios GET request.
    */
   getJurisdictionPaths() {
-    axios.get('/jurisdictions/paths').then(response => {
+    axios.get(window.BASE_PATH + '/jurisdictions/paths').then(response => {
       const responseData = response.data.jurisdiction_paths;
 
       // Swap keys and values for ease of use

--- a/app/javascript/components/admin/AuditModal.js
+++ b/app/javascript/components/admin/AuditModal.js
@@ -71,7 +71,7 @@ class AuditModal extends React.Component {
   queryServer = _.debounce(query => {
     axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
     axios
-      .post('/users/audits/' + this.props.user.id, {
+      .post(`${window.BASE_PATH}/users/audits/${this.props.user.id}`, {
         ...query,
         cancelToken: this.state.cancelToken.token,
       })
@@ -107,7 +107,7 @@ class AuditModal extends React.Component {
    * Gets the all possible jurisdictions path via an axios GET request.
    */
   getAllJurisdictionPaths() {
-    axios.get('/jurisdictions/allpaths').then(response => {
+    axios.get(`${window.BASE_PATH}/jurisdictions/allpaths`).then(response => {
       const responseData = response.data.all_jurisdiction_paths;
 
       // Swap keys and values for ease of use

--- a/app/javascript/components/analytics/widgets/GeographicSummary.js
+++ b/app/javascript/components/analytics/widgets/GeographicSummary.js
@@ -266,7 +266,7 @@ class GeographicSummary extends React.Component {
 
   loadJurisdictionData = async (jurisdictionFileName, callback) => {
     callback({
-      mapObject: await axios.get(`${window.location.origin}/county_level_maps/${jurisdictionFileName}`).then(res => res.data),
+      mapObject: await axios.get(`${window.BASE_PATH}/county_level_maps/${jurisdictionFileName}`).then(res => res.data),
     });
   };
 

--- a/app/javascript/components/assessment/AssessmentTable.js
+++ b/app/javascript/components/assessment/AssessmentTable.js
@@ -80,7 +80,7 @@ class AssessmentTable extends React.Component {
   queryServer = _.debounce((query, isInitialLoad = false) => {
     axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
     axios
-      .get('/patients/' + this.props.patient.submission_token + '/assessments', {
+      .get(window.BASE_PATH + '/patients/' + this.props.patient.submission_token + '/assessments', {
         params: {
           patient_id: this.props.patient.id,
           ...query,

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -51,7 +51,7 @@ class Contact extends React.Component {
       if (event.target.value.replace('_', '').length === 12) {
         axios({
           method: 'get',
-          url: '/patients/sms_eligibility_check',
+          url: `${window.BASE_PATH}/patients/sms_eligibility_check`,
           params: { phone_number: phoneUtil.format(phoneUtil.parse(value, 'US'), PNF.E164) },
         })
           .then(response => {

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -52,7 +52,7 @@ class Exposure extends React.Component {
         value = jurisdiction_id;
         axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
         axios
-          .post('/jurisdictions/assigned_users', {
+          .post(window.BASE_PATH + '/jurisdictions/assigned_users', {
             query: {
               jurisdiction: jurisdiction_id,
               scope: 'exact',

--- a/app/javascript/components/layout/Breadcrumb.js
+++ b/app/javascript/components/layout/Breadcrumb.js
@@ -52,20 +52,20 @@ class Breadcrumb extends React.Component {
             <ol className="breadcrumb">
               {this.props.crumbs?.map((crumb, index) => {
                 return (
-                  <li key={'bc' + index} className={'breadcrumb-item lead lead-bc ' + (crumb['href'] && 'active')}>
+                  <li key={'bc' + index} className={'breadcrumb-item lead lead-bc' + (crumb['href'] && 'active')}>
                     {crumb['href'] && (
                       <a
                         href="#"
                         onClick={() => {
                           if (this.renderWorkflowName(crumb['value']).includes('Isolation')) {
                             // Public Health "Return to Isolation Dashboard"
-                            location.assign((window.BASE_PATH ? window.BASE_PATH : '') + '/public_health/isolation');
+                            location.assign(`${window.BASE_PATH}/public_health/isolation`);
                           } else if (this.renderWorkflowName(crumb['value']).includes('Exposure')) {
                             // Public Health "Return to Exposure Dashboard"
-                            location.assign((window.BASE_PATH ? window.BASE_PATH : '') + '/public_health');
+                            location.assign(`${window.BASE_PATH}/public_health`);
                           } else if (this.renderWorkflowName(crumb['value']).includes('Dashboard')) {
                             // Enroller "Return to Dashboard"
-                            location.assign((window.BASE_PATH ? window.BASE_PATH : '') + '/patients');
+                            location.assign(`${window.BASE_PATH}/patients`);
                           } else {
                             this.goBack(this.props.crumbs.length - (index + 1));
                           }

--- a/app/javascript/components/layout/Header.js
+++ b/app/javascript/components/layout/Header.js
@@ -26,7 +26,7 @@ class Header extends React.Component {
     return (
       <React.Fragment>
         <Navbar bg={this.props.show_demo_warning ? 'danger' : 'primary'} variant="dark" expand="lg" className={this.props.show_demo_warning ? '' : 'mb-3'}>
-          <Navbar.Brand className="header-brand-text" href={this.props.report_mode ? '/' : this.props.root}>
+          <Navbar.Brand className="header-brand-text" href={`${window.BASE_PATH}/${this.props.report_mode ? '' : this.props.root}`}>
             Sara Alert<small className="nav-version ml-1">{this.props.version}</small>
           </Navbar.Brand>
           {this.props.current_user && (
@@ -98,11 +98,11 @@ class Header extends React.Component {
                 <a className="white-border-right"></a>
                 {this.props.current_user?.is_usa_admin && (
                   <React.Fragment>
-                    <Nav.Link className="text-white py-0" href="/oauth/applications">
+                    <Nav.Link className="text-white py-0" href={`${window.BASE_PATH}/oauth/applications`}>
                       <i className="fas fa-share-alt fa-fw mr-2"></i>API
                     </Nav.Link>
                     <a className="white-border-right"></a>
-                    <Nav.Link className="text-white py-0" href="/sidekiq">
+                    <Nav.Link className="text-white py-0" href={`${window.BASE_PATH}/sidekiq`}>
                       <i className="fas fa-hourglass fa-fw mr-2"></i>Jobs
                     </Nav.Link>
                     <a className="white-border-right"></a>

--- a/app/javascript/components/patient/Patient.js
+++ b/app/javascript/components/patient/Patient.js
@@ -87,7 +87,7 @@ class Patient extends React.Component {
     } else {
       return (
         <div className="edit-link">
-          <a href={window.BASE_PATH + '/patients/' + this.props.details.id + '/edit?step=' + enrollmentStep} id={sectionId} aria-label={`Edit ${section}`}>
+          <a href={`${window.BASE_PATH}/patients/${this.props.details.id}/edit?step=${enrollmentStep}`} id={sectionId} aria-label={`Edit ${section}`}>
             Edit
           </a>
         </div>
@@ -677,7 +677,7 @@ class Patient extends React.Component {
           <div id="household-member-not-hoh" className="household-info">
             <Row>
               The reporting responsibility for this monitoree is handled by another monitoree.&nbsp;
-              <a href={'/patients/' + this.props.details.responder_id}>Click here to view that monitoree</a>.
+              <a href={`${window.BASE_PATH}/patients/${this.props.details.responder_id}`}>Click here to view that monitoree</a>.
             </Row>
             <Row>
               <RemoveFromHousehold patient={this.props?.details} dependents={this.props?.dependents} authenticity_token={this.props.authenticity_token} />
@@ -703,7 +703,7 @@ class Patient extends React.Component {
                       return (
                         <tr key={`dl-${index}`}>
                           <td>
-                            <a href={'/patients/' + member.id}>
+                            <a href={`${window.BASE_PATH}/patients/${member.id}`}>
                               {member.last_name}, {member.first_name} {member.middle_name || ''}
                             </a>
                           </td>
@@ -733,7 +733,7 @@ class Patient extends React.Component {
                 {this.props?.dependents?.map((member, index) => {
                   return (
                     <Row key={'gm' + index}>
-                      <a href={'/patients/' + member.id}>
+                      <a href={`${window.BASE_PATH}/patients/${member.id}`}>
                         {member.last_name}, {member.first_name} {member.middle_name || ''}
                       </a>
                     </Row>

--- a/app/javascript/components/patient/PatientPage.js
+++ b/app/javascript/components/patient/PatientPage.js
@@ -12,7 +12,7 @@ class PatientPage extends React.Component {
 
   reloadHook = () => {
     // Optional reload, specifically for assessments
-    location.href = '/patients/' + this.props.patient.id;
+    location.href = `${window.BASE_PATH}/patients/${this.props.patient.id}`;
   };
 
   render() {

--- a/app/javascript/components/patient/vaccines/VaccineTable.js
+++ b/app/javascript/components/patient/vaccines/VaccineTable.js
@@ -71,7 +71,7 @@ class VaccineTable extends React.Component {
   queryServer = _.debounce(query => {
     axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
     axios
-      .get('/vaccines', {
+      .get(`${window.BASE_PATH}/vaccines`, {
         params: {
           patient_id: this.props.patient.id,
           ...query,
@@ -213,7 +213,7 @@ class VaccineTable extends React.Component {
   addNewVaccine = newVaccineData => {
     axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
     axios
-      .post('/vaccines', {
+      .post(`${window.BASE_PATH}/vaccines`, {
         group_name: newVaccineData.group_name,
         product_name: newVaccineData.product_name,
         administration_date: newVaccineData.administration_date,
@@ -277,7 +277,7 @@ class VaccineTable extends React.Component {
     axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
 
     axios
-      .put('/vaccines/' + currVaccineId, {
+      .put(`${window.BASE_PATH}/vaccines/${currVaccineId}`, {
         group_name: updatedVaccineData.group_name,
         product_name: updatedVaccineData.product_name,
         administration_date: updatedVaccineData.administration_date,

--- a/app/javascript/components/public_health/Import.js
+++ b/app/javascript/components/public_health/Import.js
@@ -105,7 +105,7 @@ class Import extends React.Component {
       };
       if (await confirmDialog(confirmText, options)) {
         this.setState({ isPaused: false });
-        location.href = this.props.workflow === 'exposure' ? '/public_health' : '/public_health/isolation';
+        location.href = `${window.BASE_PATH}/public_health/${this.props.workflow === 'exposure' ? '' : 'isolation'}`;
       } else {
         this.setState({ isPaused: false });
         if (this.state.acceptedAllStarted) {
@@ -164,7 +164,7 @@ class Import extends React.Component {
 
   render() {
     if (this.state.patients.length === this.state.accepted.length + this.state.rejected.length && this.state.errors.length == 0) {
-      location.href = '/';
+      location.href = `${window.BASE_PATH}/`;
     }
     return (
       <React.Fragment>

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -163,7 +163,7 @@ class PatientsTable extends React.Component {
 
     // fetch workflow and tab counts
     Object.keys(this.props.tabs).forEach(tab => {
-      axios.get(`/public_health/patients/counts/${this.props.workflow}/${tab}`).then(response => {
+      axios.get(`${window.BASE_PATH}/public_health/patients/counts/${this.props.workflow}/${tab}`).then(response => {
         const count = {};
         count[`${tab}Count`] = response.data.total;
         this.setState(count);
@@ -361,7 +361,7 @@ class PatientsTable extends React.Component {
 
   queryServer = _.debounce(query => {
     axios
-      .post('/public_health/patients', { query, cancelToken: this.state.cancelToken.token })
+      .post(window.BASE_PATH + '/public_health/patients', { query, cancelToken: this.state.cancelToken.token })
       .catch(error => {
         if (!axios.isCancel(error)) {
           this.setState(state => {
@@ -450,7 +450,7 @@ class PatientsTable extends React.Component {
   updateAssignedUsers = query => {
     if (query.tab !== 'transferred_out') {
       axios
-        .post('/jurisdictions/assigned_users', {
+        .post(window.BASE_PATH + '/jurisdictions/assigned_users', {
           query: { jurisdiction: query.jurisdiction, scope: query.scope, workflow: query.workflow, tab: query.tab },
         })
         .then(response => {
@@ -469,11 +469,11 @@ class PatientsTable extends React.Component {
       return (
         <div>
           <BadgeHOH patientId={rowData.id.toString()} customClass={'badge-hoh ml-1'} location={'right'} />
-          <a href={`/patients/${rowData.id}`}>{name}</a>
+          <a href={`${window.BASE_PATH}/patients/${rowData.id}`}>{name}</a>
         </div>
       );
     }
-    return <a href={`/patients/${rowData.id}`}>{name}</a>;
+    return <a href={`${window.BASE_PATH}/patients/${rowData.id}`}>{name}</a>;
   };
 
   formatEndOfMonitoring(data) {

--- a/app/javascript/components/public_health/PublicHealthHeader.js
+++ b/app/javascript/components/public_health/PublicHealthHeader.js
@@ -19,7 +19,7 @@ class PublicHealthHeader extends React.Component {
   }
 
   componentDidMount() {
-    axios.get('/public_health/patients/counts/workflow').then(response => {
+    axios.get(window.BASE_PATH + '/public_health/patients/counts/workflow').then(response => {
       if (response && response.data) {
         this.setState({ counts: response.data });
       }
@@ -37,7 +37,7 @@ class PublicHealthHeader extends React.Component {
         const config = { headers: { 'content-type': 'multipart/form-data' } };
         const formData = new FormData();
         formData.append('file', this.state.file);
-        const url = `/import/${this.props.workflow}/${this.state.fileType === 'epix' ? 'epix' : 'sara_alert_format'}`;
+        const url = `${window.BASE_PATH}/import/${this.props.workflow}/${this.state.fileType === 'epix' ? 'epix' : 'sara_alert_format'}`;
         axios.post(url, formData, config).then(response => {
           this.setState({
             uploading: false,
@@ -71,7 +71,7 @@ class PublicHealthHeader extends React.Component {
               additionalNote: 'Records imported prior to clicking "X" will not be deleted from the system.',
             };
             if (await confirmDialog(confirmText, options)) {
-              location.href = this.props.workflow === 'exposure' ? '/public_health' : '/public_health/isolation';
+              location.href = `${window.BASE_PATH}/public_health/${this.props.workflow === 'exposure' ? '' : 'isolation'}`;
             }
           } else {
             const confirmText = 'You are about to cancel the import process. Are you sure you want to do this?';
@@ -148,7 +148,10 @@ class PublicHealthHeader extends React.Component {
       <React.Fragment>
         <ButtonGroup>
           {this.props.abilities.enrollment && (
-            <Button variant="primary" className="ml-2 mb-4" href={this.props.workflow === 'exposure' ? '/patients/new' : '/patients/new?isolation=true'}>
+            <Button
+              variant="primary"
+              className="ml-2 mb-4"
+              href={`${window.BASE_PATH}/patients/new${this.props.workflow === 'exposure' ? '' : '?isolation=true'}`}>
               {this.props.workflow === 'exposure' && (
                 <span>
                   <i className="fas fa-user-plus"></i> Enroll New Monitoree
@@ -193,11 +196,11 @@ class PublicHealthHeader extends React.Component {
         </ButtonGroup>
 
         <ButtonGroup className="float-right mb-4 mr-2">
-          <Button variant={this.props.workflow === 'exposure' ? 'primary' : 'outline-primary'} href="/public_health">
+          <Button variant={this.props.workflow === 'exposure' ? 'primary' : 'outline-primary'} href={`${window.BASE_PATH}/public_health`}>
             <i className="fas fa-people-arrows"></i> Exposure Monitoring{' '}
             {this.state.counts.exposure !== undefined && <span id="exposureCount">({this.state.counts.exposure})</span>}
           </Button>
-          <Button variant={this.props.workflow === 'isolation' ? 'primary' : 'outline-primary'} href="/public_health/isolation">
+          <Button variant={this.props.workflow === 'isolation' ? 'primary' : 'outline-primary'} href={`${window.BASE_PATH}/public_health/isolation`}>
             <i className="fas fa-house-user"></i> Isolation Monitoring{' '}
             {this.state.counts.isolation !== undefined && <span id="isolationCount">({this.state.counts.isolation})</span>}
           </Button>

--- a/app/javascript/components/public_health/Workflow.js
+++ b/app/javascript/components/public_health/Workflow.js
@@ -17,7 +17,7 @@ class Workflow extends React.Component {
   }
 
   componentDidMount() {
-    axios.get('/jurisdictions/paths').then(response => {
+    axios.get(`${window.BASE_PATH}/jurisdictions/paths`).then(response => {
       this.setState({ jurisdiction_paths: response.data.jurisdiction_paths });
     });
   }

--- a/app/javascript/components/public_health/actions/UpdateCaseStatus.js
+++ b/app/javascript/components/public_health/actions/UpdateCaseStatus.js
@@ -27,7 +27,7 @@ class UpdateCaseStatus extends React.Component {
 
   componentDidMount() {
     axios
-      .post('/patients/current_case_status/', {
+      .post(window.BASE_PATH + '/patients/current_case_status/', {
         patient_ids: this.props.patients.map(x => x.id),
       })
       .then(response => {

--- a/app/javascript/components/public_health/custom_export/PatientsFilters.js
+++ b/app/javascript/components/public_health/custom_export/PatientsFilters.js
@@ -24,7 +24,7 @@ class PatientsFilters extends React.Component {
   // Update Assigned Users datalist
   updateAssignedUsers = () => {
     axios
-      .post('/jurisdictions/assigned_users', {
+      .post(`${window.BASE_PATH}/jurisdictions/assigned_users`, {
         query: {
           jurisdiction: this.props.query?.jurisdiction || this.props.jurisdiction?.id,
           scope: this.props.query?.scope || 'all',

--- a/app/javascript/components/subject/household_actions/ApplyToHousehold.js
+++ b/app/javascript/components/subject/household_actions/ApplyToHousehold.js
@@ -275,7 +275,7 @@ class ApplyToHousehold extends React.Component {
         <div>
           <BadgeHOH patientId={rowData.id.toString()} customClass={'badge-hoh ml-1'} location={'right'} />
           {this.validJurisdiction(rowData) ? (
-            <a href={`/patients/${rowData.id}`} rel="noreferrer" target="_blank">
+            <a href={`${window.BASE_PATH}/patients/${rowData.id}`} rel="noreferrer" target="_blank">
               {monitoreeName}
             </a>
           ) : (
@@ -285,7 +285,7 @@ class ApplyToHousehold extends React.Component {
       );
     }
     return this.validJurisdiction(rowData) ? (
-      <a href={`/patients/${rowData.id}`} rel="noreferrer" target="_blank">
+      <a href={`${window.BASE_PATH}/patients/${rowData.id}`} rel="noreferrer" target="_blank">
         {monitoreeName}
       </a>
     ) : (

--- a/app/javascript/components/subject/household_actions/EnrollHouseholdMember.js
+++ b/app/javascript/components/subject/household_actions/EnrollHouseholdMember.js
@@ -43,7 +43,7 @@ class EnrollHouseholdMember extends React.Component {
           </Button>
           <Button
             variant="primary btn-square"
-            href={window.BASE_PATH + '/patients/' + this.props.responderId + '/group'}
+            href={`${window.BASE_PATH}/patients/${this.props.responderId}/group`}
             onClick={() => {
               this.setState({ loading: true });
             }}

--- a/app/javascript/components/subject/household_actions/MoveToHousehold.js
+++ b/app/javascript/components/subject/household_actions/MoveToHousehold.js
@@ -66,11 +66,11 @@ class MoveToHousehold extends React.Component {
       return (
         <div>
           <BadgeHOH patientId={rowData.id.toString()} customClass={'badge-hoh ml-1'} location={'right'} />
-          <a href={`/patients/${rowData.id}`}>{name}</a>
+          <a href={`${window.BASE_PATH}/patients/${rowData.id}`}>{name}</a>
         </div>
       );
     }
-    return <a href={`/patients/${rowData.id}`}>{name}</a>;
+    return <a href={`${window.BASE_PATH}/patients/${rowData.id}`}>{name}</a>;
   };
 
   /**
@@ -203,7 +203,7 @@ class MoveToHousehold extends React.Component {
   queryServer = _.debounce(query => {
     axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
     axios
-      .post('/patients/head_of_household_options', {
+      .post(window.BASE_PATH + '/patients/head_of_household_options', {
         query,
         cancelToken: this.state.cancelToken.token,
       })

--- a/app/javascript/components/subject/monitoring_actions/Jurisdiction.js
+++ b/app/javascript/components/subject/monitoring_actions/Jurisdiction.js
@@ -93,8 +93,7 @@ class Jurisdiction extends React.Component {
           // check if current_user has access to the changed jurisdiction
           // if so, reload the page, if not, redirect to exposure or isolation dashboard
           if (!this.state.jurisdiction_path.startsWith(currentUserJurisdictionString)) {
-            const pathEnd = this.state.isolation ? '/isolation' : '';
-            location.assign((window.BASE_PATH ? window.BASE_PATH : '') + '/public_health' + pathEnd);
+            location.assign(`${window.BASE_PATH}/public_health${this.state.isolation ? '/isolation' : ''}`);
           } else {
             location.reload(true);
           }

--- a/app/javascript/tests/patient/Patient.test.js
+++ b/app/javascript/tests/patient/Patient.test.js
@@ -30,6 +30,10 @@ const riskFactors = [
   { key: 'Crew on Passenger or Cargo Flight', val: null },
 ];
 
+beforeEach(() => {
+  window.BASE_PATH = ""
+})
+
 describe('Patient', () => {
   it('Properly renders all main components when not in edit mode', () => {
     const wrapper = shallow(<Patient details={mockPatient1} dependents={[ mockPatient2 ]} hideBody={true} edit_mode={false}
@@ -450,7 +454,7 @@ describe('Patient', () => {
     expect(wrapper.find('#household-member-not-hoh').exists()).toBeTruthy();
     expect(wrapper.find('#household-member-not-hoh').find(Row).first().text())
       .toEqual('The reporting responsibility for this monitoree is handled by another monitoree. Click here to view that monitoree.');
-    expect(wrapper.find('#household-member-not-hoh a').prop('href')).toEqual('/patients/17');
+    expect(wrapper.find('#household-member-not-hoh a').prop('href')).toEqual(`${window.BASE_PATH}/patients/17`);
     expect(wrapper.find(RemoveFromHousehold).exists()).toBeTruthy();
     expect(wrapper.find(MoveToHousehold).exists()).toBeFalsy();
     expect(wrapper.find(ChangeHOH).exists()).toBeFalsy();
@@ -492,7 +496,7 @@ describe('Patient', () => {
     expect(wrapper.find('.edit-link').find('a').length).toEqual(7);
     wrapper.find('.edit-link').find('a').forEach(function(link, index) {
       expect(link.text()).toEqual('Edit');
-      expect(link.prop('href')).toEqual(`undefined/patients/${mockPatient1.id}/edit?step=${stepIds[index]}`);
+      expect(link.prop('href')).toEqual(`${window.BASE_PATH}/patients/${mockPatient1.id}/edit?step=${stepIds[index]}`);
     });
   });
 

--- a/app/javascript/tests/subject/household_actions/ApplyToHousehold.test.js
+++ b/app/javascript/tests/subject/household_actions/ApplyToHousehold.test.js
@@ -24,6 +24,10 @@ function getMountedWrapper() {
     handleApplyHouseholdChange={handleApplyHouseholdChangeMock} handleApplyHouseholdIdsChange={handleApplyHouseholdIdsChangeMock} />);
 }
 
+beforeEach(() => {
+  window.BASE_PATH = ""
+})
+
 afterEach(() => {
   jest.clearAllMocks();
 });
@@ -95,7 +99,7 @@ describe('ApplyToHousehold', () => {
       expect(row.find('td').at(0).find('input').exists).toBeTruthy();
       expect(row.find('td').at(0).find('input').prop('checked')).toBeFalsy();
       expect(row.find('td').at(1).find('a').exists()).toBeTruthy();
-      expect(row.find('td').at(1).find('a').prop('href')).toEqual('/patients/' + rowData.id);
+      expect(row.find('td').at(1).find('a').prop('href')).toEqual(`${window.BASE_PATH}/patients/${rowData.id}`);
       expect(row.find('td').at(1).find('a').text()).toEqual(nameFormatterAlt(rowData));
       if (rowData.id === rowData.responder_id) {
         expect(row.find('td').at(1).find(BadgeHOH).exists()).toBeTruthy();


### PR DESCRIPTION
Currently, Sara Alert has the ability to be hosted at a subpath. For example, it can be hosted at `www.xyz.com/subpath/saraalert/`. This is done by allowing the setting of a `BASE_PATH` on the backend. For normal operation, this will be the empty string `""`. 

The front-end should structure all queries (axios, href...etc) to include this `BASE_PATH`. However, in certain files, this was forgotten.

This pull request adds back `window.BASE_PATH` into all the places were it was missing. It also corrects some front-end tests to account for this.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@ : @hackrm 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] **N/A** If applicable, you have tested changes against a large database, and considered possible performance regressions


@ : @sgober 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ : @holmesie  
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions