### PR TITLE
update allUsersCount when a user is added

### DIFF
--- a/app/javascript/components/admin/AdminTable.js
+++ b/app/javascript/components/admin/AdminTable.js
@@ -293,7 +293,16 @@ class AdminTable extends React.Component {
       toast.success('Successfully added new user.', {
         position: toast.POSITION.TOP_CENTER,
       });
-      this.getTableData(this.state.query);
+      this.setState(
+        state => {
+          return {
+            allUsersCount: state.allUsersCount + 1,
+          };
+        },
+        () => {
+          this.getTableData(this.state.query);
+        }
+      );
     };
 
     const handleError = error => {


### PR DESCRIPTION
## (Bugfix) How to Replicate
Add a user on the admin panel then click the export all users button (without refreshing the page).  The exported csv does not include the user you just added

## (Bugfix) Solution
Update the allUsersCount stored when a user is added
