### PR TITLE
revert job back to printing out all sent IDs

### DIFF
--- a/app/views/user_mailer/assessment_job_email.html.erb
+++ b/app/views/user_mailer/assessment_job_email.html.erb
@@ -7,9 +7,9 @@
 <br />
   Total eligible for notifications at runtime: <%= @eligible %>
 <br />
-Sent during this job run: <b><%= @sent[:count] %></b>
+Sent during this job run: <b><%= @sent.size %></b>
 <br />
-Not sent during this job run (due to exceptions): <b><%= @not_sent.count %></b>
+Not sent during this job run (due to exceptions): <b><%= @not_sent.size %></b>
 <br />
 <h2>
   Sent
@@ -17,9 +17,8 @@ Not sent during this job run (due to exceptions): <b><%= @not_sent.count %></b>
 <br />
 Method, Count
 <br />
-<% @sent.each do |method, count| %>
-  <% next if method == :count %>
-  <%= method %>, <%= count %>
+<% @sent.each do |s| %>
+  <%= s[:id] %>, <%= s[:method] %>
   <br />
 <% end %>
 <br />


### PR DESCRIPTION
No need to review this - PR into another one of my PRs for assessing performance impact before I make a change.

https://github.com/SaraAlert/SaraAlert/pull/726