### PR TITLE
Use total time in performance testing instead of real time

### DIFF
--- a/performance/benchmark.rb
+++ b/performance/benchmark.rb
@@ -88,12 +88,12 @@ def benchmark(name: nil, time_threshold: 3600, setup: nil, teardown: nil, no_exi
   puts File.read(benchmark_file) if ENV['CAP_STDOUT']
 
   puts "\n\n"
-  puts "Acceptable real time threshold: #{format('%.3f', time_threshold).rjust(10, ' ')}"
-  puts "    Actual real time threshold: #{format('%.3f', benchmark_report.real).rjust(10, ' ')}"
+  puts "Acceptable total time threshold: #{format('%.3f', time_threshold).rjust(10, ' ')}"
+  puts "    Actual total time threshold: #{format('%.3f', benchmark_report.total).rjust(10, ' ')}"
 
   restore(ENV['MYSQL_PATH']) if ENV['APP_IN_CI'].nil?
 
-  if time_threshold < benchmark_report.real
+  if time_threshold < benchmark_report.total
     puts 'TEST FAILED'
     exit(1) unless no_exit
     false


### PR DESCRIPTION
# Description
Jira Ticket: None

This PR changes the thresholds in GitHub Actions performance testing from using real time to now use total time (user + system). This is expected to give us more consistent results - especially on the GitHub shared resources.
