### PR TITLE
DOB does not save bugfix

### DIFF
--- a/app/javascript/components/enrollment/steps/Address.js
+++ b/app/javascript/components/enrollment/steps/Address.js
@@ -9,7 +9,13 @@ import { stateOptions } from '../../../data/stateOptions';
 class Address extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { ...this.props, current: { ...this.props.currentState }, errors: {}, modified: {}, selectedTab: 'domestic' };
+    this.state = {
+      ...this.props,
+      current: { ...this.props.currentState },
+      errors: {},
+      modified: {},
+      selectedTab: 'domestic',
+    };
     if (typeof this.props.currentState.monitored_address_state !== 'undefined') {
       // When viewing existing patients, the `monitored_address_state` needs to be reverse mapped back to the abbreviation
       this.state.current.patient.monitored_address_state = stateOptions.find(state => state.name === this.props.currentState.monitored_address_state)?.abbrv;
@@ -31,8 +37,9 @@ class Address extends React.Component {
     );
   };
 
-  whereMonitoredSameAsHome = () => {
+  handleSameAsHomeClick = () => {
     let current = this.state.current;
+    let modified = this.state.modified;
     this.setState(
       {
         current: {
@@ -47,9 +54,21 @@ class Address extends React.Component {
             monitored_address_county: current.patient.address_county,
           },
         },
+        modified: {
+          ...modified,
+          patient: {
+            ...modified.patient,
+            monitored_address_line_1: current.patient.address_line_1,
+            monitored_address_city: current.patient.address_city,
+            monitored_address_state: current.patient.address_state,
+            monitored_address_line_2: current.patient.address_line_2,
+            monitored_address_zip: current.patient.address_zip,
+            monitored_address_county: current.patient.address_county,
+          },
+        },
       },
       () => {
-        this.props.setEnrollmentState({ ...this.state.current });
+        this.props.setEnrollmentState({ ...this.state.modified });
       }
     );
   };
@@ -221,7 +240,7 @@ class Address extends React.Component {
                           size="md"
                           variant="outline-primary"
                           className="ml-4 btn-square px-3"
-                          onClick={this.whereMonitoredSameAsHome}>
+                          onClick={this.handleSameAsHomeClick}>
                           Copy from Home Address
                         </Button>
                       </div>

--- a/app/javascript/components/enrollment/steps/Identification.js
+++ b/app/javascript/components/enrollment/steps/Identification.js
@@ -30,7 +30,6 @@ class Identification extends React.Component {
     let value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
     let current = this.state.current;
     let modified = this.state.modified;
-    const self = this;
     event.persist();
     this.setState(
       {
@@ -38,7 +37,7 @@ class Identification extends React.Component {
         modified: { ...modified, patient: { ...modified.patient, [event.target.id]: value } },
       },
       () => {
-        self.props.setEnrollmentState({ ...self.state.modified });
+        this.props.setEnrollmentState({ ...this.state.modified });
       }
     );
   };
@@ -51,8 +50,6 @@ class Identification extends React.Component {
     let modified_races = {};
     let current = this.state.current;
     let modified = this.state.modified;
-
-    const self = this;
     event.persist();
 
     if (value) {
@@ -60,7 +57,7 @@ class Identification extends React.Component {
       let races_to_reset = this.props.race_options.exclusive;
 
       // Reset all races if exclusive option is selected
-      if (self.props.race_options.exclusive.map(options => options.race).includes(event.target.id)) {
+      if (this.props.race_options.exclusive.map(options => options.race).includes(event.target.id)) {
         races_to_reset = races_to_reset.concat(this.props.race_options.non_exclusive);
       }
 
@@ -77,7 +74,7 @@ class Identification extends React.Component {
         modified: { ...modified, patient: { ...current.patient, ...modified_races } },
       },
       () => {
-        self.props.setEnrollmentState({ ...self.state.modified });
+        this.props.setEnrollmentState({ ...this.state.modified });
       }
     );
   };
@@ -87,49 +84,38 @@ class Identification extends React.Component {
     const current = this.state.current;
     const modified = this.state.modified;
     const isIsolation = value === 'isolation';
-    const self = this;
     this.setState(
       {
         current: { ...current, isolation: isIsolation, patient: { ...current.patient, isolation: isIsolation } },
         modified: { ...modified, isolation: isIsolation, patient: { ...modified.patient, isolation: isIsolation } },
       },
       () => {
-        self.props.setEnrollmentState({ ...self.state.modified });
+        this.props.setEnrollmentState({ ...this.state.modified });
       }
     );
   };
 
   getWorkflowValue = () => (this.state.current.isolation ? WORKFLOW_OPTIONS[1] : WORKFLOW_OPTIONS[0]);
 
-  handleDateChange = (field, date) => {
-    const self = this;
+  handleDOBChange = date => {
+    const date_of_birth = date;
+    let age;
+
+    // If date is undefined, age will stay undefined (which nulls out the age field)
+    if (date_of_birth) {
+      age = moment().diff(moment(date_of_birth), 'years');
+      age = age >= 0 ? age : this.state.age;
+    }
+
     this.setState(
       state => {
         return {
-          current: { ...state.current, patient: { ...state.current.patient, [field]: date } },
-          modified: { ...state.modified, patient: { ...state.modified.patient, [field]: date } },
+          current: { ...state.current, patient: { ...state.current.patient, date_of_birth, age } },
+          modified: { ...state.modified, patient: { ...state.modified.patient, date_of_birth, age } },
         };
       },
       () => {
-        // Automatically calculate age field once a date of birth is entered.
-        let age;
-        const dateOfBirth = self.state.current.patient.date_of_birth;
-        // If date is undefined, age will stay undefined (which nulls out the age field)
-        if (dateOfBirth) {
-          age = moment().diff(moment(dateOfBirth), 'years');
-          age = age >= 0 ? age : self.state.age;
-        }
-        self.setState(
-          state => {
-            return {
-              current: { ...state.current, patient: { ...state.current.patient, age } },
-              modified: { ...state.modified, patient: { ...state.modified.patient, age } },
-            };
-          },
-          () => {
-            self.props.setEnrollmentState({ ...self.state.modified });
-          }
-        );
+        this.props.setEnrollmentState({ ...this.state.modified });
       }
     );
   };
@@ -138,14 +124,13 @@ class Identification extends React.Component {
     const value = event.value;
     const current = this.state.current;
     const modified = this.state.modified;
-    const self = this;
     this.setState(
       {
         current: { ...current, patient: { ...current.patient, [languageType]: value } },
         modified: { ...modified, patient: { ...modified.patient, [languageType]: value } },
       },
       () => {
-        self.props.setEnrollmentState({ ...self.state.modified });
+        this.props.setEnrollmentState({ ...this.state.modified });
       }
     );
   };
@@ -311,7 +296,7 @@ class Identification extends React.Component {
                     date={this.state.current.patient.date_of_birth}
                     minDate={'1900-01-01'}
                     maxDate={moment().format('YYYY-MM-DD')}
-                    onChange={date => this.handleDateChange('date_of_birth', date)}
+                    onChange={this.handleDOBChange}
                     placement="bottom"
                     isInvalid={!!this.state.errors['date_of_birth']}
                     clearInvalid={true}
@@ -646,6 +631,7 @@ Identification.propTypes = {
   currentState: PropTypes.object,
   race_options: PropTypes.object,
   next: PropTypes.func,
+  setEnrollmentState: PropTypes.func,
 };
 
 export default Identification;


### PR DESCRIPTION
# Description
This fixes the long existing bug of how sometimes the DOB does not save.  See below for detailed steps on how to recreate this bug.

## (Bugfix) How to Replicate

1. Open up any monitoree
2. Click the edit link for the identification section
3. Edit the DOB and click next
4. DO NOT CLICK FINISH
5. Notice that the DOB is updated to what you changed it to on the review page
6. From the review page, click the edit address link
7. Update the home address (one field is fine)
8. Click the "Copy from Home Address" button
9. Click Next
10. Notice that the DOB has reverted to the original DOB, not the one you changed it to

## (Bugfix) Solution

There were two piece to this fix, one in the Identification part of the carousel and one in the Address part
1. `Identification.js` was not calling `props.setEnrollmentState` when the DOB was updated, thus not passing it back to the carousel parent
2. `Address.js` was sending the current state not the modified state back to the parent, which overwrote the changes made

In addition to those changes, I cleaned up the functions.


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@holmesie :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@DPC15038  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
