### PR TITLE
Enforce GH Actions performance testing 30m timeout

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   close-patients-job-benchmark:
     runs-on: ubuntu-18.04
+    timeout-minutes: 30
     services:
       mysql:
         image: ghcr.io/saraalert/saraalert-1m-database:latest
@@ -72,6 +73,7 @@ jobs:
 
   send-assessments-job-benchmark:
     runs-on: ubuntu-18.04
+    timeout-minutes: 30
     services:
       mysql:
         image: ghcr.io/saraalert/saraalert-1m-database:latest
@@ -139,6 +141,7 @@ jobs:
 
   micro-benchmarks:
     runs-on: ubuntu-18.04
+    timeout-minutes: 30
     services:
       mysql:
         image: ghcr.io/saraalert/saraalert-1m-database:latest
@@ -205,6 +208,7 @@ jobs:
 
   jmeter-benchmark:
     runs-on: ubuntu-18.04
+    timeout-minutes: 30
     services:
       mysql:
         image: ghcr.io/saraalert/saraalert-1m-database:latest


### PR DESCRIPTION
# Description
Jira Ticket: None

I've noticed some performance testing jobs that seem to just hang indefinitely for no apparent reason - I'm wondering if this is just an artifact of using shared GitHub resources. The default timeout from GitHub is 360 minutes, which is much longer that what we should tolerate. This PR reduces the timeout for performance testing jobs to 30 minutes.

Here is an example of one of the 6 hour timeouts: https://github.com/SaraAlert/SaraAlert/runs/2169433913?check_suite_focus=true
