### PR TITLE
SARAALERT-1421: Improve loading of assessments table on patient page

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -2,8 +2,6 @@
 
 # AssessmentsController: for assessment actions
 class AssessmentsController < ApplicationController
-  include AssessmentQueryHelper
-
   def index
     redirect_to(root_url) if ADMIN_OPTIONS['report_mode']
     redirect_to(root_url) && return unless current_user&.can_view_patient_assessments?
@@ -21,10 +19,10 @@ class AssessmentsController < ApplicationController
     assessments = patient&.assessments
     redirect_to(root_url) && return if patient.nil? || assessments.nil?
 
-    assessments = search(assessments, search_text)
-    assessments = sort(assessments, sort_order, sort_direction)
-    assessments = paginate(assessments, entries, page)
-    assessments = format_for_frontend(assessments)
+    assessments = AssessmentQueryHelper.search(assessments, search_text)
+    assessments = AssessmentQueryHelper.sort(assessments, sort_order, sort_direction)
+    assessments = AssessmentQueryHelper.paginate(assessments, entries, page)
+    assessments = AssessmentQueryHelper.format_for_frontend(assessments)
 
     render json: assessments
   end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -41,9 +41,6 @@ class PatientsController < ApplicationController
     @translations = Assessment.new.translations
 
     @history_types = History::HISTORY_TYPES
-
-    # If we failed to find a subject given the id, redirect to index
-    redirect_to(root_url) && return if @patient.nil?
   end
 
   # Returns a new (unsaved) subject, for creating a new subject

--- a/app/helpers/assessment_query_helper.rb
+++ b/app/helpers/assessment_query_helper.rb
@@ -77,8 +77,8 @@ module AssessmentQueryHelper
 
     # Get distinct threshold conditions for these assessments
     threshold_condition_hashes = ReportedCondition.where(assessment_id: assessment_ids).select(:threshold_condition_hash)
-    threshold_conditions = Hash[ThresholdCondition.where(threshold_condition_hash: threshold_condition_hashes)
-                                                  .pluck(:id, :threshold_condition_hash)].transform_values { |hash| { hash: hash, symptoms: {} } }
+    threshold_conditions = ThresholdCondition.where(threshold_condition_hash: threshold_condition_hashes).pluck(:id, :threshold_condition_hash)
+                                             .to_h.transform_values { |hash| { hash: hash, symptoms: {} } }
 
     # Get all threshold symptoms associated with the distinct threshold condition hashes
     Symptom.where(condition_id: threshold_conditions.keys)
@@ -89,11 +89,11 @@ module AssessmentQueryHelper
     threshold_symptoms = threshold_conditions.transform_keys { |condition_id| threshold_conditions[condition_id][:hash] }
 
     # Query relevant fields for all associated reported conditions
-    reported_conditions = Hash[ReportedCondition.where(assessment_id: assessment_ids).pluck(:id, :assessment_id, :threshold_condition_hash)
-                                                .map { |(id, assessment_id, hash)| [id, { assessment_id: assessment_id, hash: hash, symptoms: [] }] }]
+    reported_conditions = ReportedCondition.where(assessment_id: assessment_ids).pluck(:id, :assessment_id, :threshold_condition_hash)
+                                           .map { |(id, assessment_id, hash)| [id, { assessment_id: assessment_id, hash: hash, symptoms: [] }] }.to_h
 
     # Create hash for condition id to assessment id lookup
-    reported_condition_ids_by_assessment_id = Hash[reported_conditions.map { |id, reported_condition| [reported_condition[:assessment_id], id] }]
+    reported_condition_ids_by_assessment_id = reported_conditions.map { |id, reported_condition| [reported_condition[:assessment_id], id] }.to_h
 
     # Query relevant fields for all associated symptoms and include them in the reported conditions
     Symptom.where(condition_id: reported_conditions.keys)

--- a/app/helpers/assessment_query_helper.rb
+++ b/app/helpers/assessment_query_helper.rb
@@ -131,7 +131,7 @@ module AssessmentQueryHelper
       table_data << details
     end
 
-    { table_data: table_data, symptoms: threshold_symptoms.values.flat_map { |s| s[:symptoms]&.values } || [], total: assessments.total_entries }
+    { table_data: table_data, symptoms: threshold_symptoms.values.flat_map { |s| s[:symptoms]&.values }.uniq(&:name) || [], total: assessments.total_entries }
   end
 
   # Gets all unique symptoms (based on name and threshold_condition_hash) for a given array of assessment IDs.

--- a/app/helpers/assessment_query_helper.rb
+++ b/app/helpers/assessment_query_helper.rb
@@ -7,7 +7,7 @@ module AssessmentQueryHelper
   end
 
   # Queries assessments by ID or reporter based on search text.
