### PR TITLE
SARAALERT-1337 (continued): Bug when user presses enter and date is invalid

### DIFF
--- a/app/javascript/components/util/DateInput.js
+++ b/app/javascript/components/util/DateInput.js
@@ -65,6 +65,17 @@ class DateInput extends React.Component {
   };
 
   /**
+   * Called when any key on the key board is pressed.
+   * This will call the onBlur function only if the enter key is pressed
+   * This is to prevent entering an invalid date being overwritten by the user pressing the enter key
+   */
+  handleKeyDown = event => {
+    if (event.keyCode === 13) {
+      this.handleOnBlur();
+    }
+  };
+
+  /**
    * Returns false if date is null, undefined, invalid or falls outside the min/max date range
    * Returns true otherwise
    */
@@ -125,6 +136,7 @@ class DateInput extends React.Component {
               onChangeRaw={this.handleRawChange}
               onSelect={this.handleSelect}
               onBlur={this.handleOnBlur}
+              onKeyDown={this.handleKeyDown}
               className={this.props.customClass}
               customInput={
                 <MaskedInput


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1337](https://tracker.codev.mitre.org/browse/SARAALERT-1337)

Bug the PO team found when testing the above ticket, see steps to recreate below.

## (Bugfix) How to Replicate

1. Select a monitoree and click edit on the Identification Section
2. Confirm DoB is set to a valid non-blank date
3. Highlight the valid date (DO NOT PRESS DELETE) and type in an invalid date (e.g. 14-14-1414)
4. Hit the Enter key (don't click outside the field)
5. Notice DOB is reverted to the prior valid date

## (Bugfix) Solution

Added the onBlur functionality to a keydown function for the enter key.  That way if an invalid date is typed and the user clicks the enter key, the DOB will revert to being blank, as it would if the user had just clicked outside the field.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@ : @timwongj 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] **N/A** If applicable, you have tested changes against a large database, and considered possible performance regressions


@ : @holmesie 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] N/A The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
