### PR TITLE
SARAALERT-1250: Reminder eligible incorporation pt.2

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -145,10 +145,10 @@ class Patient < ApplicationRecord
     where(purged: false)
       .where(pause_notifications: false)
       .where('patients.id = patients.responder_id')
-      .where('last_assessment_reminder_sent <= ? OR last_assessment_reminder_sent IS NULL', 12.hours.ago)
       .where('latest_assessment_at < ? OR latest_assessment_at IS NULL', Time.now.in_time_zone('Eastern Time (US & Canada)').beginning_of_day)
       .has_usable_preferred_contact_method
       .within_preferred_contact_time
+      .reminder_not_sent_recently
   }
 
   # Patients who are eligible for reminders


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1250

This is the second PR in a series of PRs that seeks to bring the `better_reminder_eligible` scope checks into `reminder-eligible` one step at a time. This PR incorporates the `reminder_not_sent_recently` scope into the `reminder_eligble` scope.

Note that there is a slight functionality change between `reminder_not_sent_recently` and the previous check that just assumed that a reminder sent < 12 hours ago is too recent. The `reminder_not_sent_recently` scope uses the patient's local time and `reporting_period_minutes` to determine if a reminder is too recent. For example, if the `reporting_period_minutes` is 1 day, then the scope will check that the patient has not received a reminder today in their local time.

This is not expected to have a significant performance impact in either direction.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`patient.rb`
- Incorporate the `reminder_not_sent_recently` scope into the `reminder_eligble` scope.
- remove `last_assessment_reminder_sent_eligible?` check from `send_assessment`

`patient_test.rb`
- use correct minute argument (`min` instead of `minute`) [see doc](https://apidock.com/rails/Time/change)
- correct tests that used the 12 hour assumption for reminders considered being sent recently.


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@holmesie  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@Bialogs  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
