### PR TITLE
SA-NONE: Send assessment downcase

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -935,13 +935,14 @@ class Patient < ApplicationRecord
     # being sent out for the same monitoree.
     return unless last_assessment_reminder_sent_eligible? || send_now
 
-    if preferred_contact_method&.downcase == 'sms text-message' && ADMIN_OPTIONS['enable_sms']
+    contact_method = preferred_contact_method&.downcase
+    if contact_method == 'sms text-message' && ADMIN_OPTIONS['enable_sms']
       PatientMailer.assessment_sms(self).deliver_later
-    elsif preferred_contact_method&.downcase == 'sms texted weblink' && ADMIN_OPTIONS['enable_sms']
+    elsif contact_method == 'sms texted weblink' && ADMIN_OPTIONS['enable_sms']
       PatientMailer.assessment_sms_weblink(self).deliver_later
-    elsif preferred_contact_method&.downcase == 'telephone call' && ADMIN_OPTIONS['enable_voice']
+    elsif contact_method == 'telephone call' && ADMIN_OPTIONS['enable_voice']
       PatientMailer.assessment_voice(self).deliver_later
-    elsif preferred_contact_method&.downcase == 'e-mailed web link' && ADMIN_OPTIONS['enable_email']
+    elsif contact_method == 'e-mailed web link' && ADMIN_OPTIONS['enable_email']
       PatientMailer.assessment_email(self).deliver_later if email.present?
     end
   end


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-NONE

Before we were running `preferred_contact_method&.downcase` on every `if` statement in `Patient#send_assessment`. We really only need to be running this operation once and evidently it gives us a small performance improvement when running the `SendAssessmentsJob`.

## Performance Evidence

### 1.28.0 currently (as of the last recorded improvement that was merged)
<img width="307" alt="Screen Shot 2021-04-14 at 2 31 25 PM" src="https://user-images.githubusercontent.com/24628687/114775055-187f8980-9d2e-11eb-94bb-277f28941b13.png">

### This PR's performance 



## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`patient.rb`
- In `Patient#send_assessment` set `preferred_contact_method&.downcase` to a local variable and use that variable in each `if` statment.


# Checklists

**Submitter:**
- [ ] This PR describes why these changes were made.
- [ ] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA ticket reference.
- [ ] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