-  def search(assessments, search)
+  def self.search(assessments, search)
     return assessments if search.blank?
 
     assessments.where('id like ?', "#{search&.downcase}%").or(
@@ -16,7 +16,7 @@ module AssessmentQueryHelper
   end
 
   # Sorts assessments based on given column and direction.
-  def sort(assessments, order, direction)
+  def self.sort(assessments, order, direction)
     # Order by created_at date by default
     return assessments.order(created_at: 'desc') if order.blank? || direction.blank?
 
@@ -61,14 +61,14 @@ module AssessmentQueryHelper
   end
 
   # Paginates assessments data.
-  def paginate(assessments, entries, page)
+  def self.paginate(assessments, entries, page)
     return assessments if entries.blank? || entries <= 0 || page.blank? || page.negative?
 
     assessments.paginate(per_page: entries, page: page + 1)
   end
 
   # Formats assessments to be displayed on the frontend.
-  def format_for_frontend(assessments)
+  def self.format_for_frontend(assessments)
     # Select relevant fields
     assessments = assessments.select(%i[id symptomatic who_reported created_at])
 
@@ -132,14 +132,5 @@ module AssessmentQueryHelper
     end
 
     { table_data: table_data, symptoms: threshold_symptoms.values.flat_map { |s| s[:symptoms]&.values }.uniq(&:name) || [], total: assessments.total_entries }
-  end
-
-  # Gets all unique symptoms (based on name and threshold_condition_hash) for a given array of assessment IDs.
-  def get_unique_threshold_symptoms(assessment_ids)
-    # Get distinct threshold condition hashes for all assessments
-    threshold_condition_hashes = ReportedCondition.where(assessment_id: assessment_ids).distinct.pluck(:threshold_condition_hash)
-
-    # Get all threshold symptoms associated with the distinct threshold condition hashes
-    Symptom.where(condition_id: ThresholdCondition.where(threshold_condition_hash: threshold_condition_hashes))
   end
 end

--- a/app/javascript/components/admin/AdminTable.js
+++ b/app/javascript/components/admin/AdminTable.js
@@ -766,6 +766,7 @@ class AdminTable extends React.Component {
           </Col>
         </Row>
         <CustomTable
+          dataType="users"
           columnData={this.state.table.colData}
           rowData={this.state.table.rowData}
           totalRows={this.state.table.totalRows}

--- a/app/javascript/components/admin/AuditModal.js
+++ b/app/javascript/components/admin/AuditModal.js
@@ -308,6 +308,7 @@ class AuditModal extends React.Component {
               <b>User:</b> {this.props.user.email}
             </span>
             <CustomTable
+              dataType="audits"
               columnData={this.state.table.colData}
               rowData={this.state.table.rowData}
               totalRows={this.state.table.totalRows}

--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -121,7 +121,7 @@ class CustomTable extends React.Component {
   renderRowCheckbox = (rowData, rowIndex) => {
     return (
       <td>
-        <span data-for={`table-row-${rowIndex}-tooltip`} data-tip="">
+        <span data-for={`${this.props.dataType}-table-row-${rowIndex}-tooltip`} data-tip="">
           <input
             type="checkbox"
             disabled={this.props.disabledRows.includes(rowIndex)}
@@ -130,7 +130,13 @@ class CustomTable extends React.Component {
             onChange={e => this.handleCheckboxChange(e, rowIndex)}></input>
         </span>
         {this.props.disabledRows.includes(rowIndex) && (
-          <ReactTooltip id={`table-row-${rowIndex}-tooltip`} multiline={true} place="right" type="dark" effect="solid" className="tooltip-container">
+          <ReactTooltip
+            id={`${this.props.dataType}-table-row-${rowIndex}-tooltip`}
+            multiline={true}
+            place="right"
+            type="dark"
+            effect="solid"
+            className="tooltip-container">
             {this.props.disabledTooltipText}
           </ReactTooltip>
         )}
@@ -200,7 +206,7 @@ class CustomTable extends React.Component {
           className={
             this.props.getCustomTableClassName ? `table-responsive custom-table ${this.props.getCustomTableClassName()}` : 'table-responsive custom-table'
           }>
-          <Table striped bordered hover size="sm" className="opaque-table">
+          <Table striped bordered hover size="sm" id={`${this.props.dataType}-table`} className="opaque-table">
             <thead>
               <tr>
                 {this.props.isSelectable && this.props.checkboxColumnLocation === 'left' && this.renderSelectAllCheckbox()}
@@ -214,7 +220,10 @@ class CustomTable extends React.Component {
             <tbody>
               {this.props.rowData?.map((rowData, rowIndex) => {
                 return (
-                  <tr key={rowIndex} id={rowData.id ? rowData.id : rowIndex} className={this.props.getRowClassName ? this.props.getRowClassName(rowData) : ''}>
+                  <tr
+                    key={rowIndex}
+                    id={`${this.props.dataType}-${rowData.id ? rowData.id : `row-${rowIndex}`}`}
+                    className={this.props.getRowClassName ? this.props.getRowClassName(rowData) : ''}>
                     {this.props.isSelectable && this.props.checkboxColumnLocation === 'left' && this.renderRowCheckbox(rowData, rowIndex)}
                     {Object.values(this.props.columnData).map((colData, colIndex) => {
                       let value = rowData[colData.field];
@@ -227,7 +236,7 @@ class CustomTable extends React.Component {
                         value = colData.filter(filterData);
                       }
                       return (
-                        <td key={colIndex} className={colData.className ? colData.className : ''}>
+                        <td key={colIndex} id={`${this.props.dataType}-`} className={colData.className ? colData.className : ''}>
                           {colData.onClick && <span onClick={() => (colData.onClick(rowData.id.toString()) ? colData.onClick : null)}>{value}</span>}
                           {!colData.onClick && value}
                         </td>
@@ -324,6 +333,7 @@ class CustomTable extends React.Component {
 }
 
 CustomTable.propTypes = {
+  dataType: PropTypes.string.required,
   columnData: PropTypes.array,
   rowData: PropTypes.array,
   totalRows: PropTypes.number,

--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -333,7 +333,7 @@ class CustomTable extends React.Component {
 }
 
 CustomTable.propTypes = {
-  dataType: PropTypes.string.required,
+  dataType: PropTypes.string.isRequired,
   columnData: PropTypes.array,
   rowData: PropTypes.array,
   totalRows: PropTypes.number,

--- a/app/javascript/components/patient/assessment/AssessmentTable.js
+++ b/app/javascript/components/patient/assessment/AssessmentTable.js
@@ -312,7 +312,7 @@ class AssessmentTable extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Card id="assessments-table" className="mx-2 mt-3 mb-4 card-square">
+        <Card id="reports" className="mx-2 mt-3 mb-4 card-square">
           <Card.Header className="h5">Reports</Card.Header>
           <Card.Body>
             <div className="mt-4">
@@ -345,6 +345,7 @@ class AssessmentTable extends React.Component {
               </Row>
               <div className="mb-4">
                 <CustomTable
+                  dataType="assessments"
                   columnData={this.state.table.colData}
                   rowData={this.state.table.rowData}
                   totalRows={this.state.table.totalRows}

--- a/app/javascript/components/patient/household/actions/ApplyToHousehold.js
+++ b/app/javascript/components/patient/household/actions/ApplyToHousehold.js
@@ -324,6 +324,7 @@ class ApplyToHousehold extends React.Component {
         </Form.Group>
         {this.state.applyToHousehold && (
           <CustomTable
+            dataType="household-members"
             columnData={this.state.table.colData}
             rowData={this.state.table.rowData}
             totalRows={this.state.table.totalRows}

--- a/app/javascript/components/patient/household/actions/MoveToHousehold.js
+++ b/app/javascript/components/patient/household/actions/MoveToHousehold.js
@@ -316,6 +316,7 @@ class MoveToHousehold extends React.Component {
             </Row>
           </Form>
           <CustomTable
+            dataType="households"
             columnData={this.state.table.colData}
             rowData={this.state.table.rowData}
             totalRows={this.state.table.totalRows}

--- a/app/javascript/components/patient/vaccines/VaccineTable.js
+++ b/app/javascript/components/patient/vaccines/VaccineTable.js
@@ -330,7 +330,7 @@ class VaccineTable extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Card id="vaccines-table" className="mx-2 mt-3 mb-4 card-square">
+        <Card id="vaccines" className="mx-2 mt-3 mb-4 card-square">
           <Card.Header className="h5">Vaccinations</Card.Header>
           <Card.Body>
             <div className="mt-4">
@@ -366,6 +366,7 @@ class VaccineTable extends React.Component {
               </Row>
               <div className="mb-4">
                 <CustomTable
+                  dataType="vaccines"
                   columnData={this.state.table.colData}
                   rowData={this.state.table.rowData}
                   totalRows={this.state.table.totalRows}

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -678,6 +678,7 @@ class PatientsTable extends React.Component {
                 </InputGroup>
               </Form>
               <CustomTable
+                dataType="patients"
                 columnData={this.state.table.displayedColData}
                 rowData={this.state.table.rowData}
                 totalRows={this.state.table.totalRows}

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -49,8 +49,10 @@ class Assessment < ApplicationRecord
 
   def symptomatic?
     symptom_groups = []
+    threshold_symptoms = Hash[ThresholdCondition.find_by(threshold_condition_hash: reported_condition[:threshold_condition_hash]).symptoms
+                                                .map { |threshold_symptom| [threshold_symptom[:name], threshold_symptom] }]
     reported_condition.symptoms.each do |reported_symptom|
-      threshold_symptom = get_threshold_symptom(reported_symptom.name)
+      threshold_symptom = threshold_symptoms[reported_symptom.name]
       # Group represents how many have to be true in that group to be considered as symptomatic
       symptom_group_index = threshold_symptom&.group || 1
       # -1 to convert to 0-based ie: index 0 requires at least 1 true, index 1 requires at least 2 true...

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -49,10 +49,9 @@ class Assessment < ApplicationRecord
 
   def symptomatic?
     symptom_groups = []
-    threshold_symptoms = Hash[ThresholdCondition.find_by(threshold_condition_hash: reported_condition[:threshold_condition_hash]).symptoms
-                                                .map { |threshold_symptom| [threshold_symptom[:name], threshold_symptom] }]
+    threshold_symptoms = reported_condition&.threshold_condition&.symptoms&.map { |threshold_symptom| [threshold_symptom[:name], threshold_symptom] }&.to_h
     reported_condition.symptoms.each do |reported_symptom|
-      threshold_symptom = threshold_symptoms[reported_symptom.name]
+      threshold_symptom = threshold_symptoms[reported_symptom.name] unless threshold_symptoms.nil?
       # Group represents how many have to be true in that group to be considered as symptomatic
       symptom_group_index = threshold_symptom&.group || 1
       # -1 to convert to 0-based ie: index 0 requires at least 1 true, index 1 requires at least 2 true...

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -115,15 +115,6 @@ class Assessment < ApplicationRecord
     reported_condition&.symptoms&.find_by(name: symptom_name)
   end
 
-  # Gets all unique symptoms (based on name) for a given array of assessment IDs.
-  def self.get_unique_threshold_symptoms(assessment_ids, selected_fields = %i[name label type required threshold_operator bool_value int_value float_value])
-    threshold_cond_hashes = ReportedCondition.where(assessment_id: assessment_ids).pluck(:threshold_condition_hash)
-    return if threshold_cond_hashes.nil?
-
-    condition_ids = ThresholdCondition.where(threshold_condition_hash: threshold_cond_hashes)
-    Symptom.where(condition_id: condition_ids).select([:name] | selected_fields)&.uniq(&:name)
-  end
-
   def translations
     I18n.backend.send(:init_translations) unless I18n.backend.initialized?
     {

--- a/test/fixtures/conditions.yml
+++ b/test/fixtures/conditions.yml
@@ -43,37 +43,37 @@ jurisdiction_7_threshold_condition:
 
 threshold_condition_1:
   id: 8
-  threshold_condition_hash: '6287ac3ebfc5ee8404cff93d96c9b06567767e2903deec22047f34083666f8df'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1' + '2') %>
   created_at: <%= 50.days.ago %>
   updated_at: <%= 50.days.ago %>
 threshold_condition_2:
   id: 10
-  threshold_condition_hash: 'b1c270d7119f39a8f71cd83be6a76ba77951845df41ed54cd8243d0794e6ecf4'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 2' + '2') %>
   created_at: <%= 50.days.ago %>
   updated_at: <%= 50.days.ago %>
 threshold_condition_3:
   id: 12
-  threshold_condition_hash: '670abfbe4d98d89868a73f25a582bdb5c79f6562929a33230ffe39f58ea9a7c7'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 2, County 3' + '3') %>
   created_at: <%= 50.days.ago %>
   updated_at: <%= 50.days.ago %>
 threshold_condition_4:
   id: 14
-  threshold_condition_hash: 'f6c5c310f2626d43bd8cecdc53ad60536fca56b28d75d674ee66d3e63b8aff12'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 2, County 4' + '3') %>
   created_at: <%= 50.days.ago %>
   updated_at: <%= 50.days.ago %>
 threshold_condition_5:
   id: 16
-  threshold_condition_hash: 'dfcbb60856ba8516421e1f00ab53b0d91bbce19957202fab35f748a6d0421c3e'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA' + '1') %>
   created_at: <%= 50.days.ago %>
   updated_at: <%= 50.days.ago %>
 threshold_condition_6:
   id: 25
-  threshold_condition_hash: '854613cf6657d5ebfef5babcc3eb0f1a465ac723859d4df0d1cdcd5ff321d165'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1, County 2' + '3') %>
   created_at: <%= 50.days.ago %>
   updated_at: <%= 50.days.ago %>
 threshold_condition_7:
   id: 44
-  threshold_condition_hash: 'e5a3d6462ea5288c75e273cd3246432f1d3ec4534692148d2a913110555287fa'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1, County 1' + '3') %>
   created_at: <%= 50.days.ago %>
   updated_at: <%= 50.days.ago %>
 
@@ -82,124 +82,124 @@ patient_1_assessment_1_condition:
   assessment_id: 1001
   created_at: <%= 38.days.ago %>
   updated_at: <%= 32.days.ago %>
-  threshold_condition_hash: '6287ac3ebfc5ee8404cff93d96c9b06567767e2903deec22047f34083666f8df'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1' + '2') %>
   type: 'ReportedCondition'
 patient_1_assessment_2_condition:
   id: 1002
   assessment_id: 1002
   created_at: <%= 36.days.ago %>
   updated_at: <%= 32.days.ago %>
-  threshold_condition_hash: '6287ac3ebfc5ee8404cff93d96c9b06567767e2903deec22047f34083666f8df'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1' + '2') %>
   type: 'ReportedCondition'
 patient_2_assessment_1_condition:
   id: 1003
   assessment_id: 1003
   created_at: <%= 38.days.ago %>
   updated_at: <%= 32.days.ago %>
-  threshold_condition_hash: '6287ac3ebfc5ee8404cff93d96c9b06567767e2903deec22047f34083666f8df'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1' + '2') %>
   type: 'ReportedCondition'
 patient_2_assessment_2_condition:
   id: 1004
   assessment_id: 1004
   created_at: <%= 36.days.ago %>
   updated_at: <%= 32.days.ago %>
-  threshold_condition_hash: '6287ac3ebfc5ee8404cff93d96c9b06567767e2903deec22047f34083666f8df'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1' + '2') %>
   type: 'ReportedCondition'
 patient_3_assessment_1_condition:
   id: 1005
   assessment_id: 1005
   created_at: <%= 23.days.ago %>
   updated_at: <%= 23.days.ago %>
-  threshold_condition_hash: '6287ac3ebfc5ee8404cff93d96c9b06567767e2903deec22047f34083666f8df'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1' + '2') %>
   type: 'ReportedCondition'
 patient_3_assessment_2_condition:
   id: 1006
   assessment_id: 1006
   created_at: <%= 23.days.ago %>
   updated_at: <%= 23.days.ago %>
-  threshold_condition_hash: '6287ac3ebfc5ee8404cff93d96c9b06567767e2903deec22047f34083666f8df'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1' + '2') %>
   type: 'ReportedCondition'
 patient_4_assessment_1_condition:
   id: 1007
   assessment_id: 1007
   created_at: <%= 6.hours.ago %>
   updated_at: <%= 6.hours.ago %>
-  threshold_condition_hash: 'e5a3d6462ea5288c75e273cd3246432f1d3ec4534692148d2a913110555287fa'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1, County 1' + '3') %>
   type: 'ReportedCondition'
 patient_5_assessment_1_condition:
   id: 1008
   assessment_id: 1008
   created_at: <%= 24.days.ago %>
   updated_at: <%= 24.days.ago %>
-  threshold_condition_hash: '6287ac3ebfc5ee8404cff93d96c9b06567767e2903deec22047f34083666f8df'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1' + '2') %>
   type: 'ReportedCondition'
 patient_8_assessment_1_condition:
   id: 1009
   assessment_id: 1009
   created_at: <%= 24.days.ago %>
   updated_at: <%= 24.days.ago %>
-  threshold_condition_hash: '6287ac3ebfc5ee8404cff93d96c9b06567767e2903deec22047f34083666f8df'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1' + '2') %>
   type: 'ReportedCondition'
 patient_8_assessment_2_condition:
   id: 1010
   assessment_id: 1010
   created_at: <%= 5.hours.ago %>
   updated_at: <%= 5.hours.ago %>
-  threshold_condition_hash: '6287ac3ebfc5ee8404cff93d96c9b06567767e2903deec22047f34083666f8df'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1' + '2') %>
   type: 'ReportedCondition'
 patient_9_assessment_1_condition:
   id: 1011
   assessment_id: 1011
   created_at: <%= 24.days.ago %>
   updated_at: <%= 24.days.ago %>
-  threshold_condition_hash: 'b1c270d7119f39a8f71cd83be6a76ba77951845df41ed54cd8243d0794e6ecf4'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 2' + '2') %>
   type: 'ReportedCondition'
 patient_9_assessment_2_condition:
   id: 1012
   assessment_id: 1012
   created_at: <%= 24.days.ago %>
   updated_at: <%= 24.days.ago %>
-  threshold_condition_hash: 'b1c270d7119f39a8f71cd83be6a76ba77951845df41ed54cd8243d0794e6ecf4'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 2' + '2') %>
   type: 'ReportedCondition'
 patient_9_assessment_3_condition:
   id: 1013
   assessment_id: 1013
   created_at: <%= 22.days.ago %>
   updated_at: <%= 22.days.ago %>
-  threshold_condition_hash: 'b1c270d7119f39a8f71cd83be6a76ba77951845df41ed54cd8243d0794e6ecf4'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 2' + '2') %>
   type: 'ReportedCondition'
 patient_9_assessment_4_condition:
   id: 1014
   assessment_id: 1014
   created_at: <%= 10.hours.ago %>
   updated_at: <%= 10.hours.ago %>
-  threshold_condition_hash: 'b1c270d7119f39a8f71cd83be6a76ba77951845df41ed54cd8243d0794e6ecf4'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 2' + '2') %>
   type: 'ReportedCondition'
 patient_10_assessment_1_condition:
   id: 1015
   assessment_id: 1015
   created_at: <%= 26.days.ago %>
   updated_at: <%= 26.days.ago %>
-  threshold_condition_hash: 'f6c5c310f2626d43bd8cecdc53ad60536fca56b28d75d674ee66d3e63b8aff12'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 2, County 4' + '3') %>
   type: 'ReportedCondition'
 patient_10_assessment_2_condition:
   id: 1016
   assessment_id: 1016
   created_at: <%= 24.days.ago %>
   updated_at: <%= 24.days.ago %>
-  threshold_condition_hash: 'f6c5c310f2626d43bd8cecdc53ad60536fca56b28d75d674ee66d3e63b8aff12'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 2, County 4' + '3') %>
   type: 'ReportedCondition'
 patient_10_assessment_3_condition:
   id: 1017
   assessment_id: 1017
   created_at: <%= 18.hours.ago %>
   updated_at: <%= 18.hours.ago %>
-  threshold_condition_hash: 'f6c5c310f2626d43bd8cecdc53ad60536fca56b28d75d674ee66d3e63b8aff12'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 2, County 4' + '3') %>
   type: 'ReportedCondition'
 patient_50_assessment_1_condition:
   id: 1018
   assessment_id: 1018
   created_at: <%= 1.hour.ago %>
   updated_at: <%= 1.hour.ago %>
-  threshold_condition_hash: '6287ac3ebfc5ee8404cff93d96c9b06567767e2903deec22047f34083666f8df'
+  threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1' + '2') %>
   type: 'ReportedCondition'

--- a/test/fixtures/patients.yml
+++ b/test/fixtures/patients.yml
@@ -351,6 +351,7 @@ patient_12:
   id: 12
   created_at: <%= 6.days.ago %>
   updated_at: <%= 6.days.ago %>
+  responder_id: 12
   jurisdiction_id: 1
   monitoring: true
   first_name: 'David'
@@ -374,6 +375,7 @@ patient_13:
   id: 13
   created_at: <%= 4.days.ago %>
   updated_at: <%= 4.days.ago %>
+  responder_id: 13
   jurisdiction_id: 1
   monitoring: true
   first_name: 'Stephen'
@@ -397,6 +399,7 @@ patient_14:
   id: 14
   created_at: <%= 4.days.ago %>
   updated_at: <%= 4.days.ago %>
+  responder_id: 14
   jurisdiction_id: 1
   monitoring: false
   closed_at: <%= 5.hours.ago %>
@@ -420,6 +423,7 @@ patient_15:
   id: 15
   created_at: <%= 3.days.ago %>
   updated_at: <%= 3.days.ago %>
+  responder_id: 15
   jurisdiction_id: 1
   monitoring: true
   first_name: 'Jon'
@@ -444,6 +448,7 @@ patient_16:
   id: 16
   created_at: <%= 2.days.ago %>
   updated_at: <%= 2.days.ago %>
+  responder_id: 16
   jurisdiction_id: 1
   monitoring: true
   first_name: 'Stephen'
@@ -467,6 +472,7 @@ patient_17:
   id: 17
   created_at: <%= 1.day.ago %>
   updated_at: <%= 1.day.ago %>
+  responder_id: 17
   jurisdiction_id: 1
   monitoring: true
   first_name: 'Arya'
@@ -490,6 +496,7 @@ patient_18:
   id: 18
   created_at: <%= 23.hours.ago %>
   updated_at: <%= 23.hours.ago %>
+  responder_id: 18
   jurisdiction_id: 1
   monitoring: false
   closed_at: <%= 5.days.ago %>
@@ -514,6 +521,7 @@ patient_19:
   id: 19
   created_at: <%= 15.hours.ago %>
   updated_at: <%= 15.hours.ago %>
+  responder_id: 19
   jurisdiction_id: 1
   monitoring: true
   first_name: 'Laura'
@@ -537,6 +545,7 @@ patient_20:
   id: 20
   created_at: <%= 4.hours.ago %>
   updated_at: <%= 4.hours.ago %>
+  responder_id: 20
   jurisdiction_id: 1
   monitoring: true
   first_name: 'Ruby'

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -202,7 +202,7 @@ usa_super_user:
   sign_in_count: 12
   failed_attempts: 0
   force_password_change: false
-  jurisdiction_id: 2
+  jurisdiction_id: 1
   password_changed_at: "<%= 50.days.ago %>"
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"

--- a/test/models/assessment_test.rb
+++ b/test/models/assessment_test.rb
@@ -195,13 +195,13 @@ class AssessmentTest < ActiveSupport::TestCase
     patient = create(:patient)
     assessment = create(:assessment, reported_condition: reported_condition, patient: patient)
     # Assert 90.0 is less than 90.1
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
     # Assert 90.1 is not less than 90.1
     reported_symptom.update(value: 90.1)
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
     # Assert 91 is not less than 90.1
     reported_symptom.update(value: 91)
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
   end
 
   test 'float symptom less than or equal passes threshold' do
@@ -213,13 +213,13 @@ class AssessmentTest < ActiveSupport::TestCase
     patient = create(:patient)
     assessment = create(:assessment, reported_condition: reported_condition, patient: patient)
     # Assert 90.0 is less than or equal 90.1
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
     # Assert 90.1 is less than or equal 90.1
     reported_symptom.update(value: 90.1)
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
     # Assert 91 is not less than or equal 90.1
     reported_symptom.update(value: 91)
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
   end
 
   test 'float symptom greater than passes threshold' do
@@ -231,13 +231,13 @@ class AssessmentTest < ActiveSupport::TestCase
     patient = create(:patient)
     assessment = create(:assessment, reported_condition: reported_condition, patient: patient)
     # Assert 91.0 is greater than 90.1
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
     # Assert 90.1 is not greater than 90.1
     reported_symptom.update(value: 90.1)
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
     # Assert 90 is not less than 90.1
     reported_symptom.update(value: 90)
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
   end
 
   test 'float symptom greater than or equal passes threshold' do
@@ -249,13 +249,13 @@ class AssessmentTest < ActiveSupport::TestCase
     patient = create(:patient)
     assessment = create(:assessment, reported_condition: reported_condition, patient: patient)
     # Assert 91.0 is greater than or equal 90.1
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
     # Assert 90.1 is greater than or equal 90.1
     reported_symptom.update(value: 90.1)
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
     # Assert 90 is not greater than or equal 90.1
     reported_symptom.update(value: 90)
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
   end
 
   test 'float symptom equal passes threshold' do
@@ -267,10 +267,10 @@ class AssessmentTest < ActiveSupport::TestCase
     patient = create(:patient)
     assessment = create(:assessment, reported_condition: reported_condition, patient: patient)
     # Assert 90.1 is equal to 90.1
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
     # Assert 91.1 is not equal to 90.1
     reported_symptom.update(value: 91.1)
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
   end
 
   test 'float symptom not equal passes threshold' do
@@ -282,10 +282,10 @@ class AssessmentTest < ActiveSupport::TestCase
     patient = create(:patient)
     assessment = create(:assessment, reported_condition: reported_condition, patient: patient)
     # Assert 90.1 is not not equal to 90.1
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
     # Assert 91.1 is not equal to 90.1
     reported_symptom.update(value: 91.1)
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
   end
 
   test 'integer symptom less than passes threshold' do
@@ -297,13 +297,13 @@ class AssessmentTest < ActiveSupport::TestCase
     patient = create(:patient)
     assessment = create(:assessment, reported_condition: reported_condition, patient: patient)
     # Assert 90 is less than 91
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
     # Assert 91 is not less than 91
     reported_symptom.update(value: 91)
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
     # Assert 91 is not less than 91
     reported_symptom.update(value: 91)
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
   end
 
   test 'integer symptom less than or equal passes threshold' do
@@ -315,13 +315,13 @@ class AssessmentTest < ActiveSupport::TestCase
     patient = create(:patient)
     assessment = create(:assessment, reported_condition: reported_condition, patient: patient)
     # Assert 90 is less than or equal 91
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
     # Assert 91 is less than or equal 91
     reported_symptom.update(value: 91)
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
     # Assert 92 is not less than or equal 91
     reported_symptom.update(value: 92)
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
   end
 
   test 'integer symptom greater than passes threshold' do
@@ -333,13 +333,13 @@ class AssessmentTest < ActiveSupport::TestCase
     patient = create(:patient)
     assessment = create(:assessment, reported_condition: reported_condition, patient: patient)
     # Assert 92 is greater than 91
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
     # Assert 91 is not greater than 91
     reported_symptom.update(value: 91)
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
     # Assert 90 is not less than 91
     reported_symptom.update(value: 90)
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
   end
 
   test 'integer symptom greater than or equal passes threshold' do
@@ -351,13 +351,13 @@ class AssessmentTest < ActiveSupport::TestCase
     patient = create(:patient)
     assessment = create(:assessment, reported_condition: reported_condition, patient: patient)
     # Assert 91 is greater than or equal 91
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
     # Assert 91 is greater than or equal 91
     reported_symptom.update(value: 91)
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
     # Assert 90 is not greater than or equal 91
     reported_symptom.update(value: 90)
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
   end
 
   test 'integer symptom equal passes threshold' do
@@ -369,10 +369,10 @@ class AssessmentTest < ActiveSupport::TestCase
     patient = create(:patient)
     assessment = create(:assessment, reported_condition: reported_condition, patient: patient)
     # Assert 91 is equal to 91
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
     # Assert 90 is not equal to 91
     reported_symptom.update(value: 90)
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
   end
 
   test 'integer symptom not equal passes threshold' do
@@ -384,10 +384,10 @@ class AssessmentTest < ActiveSupport::TestCase
     patient = create(:patient)
     assessment = create(:assessment, reported_condition: reported_condition, patient: patient)
     # Assert 91 is not not equal to 91
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
     # Assert 90 is not equal to 91
     reported_symptom.update(value: 90)
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
   end
 
   test 'bool symptom equal passes threshold' do
@@ -399,10 +399,10 @@ class AssessmentTest < ActiveSupport::TestCase
     patient = create(:patient)
     assessment = create(:assessment, reported_condition: reported_condition, patient: patient)
     # Assert true is equal to true
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
     # Assert true is not equal to false
     reported_symptom.update(value: false)
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
   end
 
   test 'bool symptom not equal passes threshold' do
@@ -414,10 +414,10 @@ class AssessmentTest < ActiveSupport::TestCase
     patient = create(:patient)
     assessment = create(:assessment, reported_condition: reported_condition, patient: patient)
     # Assert false is not equal to true
-    assert assessment.symptom_passes_threshold('pulse-ox')
+    assert assessment.symptom_passes_threshold(reported_symptom)
     # Assert true is not equal to true
     reported_symptom.update(value: true)
-    assert_not assessment.symptom_passes_threshold('pulse-ox')
+    assert_not assessment.symptom_passes_threshold(reported_symptom)
   end
 
   test 'symptomatic when symptom groups specified' do

--- a/test/system/lib/system_test_utils.rb
+++ b/test/system/lib/system_test_utils.rb
@@ -58,6 +58,10 @@ class SystemTestUtils < ApplicationSystemTestCase
     click_on 'Previous'
   end
 
+  def go_to_patient_page(patient_id)
+    visit "/patients/#{patient_id}"
+  end
+
   def verify_user_jurisdiction(user_label)
     jurisdiction = get_user(user_label).jurisdiction
     assert page.has_content?(jurisdiction.name), get_err_msg('Dashboard', 'user jurisdiction', jurisdiction.name) unless user_label.include?('admin')

--- a/test/system/roles/public_health/dashboard/dashboard.rb
+++ b/test/system/roles/public_health/dashboard/dashboard.rb
@@ -233,7 +233,7 @@ class PublicHealthDashboard < ApplicationSystemTestCase
   end
 
   def check_patient(patient_label)
-    find_by_id(PATIENTS[patient_label]['id'].to_s).find('input').click
+    find_by_id("patients-#{PATIENTS[patient_label]['id']}").find('input').click
   end
 
   def bulk_edit_update_case_status(workflow, case_status, next_step, apply_to_household)

--- a/test/system/roles/public_health/patient_page/patient_page.rb
+++ b/test/system/roles/public_health/patient_page/patient_page.rb
@@ -11,16 +11,16 @@ class PublicHealthPatientPage < ApplicationSystemTestCase
 
   PATIENTS = SystemTestUtils::PATIENTS
 
-  def view_patients_details_and_reports(jurisdiction_id)
+  def view_patients_details(jurisdiction_id)
     monitorees = Jurisdiction.find(jurisdiction_id).all_patients_excluding_purged
     click_on 'All Monitorees'
     monitorees.where(isolation: false).where(monitoring: true).each do |patient|
-      @@public_health_patient_page_verifier.verify_patient_details_and_reports(patient, 'exposure')
+      @@public_health_patient_page_verifier.verify_patient_details(patient, 'exposure')
     end
     @@system_test_utils.go_to_workflow('isolation')
     click_on 'All Cases'
     monitorees.where(isolation: true).where(monitoring: true).each do |patient|
-      @@public_health_patient_page_verifier.verify_patient_details_and_reports(patient, 'isolation')
+      @@public_health_patient_page_verifier.verify_patient_details(patient, 'isolation')
     end
   end
 

--- a/test/system/roles/public_health/patient_page/patient_page_verifier.rb
+++ b/test/system/roles/public_health/patient_page/patient_page_verifier.rb
@@ -2,29 +2,20 @@
 
 require 'application_system_test_case'
 
-require_relative 'reports_verifier'
 require_relative '../../../lib/system_test_utils'
 
 class PublicHealthPatientPageVerifier < ApplicationSystemTestCase
-  @@public_health_patient_page_reports_verifier = PublicHealthPatientPageReportsVerifier.new(nil)
   @@system_test_utils = SystemTestUtils.new(nil)
 
-  def verify_patient_details_and_reports(patient, workflow)
+  def verify_patient_details(patient, workflow)
     sleep(0.5) # wait for any sticky filter to populate so it can be cleared during fill_in
     fill_in('search', with: patient.last_name, fill_options: { clear: :backspace })
     click_on "#{patient.last_name}, #{patient.first_name}"
-    verify_patient_details(patient)
-    @@public_health_patient_page_reports_verifier.verify_workflow(workflow)
-    @@public_health_patient_page_reports_verifier.verify_existing_reports(patient)
-    @@public_health_patient_page_reports_verifier.verify_pause_notifications(patient.pause_notifications)
-    @@system_test_utils.return_to_dashboard(workflow)
-  end
-
-  def verify_patient_details(patient)
     find('#details-expander-link').click
     fields = %w[first_name last_name]
     fields.each do |field|
       assert page.has_content?(patient[field]), @@system_test_utils.get_err_msg('Monitoree details', field, patient[field])
     end
+    @@system_test_utils.return_to_dashboard(workflow)
   end
 end

--- a/test/system/roles/public_health/patient_page/reports.rb
+++ b/test/system/roles/public_health/patient_page/reports.rb
@@ -68,11 +68,11 @@ class PublicHealthPatientPageReports < ApplicationSystemTestCase
     find('#notifications_action').click
     if submit
       click_on 'OK'
-      @@public_health_patient_page_reports_verifier.verify_pause_notifications(!pause_notifications)
+      @@public_health_patient_page_reports_verifier.verify_notifications_button_text(!pause_notifications)
       @@public_health_patient_page_history_verifier.verify_pause_notifications(user_label, !pause_notifications)
     else
       click_on 'Cancel'
-      @@public_health_patient_page_reports_verifier.verify_pause_notifications(pause_notifications)
+      @@public_health_patient_page_reports_verifier.verify_notifications_button_text(pause_notifications)
     end
   end
 

--- a/test/system/roles/public_health/patient_page/reports_verifier.rb
+++ b/test/system/roles/public_health/patient_page/reports_verifier.rb
@@ -7,11 +7,63 @@ require_relative '../../../lib/system_test_utils'
 class PublicHealthPatientPageReportsVerifier < ApplicationSystemTestCase
   @@system_test_utils = SystemTestUtils.new(nil)
 
-  def verify_existing_reports(patient)
-    assessments = Assessment.where(patient_id: patient.id)
+  STATUS_LABELS = {
+    exposure_symptomatic: 'symptomatic',
+    exposure_asymptomatic: 'asymptomatic',
+    exposure_non_reporting: 'non-reporting',
+    exposure_under_investigation: 'PUI',
+    purged: 'purged',
+    closed: 'not currently being monitored',
+    isolation_requiring_review: 'requires review',
+    isolation_symp_non_test_based: 'requires review (symptomatic non test based)',
+    isolation_asymp_non_test_based: 'requires review (asymptomatic non test based)',
+    isolation_test_based: 'requires review (test based)',
+    isolation_non_reporting: 'non-reporting',
+    isolation_reporting: 'reporting'
+  }.freeze
+
+  def verify_reports(patient_id, assessments = Assessment.where(patient_id: patient_id))
+    patient = Patient.find(patient_id)
+    reports = page.find('#reports')
+
+    verify_workflow(patient[:isolation])
+    verify_status(STATUS_LABELS[patient.status], reports)
+    verify_notifications_button_text(patient[:pause_notifications], reports)
+
+    # Wait for symptom headers to load on page
+    sleep(0.5)
+    table = reports.find('#assessments-table')
+    headers = table.find('thead').all('th').map(&:text)
+
+    # Verify that all symptom names are displayed
+    symptom_names = Hash[assessments.joins({ reported_condition: :symptoms }).distinct.pluck(:name, :label)]
+    symptom_labels = symptom_names.values
+    assert_equal symptom_labels, symptom_labels & headers, "Missing symptom headers: #{symptom_labels - (symptom_labels & headers)}"
+
+    # Determine column indexes of symptoms within table
+    symptom_column_indexes = symptom_names.transform_values { |label| headers.index(label) }
+
+    # Verify individual assessment data
     assessments.each do |assessment|
-      assert page.has_content?(assessment.who_reported), @@system_test_utils.get_err_msg('Reports', 'who reported', assessment.who_reported)
-      verify_symptoms(Condition.where(assessment_id: assessment.id).joins(:symptoms))
+      row = table.find("#assessments-#{assessment[:id]}")
+      assert_equal assessment[:symptomatic], row[:class].include?('table-danger'), "'Symptomatic color' for assessment #{assessment[:id]}"
+
+      cells = row.all('td')
+      assert_equal assessment[:id].to_s, cells[headers.index('ID')].text, "'ID' for assessment #{assessment[:id]}"
+      if headers.include?('Needs Review')
+        assert_equal assessment[:symptomatic] ? 'Yes' : 'No', cells[headers.index('Needs Review')].text, "'Needs Review' for assessment #{assessment[:id]}"
+      end
+      assert_equal assessment[:who_reported], cells[headers.index('Reporter')].text, "'Reporter' for assessment #{assessment[:id]}"
+
+      # Verify symptom values
+      assessment.reported_condition.symptoms.each do |symptom|
+        cell = cells[symptom_column_indexes[symptom[:name]]]
+        value = symptom.value
+        value = value == true ? 'Yes' : 'No' if symptom[:type] == 'BoolSymptom' && !value.nil?
+        assert_equal value || '', cell.text, "Symptom '#{symptom[:label]}' for assessment #{assessment[:id]}"
+        assert_equal assessment.symptom_passes_threshold(symptom), cell.find('span')[:class].include?('concern'),
+                     "'Symptomatic color' for symptom '#{symptom[:label]}' for assessment #{assessment[:id]}"
+      end
     end
   end
 
@@ -43,16 +95,17 @@ class PublicHealthPatientPageReportsVerifier < ApplicationSystemTestCase
     end
   end
 
-  def verify_workflow(workflow)
-    assert page.has_content?(workflow.capitalize), @@system_test_utils.get_err_msg('Reports', 'workflow', workflow.capitalize)
+  def verify_workflow(isolation, reports = page.find('#reports'))
+    workflow = isolation ? 'Isolation' : 'Exposure'
+    assert reports.has_content?(workflow), "Workflow (under 'Reports') should be #{workflow}"
   end
 
-  def verify_current_status(current_status)
-    assert page.has_content?(current_status), @@system_test_utils.get_err_msg('Reports', 'current monitoring status', current_status)
+  def verify_status(status, reports = page.find('#reports'))
+    assert reports.has_content?(status), "Status (under 'Reports') should be #{status}"
   end
 
-  def verify_pause_notifications(pause_notifications)
-    err_msg = @@system_test_utils.get_err_msg('Reports', 'notifications paused', pause_notifications)
-    assert page.has_content?("#{pause_notifications ? 'Resume' : 'Pause'} Notifications"), err_msg
+  def verify_notifications_button_text(pause_notifications, reports = page.find('#reports'))
+    notifications_button_text = "#{pause_notifications ? 'Resume' : 'Pause'} Notifications"
+    assert reports.has_content?(notifications_button_text), "Notifications button (under 'Reports') should be #{notifications_button_text}"
   end
 end

--- a/test/system/roles/public_health/patient_page/reports_verifier.rb
+++ b/test/system/roles/public_health/patient_page/reports_verifier.rb
@@ -36,7 +36,7 @@ class PublicHealthPatientPageReportsVerifier < ApplicationSystemTestCase
     headers = table.find('thead').all('th').map(&:text)
 
     # Verify that all symptom names are displayed
-    symptom_names = Hash[assessments.joins({ reported_condition: :symptoms }).distinct.pluck(:name, :label)]
+    symptom_names = assessments.joins({ reported_condition: :symptoms }).distinct.pluck(:name, :label).to_h
     symptom_labels = symptom_names.values
     assert_equal symptom_labels, symptom_labels & headers, "Missing symptom headers: #{symptom_labels - (symptom_labels & headers)}"
 

--- a/test/system/roles/public_health/public_health_patient_page_test.rb
+++ b/test/system/roles/public_health/public_health_patient_page_test.rb
@@ -11,9 +11,12 @@ class PublicHealthPatientPageTest < ApplicationSystemTestCase
   @@public_health_test_helper = PublicHealthTestHelper.new(nil)
   @@system_test_utils = SystemTestUtils.new(nil)
 
-  test 'verify patient details and reports' do
-    @@public_health_test_helper.view_patients_details_and_reports('state1_epi')
-    @@public_health_test_helper.view_patients_details_and_reports('state2_epi')
+  test 'verify patient details' do
+    @@public_health_test_helper.view_patients_details('state1_epi')
+  end
+
+  test 'verify reports' do
+    @@public_health_test_helper.view_reports('usa_super_user', [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
   end
 
   test 'update monitoring status to not monitoring' do

--- a/test/system/roles/public_health/public_health_test_helper.rb
+++ b/test/system/roles/public_health/public_health_test_helper.rb
@@ -16,6 +16,7 @@ class PublicHealthTestHelper < ApplicationSystemTestCase
   @@public_health_patient_page_actions = PublicHealthPatientPageActions.new(nil)
   @@public_health_patient_page_history = PublicHealthPatientPageHistory.new(nil)
   @@public_health_patient_page_reports = PublicHealthPatientPageReports.new(nil)
+  @@public_health_patient_page_reports_verifier = PublicHealthPatientPageReportsVerifier.new(nil)
   @@public_health_patient_page = PublicHealthPatientPage.new(nil)
   @@system_test_utils = SystemTestUtils.new(nil)
 
@@ -25,9 +26,18 @@ class PublicHealthTestHelper < ApplicationSystemTestCase
     @@system_test_utils.logout
   end
 
-  def view_patients_details_and_reports(user_label)
+  def view_patients_details(user_label)
     jurisdiction_id = @@system_test_utils.login(user_label)
-    @@public_health_patient_page.view_patients_details_and_reports(jurisdiction_id)
+    @@public_health_patient_page.view_patients_details(jurisdiction_id)
+    @@system_test_utils.logout
+  end
+
+  def view_reports(user_label, patient_ids)
+    @@system_test_utils.login(user_label)
+    patient_ids.each do |patient_id|
+      @@system_test_utils.go_to_patient_page(patient_id)
+      @@public_health_patient_page_reports_verifier.verify_reports(patient_id)
+    end
     @@system_test_utils.logout
   end
 

--- a/test/system/workflow/workflow_test.rb
+++ b/test/system/workflow/workflow_test.rb
@@ -42,11 +42,11 @@ class WorkflowTest < ApplicationSystemTestCase
     @@enroller_test_helper.enroll_monitoree(epi_enroller_user_label, monitoree_label, is_epi: true)
     @@system_test_utils.login(epi_enroller_user_label)
     @@public_health_dashboard.search_for_and_view_monitoree('asymptomatic', monitoree_label)
-    @@public_health_patient_page_reports_verifier.verify_current_status('asymptomatic')
+    @@public_health_patient_page_reports_verifier.verify_status('asymptomatic')
 
     # add symptomatic report, should be symptomatic
     @@public_health_patient_page_reports.add_report(epi_enroller_user_label, SystemTestUtils::ASSESSMENTS['assessment_1'])
-    @@public_health_patient_page_reports_verifier.verify_current_status('symptomatic')
+    @@public_health_patient_page_reports_verifier.verify_status('symptomatic')
     @@system_test_utils.return_to_dashboard('exposure')
     @@public_health_dashboard.search_for_and_view_monitoree('symptomatic', monitoree_label)
 
@@ -80,11 +80,11 @@ class WorkflowTest < ApplicationSystemTestCase
     epi_user_label = 'state1_epi'
     @@system_test_utils.login(epi_user_label)
     @@public_health_dashboard.search_for_and_view_monitoree('asymptomatic', monitoree_label)
-    @@public_health_patient_page_reports_verifier.verify_current_status('asymptomatic')
+    @@public_health_patient_page_reports_verifier.verify_status('asymptomatic')
     @@assessment_form.complete_assessment(nil, Patient.order(created_at: :desc).first, 'assessment_2')
     visit '/'
     @@public_health_dashboard.search_for_and_view_monitoree('symptomatic', monitoree_label)
-    @@public_health_patient_page_reports_verifier.verify_current_status('symptomatic')
+    @@public_health_patient_page_reports_verifier.verify_status('symptomatic')
     @@public_health_patient_page_reports_verifier.verify_new_report(SystemTestUtils::ASSESSMENTS['assessment_2'])
   end
 


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1421](https://tracker.codev.mitre.org/browse/SARAALERT-1421)

Currently, hundreds of queries (although cached, still slower) are being executed to load the assessments table, which is responsible for a noticeable amount of the loading time of the patient page. This is due to the fact that each symptom of each assessment is being queried separately.

The changes in this PR aim to improve the performance of this by querying these assessments and symptoms in bulk rather than individually

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x]  This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] **N/A** If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@jkufro  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@mayerm94  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
