### PR TITLE
SARAALERT-1354: Resolve HOH issue when populating demo data

### DIFF
--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -981,7 +981,12 @@ desc 'Backup the database'
   end
 
   def create_fake_timestamp(from, to)
-    Faker::Time.between_dates(from: from, to: to >= Date.today ? Time.now : to, period: :all)
+    timestamp = Faker::Time.between_dates(from: from, to: to >= Date.today ? Time.now : to, period: :all)
+    # Ensure the UTC timezone conversion of the returned timestamp is within the desired timeframe
+    while(timestamp.utc > to + 1)
+      timestamp = Faker::Time.between_dates(from: from, to: to >= Date.today ? Time.now : to, period: :all)
+    end
+    timestamp
   end
 
   def duplicate_timestamps(from, to)

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -412,7 +412,7 @@ desc 'Backup the database'
     end
 
     Patient.import! patients
-    new_patients = Patient.where('created_at >= ?', today)
+    new_patients = Patient.where('created_at >= ?', today - DateTime.now.utc_offset)
     new_patients.update_all('responder_id = id')
 
     # Create household members (10-20% of patients are managed by a HoH)
@@ -981,12 +981,7 @@ desc 'Backup the database'
   end
 
   def create_fake_timestamp(from, to)
-    timestamp = Faker::Time.between_dates(from: from, to: to >= Date.today ? Time.now : to, period: :all)
-    # Ensure the UTC timezone conversion of the returned timestamp is within the desired timeframe
-    while(timestamp.utc > to + 1)
-      timestamp = Faker::Time.between_dates(from: from, to: to >= Date.today ? Time.now : to, period: :all)
-    end
-    timestamp
+    Faker::Time.between_dates(from: from, to: to >= Date.today ? Time.now : to, period: :all)
   end
 
   def duplicate_timestamps(from, to)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1354](https://tracker.codev.mitre.org/browse/SARAALERT-1354)

Some monitorees in the demo data generated through the `populate` script were being erroneously marked as HOHs. This PR fixes the issue in the demo script (root cause was a timezone issue) to ensure generated monitorees won't get into this state when generated. 

## Bug - How to Replicate
While on the `v1.28.0` branch, complete the following:
1. If you haven't run the populate script to poplate your local database, do so: `bundle exec rake demo:populate`
2. In MySQL Workbench or through the rails console, query for the moniotrees who are in the erroneous HOH state:

If using MySQL Workbench:
```
SELECT id, first_name, last_name
FROM disease_trakker_development.patients
WHERE responder_id = id AND head_of_household = 1 AND id in (SELECT responder_id FROM disease_trakker_development.patients GROUP BY responder_id HAVING count(*) = 1);
```
If using the rails console:
```
sql = """SELECT id, first_name, last_name FROM patients WHERE responder_id = id AND head_of_household = 1 AND id in (
SELECT responder_id FROM patients GROUP BY responder_id HAVING count(*) = 1);"""
results = ActiveRecord::Base.connection.exec_query(sql)
results.rows
```
3. The monitorees returned are the ones who are incorrectly marked as HOHs. To validate this, go to any of their profile pages in the UI and verify they don't have an household members lists while they are show on the dashboard as an HOH. 

## Bugfix - How to Test
While on the `1354-demo-hoh-bug` branch, complete the following:
1. (optional) If you want to re-use your existing database, be sure to save a copy of it through the `demo:backup_database` script. You can reload it after completeing this test by running `bundle exec rake db:drop:all` and then using the `demo:restore_database` script while referencing the SQL file that holds your database copy. 
2. Drop your current databases by running: `bundle exec rake db:drop:all`
3. Run the following commands in order:
```
rails db:create
rails db:schema:load
bundle exec rake admin:import_or_update_jurisdictions 
bundle exec rake demo:setup demo:populate
```
4.  In MySQL Workbench or through the rails console, query to see if there are any moniotrees who are in the erroneous HOH state:

If using MySQL Workbench:
```
SELECT id, first_name, last_name
FROM disease_trakker_development.patients
WHERE responder_id = id AND head_of_household = 1 AND id in (SELECT responder_id FROM disease_trakker_development.patients GROUP BY responder_id HAVING count(*) = 1);
```
If using the rails console:
```
sql = """SELECT id, first_name, last_name FROM patients WHERE responder_id = id AND head_of_household = 1 AND id in (
SELECT responder_id FROM patients GROUP BY responder_id HAVING count(*) = 1);"""
results = ActiveRecord::Base.connection.exec_query(sql)
results.rows
```
5. Verify that the SQL query doesn't return any records, meaning there are no monitorees in this incorrect state of being erroneously marked as an HOH. 

## Bugfix - Cause of the Bug & the Solution
The root cause of this was a timezone issue on [this line](https://github.com/SaraAlert/SaraAlert/blob/master/lib/tasks/demo.rake#L398). The timestamp generated for the dummy monitoree's `created_at` value was automatically being converted to UTC when assigned to the montioree. This conversion resulted in some monitorees appearing to have been created on a future day instead of the current day the script was working on. So when the script tried to query for monitorees to group into households on [this line](https://github.com/SaraAlert/SaraAlert/blob/master/lib/tasks/demo.rake#L415), this timezone issue resulted in some monitorees being elidgible to place into households for two days, instead of the intended single day. This caused situations such as the following that resulted in the issue addressed by this ticket: While generating day 1 data, monitoree A was created with a `created_at` value on day 2 due to the timezone conversion issue. While still working on day 1 data, Monitoree A was marked as a household member for another monitoree created on day 1. When the script goes on to generate day 2 data, monitoree A was included in the list of possible monitorees used to create households with. As a result, moniotree A was assigned as a household member under a day 2 monitoree. This ultimately led to monitoree A's original day 1 HOH in the erroneous state that was being observed. 

To resolve this, the `create_fake_timestamp` function used to generate the `created_at` timestamp was updated to validate that the returned timestamp falls within the desired window even after it was converted to UTC. This approach was used since it doesn't appear that the Faker `between_dates` function has a timezone arguement that can be set. 

This issue shouldn't be possible to replicate through the UI due to work from [this previous ticket](https://tracker.codev.mitre.org/browse/SARAALERT-1093). This issue would only be possible on the Production instance if somone forces the reassignement of a household member through a rails console session, so on Production this issue is not expected. 

## Important Changes

`lib/tasks/demo.rake`
- Updated the `create_fake_timestamp` function so it only returns a UTC converted timestamp within the provided timeframe. 

# Checklists

**Submitter:** @hackrm & @timwongj 
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] **N/A** If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] **N/A** Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] **N/A** Test fixtures updated and documented as necessary


@sgober :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
