### PR TITLE
SARAALERT-1055: Advanced Filter Lab Results

### DIFF
--- a/app/controllers/user_filters_controller.rb
+++ b/app/controllers/user_filters_controller.rb
@@ -19,7 +19,7 @@ class UserFiltersController < ApplicationController
 
     active_filter_options = params.require(:activeFilterOptions).collect do |filter|
       {
-        filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, :hasTimestamp, :allowRange, options: []),
+        filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, :hasTimestamp, :allowRange, :tooltip, options: [], fields: [ :name, :title, :type, options: [] ]),
         value: filter.permit(:value)[:value] || filter.require(:value) || false,
         numberOption: filter.permit(:numberOption)[:numberOption],
         dateOption: filter.permit(:dateOption)[:dateOption],
@@ -34,7 +34,7 @@ class UserFiltersController < ApplicationController
   def update
     active_filter_options = params.require(:activeFilterOptions).collect do |filter|
       {
-        filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, :hasTimestamp, :allowRange, options: []),
+        filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, :hasTimestamp, :allowRange, :tooltip, options: [], fields: [ :name, :title, :type, options: [] ]),
         value: filter.permit(:value)[:value] || filter.require(:value) || false,
         numberOption: filter.permit(:numberOption)[:numberOption],
         dateOption: filter.permit(:dateOption)[:dateOption],

--- a/app/controllers/user_filters_controller.rb
+++ b/app/controllers/user_filters_controller.rb
@@ -19,7 +19,8 @@ class UserFiltersController < ApplicationController
 
     active_filter_options = params.require(:activeFilterOptions).collect do |filter|
       {
-        filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, :hasTimestamp, :allowRange, :tooltip, options: [], fields: [ :name, :title, :type, options: [] ]),
+        filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, :hasTimestamp, :allowRange, :tooltip,
+                                                           options: [], fields: [:name, :title, :type, { options: [] }]),
         value: filter.permit(:value)[:value] || filter.require(:value) || false,
         numberOption: filter.permit(:numberOption)[:numberOption],
         dateOption: filter.permit(:dateOption)[:dateOption],
@@ -34,7 +35,8 @@ class UserFiltersController < ApplicationController
   def update
     active_filter_options = params.require(:activeFilterOptions).collect do |filter|
       {
-        filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, :hasTimestamp, :allowRange, :tooltip, options: [], fields: [ :name, :title, :type, options: [] ]),
+        filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, :hasTimestamp, :allowRange, :tooltip,
+                                                           options: [], fields: [:name, :title, :type, { options: [] }]),
         value: filter.permit(:value)[:value] || filter.require(:value) || false,
         numberOption: filter.permit(:numberOption)[:numberOption],
         dateOption: filter.permit(:dateOption)[:dateOption],

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -70,7 +70,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
       query[:filter] = unsanitized_query[:filter].collect do |filter|
         permitted_filter_params = filter.permit(:value, :numberOption, :dateOption, :relativeOption, :additionalFilterOption, filterOption: {}, value: {})
         {
-          filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, :hasTimestamp, options: []),
+          filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, :hasTimestamp, :tooltip, options: [], fields: [ :name, :title, :type, options: [] ]),
           value: permitted_filter_params[:value] || filter.require(:value) || false,
           numberOption: permitted_filter_params[:numberOption],
           dateOption: permitted_filter_params[:dateOption],

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -480,30 +480,31 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
   end
 
   def advanced_filter_lab_result(patients, filter)
+    labs = patients.joins(:laboratories)
     filter[:value].each do |field|
       case field[:name]
+      when 'lab-type'
+        labs = labs.where('laboratories.lab_type = ?', field[:value])
       when 'result'
-        patients = patients.where(id: patients.joins(:laboratories).where('laboratories.result = ?', field[:value]))
-      when 'test-type'
-        patients = patients.where(id: patients.joins(:laboratories).where('laboratories.lab_type = ?', field[:value]))
-      when 'specimen-collection-date'
+        labs = labs.where('laboratories.result = ?', field[:value])
+      when 'specimen-collection'
         case field[:value][:when]
         when 'before'
-          patients = patients.where(id: patients.joins(:laboratories).where('laboratories.specimen_collection < ?', field[:value][:date]))
+          labs = labs.where('laboratories.specimen_collection < ?', field[:value][:date])
         when 'after'
-          patients = patients.where(id: patients.joins(:laboratories).where('laboratories.specimen_collection > ?', field[:value][:date]))
+          labs = labs.where('laboratories.specimen_collection > ?', field[:value][:date])
         end
-      when 'report-date'
+      when 'report'
         case field[:value][:when]
         when 'before'
-          patients = patients.where(id: patients.joins(:laboratories).where('laboratories.report < ?', field[:value][:date]))
+          labs = labs.where('laboratories.report < ?', field[:value][:date])
         when 'after'
-          patients = patients.where(id: patients.joins(:laboratories).where('laboratories.report > ?', field[:value][:date]))
+          labs = labs.where('laboratories.report > ?', field[:value][:date])
         end
       end
     end
 
-    patients
+    patients.where(id: labs)
   end
 
   # Filter patients by a set time range for the given field

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -483,22 +483,22 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     filter[:value].each do |field|
       case field[:name]
       when 'result'
-        patients = patients.joins(:laboratories).where('laboratories.result = ?', field[:value])
+        patients = patients.where(id: patients.joins(:laboratories).where('laboratories.result = ?', field[:value]))
       when 'test-type'
-        patients = patients.joins(:laboratories).where('laboratories.lab_type = ?', field[:value])
+        patients = patients.where(id: patients.joins(:laboratories).where('laboratories.lab_type = ?', field[:value]))
       when 'specimen-collection-date'
         case field[:value][:when]
         when 'before'
-          patients = patients.joins(:laboratories).where('laboratories.specimen_collection < ?', field[:value][:date])
+          patients = patients.where(id: patients.joins(:laboratories).where('laboratories.specimen_collection < ?', field[:value][:date]))
         when 'after'
-          patients = patients.joins(:laboratories).where('laboratories.specimen_collection > ?', field[:value][:date])
+          patients = patients.where(id: patients.joins(:laboratories).where('laboratories.specimen_collection > ?', field[:value][:date]))
         end
       when 'report-date'
         case field[:value][:when]
         when 'before'
-          patients = patients.joins(:laboratories).where('laboratories.report < ?', field[:value][:date])
+          patients = patients.where(id: patients.joins(:laboratories).where('laboratories.report < ?', field[:value][:date]))
         when 'after'
-          patients = patients.joins(:laboratories).where('laboratories.report > ?', field[:value][:date])
+          patients = patients.where(id: patients.joins(:laboratories).where('laboratories.report > ?', field[:value][:date]))
         end
       end
     end

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -299,8 +299,18 @@ class AdvancedFilter extends React.Component {
   };
 
   // TO DO: ADD ME
-  removeMultiStatement = index => {
-    console.log('removing multi statement row: ' + index);
+  removeMultiStatement = (statementIndex, multiIndex) => {
+    const currentMultiFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
+    let oldValue = [...currentMultiFilter.value];
+
+    // if removing the last multi statement, remove the whole filter
+    // otherwise just remove that multi statement
+    if (oldValue.length === 1) {
+      this.removeStatement(statementIndex);
+    } else {
+      const newValue = oldValue.slice(0, multiIndex).concat(oldValue.slice(multiIndex + 1, oldValue.length));
+      this.changeValue(statementIndex, newValue);
+    }
   };
 
   /**
@@ -590,9 +600,9 @@ class AdvancedFilter extends React.Component {
    * Renders remove statement button (minus button at far right of statement)
    * @param {Number} index - Filter index
    */
-  renderRemoveStatementButton = (index, remove) => {
+  renderRemoveStatementButton = (index, sub_index, remove) => {
     return (
-      <Button className="remove-filter-row" variant="danger" onClick={() => remove(index)} aria-label="Remove Advanced Filter Option">
+      <Button className="remove-filter-row" variant="danger" onClick={() => remove(index, sub_index)} aria-label="Remove Advanced Filter Option">
         <i className="fas fa-minus"></i>
       </Button>
     );
@@ -1113,7 +1123,7 @@ class AdvancedFilter extends React.Component {
           <Col className="p-0" md="auto">
             {multiIndex === 0 && filter.tooltip && this.renderStatementTooltip(filter.name, statementIndex, filter.tooltip)}
           </Col>
-          <Col md="auto">{this.renderRemoveStatementButton(statementIndex, this.removeMultiStatement)}</Col>
+          <Col md="auto">{this.renderRemoveStatementButton(statementIndex, multiIndex, this.removeMultiStatement)}</Col>
         </Row>
       </React.Fragment>
     );
@@ -1167,7 +1177,7 @@ class AdvancedFilter extends React.Component {
           </Col>
           {filterOption?.type !== 'multi' && (
             <Col className="py-0" md="auto">
-              {this.renderRemoveStatementButton(index, this.removeStatement)}
+              {this.renderRemoveStatementButton(index, null, this.removeStatement)}
             </Col>
           )}
         </Row>

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -294,7 +294,11 @@ class AdvancedFilter extends React.Component {
   // TO DO: ADD ME
   addMultiStatement = (filter, statementIndex) => {
     const currentMultiFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
-    const newValue = [...currentMultiFilter.value, this.getDefaultMultiValue(filter, 'result')]; // change me
+    let possibleFields = currentMultiFilter.filterOption.fields;
+    currentMultiFilter.value.forEach(value => {
+      possibleFields = possibleFields.filter(field => field.name !== value.name);
+    });
+    const newValue = [...currentMultiFilter.value, this.getDefaultMultiValue(filter, possibleFields[0].name)];
     this.changeValue(statementIndex, newValue);
   };
 
@@ -475,6 +479,18 @@ class AdvancedFilter extends React.Component {
     const newValue = [...currentMultiFilter.value];
     newValue[parseInt(multiIndex)] = value;
     this.changeValue(statementIndex, newValue);
+  };
+
+  // TO DO ADD ME
+  multiFieldDisabled = (name, multiIndex, statementIndex) => {
+    const currentMultiFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
+    let disabled = false;
+    currentMultiFilter.value.forEach((value, index) => {
+      if (value.name === name && index !== multiIndex) {
+        disabled = true;
+      }
+    });
+    return disabled;
   };
 
   // TO DO ADD ME
@@ -1051,7 +1067,7 @@ class AdvancedFilter extends React.Component {
                 }}>
                 {filter.fields?.map((field, f_index) => {
                   return (
-                    <option key={f_index} value={field.name}>
+                    <option key={f_index} value={field.name} disabled={this.multiFieldDisabled(field.name, multiIndex, statementIndex)}>
                       {field.title}
                     </option>
                   );

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -1152,17 +1152,22 @@ class AdvancedFilter extends React.Component {
                 </React.Fragment>
               )}
               {multiIndex + 1 === total && multiIndex + 1 < filter.fields.length && (
-                <div className="my-auto">
-                  <Button
-                    className="btn-circle"
-                    variant="secondary"
-                    onClick={() => {
-                      this.addMultiStatement(filter, statementIndex);
-                    }}
-                    aria-label="Add Advanced Filter Multi Option">
-                    <i className="fas fa-plus"></i>
-                  </Button>
-                </div>
+                <React.Fragment>
+                  <div className="my-auto" data-for={`${filter.name}-${statementIndex}-multi-add`} data-tip="">
+                    <Button
+                      className="btn-circle"
+                      variant="secondary"
+                      onClick={() => {
+                        this.addMultiStatement(filter, statementIndex);
+                      }}
+                      aria-label="Add Advanced Filter Multi Option">
+                      <i className="fas fa-plus"></i>
+                    </Button>
+                  </div>
+                  <ReactTooltip id={`${filter.name}-${statementIndex}-multi-add`} multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
+                    <span>Select to add multiple Lab Result search criteria.</span>
+                  </ReactTooltip>
+                </React.Fragment>
               )}
             </Form.Group>
           </Col>

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -333,7 +333,7 @@ class AdvancedFilter extends React.Component {
     } else if (filterOption.type === 'search') {
       value = '';
     } else if (filterOption.type === 'multi') {
-      value = this.getDefaultMultiValue(filterOption, filterOption.fields[0].name);
+      value = [this.getDefaultMultiValue(filterOption, filterOption.fields[0].name)];
     }
 
     activeFilterOptions[parseInt(index)] = {
@@ -458,11 +458,11 @@ class AdvancedFilter extends React.Component {
   };
 
   // TO DO ADD ME
-  changeMultiValue = (statementIndex, value) => {
-    // TO DO update value array here
-    let activeFilterOptions = [...this.state.activeFilterOptions];
-    activeFilterOptions[parseInt(statementIndex)]['value'] = value;
-    this.setState({ activeFilterOptions });
+  changeMultiValue = (statementIndex, multiIndex, value) => {
+    const currentMultiFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
+    const newValue = [...currentMultiFilter.value];
+    newValue[parseInt(multiIndex)] = value;
+    this.changeValue(statementIndex, newValue);
   };
 
   // TO DO ADD ME
@@ -473,7 +473,6 @@ class AdvancedFilter extends React.Component {
   // TO DO ADD ME
   getDefaultMultiValue = (filter, name) => {
     const multiFilter = this.getMultiFilter(filter, name);
-    console.log(multiFilter);
     let value = null;
     if (multiFilter.type === 'select') {
       value = { name: name, value: multiFilter.options[0] };
@@ -1019,10 +1018,10 @@ class AdvancedFilter extends React.Component {
   };
 
   // TO DO ADD ME
-  renderMultiStatement = (filter, statementIndex, value) => {
+  renderMultiStatement = (filter, statementIndex, multiIndex, value) => {
     // change value name?
     return (
-      <Row className="m-0">
+      <Row key={'rowkey-filter-m' + multiIndex} className="m-0">
         <Col className="p-0">
           <Form.Group className="form-group-inline py-0 my-0">
             <Form.Control
@@ -1031,7 +1030,7 @@ class AdvancedFilter extends React.Component {
               className="advanced-filter-multi-options advanced-filter-select py-0 my-0"
               aria-label="Advanced Filter Multi Select Options"
               onChange={event => {
-                this.changeMultiValue(statementIndex, this.getDefaultMultiValue(filter, event.target.value));
+                this.changeMultiValue(statementIndex, multiIndex, this.getDefaultMultiValue(filter, event.target.value));
               }}>
               {filter.fields?.map((field, f_index) => {
                 return (
@@ -1048,7 +1047,7 @@ class AdvancedFilter extends React.Component {
                 className="advanced-filter-multi-options advanced-filter-select my-0 mx-3 py-0"
                 aria-label="Advanced Filter Multi Select Options"
                 onChange={event => {
-                  this.changeMultiValue(statementIndex, { name: value.name, value: event.target.value });
+                  this.changeMultiValue(statementIndex, multiIndex, { name: value.name, value: event.target.value });
                 }}>
                 {this.getMultiFilter(filter, value.name).options.map((option, o_index) => {
                   return <option key={o_index}>{option}</option>;
@@ -1063,7 +1062,7 @@ class AdvancedFilter extends React.Component {
                   className="advanced-filter-date-options py-0 my-0 mx-3"
                   aria-label="Advanced Filter Date Select Options"
                   onChange={event => {
-                    this.changeMultiValue(statementIndex, { name: value.name, value: { when: event.target.value, date: value.value.date } });
+                    this.changeMultiValue(statementIndex, multiIndex, { name: value.name, value: { when: event.target.value, date: value.value.date } });
                   }}>
                   <option value="before">before</option>
                   <option value="after">after</option>
@@ -1072,7 +1071,7 @@ class AdvancedFilter extends React.Component {
                   <DateInput
                     date={value.value.date}
                     onChange={date => {
-                      this.changeMultiValue(statementIndex, { name: value.name, value: { when: value.value.when, date: date } });
+                      this.changeMultiValue(statementIndex, multiIndex, { name: value.name, value: { when: value.value.when, date: date } });
                     }}
                     placement="bottom"
                     customClass="form-control-md"
@@ -1135,7 +1134,13 @@ class AdvancedFilter extends React.Component {
             {filterOption?.type === 'number' && this.renderNumberStatement(filterOption, index, value, numberOption, additionalFilterOption)}
             {filterOption?.type === 'date' && this.renderDateStatement(index, value, dateOption)}
             {filterOption?.type === 'relative' && this.renderRelativeDateStatement(filterOption, index, value, relativeOption)}
-            {filterOption?.type === 'multi' && this.renderMultiStatement(filterOption, index, value)}
+            {filterOption?.type === 'multi' && (
+              <React.Fragment>
+                {value.map((value, m_index) => {
+                  return this.renderMultiStatement(filterOption, index, m_index, value);
+                })}
+              </React.Fragment>
+            )}
           </Col>
           {filterOption?.type !== 'multi' && (
             <Col className="py-0" md="auto">

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -321,7 +321,7 @@ class AdvancedFilter extends React.Component {
     if (value.length === 1) {
       this.removeStatement(statementIndex);
     } else {
-      value.splice(multiIndex, 1)
+      value.splice(multiIndex, 1);
       this.changeValue(statementIndex, value);
     }
   };

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -291,6 +291,11 @@ class AdvancedFilter extends React.Component {
     }));
   };
 
+  // TO DO: ADD ME
+  removeMultiStatement = index => {
+    console.log('removing multi statement row: ' + index);
+  };
+
   /**
    * Change the main filter option dropdown
    * @param {Number} index - Current filter index
@@ -548,10 +553,10 @@ class AdvancedFilter extends React.Component {
    * Renders remove statement button (minus button at far right of statement)
    * @param {Number} index - Filter index
    */
-  renderRemoveStatementButton = index => {
+  renderRemoveStatementButton = (index, remove) => {
     return (
-      <div className="float-right">
-        <Button className="remove-filter-row" variant="danger" onClick={() => this.removeStatement(index)} aria-label="Remove Advanced Filter Option">
+      <div>
+        <Button className="remove-filter-row" variant="danger" onClick={() => remove(index)} aria-label="Remove Advanced Filter Option">
           <i className="fas fa-minus"></i>
         </Button>
       </div>
@@ -606,7 +611,7 @@ class AdvancedFilter extends React.Component {
         }}
         placeholder="Select Field...."
         aria-label="Advanced Filter Options Dropdown"
-        className="advanced-filter-select"
+        className="advanced-filter-options-dropdown"
         styles={cursorPointerStyle}
         theme={theme => ({
           ...theme,
@@ -735,7 +740,7 @@ class AdvancedFilter extends React.Component {
         <Form.Control
           as="select"
           value={value}
-          className="advanced-filter-select-dropdown py-0 my-0"
+          className="advanced-filter-select py-0 my-0"
           aria-label="Advanced Filter Option Select"
           onChange={event => {
             this.changeValue(index, event.target.value);
@@ -977,6 +982,40 @@ class AdvancedFilter extends React.Component {
     );
   };
 
+  // TO DO ADD ME
+  renderMultiStatement = (filter, index, value) => {
+    console.log(value);
+    return (
+      <Row className="m-0">
+        <Col className="p-0">
+          <Form.Group className="form-group-inline py-0 my-0">
+            <Form.Control
+              as="select"
+              // value={dateOption}
+              className="advanced-filter-multi-options advanced-filter-select py-0 my-0"
+              aria-label="Advanced Filter Multi Select Options"
+              // onChange={event => {
+              //   this.changeFilterDateOption(index, event.target.value);
+              // }}
+            >
+              {filter.fields?.map((field, f_index) => {
+                return (
+                  <option key={f_index} value={field.name}>
+                    {field.title}
+                  </option>
+                );
+              })}
+            </Form.Control>
+          </Form.Group>
+        </Col>
+        <Col className="p-0" md="auto">
+          {filter.tooltip && this.renderStatementTooltip(filter.name, index, filter.tooltip)}
+        </Col>
+        <Col md="auto">{this.renderRemoveStatementButton(index, this.removeMultiStatement)}</Col>
+      </Row>
+    );
+  };
+
   /**
    * Renders a single line "statement"
    * @param {Object} filterOption - Filter currently selected
@@ -1015,10 +1054,13 @@ class AdvancedFilter extends React.Component {
             {filterOption?.type === 'number' && this.renderNumberStatement(filterOption, index, value, numberOption, additionalFilterOption)}
             {filterOption?.type === 'date' && this.renderDateStatement(index, value, dateOption)}
             {filterOption?.type === 'relative' && this.renderRelativeDateStatement(filterOption, index, value, relativeOption)}
+            {filterOption?.type === 'multi' && this.renderMultiStatement(filterOption, index, value)}
           </Col>
-          <Col className="py-0" md="auto">
-            {this.renderRemoveStatementButton(index)}
-          </Col>
+          {filterOption?.type !== 'multi' && (
+            <Col className="py-0" md="auto">
+              {this.renderRemoveStatementButton(index, this.removeStatement)}
+            </Col>
+          )}
         </Row>
       </React.Fragment>
     );

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -291,7 +291,12 @@ class AdvancedFilter extends React.Component {
     }));
   };
 
-  // TO DO: ADD ME
+  /**
+   * Adds another multi filter statement at certain index
+   * Ensures no field is repeated when a new statement is added
+   * @param {Object} filter - Current multi filter object containing all the possible fields
+   * @param {Number} statementIndex - Current overall statement filter index
+   */
   addMultiStatement = (filter, statementIndex) => {
     const currentMultiFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
     let possibleFields = currentMultiFilter.filterOption.fields;
@@ -302,7 +307,11 @@ class AdvancedFilter extends React.Component {
     this.changeValue(statementIndex, newValue);
   };
 
-  // TO DO: ADD ME
+  /**
+   * Removes one of the multi filter statements at certain index
+   * @param {Number} statementIndex - Current overall statement filter index
+   * @param {Number} multiIndex - Index of the statement within the multi filter that will be removed
+   */
   removeMultiStatement = (statementIndex, multiIndex) => {
     const currentMultiFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
     let oldValue = [...currentMultiFilter.value];
@@ -473,7 +482,12 @@ class AdvancedFilter extends React.Component {
     this.setState({ activeFilterOptions });
   };
 
-  // TO DO ADD ME
+  /**
+   * Change value of a filter statement of type multi
+   * @param {Number} statementIndex - Current overall statement filter index
+   * @param {Number} multiIndex - Index of the statement within the multi filter that needs to be updated
+   * @param {*} value - New value for the statement at the multi index
+   */
   changeMultiValue = (statementIndex, multiIndex, value) => {
     const currentMultiFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
     const newValue = [...currentMultiFilter.value];
@@ -481,7 +495,13 @@ class AdvancedFilter extends React.Component {
     this.changeValue(statementIndex, newValue);
   };
 
-  // TO DO ADD ME
+  /**
+   * Determines if a field within a multi statement should be disabled
+   * A field is disabled if it already exists in a different multi statement, but not the one it is selected in
+   * @param {String} name - Field name attribute of the dropdown option
+   * @param {Number} statementIndex - Current overall statement filter index
+   * @param {Number} multiIndex - Index of the statement within the multi filter
+   */
   multiFieldDisabled = (name, multiIndex, statementIndex) => {
     const currentMultiFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
     let disabled = false;
@@ -493,12 +513,21 @@ class AdvancedFilter extends React.Component {
     return disabled;
   };
 
-  // TO DO ADD ME
+  /**
+   * Returns the field of a filter when given the name of that filter
+   * @param {Object} filter - Multi filter object containing all the possible fields
+   * @param {String} name - Field name attribute
+   */
   getMultiFilter = (filter, name) => {
     return filter.fields.find(field => field.name === name);
   };
 
-  // TO DO ADD ME
+  /**
+   * Given the name on of a field for a certain multi filter, returns the default value
+   * The default value is determined by the type of the field
+   * @param {Object} filter - Multi filter object containing all the possible fields
+   * @param {String} name - Field name attribute
+   */
   getDefaultMultiValue = (filter, name) => {
     const multiFilter = this.getMultiFilter(filter, name);
     let value = null;
@@ -1043,7 +1072,14 @@ class AdvancedFilter extends React.Component {
     );
   };
 
-  // TO DO ADD ME
+  /**
+   * Renders multi-select type line "statement"
+   * @param {Object} filter - Multi filter object containing all the possible fields
+   * @param {Number} statementIndex - Current overall statement filter index
+   * @param {Number} multiIndex - Index of the statement within the multi filter
+   * @param {Number} total - Total number of statments within the multi filter
+   * @param {*} multiValue - Value of this statement within the multi filter (name/value pair)
+   */
   renderMultiStatement = (filter, statementIndex, multiIndex, total, multiValue) => {
     return (
       <React.Fragment key={'rowkey-filter-m' + multiIndex}>
@@ -1054,7 +1090,7 @@ class AdvancedFilter extends React.Component {
             </Col>
           </Row>
         )}
-        <Row className="m-0">
+        <Row className="advanced-filter-multi-type-statement m-0">
           <Col className="p-0">
             <Form.Group className="form-group-inline py-0 my-0">
               <Form.Control
@@ -1077,7 +1113,7 @@ class AdvancedFilter extends React.Component {
                 <Form.Control
                   as="select"
                   value={multiValue.value}
-                  className="advanced-filter-multi-options advanced-filter-select my-0 mx-3 py-0"
+                  className="advanced-filter-multi-select-options advanced-filter-select my-0 mx-3 py-0"
                   aria-label="Advanced Filter Multi Select Options"
                   onChange={event => {
                     this.changeMultiValue(statementIndex, multiIndex, { name: multiValue.name, value: event.target.value });

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -286,9 +286,9 @@ class AdvancedFilter extends React.Component {
    * @param {Number} index - Current filter index
    */
   removeStatement = index => {
-    this.setState(state => ({
-      activeFilterOptions: state.activeFilterOptions.slice(0, index).concat(state.activeFilterOptions.slice(index + 1, state.activeFilterOptions?.length)),
-    }));
+    let activeFilterOptions = this.state.activeFilterOptions;
+    activeFilterOptions.splice(index, 1);
+    this.setState({ activeFilterOptions });
   };
 
   /**
@@ -314,15 +314,15 @@ class AdvancedFilter extends React.Component {
    */
   removeMultiStatement = (statementIndex, multiIndex) => {
     const currentMultiFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
-    let oldValue = [...currentMultiFilter.value];
+    let value = [...currentMultiFilter.value];
 
     // if removing the last multi statement, remove the whole filter
     // otherwise just remove that multi statement
-    if (oldValue.length === 1) {
+    if (value.length === 1) {
       this.removeStatement(statementIndex);
     } else {
-      const newValue = oldValue.slice(0, multiIndex).concat(oldValue.slice(multiIndex + 1, oldValue.length));
-      this.changeValue(statementIndex, newValue);
+      value.splice(multiIndex, 1)
+      this.changeValue(statementIndex, value);
     }
   };
 
@@ -504,13 +504,7 @@ class AdvancedFilter extends React.Component {
    */
   multiFieldDisabled = (name, multiIndex, statementIndex) => {
     const currentMultiFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
-    let disabled = false;
-    currentMultiFilter.value.forEach((value, index) => {
-      if (value.name === name && index !== multiIndex) {
-        disabled = true;
-      }
-    });
-    return disabled;
+    return currentMultiFilter.value.some((value, index) => value.name === name && index !== multiIndex);
   };
 
   /**

--- a/app/javascript/data/advancedFilterOptions.js
+++ b/app/javascript/data/advancedFilterOptions.js
@@ -273,18 +273,18 @@ export const advancedFilterOptions = [
         options: ['positive', 'negative', 'indeterminate', 'other']
       },
       {
-        name: 'test-type',
+        name: 'lab-type',
         title: 'test type',
         type: 'select',
         options: ['PCR', 'Antigen', 'Total Antibody', 'IgG Antibody', 'IgM Antibody', 'IgA Antibody', 'Other']
       },
       {
-        name: 'specimen-collection-date',
+        name: 'specimen-collection',
         title: 'specimen collection date',
         type: 'date'
       },
       {
-        name: 'report-date',
+        name: 'report',
         title: 'report',
         type: 'date'
       }

--- a/app/javascript/data/advancedFilterOptions.js
+++ b/app/javascript/data/advancedFilterOptions.js
@@ -207,25 +207,25 @@ export const advancedFilterOptions = [
     name: 'enrolled',
     title: 'Enrolled (Date)',
     description: 'Monitorees enrolled in system during specified date range',
-    type: 'date',
+    type: 'date'
   },
   {
     name: 'latest-report',
     title: 'Latest Report (Date)',
     description: 'Monitorees with latest report during specified date range',
-    type: 'date',
+    type: 'date'
   },
   {
     name: 'last-date-exposure',
     title: 'Last Date of Exposure (Date)',
     description: 'Monitorees who have a last date of exposure during specified date range',
-    type: 'date',
+    type: 'date'
   },
   {
     name: 'symptom-onset',
     title: 'Symptom Onset (Date)',
     description: 'Monitorees who have a symptom onset date during specified date range',
-    type: 'date',
+    type: 'date'
   },
 
   /* RELATIVE DATE FILTER OPTIONS */
@@ -234,27 +234,58 @@ export const advancedFilterOptions = [
     title: 'Enrolled (Relative Date)',
     description: 'Monitorees enrolled in system during specified date range (relative to the current date)',
     type: 'relative',
-    hasTimestamp: true,
+    hasTimestamp: true
   },
   {
     name: 'latest-report-relative',
     title: 'Latest Report (Relative Date)',
     description: 'Monitorees with latest report during specified date range (relative to the current date)',
     type: 'relative',
-    hasTimestamp: true,
+    hasTimestamp: true
   },
   {
     name: 'last-date-exposure-relative',
     title: 'Last Date of Exposure (Relative Date)',
     description: 'Monitorees who have a last date of exposure during specified date range (relative to the current date)',
     type: 'relative',
-    hasTimestamp: false,
+    hasTimestamp: false
   },
   {
     name: 'symptom-onset-relative',
     title: 'Symptom Onset (Relative Date)',
     description: 'Monitorees who have a symptom onset date during specified date range (relative to the current date)',
     type: 'relative',
-    hasTimestamp: false,
+    hasTimestamp: false
+  },
+
+  /* MULTI FILTER OPTIONS */
+  {
+    name: 'lab-result',
+    title: 'Lab Result (Multi)',
+    description: 'ADD DESCRIPTION HERE',
+    type: 'multi',
+    tooltip: 'hi I am a tooltip please add me',
+    fields: [
+      {
+        name: 'result',
+        title: 'result',
+        type: 'select'
+      },
+      {
+        name: 'test-type',
+        title: 'test type',
+        type: 'select'
+      },
+      {
+        name: 'specimen-collection-date',
+        title: 'specimen collection date',
+        type: 'date'
+      },
+      {
+        name: 'report-date',
+        title: 'report',
+        type: 'date'
+      }
+    ]
   }
 ]

--- a/app/javascript/data/advancedFilterOptions.js
+++ b/app/javascript/data/advancedFilterOptions.js
@@ -285,7 +285,7 @@ export const advancedFilterOptions = [
       },
       {
         name: 'report',
-        title: 'report',
+        title: 'report date',
         type: 'date'
       }
     ]

--- a/app/javascript/data/advancedFilterOptions.js
+++ b/app/javascript/data/advancedFilterOptions.js
@@ -261,10 +261,10 @@ export const advancedFilterOptions = [
   /* MULTI FILTER OPTIONS */
   {
     name: 'lab-result',
-    title: 'Lab Result (Multi)',
-    description: 'ADD DESCRIPTION HERE',
+    title: 'Lab Result (Multi-select)',
+    description: 'Monitorees with specified Lab Result criteria',
     type: 'multi',
-    tooltip: 'hi I am a tooltip please add me',
+    tooltip: 'Returns records that contain at least one Lab Result entry that meets all user-specified criteria (e.g., searching for a specific Lab Test Type and Report Date will only return records containing at least one Lab Result entry with matching values in both fields).',
     fields: [
       {
         name: 'result',

--- a/app/javascript/data/advancedFilterOptions.js
+++ b/app/javascript/data/advancedFilterOptions.js
@@ -269,12 +269,14 @@ export const advancedFilterOptions = [
       {
         name: 'result',
         title: 'result',
-        type: 'select'
+        type: 'select',
+        options: ['positive', 'negative', 'indeterminate', 'other']
       },
       {
         name: 'test-type',
         title: 'test type',
-        type: 'select'
+        type: 'select',
+        options: ['PCR', 'Antigen', 'Total Antibody', 'IgG Antibody', 'IgM Antibody', 'IgA Antibody', 'Other']
       },
       {
         name: 'specimen-collection-date',

--- a/app/javascript/packs/stylesheets/advanced_filter.scss
+++ b/app/javascript/packs/stylesheets/advanced_filter.scss
@@ -14,7 +14,7 @@
   overflow: hidden !important;
 }
 
-.advanced-filter-select-dropdown {
+.advanced-filter-select {
   padding-right: 25px;
   width: auto;
 }

--- a/app/javascript/packs/stylesheets/bootstrap.scss
+++ b/app/javascript/packs/stylesheets/bootstrap.scss
@@ -27,8 +27,20 @@ body {
   background-size: 100px 100px;
 }
 
+.btn {
+  border-radius: 0 !important;
+}
+
 .btn.btn-square {
   border-radius: 0;
+}
+
+.btn.btn-circle {
+  width: 30px; 
+  height: 30px; 
+  padding: 2px 5px; 
+  border-radius: 15px !important; 
+  text-align: center; 
 }
 
 .react-datepicker-popper {
@@ -37,10 +49,6 @@ body {
 
 .custom-control {
   z-index: 0 !important;
-}
-
-.btn {
-  border-radius: 0 !important;
 }
 
 .popover {

--- a/app/javascript/tests/mocks/mockFilters.js
+++ b/app/javascript/tests/mocks/mockFilters.js
@@ -1,87 +1,86 @@
 import moment from 'moment';
+import { advancedFilterOptions } from '../../data/advancedFilterOptions';
 
-const mockFilterDefaultBoolOption = {
+/* BOOLEAN TYPE MOCK FILTERS */
+const mockFilterMonitoringStatusTrue = {
   additionalFilterOption: null,
   dateOption: null,
-  filterOption: {
-    description: 'Monitorees who are currently under active monitoring',
-    name: 'monitoring-status',
-    title: 'Active Monitoring (Boolean)',
-    type: 'boolean'
-  },
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'monitoring-status'),
   numberOption: null,
   relativeOption: null,
   value: true
 }
 
-const mockFilterBoolOption = {
+const mockFilterMonitoringStatusFalse = {
   additionalFilterOption: null,
   dateOption: null,
-  filterOption: {
-    description: 'Monitorees who are currently under active monitoring',
-    name: 'monitoring-status',
-    title: 'Active Monitoring (Boolean)',
-    type: 'boolean'
-  },
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'monitoring-status'),
   numberOption: null,
   relativeOption: null,
   value: false
 }
 
-const mockFilterOptionsOption = {
+const mockFilterSevenDayQuarantine = {
   additionalFilterOption: null,
   dateOption: null,
-  filterOption: {
-    name: 'preferred-contact-time',
-    title: 'Preferred Contact Time (Select)',
-    description: 'Monitoree preferred contact time',
-    type: 'select',
-    options: ['Morning', 'Afternoon', 'Evening', '']
-  },
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'seven-day-quarantine'),
+  numberOption: null,
+  relativeOption: null,
+  value: false
+}
+
+/* SELECT TYPE MOCK FILTERS */
+const mockFilterPreferredContactTime = {
+  additionalFilterOption: null,
+  dateOption: null,
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'preferred-contact-time'),
   numberOption: null,
   relativeOption: null,
   value: 'Morning'
 }
 
-const mockFilterDefaultNumberOption = {
+/* NUMBER TYPE MOCK FILTERS */
+const mockFilterAgeEqual = {
   additionalFilterOption: null,
   dateOption: null,
-  filterOption: {
-    name: 'age',
-    title: 'Age (Number)',
-    description: 'Current Monitoree Age',
-    type: 'number',
-    allowRange: true
-  },
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'age'),
   numberOption: 'equal',
   relativeOption: null,
   value: 0
 }
 
-const mockFilterNumberOption = {
+const mockFilterAgeBetween = {
   additionalFilterOption: null,
   dateOption: null,
-  filterOption: {
-    name: 'age',
-    title: 'Age (Number)',
-    description: 'Current Monitoree Age',
-    type: 'number',
-    allowRange: true
-  },
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'age'),
   numberOption: 'between',
   relativeOption: null,
   value: {firstBound: 20, secondBound: 30}
 }
 
-const mockFilterDefaultDateOption = {
+const mockFilterManualContactAttemptsEqual = {
+  additionalFilterOption: 'Successful',
+  dateOption: null,
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'manual-contact-attempts'),
+  numberOption: 'equal',
+  relativeOption: null,
+  value: 0
+}
+
+const mockFilterManualContactAttemptsLessThan = {
+  additionalFilterOption: 'All',
+  dateOption: null,
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'manual-contact-attempts'),
+  numberOption: 'less-than',
+  relativeOption: null,
+  value: 2
+}
+
+/* DATE TYPE MOCK FILTERS */
+const mockFilterEnrolledDateWithin = {
   additionalFilterOption: null,
   dateOption: 'within',
-  filterOption: {
-    description: 'Monitorees enrolled in system during specified date range',
-    name: 'enrolled',
-    title: 'Enrolled (Date)',
-    type: 'date'
-  },
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'enrolled'),
   numberOption: null,
   relativeOption: null,
   value: { 
@@ -90,60 +89,38 @@ const mockFilterDefaultDateOption = {
   }
 }
 
-const mockFilterDateOption = {
+const mockFilterEnrolledDateBefore = {
   additionalFilterOption: null,
   dateOption: 'before',
-  filterOption: {
-    description: 'Monitorees enrolled in system during specified date range',
-    name: 'enrolled',
-    title: 'Enrolled (Date)',
-    type: 'date'
-  },
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'enrolled'),
   numberOption: null,
   relativeOption: null,
   value: '2020-12-30'
 }
 
-const mockFilterDefaultRelativeOption = {
+/* RELATIVE TYPE MOCK FILTERS */
+const mockFilterLatestReportRelativeToday = {
   additionalFilterOption: null,
   dateOption: null,
-  filterOption: {
-    name: 'latest-report-relative',
-    title: 'Latest Report (Relative Date)',
-    description: 'Monitorees with latest report during specified date range (relative to the current date)',
-    type: 'relative',
-    hasTimestamp: true
-  },
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'latest-report-relative'),
   numberOption: null,
   relativeOption: 'today',
   value: 'today'
 }
 
-const mockFilterRelativeOption = {
+const mockFilterLatestReportRelativeYesterday = {
   additionalFilterOption: null,
   dateOption: null,
-  filterOption: {
-    name: 'latest-report-relative',
-    title: 'Latest Report (Relative Date)',
-    description: 'Monitorees with latest report during specified date range (relative to the current date)',
-    type: 'relative',
-    hasTimestamp: true
-  },
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'latest-report-relative'),
   numberOption: null,
   relativeOption: 'yesterday',
   value: 'yesterday'
 }
 
-const mockFilterDefaultCustomRelativeOption1 = {
+const mockFilterLatestReportRelativeCustomPast = {
   additionalFilterOption: null,
   dateOption: null,
-  filterOption: {
-    name: 'latest-report-relative',
-    title: 'Latest Report (Relative Date)',
-    description: 'Monitorees with latest report during specified date range (relative to the current date)',
-    type: 'relative',
-    hasTimestamp: true
-  },
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'latest-report-relative'),
   numberOption: null,
   relativeOption: 'custom',
   value: {
@@ -154,36 +131,10 @@ const mockFilterDefaultCustomRelativeOption1 = {
   }
 }
 
-const mockFilterDefaultCustomRelativeOption2 = {
+const mockFilterLatestReportRelativeCustomFuture = {
   additionalFilterOption: null,
   dateOption: null,
-  filterOption: {
-    name: 'symptom-onset-relative',
-    title: 'Symptom Onset (Relative Date)',
-    description: 'Monitorees who have a symptom onset date during specified date range (relative to the current date)',
-    type: 'relative',
-    hasTimestamp: false,
-  },
-  numberOption: null,
-  relativeOption: 'custom',
-  value: {
-    operator: 'less-than',
-    number: 1,
-    unit: 'days',
-    when: 'past'
-  }
-}
-
-const mockFilterCustomRelativeOption = {
-  additionalFilterOption: null,
-  dateOption: null,
-  filterOption: {
-    name: 'latest-report-relative',
-    title: 'Latest Report (Relative Date)',
-    description: 'Monitorees with latest report during specified date range (relative to the current date)',
-    type: 'relative',
-    hasTimestamp: true
-  },
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'latest-report-relative'),
   numberOption: null,
   relativeOption: 'custom',
   value: {
@@ -194,84 +145,52 @@ const mockFilterCustomRelativeOption = {
   }
 }
 
-const mockFilterDefaultSearchOption = {
+const mockFilterSymptomOnsetRelativeCustomPast = {
   additionalFilterOption: null,
   dateOption: null,
-  filterOption: {
-    description: 'Monitoree Address 1, Town/City, Country, Address 2, Postal Code, Address 3 or State/Province (outside USA)',
-    name: 'address-foreign',
-    title: 'Address (outside USA) (Text)',
-    type: 'search'
-  },
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'symptom-onset-relative'),
+  numberOption: null,
+  relativeOption: 'custom',
+  value: {
+    operator: 'less-than',
+    number: 1,
+    unit: 'days',
+    when: 'past'
+  }
+}
+
+/* SEARCH TYPE MOCK FILTERS */
+const mockFilterAddressForeignEmpty = {
+  additionalFilterOption: null,
+  dateOption: null,
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'address-foreign'),
   numberOption: null,
   relativeOption: null,
   value: ''
 }
 
-const mockFilterSearchOption = {
+const mockFilterAddressForeign = {
   additionalFilterOption: null,
   dateOption: null,
-  filterOption: {
-    description: 'Monitoree Address 1, Town/City, Country, Address 2, Postal Code, Address 3 or State/Province (outside USA)',
-    name: 'address-foreign',
-    title: 'Address (outside USA) (Text)',
-    type: 'search'
-  },
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'address-foreign'),
   numberOption: null,
   relativeOption: null,
   value: '42 Wallaby Way'
 }
 
-const mockFilterDefaultAdditionalOption = {
-  additionalFilterOption: 'Successful',
-  dateOption: null,
-  filterOption: {
-    name: 'manual-contact-attempts',
-    title: 'Manual Contact Attempts (Number)',
-    description: 'All records with the specified number of manual contact attempts',
-    type: 'number',
-    options: ['Successful', 'Unsuccessful', 'All']
-  },
-  numberOption: 'equal',
-  relativeOption: null,
-  value: 0
-}
-
-const mockFilterAdditionalOption = {
-  additionalFilterOption: 'All',
-  dateOption: null,
-  filterOption: {
-    name: 'manual-contact-attempts',
-    title: 'Manual Contact Attempts (Number)',
-    description: 'All records with the specified number of manual contact attempts',
-    type: 'number',
-    options: ['Successful', 'Unsuccessful', 'All']
-  },
-  numberOption: 'less-than',
-  relativeOption: null,
-  value: 2
-}
-
-const mockFilterIncludesTooltip = {
+/* MULTI TYPE MOCK FILTERS */
+const mockFilterLabResults = {
   additionalFilterOption: null,
   dateOption: null,
-  filterOption: {
-    name: 'seven-day-quarantine',
-    title: 'Candidate to Reduce Quarantine after 7 Days (Boolean)',
-    description:
-      'All asymptomatic records that meet CDC criteria to end quarantine after Day 7 (based on last date of exposure and most recent lab result)',
-    type: 'boolean',
-    tooltip:
-      'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom ' +
-      'Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.',
-  },
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'lab-result'),
   numberOption: null,
   relativeOption: null,
-  value: false
+  value: [ {name: 'result', value: 'positive'} ]
 }
 
+/* MOCK SAVED FILTERS */
 const mockFilter1 = {
-  contents: [ mockFilterSearchOption ],
+  contents: [ mockFilterAddressForeign ],
   created_at: '2021-01-11T14:04:32.994Z',
   id: 2,
   name: 'my new filter',
@@ -280,7 +199,7 @@ const mockFilter1 = {
 }
 
 const mockFilter2 = {
-  contents: [ mockFilterBoolOption, mockFilterDateOption ],
+  contents: [ mockFilterMonitoringStatusFalse, mockFilterEnrolledDateBefore],
   created_at: '2020-11-11T02:43:56.234Z',
   id: 1,
   name: 'my filter',
@@ -291,23 +210,24 @@ const mockFilter2 = {
 const mockSavedFilters = [ mockFilter1, mockFilter2 ]
 
 export {
-  mockFilterDefaultBoolOption,
-  mockFilterBoolOption,
-  mockFilterOptionsOption,
-  mockFilterDefaultNumberOption,
-  mockFilterNumberOption,
-  mockFilterDefaultDateOption,
-  mockFilterDateOption,
-  mockFilterDefaultRelativeOption,
-  mockFilterRelativeOption,
-  mockFilterDefaultCustomRelativeOption1,
-  mockFilterDefaultCustomRelativeOption2,
-  mockFilterCustomRelativeOption,
-  mockFilterDefaultSearchOption,
-  mockFilterSearchOption,
-  mockFilterDefaultAdditionalOption,
-  mockFilterAdditionalOption,
-  mockFilterIncludesTooltip,
+  mockFilterMonitoringStatusTrue,
+  mockFilterMonitoringStatusFalse,
+  mockFilterSevenDayQuarantine,
+  mockFilterPreferredContactTime,
+  mockFilterAgeEqual,
+  mockFilterAgeBetween,
+  mockFilterManualContactAttemptsEqual,
+  mockFilterManualContactAttemptsLessThan,
+  mockFilterEnrolledDateWithin,
+  mockFilterEnrolledDateBefore,
+  mockFilterLatestReportRelativeToday,
+  mockFilterLatestReportRelativeYesterday,
+  mockFilterLatestReportRelativeCustomPast,
+  mockFilterSymptomOnsetRelativeCustomPast,
+  mockFilterLatestReportRelativeCustomFuture,
+  mockFilterAddressForeignEmpty,
+  mockFilterAddressForeign,
+  mockFilterLabResults,
   mockFilter1,
   mockFilter2,
   mockSavedFilters

--- a/app/javascript/tests/public_health/query/AdvancedFilter.test.js
+++ b/app/javascript/tests/public_health/query/AdvancedFilter.test.js
@@ -10,23 +10,24 @@ import { advancedFilterOptions } from '../../../data/advancedFilterOptions';
 import {
   mockFilter1,
   mockFilter2,
-  mockFilterDefaultSearchOption,
-  mockFilterSearchOption,
-  mockFilterDefaultBoolOption,
-  mockFilterBoolOption,
-  mockFilterOptionsOption,
-  mockFilterDefaultNumberOption,
-  mockFilterNumberOption,
-  mockFilterDefaultDateOption,
-  mockFilterDateOption,
-  mockFilterDefaultRelativeOption,
-  mockFilterRelativeOption,
-  mockFilterDefaultCustomRelativeOption1,
-  mockFilterDefaultCustomRelativeOption2,
-  mockFilterCustomRelativeOption,
-  mockFilterDefaultAdditionalOption,
-  mockFilterAdditionalOption,
-  mockFilterIncludesTooltip,
+  mockFilterMonitoringStatusTrue,
+  mockFilterMonitoringStatusFalse,
+  mockFilterSevenDayQuarantine,
+  mockFilterPreferredContactTime,
+  mockFilterAgeEqual,
+  mockFilterAgeBetween,
+  mockFilterManualContactAttemptsEqual,
+  mockFilterManualContactAttemptsLessThan,
+  mockFilterEnrolledDateWithin,
+  mockFilterEnrolledDateBefore,
+  mockFilterLatestReportRelativeToday,
+  mockFilterLatestReportRelativeYesterday,
+  mockFilterLatestReportRelativeCustomPast,
+  mockFilterSymptomOnsetRelativeCustomPast,
+  mockFilterLatestReportRelativeCustomFuture,
+  mockFilterAddressForeignEmpty,
+  mockFilterAddressForeign,
+  mockFilterLabResults,
   mockSavedFilters
 } from '../../mocks/mockFilters';
 
@@ -35,6 +36,7 @@ const authyToken = "Q1z4yZXLdN+tZod6dBSIlMbZ3yWAUFdY44U06QWffEP76nx1WGMHIz8rYxEU
 const numberOptionValues = [ 'less-than', 'less-than-equal', 'equal', 'greater-than-equal', 'greater-than', 'between' ];
 const numberOptionValuesText = [ 'less than', 'less than or equal to', 'equal to', 'greater than or equal to', 'greater than', 'between' ];
 const dateOptionValues = [ 'within', 'before', 'after' ];
+const multiDateOptionValues = [ 'before', 'after' ];
 const relativeOptionValues = [ 'today', 'tomorrow', 'yesterday', 'custom' ];
 const relativeOptionOperatorValues = [ 'less-than', 'more-than' ];
 const relativeOptionUnitValues = [ 'day(s)', 'week(s)', 'month(s)' ];
@@ -80,7 +82,7 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find(Dropdown.Divider).length).toEqual(1);
     expect(wrapper.find(Dropdown.Header).length).toEqual(1);
     expect(wrapper.find(Dropdown.Header).text()).toEqual('Saved Filters');
-    mockSavedFilters.forEach(function(filter, index) {
+    mockSavedFilters.forEach((filter, index) => {
       expect(wrapper.find(Dropdown.Item).at(index+1).text()).toEqual(filter.name);
     });
     expect(wrapper.find(Modal).exists()).toBeFalsy();
@@ -142,8 +144,8 @@ describe('AdvancedFilter', () => {
       return a?.title?.localeCompare(b?.title);
     });
     wrapper.find(Button).simulate('click');
-    expect(wrapper.find('.advanced-filter-select').prop('options').length).toEqual(filterOptions.length);
-    wrapper.find('.advanced-filter-select').prop('options').forEach(function(option, index) {
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('options').length).toEqual(filterOptions.length);
+    wrapper.find('.advanced-filter-options-dropdown').prop('options').forEach((option, index) => {
       expect(option.label).toEqual(filterOptions[index].title);
       expect(option.subLabel).toEqual(filterOptions[index].description);
       expect(option.value).toEqual(filterOptions[index].name);
@@ -195,10 +197,10 @@ describe('AdvancedFilter', () => {
     wrapper.setState({ savedFilters: mockSavedFilters });
     wrapper.find(Dropdown.Item).at(2).simulate('click');
     expect(wrapper.find('.advanced-filter-statement').length).toEqual(2);
-    expect(wrapper.find('.advanced-filter-select').at(0).prop('value').value).toEqual(mockFilter2.contents[0].filterOption.name);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(0).prop('value').value).toEqual(mockFilter2.contents[0].filterOption.name);
     expect(wrapper.find(ToggleButton).at(0).prop('checked')).toEqual(mockFilter2.contents[0].value);
     expect(wrapper.find(ToggleButton).at(1).prop('checked')).toEqual(!mockFilter2.contents[0].value);
-    expect(wrapper.find('.advanced-filter-select').at(1).prop('value').value).toEqual(mockFilter2.contents[1].filterOption.name);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(1).prop('value').value).toEqual(mockFilter2.contents[1].filterOption.name);
     expect(wrapper.find('.advanced-filter-date-options').prop('value')).toEqual(mockFilter2.contents[1].dateOption);
     expect(wrapper.find(DateInput).length).toEqual(1);
     expect(wrapper.find(DateInput).prop('date')).toEqual(mockFilter2.contents[1].value);
@@ -265,44 +267,44 @@ describe('AdvancedFilter', () => {
     _.times(4, () => {
       wrapper.find('#add-filter-row').simulate('click');
     });
-    wrapper.find('.advanced-filter-select').at(0).simulate('change', { value: mockFilterDefaultBoolOption.filterOption.name });
-    wrapper.find('.advanced-filter-select').at(1).simulate('change', { value: mockFilterOptionsOption.filterOption.name });
-    wrapper.find('.advanced-filter-select').at(2).simulate('change', { value: mockFilterDefaultNumberOption.filterOption.name });
-    wrapper.find('.advanced-filter-select').at(3).simulate('change', { value: mockFilterDefaultSearchOption.filterOption.name });
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultBoolOption, mockFilterOptionsOption, mockFilterDefaultNumberOption, mockFilterDefaultSearchOption, { filterOption: null } ]);
-    expect(wrapper.find('.advanced-filter-select').at(0).prop('value').value).toEqual(mockFilterDefaultBoolOption.filterOption.name);
-    expect(wrapper.find('.advanced-filter-select').at(1).prop('value').value).toEqual(mockFilterOptionsOption.filterOption.name);
-    expect(wrapper.find('.advanced-filter-select').at(2).prop('value').value).toEqual(mockFilterDefaultNumberOption.filterOption.name);
-    expect(wrapper.find('.advanced-filter-select').at(3).prop('value').value).toEqual(mockFilterDefaultSearchOption.filterOption.name);
-    expect(wrapper.find('.advanced-filter-select').at(4).prop('value')).toEqual(null);
+    wrapper.find('.advanced-filter-options-dropdown').at(0).simulate('change', { value: mockFilterMonitoringStatusTrue.filterOption.name });
+    wrapper.find('.advanced-filter-options-dropdown').at(1).simulate('change', { value: mockFilterPreferredContactTime.filterOption.name });
+    wrapper.find('.advanced-filter-options-dropdown').at(2).simulate('change', { value: mockFilterAgeEqual.filterOption.name });
+    wrapper.find('.advanced-filter-options-dropdown').at(3).simulate('change', { value: mockFilterAddressForeignEmpty.filterOption.name });
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterMonitoringStatusTrue, mockFilterPreferredContactTime, mockFilterAgeEqual, mockFilterAddressForeignEmpty, { filterOption: null } ]);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(0).prop('value').value).toEqual(mockFilterMonitoringStatusTrue.filterOption.name);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(1).prop('value').value).toEqual(mockFilterPreferredContactTime.filterOption.name);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(2).prop('value').value).toEqual(mockFilterAgeEqual.filterOption.name);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(3).prop('value').value).toEqual(mockFilterAddressForeignEmpty.filterOption.name);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(4).prop('value')).toEqual(null);
     wrapper.find('.remove-filter-row').at(3).simulate('click');
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultBoolOption, mockFilterOptionsOption, mockFilterDefaultNumberOption, { filterOption: null } ]);
-    expect(wrapper.find('.advanced-filter-select').at(0).prop('value').value).toEqual(mockFilterDefaultBoolOption.filterOption.name);
-    expect(wrapper.find('.advanced-filter-select').at(1).prop('value').value).toEqual(mockFilterOptionsOption.filterOption.name);
-    expect(wrapper.find('.advanced-filter-select').at(2).prop('value').value).toEqual(mockFilterDefaultNumberOption.filterOption.name);
-    expect(wrapper.find('.advanced-filter-select').at(3).prop('value')).toEqual(null);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterMonitoringStatusTrue, mockFilterPreferredContactTime, mockFilterAgeEqual, { filterOption: null } ]);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(0).prop('value').value).toEqual(mockFilterMonitoringStatusTrue.filterOption.name);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(1).prop('value').value).toEqual(mockFilterPreferredContactTime.filterOption.name);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(2).prop('value').value).toEqual(mockFilterAgeEqual.filterOption.name);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(3).prop('value')).toEqual(null);
     wrapper.find('.remove-filter-row').at(1).simulate('click');
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultBoolOption, mockFilterDefaultNumberOption, { filterOption: null } ]);
-    expect(wrapper.find('.advanced-filter-select').at(0).prop('value').value).toEqual(mockFilterDefaultBoolOption.filterOption.name);
-    expect(wrapper.find('.advanced-filter-select').at(1).prop('value').value).toEqual(mockFilterDefaultNumberOption.filterOption.name);
-    expect(wrapper.find('.advanced-filter-select').at(2).prop('value')).toEqual(null);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterMonitoringStatusTrue, mockFilterAgeEqual, { filterOption: null } ]);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(0).prop('value').value).toEqual(mockFilterMonitoringStatusTrue.filterOption.name);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(1).prop('value').value).toEqual(mockFilterAgeEqual.filterOption.name);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(2).prop('value')).toEqual(null);
     wrapper.find('.remove-filter-row').at(1).simulate('click');
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultBoolOption, { filterOption: null } ]);
-    expect(wrapper.find('.advanced-filter-select').at(0).prop('value').value).toEqual(mockFilterDefaultBoolOption.filterOption.name);
-    expect(wrapper.find('.advanced-filter-select').at(1).prop('value')).toEqual(null);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterMonitoringStatusTrue, { filterOption: null } ]);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(0).prop('value').value).toEqual(mockFilterMonitoringStatusTrue.filterOption.name);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(1).prop('value')).toEqual(null);
     wrapper.find('.remove-filter-row').at(0).simulate('click');
     expect(wrapper.state('activeFilterOptions')).toEqual([ { filterOption: null } ]);
-    expect(wrapper.find('.advanced-filter-select').at(0).prop('value')).toEqual(null);
+    expect(wrapper.find('.advanced-filter-options-dropdown').at(0).prop('value')).toEqual(null);
     wrapper.find('.remove-filter-row').at(0).simulate('click');
     expect(wrapper.state('activeFilterOptions')).toEqual([ ]);
-    expect(wrapper.find('.advanced-filter-select').length).toEqual(0);
+    expect(wrapper.find('.advanced-filter-options-dropdown').length).toEqual(0);
   });
 
   it('Properly renders advanced filter boolean type statement', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterBoolOption.filterOption.name });
-    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterBoolOption.filterOption.name);
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterMonitoringStatusFalse.filterOption.name });
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterMonitoringStatusFalse.filterOption.name);
     expect(wrapper.find(ButtonGroup).exists()).toBeTruthy();
     expect(wrapper.find(ToggleButton).length).toEqual(2);
     expect(wrapper.find(ToggleButton).at(0).prop('checked')).toBeTruthy();
@@ -314,12 +316,12 @@ describe('AdvancedFilter', () => {
   it('Properly renders advanced filter option type statement', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterOptionsOption.filterOption.name });
-    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterOptionsOption.filterOption.name);
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterPreferredContactTime.filterOption.name });
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterPreferredContactTime.filterOption.name);
     expect(wrapper.find(Form.Control).length).toEqual(1);
-    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterOptionsOption.filterOption.options[0]);
-    expect(wrapper.find(Form.Control).find('option').length).toEqual(mockFilterOptionsOption.filterOption.options.length);
-    mockFilterOptionsOption.filterOption.options.forEach(function(option, index) {
+    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterPreferredContactTime.filterOption.options[0]);
+    expect(wrapper.find(Form.Control).find('option').length).toEqual(mockFilterPreferredContactTime.filterOption.options.length);
+    mockFilterPreferredContactTime.filterOption.options.forEach((option, index) => {
       expect(wrapper.find(Form.Control).find('option').at(index).text()).toEqual(option);
       expect(wrapper.find(Form.Control).find('option').at(index).prop('value')).toEqual(option);
     });
@@ -330,12 +332,12 @@ describe('AdvancedFilter', () => {
   it('Properly renders advanced filter number type statement with single number', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterNumberOption.filterOption.name });
-    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterNumberOption.filterOption.name);
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterAgeBetween.filterOption.name });
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterAgeBetween.filterOption.name);
     expect(wrapper.find(Form.Control).length).toEqual(2);
     expect(wrapper.find(Form.Control).at(0).prop('value')).toEqual('equal');
     expect(wrapper.find(Form.Control).find('option').length).toEqual(numberOptionValues.length);
-    numberOptionValues.forEach(function(value, index) {
+    numberOptionValues.forEach((value, index) => {
       expect(wrapper.find(Form.Control).at(0).find('option').at(index).text()).toEqual(numberOptionValuesText[index]);
       expect(wrapper.find(Form.Control).at(0).find('option').at(index).prop('value')).toEqual(value);
     });
@@ -347,13 +349,13 @@ describe('AdvancedFilter', () => {
   it('Properly renders advanced filter number type statement with number range', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterNumberOption.filterOption.name });
-    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterNumberOption.filterOption.name);
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterAgeBetween.filterOption.name });
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterAgeBetween.filterOption.name);
     wrapper.find('.advanced-filter-number-options').simulate('change', { target: { value: 'between' } });
     expect(wrapper.find(Form.Control).length).toEqual(3);
     expect(wrapper.find(Form.Control).at(0).prop('value')).toEqual('between');
     expect(wrapper.find(Form.Control).find('option').length).toEqual(numberOptionValues.length);
-    numberOptionValues.forEach(function(value, index) {
+    numberOptionValues.forEach((value, index) => {
       expect(wrapper.find(Form.Control).at(0).find('option').at(index).text()).toEqual(numberOptionValuesText[index]);
       expect(wrapper.find(Form.Control).at(0).find('option').at(index).prop('value')).toEqual(value);
     });
@@ -368,13 +370,13 @@ describe('AdvancedFilter', () => {
   it('Properly renders advanced filter date type statement with single date', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDateOption.filterOption.name });
-    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterDateOption.filterOption.name);
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterEnrolledDateBefore.filterOption.name });
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterEnrolledDateBefore.filterOption.name);
     wrapper.find('.advanced-filter-date-options').simulate('change', { target: { value: 'before' } });
     expect(wrapper.find(Form.Control).length).toEqual(1);
     expect(wrapper.find(Form.Control).prop('value')).toEqual('before');
     expect(wrapper.find(Form.Control).find('option').length).toEqual(dateOptionValues.length);
-    dateOptionValues.forEach(function(value, index) {
+    dateOptionValues.forEach((value, index) => {
       expect(wrapper.find(Form.Control).find('option').at(index).text()).toEqual(value);
       expect(wrapper.find(Form.Control).find('option').at(index).prop('value')).toEqual(value);
     });
@@ -388,12 +390,12 @@ describe('AdvancedFilter', () => {
   it('Properly renders advanced filter date type statement with date range', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDateOption.filterOption.name });
-    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterDateOption.filterOption.name);
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterEnrolledDateWithin.filterOption.name });
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterEnrolledDateWithin.filterOption.name);
     expect(wrapper.find(Form.Control).length).toEqual(1);
     expect(wrapper.find(Form.Control).prop('value')).toEqual('within');
     expect(wrapper.find(Form.Control).find('option').length).toEqual(dateOptionValues.length);
-    dateOptionValues.forEach(function(value, index) {
+    dateOptionValues.forEach((value, index) => {
       expect(wrapper.find(Form.Control).find('option').at(index).text()).toEqual(value);
       expect(wrapper.find(Form.Control).find('option').at(index).prop('value')).toEqual(value);
     });
@@ -408,13 +410,13 @@ describe('AdvancedFilter', () => {
   it('Properly renders advanced filter relative type statement', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDefaultCustomRelativeOption1.filterOption.name });
-    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterDefaultCustomRelativeOption1.filterOption.name);
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLatestReportRelativeCustomPast.filterOption.name });
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterLatestReportRelativeCustomPast.filterOption.name);
     expect(wrapper.find(Form.Control).length).toEqual(1);
     expect(wrapper.find('.advanced-filter-relative-options').exists()).toBeTruthy();
     expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual('today');
     expect(wrapper.find('.advanced-filter-relative-options').find('option').length).toEqual(relativeOptionValues.length);
-    relativeOptionValues.forEach(function(value, index) {
+    relativeOptionValues.forEach((value, index) => {
       expect(wrapper.find('.advanced-filter-relative-options').find('option').at(index).text()).toEqual(value);
       expect(wrapper.find('.advanced-filter-relative-options').find('option').at(index).prop('value')).toEqual(value);
     });
@@ -429,37 +431,37 @@ describe('AdvancedFilter', () => {
   it('Properly renders advanced filter relative type custom statement', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDefaultCustomRelativeOption2.filterOption.name });
-    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterDefaultCustomRelativeOption2.filterOption.name);
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterSymptomOnsetRelativeCustomPast.filterOption.name });
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterSymptomOnsetRelativeCustomPast.filterOption.name);
     wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: 'custom' } });
     expect(wrapper.find(Form.Control).length).toEqual(5);
     expect(wrapper.find('.advanced-filter-relative-options').exists()).toBeTruthy();
     expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual('custom');
     expect(wrapper.find('.advanced-filter-relative-options').find('option').length).toEqual(relativeOptionValues.length);
-    relativeOptionValues.forEach(function(value, index) {
+    relativeOptionValues.forEach((value, index) => {
       expect(wrapper.find('.advanced-filter-relative-options').find('option').at(index).text()).toEqual(value);
       expect(wrapper.find('.advanced-filter-relative-options').find('option').at(index).prop('value')).toEqual(value);
     });
     expect(wrapper.find('.advanced-filter-operator-input').exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption2.value.operator);
+    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterSymptomOnsetRelativeCustomPast.value.operator);
     expect(wrapper.find('.advanced-filter-operator-input').find('option').length).toEqual(relativeOptionOperatorValues.length);
-    relativeOptionOperatorValues.forEach(function(value, index) {
+    relativeOptionOperatorValues.forEach((value, index) => {
       expect(wrapper.find('.advanced-filter-operator-input').find('option').at(index).text()).toEqual(value.replace('-', ' '));
       expect(wrapper.find('.advanced-filter-operator-input').find('option').at(index).prop('value')).toEqual(value);
     });
     expect(wrapper.find('.advanced-filter-number-input').exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption2.value.number);
+    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterSymptomOnsetRelativeCustomPast.value.number);
     expect(wrapper.find('.advanced-filter-unit-input').exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption2.value.unit);
+    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterSymptomOnsetRelativeCustomPast.value.unit);
     expect(wrapper.find('.advanced-filter-unit-input').find('option').length).toEqual(relativeOptionUnitValues.length);
-    relativeOptionUnitValues.forEach(function(value, index) {
+    relativeOptionUnitValues.forEach((value, index) => {
       expect(wrapper.find('.advanced-filter-unit-input').find('option').at(index).text()).toEqual(value);
       expect(wrapper.find('.advanced-filter-unit-input').find('option').at(index).prop('value')).toEqual(value.replace('(', '').replace(')', ''));
     });
     expect(wrapper.find('.advanced-filter-when-input').exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption2.value.when);
+    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterSymptomOnsetRelativeCustomPast.value.when);
     expect(wrapper.find('.advanced-filter-when-input').find('option').length).toEqual(relativeOptionWhenValues.length);
-    relativeOptionWhenValues.forEach(function(value, index) {
+    relativeOptionWhenValues.forEach((value, index) => {
       expect(wrapper.find('.advanced-filter-when-input').find('option').at(index).text()).toEqual(`in the ${value}`);
       expect(wrapper.find('.advanced-filter-when-input').find('option').at(index).prop('value')).toEqual(value);
     });
@@ -470,8 +472,8 @@ describe('AdvancedFilter', () => {
   it('Properly renders advanced filter search type statement', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterSearchOption.filterOption.name });
-    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterSearchOption.filterOption.name);
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterAddressForeign.filterOption.name });
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterAddressForeign.filterOption.name);
     expect(wrapper.find(Form.Control).length).toEqual(1);
     expect(wrapper.find(Form.Control).hasClass('advanced-filter-search-input')).toBeTruthy();
     expect(wrapper.find('.advanced-filter-search-input').prop('value')).toEqual('');
@@ -482,12 +484,12 @@ describe('AdvancedFilter', () => {
   it('Properly renders advanced filter type with additional dropdown options statement', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterAdditionalOption.filterOption.name });
-    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterAdditionalOption.filterOption.name);
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterManualContactAttemptsLessThan.filterOption.name });
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterManualContactAttemptsLessThan.filterOption.name);
     expect(wrapper.find('.advanced-filter-additional-filter-options').exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-additional-filter-options').prop('value')).toEqual(mockFilterAdditionalOption.filterOption.options[0]);
-    expect(wrapper.find('.advanced-filter-additional-filter-options').find('option').length).toEqual(mockFilterAdditionalOption.filterOption.options.length);
-    mockFilterAdditionalOption.filterOption.options.forEach(function(option, index) {
+    expect(wrapper.find('.advanced-filter-additional-filter-options').prop('value')).toEqual(mockFilterManualContactAttemptsLessThan.filterOption.options[0]);
+    expect(wrapper.find('.advanced-filter-additional-filter-options').find('option').length).toEqual(mockFilterManualContactAttemptsLessThan.filterOption.options.length);
+    mockFilterManualContactAttemptsLessThan.filterOption.options.forEach((option, index) => {
       expect(wrapper.find('.advanced-filter-additional-filter-options').find('option').at(index).text()).toEqual(option);
       expect(wrapper.find('.advanced-filter-additional-filter-options').find('option').at(index).prop('value')).toEqual(option);
     });
@@ -497,10 +499,240 @@ describe('AdvancedFilter', () => {
   it('Properly renders tooltip when defined with advanced filter option', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterIncludesTooltip.filterOption.name });
-    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterIncludesTooltip.filterOption.name);
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterSevenDayQuarantine.filterOption.name });
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterSevenDayQuarantine.filterOption.name);
     expect(wrapper.find(ReactTooltip).exists()).toBeTruthy();
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(mockFilterIncludesTooltip.filterOption.tooltip);
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(mockFilterSevenDayQuarantine.filterOption.tooltip);
+  });
+
+  it('Properly renders main components of advanced filter multi type statement', () => {
+    const wrapper = getWrapper();
+    wrapper.find(Button).simulate('click');
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterLabResults.filterOption.name);
+    expect(wrapper.find('.advanced-filter-multi-type-statement').exists()).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(1);
+    expect(wrapper.find('.advanced-filter-multi-options').exists()).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-multi-options').prop('value')).toEqual(mockFilterLabResults.filterOption.fields[0].name);
+    expect(wrapper.find('.advanced-filter-multi-options').find('option').length).toEqual(mockFilterLabResults.filterOption.fields.length);
+    mockFilterLabResults.filterOption.fields.forEach((field, index) => {
+      expect(wrapper.find('.advanced-filter-multi-options').find('option').at(index).text()).toEqual(field.title);
+      expect(wrapper.find('.advanced-filter-multi-options').find('option').at(index).prop('value')).toEqual(field.name);
+      expect(wrapper.find('.advanced-filter-multi-options').find('option').at(index).prop('disabled')).toBeFalsy();
+    });
+    expect(wrapper.find('.advanced-filter-multi-type-statement').find(Button).length).toEqual(2);
+    expect(wrapper.find('.advanced-filter-multi-type-statement').find(Button).at(0).find('i').hasClass('fa-plus')).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-multi-type-statement').find(Button).at(1).find('i').hasClass('fa-minus')).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-additional-filter-options').exists()).toBeFalsy();
+    expect(wrapper.find(ReactTooltip).exists()).toBeTruthy();
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(mockFilterLabResults.filterOption.tooltip);
+  });
+
+  it('Properly renders select option of advanced filter multi type statement', () => {
+    const wrapper = getWrapper();
+    wrapper.find(Button).simulate('click');
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
+    expect(wrapper.find('.advanced-filter-multi-type-statement').find(Form.Control).length).toEqual(2);
+    expect(wrapper.find('.advanced-filter-multi-options').exists()).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-multi-select-options').exists()).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-date-options').exists()).toBeFalsy();
+    expect(wrapper.find(DateInput).exists()).toBeFalsy();
+    expect(wrapper.find('.advanced-filter-multi-select-options').prop('value')).toEqual(mockFilterLabResults.filterOption.fields[0].options[0]);
+    expect(wrapper.find('.advanced-filter-multi-select-options').find('option').length).toEqual(mockFilterLabResults.filterOption.fields[0].options.length);
+    mockFilterLabResults.filterOption.fields[0].options.forEach((option, index) => {
+      expect(wrapper.find('.advanced-filter-multi-select-options').find('option').at(index).text()).toEqual(option);
+      expect(wrapper.find('.advanced-filter-multi-select-options').find('option').at(index).prop('disabled')).toBeFalsy();
+    });
+  });
+
+  it('Properly renders date option of advanced filter multi type statement', () => {
+    const wrapper = getWrapper();
+    wrapper.find(Button).simulate('click');
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
+    wrapper.find('.advanced-filter-multi-options').simulate('change', { target: { value: 'report'} });
+    expect(wrapper.find('.advanced-filter-multi-type-statement').find(Form.Control).length).toEqual(2);
+    expect(wrapper.find('.advanced-filter-multi-options').exists()).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-multi-select-options').exists()).toBeFalsy();
+    expect(wrapper.find('.advanced-filter-date-options').exists()).toBeTruthy();
+    expect(wrapper.find(DateInput).exists()).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-date-options').prop('value')).toEqual(multiDateOptionValues[0]);
+    expect(wrapper.find('.advanced-filter-date-options').find('option').length).toEqual(multiDateOptionValues.length);
+    multiDateOptionValues.forEach((value, index) => {
+      expect(wrapper.find('.advanced-filter-date-options').find('option').at(index).text()).toEqual(value);
+      expect(wrapper.find('.advanced-filter-date-options').find('option').at(index).prop('disabled')).toBeFalsy();
+    });
+    expect(wrapper.find('.advanced-filter-multi-type-statement').find(DateInput).prop('date')).toEqual(moment().format('YYYY-MM-DD'));
+  });
+
+  it('Clicking the multi type "+" button adds another multi statement and displays "AND" row', () => {
+    const wrapper = getWrapper();
+    wrapper.find(Button).simulate('click');
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
+    _.times(mockFilterLabResults.filterOption.fields.length-1, (i) => {
+      expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(i+1);
+      expect(wrapper.find('.and-row').length).toEqual(i);
+      wrapper.find('.btn-circle').simulate('click');
+    });
+    expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(mockFilterLabResults.filterOption.fields.length);
+    expect(wrapper.find('.and-row').length).toEqual(mockFilterLabResults.filterOption.fields.length-1);
+  });
+
+  it('Adding additional fields to multi filter does not allow for repeats', () => {
+    const wrapper = getWrapper();
+    let activeMultiValues = [];
+    wrapper.find(Button).simulate('click');
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
+    _.times(mockFilterLabResults.filterOption.fields.length, (i) => {
+      activeMultiValues.push(mockFilterLabResults.filterOption.fields[i].name);
+      expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(i+1);
+      wrapper.find('.advanced-filter-multi-type-statement').forEach(statement => {
+        let statementValue = statement.find('.advanced-filter-multi-options').prop('value');
+        expect(activeMultiValues.filter((value) => (value === statementValue)).length).toEqual(1);
+        statement.find('.advanced-filter-multi-options').find('option').forEach(option => {
+          let optionValue = option.prop('value');
+          expect(option.prop('disabled')).toEqual(activeMultiValues.includes(optionValue) && optionValue !== statementValue);
+        });
+      });
+      if (i < mockFilterLabResults.filterOption.fields.length-1) {
+        wrapper.find('.btn-circle').simulate('click');
+      }
+    });
+    _.times(mockFilterLabResults.filterOption.fields.length-1, (i) => {
+      let random = _.random(0, wrapper.find('.remove-filter-row').length-1);
+      activeMultiValues = activeMultiValues.slice(0, random).concat(activeMultiValues.slice(random+1, activeMultiValues.length));
+      wrapper.find('.remove-filter-row').at(random).simulate('click');
+      expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(mockFilterLabResults.filterOption.fields.length-1-i);
+      wrapper.find('.advanced-filter-multi-type-statement').forEach(statement => {
+        let statementValue = statement.find('.advanced-filter-multi-options').prop('value');
+        expect(activeMultiValues.filter((value) => (value === statementValue)).length).toEqual(1);
+        statement.find('.advanced-filter-multi-options').find('option').forEach(option => {
+          let optionValue = option.prop('value');
+          expect(option.prop('disabled')).toEqual(activeMultiValues.includes(optionValue) && optionValue !== statementValue);
+        });
+      });
+    });
+  });
+
+  it('Removes the multi type "+" button when all the filter option fields are displayed', () => {
+    const wrapper = getWrapper();
+    wrapper.find(Button).simulate('click');
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
+    _.times(mockFilterLabResults.filterOption.fields.length-1, (i) => {
+      expect(wrapper.find('.advanced-filter-multi-type-statement').find('.btn-circle').exists()).toBeTruthy();
+      wrapper.find('.btn-circle').simulate('click');
+    });
+    expect(wrapper.find('.advanced-filter-multi-type-statement').find('.btn-circle').exists()).toBeFalsy();
+  });
+
+  it('Clicking the multi type "-" removes multi statements until there is one left, then removed the entire filter statement', () => {
+    const wrapper = getWrapper();
+    wrapper.find(Button).simulate('click');
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
+    _.times(mockFilterLabResults.filterOption.fields.length-1, (i) => {
+      wrapper.find('.btn-circle').simulate('click');
+    });
+    _.times(mockFilterLabResults.filterOption.fields.length, (i) => {
+      let random = _.random(0, wrapper.find('.remove-filter-row').length-1);
+      expect(wrapper.find('.advanced-filter-statement').length).toEqual(1);
+      expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(mockFilterLabResults.filterOption.fields.length-i);
+      wrapper.find('.remove-filter-row').at(random).simulate('click');
+    });
+    expect(wrapper.find('.advanced-filter-statement').exists()).toBeFalsy();
+    expect(wrapper.find('.advanced-filter-multi-type-statement').exists()).toBeFalsy();
+  });
+
+  it('Clicking the multi type "+" and "-" properly updates state and value', () => {
+    const wrapper = getWrapper();
+    let activeMultiValues = [];
+    wrapper.find(Button).simulate('click');
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
+    _.times(mockFilterLabResults.filterOption.fields.length, (i) => {
+      let newField = mockFilterLabResults.filterOption.fields[i];
+      let newValue = newField.type === 'select' ? newField.options[0] : { when: 'before', date: moment().format('YYYY-MM-DD') };
+      activeMultiValues.push({ name: newField.name , value: newValue });
+      expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(i+1);
+      expect(wrapper.state('activeFilterOptions')[0].value.length).toEqual(i+1);
+      expect(wrapper.state('activeFilterOptions')[0].value).toEqual(activeMultiValues);
+      wrapper.find('.advanced-filter-multi-type-statement').forEach((statement, index) => {
+        expect(statement.find('.advanced-filter-multi-options').prop('value')).toEqual(activeMultiValues[index].name);
+        if (mockFilterLabResults.filterOption.fields.filter((field) => (field.name === activeMultiValues[index].name)).type === 'select') {
+          expect(statement.find('.advanced-filter-multi-select-options').prop('value')).toEqual(activeMultiValues[index].value);
+        } else if (mockFilterLabResults.filterOption.fields.filter((field) => (field.name === activeMultiValues[index].name)).type === 'date') {
+          expect(statement.find('.advanced-filter-date-options').prop('value')).toEqual(activeMultiValues[index].value.when);
+          expect(statement.find(DateInput).prop('date')).toEqual(activeMultiValues[index].value.date);
+        }
+      });
+      if (i < mockFilterLabResults.filterOption.fields.length-1) {
+        wrapper.find('.btn-circle').simulate('click');
+      }
+    });
+    _.times(mockFilterLabResults.filterOption.fields.length-1, (i) => {
+      let random = _.random(0, wrapper.find('.remove-filter-row').length-1);
+      activeMultiValues = activeMultiValues.slice(0, random).concat(activeMultiValues.slice(random+1, activeMultiValues.length));
+      wrapper.find('.remove-filter-row').at(random).simulate('click');
+      expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(mockFilterLabResults.filterOption.fields.length-1-i);
+      expect(wrapper.state('activeFilterOptions')[0].value.length).toEqual(mockFilterLabResults.filterOption.fields.length-1-i);
+      expect(wrapper.state('activeFilterOptions')[0].value).toEqual(activeMultiValues);
+      wrapper.find('.advanced-filter-multi-type-statement').forEach((statement, index) => {
+        expect(statement.find('.advanced-filter-multi-options').prop('value')).toEqual(activeMultiValues[index].name);
+        if (mockFilterLabResults.filterOption.fields.filter((field) => (field.name === activeMultiValues[index].name)).type === 'select') {
+          expect(statement.find('.advanced-filter-multi-select-options').prop('value')).toEqual(activeMultiValues[index].value);
+        } else if (mockFilterLabResults.filterOption.fields.filter((field) => (field.name === activeMultiValues[index].name)).type === 'date') {
+          expect(statement.find('.advanced-filter-date-options').prop('value')).toEqual(activeMultiValues[index].value.when);
+          expect(statement.find(DateInput).prop('date')).toEqual(activeMultiValues[index].value.date);
+        }
+      });
+    });
+  });
+
+  it('Changing the multi type dropdowns and date inputs properly updates ', () => {
+    const wrapper = getWrapper();
+    const selectField = mockFilterLabResults.filterOption.fields.filter((field) => (field.type === 'select'))[0];
+    const dateField = mockFilterLabResults.filterOption.fields.filter((field) => (field.type === 'date'))[0];
+    const random = _.random(0, selectField.length-1);
+    const initialDate = moment().format('YYYY-MM-DD');
+    const newDate = moment(new Date()).subtract(14,'d').format('YYYY-MM-DD');
+
+    wrapper.find(Button).simulate('click');
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
+    wrapper.find('.advanced-filter-multi-options').simulate('change', { target: { value: selectField.name } });
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: selectField.name, value: selectField.options[0] }]);
+    expect(wrapper.find('.advanced-filter-multi-options').prop('value')).toEqual(selectField.name);
+    expect(wrapper.find('.advanced-filter-multi-select-options').prop('value')).toEqual(selectField.options[0]);
+
+    wrapper.find('.advanced-filter-multi-select-options').simulate('change', { target: { value: selectField.options[random] } });
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: selectField.name, value: selectField.options[random] }]);
+    expect(wrapper.find('.advanced-filter-multi-options').prop('value')).toEqual(selectField.name);
+    expect(wrapper.find('.advanced-filter-multi-select-options').prop('value')).toEqual(selectField.options[random]);
+
+    wrapper.find('.advanced-filter-multi-options').simulate('change', { target: { value: dateField.name } });
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: dateField.name, value: { when: multiDateOptionValues[0], date: initialDate } }]);
+    expect(wrapper.find('.advanced-filter-multi-options').prop('value')).toEqual(dateField.name);
+    expect(wrapper.find('.advanced-filter-date-options').prop('value')).toEqual(multiDateOptionValues[0]);
+    expect(wrapper.find(DateInput).prop('date')).toEqual(initialDate);
+
+    wrapper.find('.advanced-filter-date-options').simulate('change', { target: { value: multiDateOptionValues[1] } });
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: dateField.name, value: { when: multiDateOptionValues[1], date: initialDate } }]);
+    expect(wrapper.find('.advanced-filter-multi-options').prop('value')).toEqual(dateField.name);
+    expect(wrapper.find('.advanced-filter-date-options').prop('value')).toEqual(multiDateOptionValues[1]);
+    expect(wrapper.find(DateInput).prop('date')).toEqual(initialDate);
+
+    wrapper.find(DateInput).simulate('change', newDate);
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: dateField.name, value: { when: multiDateOptionValues[1], date: newDate } }]);
+    expect(wrapper.find('.advanced-filter-multi-options').prop('value')).toEqual(dateField.name);
+    expect(wrapper.find('.advanced-filter-date-options').prop('value')).toEqual(multiDateOptionValues[1]);
+    expect(wrapper.find(DateInput).prop('date')).toEqual(newDate);
+
+    wrapper.find('.advanced-filter-date-options').simulate('change', { target: { value: multiDateOptionValues[0] } });
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: dateField.name, value: { when: multiDateOptionValues[0], date: newDate } }]);
+    expect(wrapper.find('.advanced-filter-multi-options').prop('value')).toEqual(dateField.name);
+    expect(wrapper.find('.advanced-filter-date-options').prop('value')).toEqual(multiDateOptionValues[0]);
+    expect(wrapper.find(DateInput).prop('date')).toEqual(newDate);
+
+    wrapper.find('.advanced-filter-multi-options').simulate('change', { target: { value: selectField.name } });
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: selectField.name, value: selectField.options[0] }]);
+    expect(wrapper.find('.advanced-filter-multi-options').prop('value')).toEqual(selectField.name);
+    expect(wrapper.find('.advanced-filter-multi-select-options').prop('value')).toEqual(selectField.options[0]);
   });
 
   it('Toggling boolean buttons properly updates state and value', () => {
@@ -508,43 +740,43 @@ describe('AdvancedFilter', () => {
     wrapper.find(Button).simulate('click');
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')).toEqual([ { 'filterOption': null } ]);
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterBoolOption.filterOption.name });
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterMonitoringStatusFalse.filterOption.name });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultBoolOption ]);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterMonitoringStatusTrue ]);
     expect(wrapper.find('.advanced-filter-boolean-true').prop('checked')).toBeTruthy();
     expect(wrapper.find('.advanced-filter-boolean-false').prop('checked')).toBeFalsy();
     wrapper.find('.advanced-filter-boolean-false').simulate('change');
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterBoolOption ]);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterMonitoringStatusFalse ]);
     expect(wrapper.find('.advanced-filter-boolean-true').prop('checked')).toBeFalsy();
     expect(wrapper.find('.advanced-filter-boolean-false').prop('checked')).toBeTruthy();
     wrapper.find('.advanced-filter-boolean-true').simulate('change');
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultBoolOption ]);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterMonitoringStatusTrue ]);
     expect(wrapper.find('.advanced-filter-boolean-true').prop('checked')).toBeTruthy();
     expect(wrapper.find('.advanced-filter-boolean-false').prop('checked')).toBeFalsy();
   });
 
   it('Changing advanced filter option dropdown properly updates state and value', () => {
     const wrapper = getWrapper();
-    const randomNumber = _.random(0, mockFilterOptionsOption.filterOption.options.length - 1);
-    let newMockFilterOptionsOption = _.clone(mockFilterOptionsOption);
-    newMockFilterOptionsOption.value = mockFilterOptionsOption.filterOption.options[randomNumber];
+    const randomNumber = _.random(0, mockFilterPreferredContactTime.filterOption.options.length - 1);
+    let newMockFilterOptionsOption = _.clone(mockFilterPreferredContactTime);
+    newMockFilterOptionsOption.value = mockFilterPreferredContactTime.filterOption.options[randomNumber];
     wrapper.find(Button).simulate('click');
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')).toEqual([ { 'filterOption': null } ]);
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterOptionsOption.filterOption.name });
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterPreferredContactTime.filterOption.name });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterOptionsOption ]);
-    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterOptionsOption.filterOption.options[0]);
-    wrapper.find(Form.Control).simulate('change', { target: { value: mockFilterOptionsOption.filterOption.options[randomNumber] } });
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterPreferredContactTime ]);
+    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterPreferredContactTime.filterOption.options[0]);
+    wrapper.find(Form.Control).simulate('change', { target: { value: mockFilterPreferredContactTime.filterOption.options[randomNumber] } });
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')).toEqual([ newMockFilterOptionsOption ]);
-    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterOptionsOption.filterOption.options[randomNumber]);
-    wrapper.find(Form.Control).simulate('change', { target: { value: mockFilterOptionsOption.filterOption.options[0] } });
+    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterPreferredContactTime.filterOption.options[randomNumber]);
+    wrapper.find(Form.Control).simulate('change', { target: { value: mockFilterPreferredContactTime.filterOption.options[0] } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterOptionsOption ]);
-    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterOptionsOption.filterOption.options[0]);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterPreferredContactTime ]);
+    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterPreferredContactTime.filterOption.options[0]);
   });
 
   it('Changing advanced filter numberOption and value for number type advanced filters properly updates state and value', () => {
@@ -552,16 +784,16 @@ describe('AdvancedFilter', () => {
     wrapper.find(Button).simulate('click');
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')).toEqual([ { 'filterOption': null } ]);
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterNumberOption.filterOption.name });
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterAgeBetween.filterOption.name });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultNumberOption ]);
-    expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual(mockFilterDefaultNumberOption.numberOption);
-    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterDefaultNumberOption.value);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterAgeEqual ]);
+    expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual(mockFilterAgeEqual.numberOption);
+    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterAgeEqual.value);
     wrapper.find('.advanced-filter-number-input').simulate('change', { target: { value: 12 } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')[0].numberOption).toEqual(mockFilterDefaultNumberOption.numberOption);
+    expect(wrapper.state('activeFilterOptions')[0].numberOption).toEqual(mockFilterAgeEqual.numberOption);
     expect(wrapper.state('activeFilterOptions')[0].value).toEqual(12);
-    expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual(mockFilterDefaultNumberOption.numberOption);
+    expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual(mockFilterAgeEqual.numberOption);
     expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(12);
     wrapper.find('.advanced-filter-number-options').simulate('change', { target: { value: 'less-than' } });
     expect(wrapper.state('activeFilter')).toEqual(null);
@@ -576,24 +808,24 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual('between');
     expect(wrapper.find('.advanced-filter-number-input').at(0).prop('value')).toEqual(0);
     expect(wrapper.find('.advanced-filter-number-input').at(1).prop('value')).toEqual(0);
-    wrapper.find('.advanced-filter-number-input').at(1).simulate('change', { target: { value: mockFilterNumberOption.value.secondBound } });
+    wrapper.find('.advanced-filter-number-input').at(1).simulate('change', { target: { value: mockFilterAgeBetween.value.secondBound } });
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')[0].numberOption).toEqual('between');
-    expect(wrapper.state('activeFilterOptions')[0].value).toEqual({ firstBound: 0, secondBound: mockFilterNumberOption.value.secondBound });
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual({ firstBound: 0, secondBound: mockFilterAgeBetween.value.secondBound });
     expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual('between');
     expect(wrapper.find('.advanced-filter-number-input').at(0).prop('value')).toEqual(0);
-    expect(wrapper.find('.advanced-filter-number-input').at(1).prop('value')).toEqual(mockFilterNumberOption.value.secondBound);
+    expect(wrapper.find('.advanced-filter-number-input').at(1).prop('value')).toEqual(mockFilterAgeBetween.value.secondBound);
     wrapper.find('.advanced-filter-number-input').at(0).simulate('change', { target: { value: 20 } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterNumberOption ]);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterAgeBetween ]);
     expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual('between');
-    expect(wrapper.find('.advanced-filter-number-input').at(0).prop('value')).toEqual(mockFilterNumberOption.value.firstBound);
-    expect(wrapper.find('.advanced-filter-number-input').at(1).prop('value')).toEqual(mockFilterNumberOption.value.secondBound);
+    expect(wrapper.find('.advanced-filter-number-input').at(0).prop('value')).toEqual(mockFilterAgeBetween.value.firstBound);
+    expect(wrapper.find('.advanced-filter-number-input').at(1).prop('value')).toEqual(mockFilterAgeBetween.value.secondBound);
     wrapper.find('.advanced-filter-number-options').simulate('change', { target: { value: 'equal' } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultNumberOption ]);
-    expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual(mockFilterDefaultNumberOption.numberOption);
-    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterDefaultNumberOption.value);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterAgeEqual ]);
+    expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual(mockFilterAgeEqual.numberOption);
+    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterAgeEqual.value);
   });
 
   it('Changing advanced filter dateOption and values for date type advanced filters properly updates state and value', () => {
@@ -602,38 +834,38 @@ describe('AdvancedFilter', () => {
     wrapper.find(Button).simulate('click');
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')).toEqual([ { 'filterOption': null } ]);
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDateOption.filterOption.name });
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterEnrolledDateWithin.filterOption.name });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultDateOption ]);
-    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterDefaultDateOption.dateOption);
-    expect(wrapper.find(DateInput).at(0).prop('date')).toEqual(mockFilterDefaultDateOption.value.start);
-    expect(wrapper.find(DateInput).at(1).prop('date')).toEqual(mockFilterDefaultDateOption.value.end);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterEnrolledDateWithin ]);
+    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterEnrolledDateWithin.dateOption);
+    expect(wrapper.find(DateInput).at(0).prop('date')).toEqual(mockFilterEnrolledDateWithin.value.start);
+    expect(wrapper.find(DateInput).at(1).prop('date')).toEqual(mockFilterEnrolledDateWithin.value.end);
     wrapper.find(DateInput).at(0).simulate('change', newDate);
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')[0].dateOption).toEqual(mockFilterDefaultDateOption.dateOption);
-    expect(wrapper.state('activeFilterOptions')[0].value).toEqual({ start: newDate, end: mockFilterDefaultDateOption.value.end });
-    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterDefaultDateOption.dateOption);
+    expect(wrapper.state('activeFilterOptions')[0].dateOption).toEqual(mockFilterEnrolledDateWithin.dateOption);
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual({ start: newDate, end: mockFilterEnrolledDateWithin.value.end });
+    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterEnrolledDateWithin.dateOption);
     expect(wrapper.find(DateInput).at(0).prop('date')).toEqual(newDate);
-    expect(wrapper.find(DateInput).at(1).prop('date')).toEqual(mockFilterDefaultDateOption.value.end);
-    wrapper.find(DateInput).at(1).simulate('change', mockFilterDefaultDateOption.value.start);
+    expect(wrapper.find(DateInput).at(1).prop('date')).toEqual(mockFilterEnrolledDateWithin.value.end);
+    wrapper.find(DateInput).at(1).simulate('change', mockFilterEnrolledDateWithin.value.start);
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')[0].dateOption).toEqual(mockFilterDefaultDateOption.dateOption);
-    expect(wrapper.state('activeFilterOptions')[0].value).toEqual({ start: newDate, end: mockFilterDefaultDateOption.value.start });
-    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterDefaultDateOption.dateOption);
+    expect(wrapper.state('activeFilterOptions')[0].dateOption).toEqual(mockFilterEnrolledDateWithin.dateOption);
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual({ start: newDate, end: mockFilterEnrolledDateWithin.value.start });
+    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterEnrolledDateWithin.dateOption);
     expect(wrapper.find(DateInput).at(0).prop('date')).toEqual(newDate);
-    expect(wrapper.find(DateInput).at(1).prop('date')).toEqual(mockFilterDefaultDateOption.value.start);
-    wrapper.find(Form.Control).simulate('change', { target: { value: mockFilterDateOption.dateOption } });
+    expect(wrapper.find(DateInput).at(1).prop('date')).toEqual(mockFilterEnrolledDateWithin.value.start);
+    wrapper.find(Form.Control).simulate('change', { target: { value: mockFilterEnrolledDateBefore.dateOption } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')[0].dateOption).toEqual(mockFilterDateOption.dateOption);
-    expect(wrapper.state('activeFilterOptions')[0].value).toEqual(mockFilterDefaultDateOption.value.end);
-    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterDateOption.dateOption);
-    expect(wrapper.find(DateInput).prop('date')).toEqual(mockFilterDefaultDateOption.value.end);
-    wrapper.find(DateInput).simulate('change', mockFilterDateOption.value);
+    expect(wrapper.state('activeFilterOptions')[0].dateOption).toEqual(mockFilterEnrolledDateBefore.dateOption);
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual(mockFilterEnrolledDateWithin.value.end);
+    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterEnrolledDateBefore.dateOption);
+    expect(wrapper.find(DateInput).prop('date')).toEqual(mockFilterEnrolledDateWithin.value.end);
+    wrapper.find(DateInput).simulate('change', mockFilterEnrolledDateBefore.value);
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')[0].dateOption).toEqual(mockFilterDateOption.dateOption);
-    expect(wrapper.state('activeFilterOptions')[0].value).toEqual(mockFilterDateOption.value);
-    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterDateOption.dateOption);
-    expect(wrapper.find(DateInput).prop('date')).toEqual(mockFilterDateOption.value);
+    expect(wrapper.state('activeFilterOptions')[0].dateOption).toEqual(mockFilterEnrolledDateBefore.dateOption);
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual(mockFilterEnrolledDateBefore.value);
+    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterEnrolledDateBefore.dateOption);
+    expect(wrapper.find(DateInput).prop('date')).toEqual(mockFilterEnrolledDateBefore.value);
   });
 
   it('Changing advanced filter relativeOption and values for relative type advanced filters properly updates state and value', () => {
@@ -641,66 +873,66 @@ describe('AdvancedFilter', () => {
     wrapper.find(Button).simulate('click');
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')).toEqual([ { 'filterOption': null } ]);
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDefaultRelativeOption.filterOption.name });
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLatestReportRelativeToday.filterOption.name });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultRelativeOption ]);
-    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterDefaultRelativeOption.relativeOption);
-    wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: mockFilterRelativeOption.relativeOption } });
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterLatestReportRelativeToday ]);
+    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterLatestReportRelativeToday.relativeOption);
+    wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: mockFilterLatestReportRelativeYesterday.relativeOption } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterRelativeOption ]);
-    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterRelativeOption.relativeOption);
-    wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: mockFilterDefaultCustomRelativeOption1.relativeOption } });
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterLatestReportRelativeYesterday ]);
+    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterLatestReportRelativeYesterday.relativeOption);
+    wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: mockFilterLatestReportRelativeCustomPast.relativeOption } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultCustomRelativeOption1 ]);
-    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption1.relativeOption);
-    wrapper.find('.advanced-filter-operator-input').simulate('change', { target: { value: mockFilterCustomRelativeOption.value.operator } });
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterLatestReportRelativeCustomPast ]);
+    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterLatestReportRelativeCustomPast.relativeOption);
+    wrapper.find('.advanced-filter-operator-input').simulate('change', { target: { value: mockFilterLatestReportRelativeCustomFuture.value.operator } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')[0].relativeOption).toEqual(mockFilterCustomRelativeOption.relativeOption);
-    expect(wrapper.state('activeFilterOptions')[0].value.operator).toEqual(mockFilterCustomRelativeOption.value.operator);
-    expect(wrapper.state('activeFilterOptions')[0].value.number).toEqual(mockFilterDefaultCustomRelativeOption1.value.number);
-    expect(wrapper.state('activeFilterOptions')[0].value.unit).toEqual(mockFilterDefaultCustomRelativeOption1.value.unit);
-    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterDefaultCustomRelativeOption1.value.when);
-    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterCustomRelativeOption.relativeOption);
-    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.operator);
-    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption1.value.number);
-    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption1.value.unit);
-    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption1.value.when);
-    wrapper.find('.advanced-filter-number-input').simulate('change', { target: { value: mockFilterCustomRelativeOption.value.number } });
+    expect(wrapper.state('activeFilterOptions')[0].relativeOption).toEqual(mockFilterLatestReportRelativeCustomFuture.relativeOption);
+    expect(wrapper.state('activeFilterOptions')[0].value.operator).toEqual(mockFilterLatestReportRelativeCustomFuture.value.operator);
+    expect(wrapper.state('activeFilterOptions')[0].value.number).toEqual(mockFilterLatestReportRelativeCustomPast.value.number);
+    expect(wrapper.state('activeFilterOptions')[0].value.unit).toEqual(mockFilterLatestReportRelativeCustomPast.value.unit);
+    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterLatestReportRelativeCustomPast.value.when);
+    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterLatestReportRelativeCustomFuture.relativeOption);
+    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterLatestReportRelativeCustomFuture.value.operator);
+    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterLatestReportRelativeCustomPast.value.number);
+    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterLatestReportRelativeCustomPast.value.unit);
+    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterLatestReportRelativeCustomPast.value.when);
+    wrapper.find('.advanced-filter-number-input').simulate('change', { target: { value: mockFilterLatestReportRelativeCustomFuture.value.number } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')[0].relativeOption).toEqual(mockFilterCustomRelativeOption.relativeOption);
-    expect(wrapper.state('activeFilterOptions')[0].value.operator).toEqual(mockFilterCustomRelativeOption.value.operator);
-    expect(wrapper.state('activeFilterOptions')[0].value.number).toEqual(mockFilterCustomRelativeOption.value.number);
-    expect(wrapper.state('activeFilterOptions')[0].value.unit).toEqual(mockFilterDefaultCustomRelativeOption1.value.unit);
-    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterDefaultCustomRelativeOption1.value.when);
-    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterCustomRelativeOption.relativeOption);
-    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.operator);
-    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.number);
-    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption1.value.unit);
-    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption1.value.when);
-    wrapper.find('.advanced-filter-unit-input').simulate('change', { target: { value: mockFilterCustomRelativeOption.value.unit } });
+    expect(wrapper.state('activeFilterOptions')[0].relativeOption).toEqual(mockFilterLatestReportRelativeCustomFuture.relativeOption);
+    expect(wrapper.state('activeFilterOptions')[0].value.operator).toEqual(mockFilterLatestReportRelativeCustomFuture.value.operator);
+    expect(wrapper.state('activeFilterOptions')[0].value.number).toEqual(mockFilterLatestReportRelativeCustomFuture.value.number);
+    expect(wrapper.state('activeFilterOptions')[0].value.unit).toEqual(mockFilterLatestReportRelativeCustomPast.value.unit);
+    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterLatestReportRelativeCustomPast.value.when);
+    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterLatestReportRelativeCustomFuture.relativeOption);
+    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterLatestReportRelativeCustomFuture.value.operator);
+    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterLatestReportRelativeCustomFuture.value.number);
+    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterLatestReportRelativeCustomPast.value.unit);
+    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterLatestReportRelativeCustomPast.value.when);
+    wrapper.find('.advanced-filter-unit-input').simulate('change', { target: { value: mockFilterLatestReportRelativeCustomFuture.value.unit } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')[0].relativeOption).toEqual(mockFilterCustomRelativeOption.relativeOption);
-    expect(wrapper.state('activeFilterOptions')[0].value.operator).toEqual(mockFilterCustomRelativeOption.value.operator);
-    expect(wrapper.state('activeFilterOptions')[0].value.number).toEqual(mockFilterCustomRelativeOption.value.number);
-    expect(wrapper.state('activeFilterOptions')[0].value.unit).toEqual(mockFilterCustomRelativeOption.value.unit);
-    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterDefaultCustomRelativeOption1.value.when);
-    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterCustomRelativeOption.relativeOption);
-    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.operator);
-    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.number);
-    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.unit);
-    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterDefaultCustomRelativeOption1.value.when);
-    wrapper.find('.advanced-filter-when-input').simulate('change', { target: { value: mockFilterCustomRelativeOption.value.when } });
+    expect(wrapper.state('activeFilterOptions')[0].relativeOption).toEqual(mockFilterLatestReportRelativeCustomFuture.relativeOption);
+    expect(wrapper.state('activeFilterOptions')[0].value.operator).toEqual(mockFilterLatestReportRelativeCustomFuture.value.operator);
+    expect(wrapper.state('activeFilterOptions')[0].value.number).toEqual(mockFilterLatestReportRelativeCustomFuture.value.number);
+    expect(wrapper.state('activeFilterOptions')[0].value.unit).toEqual(mockFilterLatestReportRelativeCustomFuture.value.unit);
+    expect(wrapper.state('activeFilterOptions')[0].value.when).toEqual(mockFilterLatestReportRelativeCustomPast.value.when);
+    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterLatestReportRelativeCustomFuture.relativeOption);
+    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterLatestReportRelativeCustomFuture.value.operator);
+    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterLatestReportRelativeCustomFuture.value.number);
+    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterLatestReportRelativeCustomFuture.value.unit);
+    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterLatestReportRelativeCustomPast.value.when);
+    wrapper.find('.advanced-filter-when-input').simulate('change', { target: { value: mockFilterLatestReportRelativeCustomFuture.value.when } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterCustomRelativeOption ]);
-    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterCustomRelativeOption.relativeOption);
-    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.operator);
-    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.number);
-    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.unit);
-    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterCustomRelativeOption.value.when);
-    wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: mockFilterDefaultRelativeOption.relativeOption } });
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterLatestReportRelativeCustomFuture ]);
+    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterLatestReportRelativeCustomFuture.relativeOption);
+    expect(wrapper.find('.advanced-filter-operator-input').prop('value')).toEqual(mockFilterLatestReportRelativeCustomFuture.value.operator);
+    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterLatestReportRelativeCustomFuture.value.number);
+    expect(wrapper.find('.advanced-filter-unit-input').prop('value')).toEqual(mockFilterLatestReportRelativeCustomFuture.value.unit);
+    expect(wrapper.find('.advanced-filter-when-input').prop('value')).toEqual(mockFilterLatestReportRelativeCustomFuture.value.when);
+    wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: mockFilterLatestReportRelativeToday.relativeOption } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultRelativeOption ]);
-    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterDefaultRelativeOption.relativeOption);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterLatestReportRelativeToday ]);
+    expect(wrapper.find('.advanced-filter-relative-options').prop('value')).toEqual(mockFilterLatestReportRelativeToday.relativeOption);
   });
 
   it('Changing input text for search type advanced filter properly updates state and value', () => {
@@ -708,17 +940,17 @@ describe('AdvancedFilter', () => {
     wrapper.find(Button).simulate('click');
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')).toEqual([ { 'filterOption': null } ]);
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterSearchOption.filterOption.name });
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterAddressForeign.filterOption.name });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultSearchOption ]);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterAddressForeignEmpty ]);
     expect(wrapper.find('.advanced-filter-search-input').prop('value')).toEqual('');
-    wrapper.find('.advanced-filter-search-input').simulate('change', { target: { value: mockFilterSearchOption.value } });
+    wrapper.find('.advanced-filter-search-input').simulate('change', { target: { value: mockFilterAddressForeign.value } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterSearchOption ]);
-    expect(wrapper.find('.advanced-filter-search-input').prop('value')).toEqual(mockFilterSearchOption.value);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterAddressForeign ]);
+    expect(wrapper.find('.advanced-filter-search-input').prop('value')).toEqual(mockFilterAddressForeign.value);
     wrapper.find('.advanced-filter-search-input').simulate('change', { target: { value: '' } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultSearchOption ]);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterAddressForeignEmpty ]);
     expect(wrapper.find('.advanced-filter-search-input').prop('value')).toEqual('');
   });
 
@@ -727,35 +959,35 @@ describe('AdvancedFilter', () => {
     wrapper.find(Button).simulate('click');
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')).toEqual([ { 'filterOption': null } ]);
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterAdditionalOption.filterOption.name });
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterManualContactAttemptsLessThan.filterOption.name });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultAdditionalOption ]);
-    expect(wrapper.find('.advanced-filter-additional-filter-options').prop('value')).toEqual(mockFilterAdditionalOption.filterOption.options[0]);
-    expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual(mockFilterDefaultAdditionalOption.numberOption);
-    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterDefaultAdditionalOption.value);
-    wrapper.find('.advanced-filter-additional-filter-options').simulate('change', { target: { value: mockFilterAdditionalOption.additionalFilterOption } });
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterManualContactAttemptsEqual ]);
+    expect(wrapper.find('.advanced-filter-additional-filter-options').prop('value')).toEqual(mockFilterManualContactAttemptsLessThan.filterOption.options[0]);
+    expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual(mockFilterManualContactAttemptsEqual.numberOption);
+    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterManualContactAttemptsEqual.value);
+    wrapper.find('.advanced-filter-additional-filter-options').simulate('change', { target: { value: mockFilterManualContactAttemptsLessThan.additionalFilterOption } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')[0].additionalFilterOption).toEqual(mockFilterAdditionalOption.additionalFilterOption);
-    expect(wrapper.state('activeFilterOptions')[0].numberOption).toEqual(mockFilterDefaultAdditionalOption.numberOption);
-    expect(wrapper.state('activeFilterOptions')[0].value).toEqual(mockFilterDefaultAdditionalOption.value);
-    expect(wrapper.find('.advanced-filter-additional-filter-options').prop('value')).toEqual(mockFilterAdditionalOption.additionalFilterOption);
-    expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual(mockFilterDefaultAdditionalOption.numberOption);
-    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterDefaultAdditionalOption.value);
+    expect(wrapper.state('activeFilterOptions')[0].additionalFilterOption).toEqual(mockFilterManualContactAttemptsLessThan.additionalFilterOption);
+    expect(wrapper.state('activeFilterOptions')[0].numberOption).toEqual(mockFilterManualContactAttemptsEqual.numberOption);
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual(mockFilterManualContactAttemptsEqual.value);
+    expect(wrapper.find('.advanced-filter-additional-filter-options').prop('value')).toEqual(mockFilterManualContactAttemptsLessThan.additionalFilterOption);
+    expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual(mockFilterManualContactAttemptsEqual.numberOption);
+    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterManualContactAttemptsEqual.value);
     wrapper.find('.advanced-filter-number-input').simulate('change', { target: { value: 2 } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')[0].additionalFilterOption).toEqual(mockFilterAdditionalOption.additionalFilterOption);
-    expect(wrapper.state('activeFilterOptions')[0].numberOption).toEqual(mockFilterDefaultAdditionalOption.numberOption);
+    expect(wrapper.state('activeFilterOptions')[0].additionalFilterOption).toEqual(mockFilterManualContactAttemptsLessThan.additionalFilterOption);
+    expect(wrapper.state('activeFilterOptions')[0].numberOption).toEqual(mockFilterManualContactAttemptsEqual.numberOption);
     expect(wrapper.state('activeFilterOptions')[0].value).toEqual(2);
-    expect(wrapper.find('.advanced-filter-additional-filter-options').prop('value')).toEqual(mockFilterAdditionalOption.additionalFilterOption);
-    expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual(mockFilterDefaultAdditionalOption.numberOption);
+    expect(wrapper.find('.advanced-filter-additional-filter-options').prop('value')).toEqual(mockFilterManualContactAttemptsLessThan.additionalFilterOption);
+    expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual(mockFilterManualContactAttemptsEqual.numberOption);
     expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(2);
     wrapper.find('.advanced-filter-additional-filter-options').simulate('change', { target: { value: 'Unsuccessful' } });
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('activeFilterOptions')[0].additionalFilterOption).toEqual('Unsuccessful');
-    expect(wrapper.state('activeFilterOptions')[0].numberOption).toEqual(mockFilterDefaultAdditionalOption.numberOption);
+    expect(wrapper.state('activeFilterOptions')[0].numberOption).toEqual(mockFilterManualContactAttemptsEqual.numberOption);
     expect(wrapper.state('activeFilterOptions')[0].value).toEqual(2);
     expect(wrapper.find('.advanced-filter-additional-filter-options').prop('value')).toEqual('Unsuccessful');
-    expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual(mockFilterDefaultAdditionalOption.numberOption);
+    expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual(mockFilterManualContactAttemptsEqual.numberOption);
     expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(2);
     wrapper.find('.advanced-filter-number-options').simulate('change', { target: { value: 'less-than' } });
     expect(wrapper.state('activeFilter')).toEqual(null);
@@ -765,18 +997,18 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find('.advanced-filter-additional-filter-options').prop('value')).toEqual('Unsuccessful');
     expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual('less-than');
     expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(2);
-    wrapper.find('.advanced-filter-additional-filter-options').simulate('change', { target: { value: mockFilterAdditionalOption.additionalFilterOption } });
+    wrapper.find('.advanced-filter-additional-filter-options').simulate('change', { target: { value: mockFilterManualContactAttemptsLessThan.additionalFilterOption } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterAdditionalOption ]);
-    expect(wrapper.find('.advanced-filter-additional-filter-options').prop('value')).toEqual(mockFilterAdditionalOption.additionalFilterOption);
-    expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual(mockFilterAdditionalOption.numberOption);
-    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterAdditionalOption.value);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterManualContactAttemptsLessThan ]);
+    expect(wrapper.find('.advanced-filter-additional-filter-options').prop('value')).toEqual(mockFilterManualContactAttemptsLessThan.additionalFilterOption);
+    expect(wrapper.find('.advanced-filter-number-options').prop('value')).toEqual(mockFilterManualContactAttemptsLessThan.numberOption);
+    expect(wrapper.find('.advanced-filter-number-input').prop('value')).toEqual(mockFilterManualContactAttemptsLessThan.value);
   });
 
   it('Relative date with timestamp custom tooltip dynamically updates as options change', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDefaultCustomRelativeOption1.filterOption.name });
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLatestReportRelativeCustomPast.filterOption.name });
     expect(wrapper.find(ReactTooltip).exists()).toBeFalsy();
     wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: 'custom' } });
     expect(wrapper.find(ReactTooltip).exists()).toBeTruthy(); 
@@ -794,7 +1026,7 @@ describe('AdvancedFilter', () => {
   it('Relative date without timestamp custom tooltip dynamically updates as options change', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDefaultCustomRelativeOption2.filterOption.name });
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterSymptomOnsetRelativeCustomPast.filterOption.name });
     expect(wrapper.find(ReactTooltip).exists()).toBeFalsy();
     wrapper.find('.advanced-filter-relative-options').simulate('change', { target: { value: 'custom' } });
     expect(wrapper.find(ReactTooltip).exists()).toBeTruthy(); 
@@ -900,25 +1132,25 @@ describe('AdvancedFilter', () => {
   it('Opening Filter Name modal and clicking "Cancel" button maintains advanced filter modal state', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterSearchOption.filterOption.name });
-    wrapper.find('.advanced-filter-search-input').simulate('change', { target: { value: mockFilterSearchOption.value } });
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterAddressForeign.filterOption.name });
+    wrapper.find('.advanced-filter-search-input').simulate('change', { target: { value: mockFilterAddressForeign.value } });
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterSearchOption ]);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterAddressForeign ]);
     expect(wrapper.state('showAdvancedFilterModal')).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterSearchOption.filterOption.name);
-    expect(wrapper.find('.advanced-filter-search-input').prop('value')).toEqual(mockFilterSearchOption.value);
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterAddressForeign.filterOption.name);
+    expect(wrapper.find('.advanced-filter-search-input').prop('value')).toEqual(mockFilterAddressForeign.value);
     wrapper.find('#advanced-filter-save').simulate('click');
     expect(wrapper.state('showAdvancedFilterModal')).toBeFalsy();
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterSearchOption ]);
-    expect(wrapper.find('.advanced-filter-select').exists()).toBeFalsy();
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterAddressForeign ]);
+    expect(wrapper.find('.advanced-filter-options-dropdown').exists()).toBeFalsy();
     expect(wrapper.find('.advanced-filter-search-input').exists()).toBeFalsy();
     wrapper.find('#filter-name-cancel').simulate('click');
     expect(wrapper.state('showAdvancedFilterModal')).toBeTruthy();
     expect(wrapper.state('activeFilter')).toEqual(null);
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterSearchOption ]);
-    expect(wrapper.find('.advanced-filter-select').prop('value').value).toEqual(mockFilterSearchOption.filterOption.name);
-    expect(wrapper.find('.advanced-filter-search-input').prop('value')).toEqual(mockFilterSearchOption.value);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterAddressForeign ]);
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterAddressForeign.filterOption.name);
+    expect(wrapper.find('.advanced-filter-search-input').prop('value')).toEqual(mockFilterAddressForeign.value);
   });
 
   it('Clicking Filter Name modal "Save" button calls save method', () => {
@@ -1063,14 +1295,14 @@ describe('AdvancedFilter', () => {
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('lastAppliedFilter')).toEqual(null);
     expect(wrapper.find(Form.Control).exists()).toBeFalsy();
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterSearchOption.filterOption.name });
-    wrapper.find('.advanced-filter-search-input').simulate('change', { target: { value: mockFilterSearchOption.value } });
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterAddressForeign.filterOption.name });
+    wrapper.find('.advanced-filter-search-input').simulate('change', { target: { value: mockFilterAddressForeign.value } });
     expect(wrapper.state('applied')).toBeFalsy();
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterSearchOption ]);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterAddressForeign ]);
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('lastAppliedFilter')).toEqual(null);
     expect(wrapper.find(Form.Control).exists()).toBeTruthy();
-    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterSearchOption.value);
+    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterAddressForeign.value);
     wrapper.find('#advanced-filter-cancel').simulate('click');
     wrapper.find(Button).simulate('click');
     expect(wrapper.state('applied')).toBeFalsy();
@@ -1083,9 +1315,9 @@ describe('AdvancedFilter', () => {
   it('Clicking "Cancel" button after making changes properly resets modal to the most recent filter applied', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterDefaultBoolOption.filterOption.name });
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterMonitoringStatusTrue.filterOption.name });
     expect(wrapper.state('applied')).toBeFalsy();
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultBoolOption ]);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterMonitoringStatusTrue ]);
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('lastAppliedFilter')).toEqual(null);
     expect(wrapper.find(ToggleButton).at(0).prop('checked')).toBeTruthy();
@@ -1093,59 +1325,59 @@ describe('AdvancedFilter', () => {
     wrapper.find('#advanced-filter-apply').simulate('click');
     wrapper.find(Button).simulate('click');
     expect(wrapper.state('applied')).toBeTruthy();
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultBoolOption ]);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterMonitoringStatusTrue ]);
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('lastAppliedFilter').activeFilter).toEqual(null);
-    expect(wrapper.state('lastAppliedFilter').activeFilterOptions).toEqual([ mockFilterDefaultBoolOption ]);
+    expect(wrapper.state('lastAppliedFilter').activeFilterOptions).toEqual([ mockFilterMonitoringStatusTrue ]);
     expect(wrapper.find(ToggleButton).at(0).prop('checked')).toBeTruthy();
     expect(wrapper.find(ToggleButton).at(1).prop('checked')).toBeFalsy();
     wrapper.find('.advanced-filter-boolean-false').simulate('change');
     expect(wrapper.state('applied')).toBeTruthy();
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterBoolOption ]);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterMonitoringStatusFalse ]);
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('lastAppliedFilter').activeFilter).toEqual(null);
-    expect(wrapper.state('lastAppliedFilter').activeFilterOptions).toEqual([ mockFilterDefaultBoolOption ]);
+    expect(wrapper.state('lastAppliedFilter').activeFilterOptions).toEqual([ mockFilterMonitoringStatusTrue ]);
     expect(wrapper.find(ToggleButton).at(0).prop('checked')).toBeFalsy();
     expect(wrapper.find(ToggleButton).at(1).prop('checked')).toBeTruthy();
     wrapper.find('#advanced-filter-cancel').simulate('click');
     wrapper.find(Button).simulate('click');
     expect(wrapper.state('applied')).toBeTruthy();
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterDefaultBoolOption ]);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterMonitoringStatusTrue ]);
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('lastAppliedFilter').activeFilter).toEqual(null);
-    expect(wrapper.state('lastAppliedFilter').activeFilterOptions).toEqual([ mockFilterDefaultBoolOption ]);
+    expect(wrapper.state('lastAppliedFilter').activeFilterOptions).toEqual([ mockFilterMonitoringStatusTrue ]);
     expect(wrapper.find(ToggleButton).at(0).prop('checked')).toBeTruthy();
     expect(wrapper.find(ToggleButton).at(1).prop('checked')).toBeFalsy();
-    wrapper.find('.advanced-filter-select').simulate('change', { value: mockFilterSearchOption.filterOption.name });
-    wrapper.find('.advanced-filter-search-input').simulate('change', { target: { value: mockFilterSearchOption.value } });
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterAddressForeign.filterOption.name });
+    wrapper.find('.advanced-filter-search-input').simulate('change', { target: { value: mockFilterAddressForeign.value } });
     expect(wrapper.state('applied')).toBeTruthy();
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterSearchOption ]);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterAddressForeign ]);
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('lastAppliedFilter').activeFilter).toEqual(null);
-    expect(wrapper.state('lastAppliedFilter').activeFilterOptions).toEqual([ mockFilterDefaultBoolOption ]);
-    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterSearchOption.value);
+    expect(wrapper.state('lastAppliedFilter').activeFilterOptions).toEqual([ mockFilterMonitoringStatusTrue ]);
+    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterAddressForeign.value);
     wrapper.find('#advanced-filter-apply').simulate('click');
     wrapper.find(Button).simulate('click');
     expect(wrapper.state('applied')).toBeTruthy();
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterSearchOption ]);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterAddressForeign ]);
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('lastAppliedFilter').activeFilter).toEqual(null);
-    expect(wrapper.state('lastAppliedFilter').activeFilterOptions).toEqual([ mockFilterSearchOption ]);
-    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterSearchOption.value);
-    wrapper.find('.advanced-filter-search-input').simulate('change', { target: { value: `${mockFilterSearchOption.value}!!!` } });
+    expect(wrapper.state('lastAppliedFilter').activeFilterOptions).toEqual([ mockFilterAddressForeign ]);
+    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterAddressForeign.value);
+    wrapper.find('.advanced-filter-search-input').simulate('change', { target: { value: `${mockFilterAddressForeign.value}!!!` } });
     expect(wrapper.state('applied')).toBeTruthy();
-    expect(wrapper.state('activeFilterOptions')[0].value).toEqual(`${mockFilterSearchOption.value}!!!`);
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual(`${mockFilterAddressForeign.value}!!!`);
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('lastAppliedFilter').activeFilter).toEqual(null);
-    expect(wrapper.state('lastAppliedFilter').activeFilterOptions).toEqual([ mockFilterSearchOption ]);
-    expect(wrapper.find(Form.Control).prop('value')).toEqual(`${mockFilterSearchOption.value}!!!`);
+    expect(wrapper.state('lastAppliedFilter').activeFilterOptions).toEqual([ mockFilterAddressForeign ]);
+    expect(wrapper.find(Form.Control).prop('value')).toEqual(`${mockFilterAddressForeign.value}!!!`);
     wrapper.find('#advanced-filter-cancel').simulate('click');
     wrapper.find(Button).simulate('click');
     expect(wrapper.state('applied')).toBeTruthy();
-    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterSearchOption ]);
+    expect(wrapper.state('activeFilterOptions')).toEqual([ mockFilterAddressForeign ]);
     expect(wrapper.state('activeFilter')).toEqual(null);
     expect(wrapper.state('lastAppliedFilter').activeFilter).toEqual(null);
-    expect(wrapper.state('lastAppliedFilter').activeFilterOptions).toEqual([ mockFilterSearchOption ]);
-    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterSearchOption.value);
+    expect(wrapper.state('lastAppliedFilter').activeFilterOptions).toEqual([ mockFilterAddressForeign ]);
+    expect(wrapper.find(Form.Control).prop('value')).toEqual(mockFilterAddressForeign.value);
   });
 });

--- a/app/javascript/tests/public_health/query/AdvancedFilter.test.js
+++ b/app/javascript/tests/public_health/query/AdvancedFilter.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import _ from 'lodash';
 import moment from 'moment';
 import ReactTooltip from 'react-tooltip';
-import { Button, ButtonGroup, Dropdown, Form, Modal, OverlayTrigger, ToggleButton } from 'react-bootstrap';
+import { Button, ButtonGroup, Col, Dropdown, Form, Modal, OverlayTrigger, ToggleButton } from 'react-bootstrap';
 import AdvancedFilter from '../../../components/public_health/query/AdvancedFilter';
 import DateInput from '../../../components/util/DateInput';
 import { advancedFilterOptions } from '../../../data/advancedFilterOptions';
@@ -525,7 +525,9 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find('.advanced-filter-multi-type-statement').find(Button).at(1).find('i').hasClass('fa-minus')).toBeTruthy();
     expect(wrapper.find('.advanced-filter-additional-filter-options').exists()).toBeFalsy();
     expect(wrapper.find(ReactTooltip).exists()).toBeTruthy();
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(mockFilterLabResults.filterOption.tooltip);
+    expect(wrapper.find(ReactTooltip).length).toEqual(2);
+    expect(wrapper.find(ReactTooltip).at(0).find('span').text()).toEqual('Select to add multiple Lab Result search criteria.');
+    expect(wrapper.find(ReactTooltip).at(1).find('span').text()).toEqual(mockFilterLabResults.filterOption.tooltip);
   });
 
   it('Properly renders select option of advanced filter multi type statement', () => {
@@ -571,10 +573,12 @@ describe('AdvancedFilter', () => {
     _.times(mockFilterLabResults.filterOption.fields.length-1, (i) => {
       expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(i+1);
       expect(wrapper.find('.and-row').length).toEqual(i);
+      expect(wrapper.find('#lab-result-0-multi-add').exists()).toBeTruthy();
       wrapper.find('.btn-circle').simulate('click');
     });
     expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(mockFilterLabResults.filterOption.fields.length);
     expect(wrapper.find('.and-row').length).toEqual(mockFilterLabResults.filterOption.fields.length-1);
+    expect(wrapper.find('#lab-result-0-multi-add').exists()).toBeFalsy();
   });
 
   it('Adding additional fields to multi filter does not allow for repeats', () => {

--- a/test/helpers/patient_query_helper_test.rb
+++ b/test/helpers/patient_query_helper_test.rb
@@ -3,6 +3,38 @@
 require 'test_case'
 
 class PatientQueryHelperTest < ActionView::TestCase
+  # BOOLEAN ADVANCED FILTER QUERIES
+
+  test 'advanced filter blocked sms properly filters those with blocked numbers' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user, primary_telephone: '1111111111')
+    patient_2 = create(:patient, creator: user, primary_telephone: '2222222222')
+    patient_3 = create(:patient, creator: user, primary_telephone: '3333333333')
+    BlockedNumber.destroy_all
+    BlockedNumber.create(phone_number: '1111111111')
+    BlockedNumber.create(phone_number: '2222222222')
+    patients = Patient.all
+
+    filters = [{ filterOption: {}, additionalFilterOption: nil, value: nil }]
+    filters[0][:filterOption]['name'] = 'sms-blocked'
+    tz_offset = 300
+
+    # Check for monitorees who have blocked the system
+    filters[0][:value] = true
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+
+    # Check for monitorees who have NOT blocked the system
+    filters[0][:value] = false
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_3]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  # SEARCH ADVANCED FILTER QUERIES
+
   test 'advanced filter close contact with known case id exact match single value' do
     Patient.destroy_all
     user = create(:public_health_enroller_user)
@@ -106,31 +138,304 @@ class PatientQueryHelperTest < ActionView::TestCase
     assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
   end
 
-  test 'advanced filter blocked sms properly filters those with blocked numbers' do
+  # MULTI ADVANCED FILTER QUERIES
+
+  test 'advanced filter laboratory single filter option results' do
     Patient.destroy_all
     user = create(:public_health_enroller_user)
-    patient_1 = create(:patient, creator: user, primary_telephone: '1111111111')
-    patient_2 = create(:patient, creator: user, primary_telephone: '2222222222')
-    patient_3 = create(:patient, creator: user, primary_telephone: '3333333333')
-    BlockedNumber.destroy_all
-    BlockedNumber.create(phone_number: '1111111111')
-    BlockedNumber.create(phone_number: '2222222222')
+    patient_1 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_1, result: 'positive')
+    create(:laboratory, patient: patient_1, result: 'negative')
+    patient_2 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_2, result: 'negative')
+    patient_3 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_3, result: 'indeterminate')
+    patient_4 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_4, result: 'positive')
+    patient_5 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_5, result: 'negative')
+    create(:laboratory, patient: patient_5, result: 'indeterminate')
+    patient_6 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_6, result: 'positive')
+    create(:laboratory, patient: patient_6, result: 'positive')
+    create(:patient, creator: user)
+
     patients = Patient.all
-
-    filters = [{ filterOption: {}, additionalFilterOption: nil, value: nil }]
-    filters[0][:filterOption]['name'] = 'sms-blocked'
+    filters = [{ filterOption: {}, value: [{ name: 'result', value: 'positive' }] }]
+    filters[0][:filterOption]['name'] = 'lab-result'
     tz_offset = 300
-
-    # Check for monitorees who have blocked the system
-    filters[0][:value] = true
     filtered_patients = advanced_filter(patients, filters, tz_offset)
-    filtered_patients_array = [patient_1, patient_2]
+    filtered_patients_array = [patient_1, patient_4, patient_6]
     assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
 
-    # Check for monitorees who have NOT blocked the system
-    filters[0][:value] = false
+  test 'advanced filter laboratory single filter option test type' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_1, lab_type: 'PCR')
+    create(:laboratory, patient: patient_1, lab_type: 'Antigen')
+    patient_2 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_2, lab_type: 'Antigen')
+    patient_3 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_3, lab_type: 'Total Antibody')
+    patient_4 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_4, lab_type: 'PCR')
+    patient_5 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_5, lab_type: 'Total Antibody')
+    create(:laboratory, patient: patient_5, lab_type: 'Other')
+    patient_6 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_6, lab_type: 'PCR')
+    create(:laboratory, patient: patient_6, lab_type: 'PCR')
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filters = [{ filterOption: {}, value: [{ name: 'lab-type', value: 'PCR' }] }]
+    filters[0][:filterOption]['name'] = 'lab-result'
+    tz_offset = 300
     filtered_patients = advanced_filter(patients, filters, tz_offset)
-    filtered_patients_array = [patient_3]
+    filtered_patients_array = [patient_1, patient_4, patient_6]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter laboratory single filter option specimen collection date' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_1, specimen_collection: DateTime.new(2021, 3, 1))
+    create(:laboratory, patient: patient_1, specimen_collection: DateTime.new(2021, 4, 1))
+    patient_2 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_2, specimen_collection: DateTime.new(2021, 3, 24))
+    patient_3 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_3, specimen_collection: DateTime.new(2021, 3, 25))
+    patient_4 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_4, specimen_collection: DateTime.new(2021, 3, 26))
+    patient_5 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_5, specimen_collection: DateTime.new(2021, 3, 1))
+    create(:laboratory, patient: patient_5, specimen_collection: DateTime.new(2021, 3, 15))
+    patient_6 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_6, specimen_collection: DateTime.new(2021, 4, 1))
+    create(:laboratory, patient: patient_6, specimen_collection: DateTime.new(2021, 4, 3))
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filters = [{ filterOption: {}, value: [{ name: 'specimen-collection', value: { when: 'before', date: '2021-03-25' } }] }]
+    filters[0][:filterOption]['name'] = 'lab-result'
+    tz_offset = 300
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2, patient_5]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter laboratory single filter option report date' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_1, report: DateTime.new(2021, 3, 1))
+    create(:laboratory, patient: patient_1, report: DateTime.new(2021, 4, 1))
+    patient_2 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_2, report: DateTime.new(2021, 3, 24))
+    patient_3 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_3, report: DateTime.new(2021, 3, 25))
+    patient_4 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_4, report: DateTime.new(2021, 3, 26))
+    patient_5 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_5, report: DateTime.new(2021, 3, 1))
+    create(:laboratory, patient: patient_5, report: DateTime.new(2021, 3, 15))
+    patient_6 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_6, report: DateTime.new(2021, 4, 1))
+    create(:laboratory, patient: patient_6, report: DateTime.new(2021, 4, 3))
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filters = [{ filterOption: {}, value: [{ name: 'report', value: { when: 'after', date: '2021-03-25' } }] }]
+    filters[0][:filterOption]['name'] = 'lab-result'
+    tz_offset = 300
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_4, patient_6]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter laboratory single filter option muliple values' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_1, result: 'positive', lab_type: 'PCR')
+    create(:laboratory, patient: patient_1, result: 'positive', lab_type: 'Antigen')
+    patient_2 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_2, result: 'positive', lab_type: 'Antigen')
+    patient_3 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_3, result: 'positive', lab_type: 'Total Antibody')
+    patient_4 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_4, result: 'negative', lab_type: 'PCR')
+    patient_5 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_5, result: 'positive', lab_type: 'PCR')
+    create(:laboratory, patient: patient_5, result: 'positive', lab_type: 'PCR')
+    create(:laboratory, patient: patient_5, result: 'negative', lab_type: 'PCR')
+    create(:laboratory, patient: patient_5, result: 'positive', lab_type: 'Antigen')
+    patient_6 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_6, result: 'negative', lab_type: 'PCR')
+    create(:laboratory, patient: patient_6, result: 'positive', lab_type: 'Antigen')
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filters = [{ filterOption: {}, value: [{ name: 'result', value: 'positive' }, { name: 'lab-type', value: 'PCR' }] }]
+    filters[0][:filterOption]['name'] = 'lab-result'
+    tz_offset = 300
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_5]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter laboratory single filter option all values' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_1, result: 'positive', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 24),
+                        report: DateTime.new(2021, 3, 26))
+    create(:laboratory, patient: patient_1, result: 'positive', lab_type: 'Antigen', specimen_collection: DateTime.new(2021, 3, 15),
+                        report: DateTime.new(2021, 3, 18))
+    patient_2 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_2, result: 'positive', lab_type: 'Antigen', specimen_collection: DateTime.new(2021, 3, 15),
+                        report: DateTime.new(2021, 3, 28))
+    patient_3 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_3, result: 'positive', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 15),
+                        report: DateTime.new(2021, 3, 18))
+    patient_4 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_4, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 15),
+                        report: DateTime.new(2021, 3, 28))
+    patient_5 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_5, result: 'positive', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 24),
+                        report: DateTime.new(2021, 3, 26))
+    create(:laboratory, patient: patient_5, result: 'positive', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 1),
+                        report: DateTime.new(2021, 4, 1))
+    create(:laboratory, patient: patient_5, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 1),
+                        report: DateTime.new(2021, 3, 4))
+    create(:laboratory, patient: patient_5, result: 'positive', lab_type: 'Antigen', specimen_collection: DateTime.new(2021, 3, 15),
+                        report: DateTime.new(2021, 3, 16))
+    patient_6 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_6, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 24),
+                        report: DateTime.new(2021, 3, 26))
+    create(:laboratory, patient: patient_6, result: 'positive', lab_type: 'Antigen', specimen_collection: DateTime.new(2021, 3, 24),
+                        report: DateTime.new(2021, 3, 26))
+    create(:laboratory, patient: patient_6, result: 'positive', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 25),
+                        report: DateTime.new(2021, 3, 26))
+    create(:laboratory, patient: patient_6, result: 'positive', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 24),
+                        report: DateTime.new(2021, 3, 25))
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filters = [{ filterOption: {},
+                 value: [{ name: 'result', value: 'positive' }, { name: 'lab-type', value: 'PCR' },
+                         { name: 'specimen-collection', value: { when: 'before', date: '2021-03-25' } },
+                         { name: 'report', value: { when: 'after', date: '2021-03-25' } }] }]
+    filters[0][:filterOption]['name'] = 'lab-result'
+    tz_offset = 300
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_5]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter laboratory multiple filter options some values' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_1, result: 'positive', lab_type: 'PCR')
+    create(:laboratory, patient: patient_1, result: 'positive', lab_type: 'Antigen')
+    patient_2 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_2, result: 'positive', lab_type: 'Antigen')
+    patient_3 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_3, result: 'negative', lab_type: 'Antigen')
+    patient_4 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_4, result: 'positive', lab_type: 'PCR')
+    patient_5 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_5, result: 'negative', lab_type: 'PCR')
+    patient_6 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_6, result: 'positive', lab_type: 'PCR')
+    create(:laboratory, patient: patient_6, result: 'positive', lab_type: 'PCR')
+    create(:laboratory, patient: patient_6, result: 'negative', lab_type: 'PCR')
+    create(:laboratory, patient: patient_6, result: 'positive', lab_type: 'Antigen')
+    create(:laboratory, patient: patient_6, result: 'negative', lab_type: 'Antigen')
+    patient_7 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_7, result: 'positive', lab_type: 'PCR')
+    create(:laboratory, patient: patient_7, result: 'negative', lab_type: 'PCR')
+    create(:laboratory, patient: patient_7, result: 'negative', lab_type: 'Antigen')
+    patient_8 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_8, result: 'negative', lab_type: 'PCR')
+    create(:laboratory, patient: patient_8, result: 'negative', lab_type: 'Antigen')
+    create(:laboratory, patient: patient_8, result: 'positive', lab_type: 'Antigen')
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filter_option_1 = { filterOption: {}, value: [{ name: 'result', value: 'positive' }, { name: 'lab-type', value: 'PCR' }] }
+    filter_option_2 = { filterOption: {}, value: [{ name: 'result', value: 'positive' }, { name: 'lab-type', value: 'Antigen' }] }
+    filter_option_1[:filterOption]['name'] = 'lab-result'
+    filter_option_2[:filterOption]['name'] = 'lab-result'
+    filters = [filter_option_1, filter_option_2]
+    tz_offset = 300
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_6]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter laboratory multiple filter options all values' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_1, result: 'positive', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 24),
+                        report: DateTime.new(2021, 3, 26))
+    create(:laboratory, patient: patient_1, result: 'negative', lab_type: 'Antigen', specimen_collection: DateTime.new(2021, 3, 15),
+                        report: DateTime.new(2021, 3, 18))
+    create(:laboratory, patient: patient_1, result: 'indeterminate', lab_type: 'Antigen', specimen_collection: DateTime.new(2021, 3, 5),
+                        report: DateTime.new(2021, 3, 28))
+    patient_2 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_2, result: 'positive', lab_type: 'Antigen', specimen_collection: DateTime.new(2021, 3, 15),
+                        report: DateTime.new(2021, 3, 18))
+    patient_3 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_3, result: 'positive', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 1),
+                        report: DateTime.new(2021, 3, 3))
+    patient_4 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_4, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 15),
+                        report: DateTime.new(2021, 3, 18))
+    patient_5 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_5, result: 'positive', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 24),
+                        report: DateTime.new(2021, 3, 26))
+    create(:laboratory, patient: patient_5, result: 'positive', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 1),
+                        report: DateTime.new(2021, 4, 1))
+    create(:laboratory, patient: patient_5, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 1),
+                        report: DateTime.new(2021, 3, 4))
+    create(:laboratory, patient: patient_5, result: 'indeterminate', lab_type: 'Antigen', specimen_collection: DateTime.new(2021, 3, 15),
+                        report: DateTime.new(2021, 3, 16))
+    create(:laboratory, patient: patient_5, result: 'positive', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 25),
+                        report: DateTime.new(2021, 3, 26))
+    create(:laboratory, patient: patient_5, result: 'positive', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 24),
+                        report: DateTime.new(2021, 3, 25))
+    patient_6 = create(:patient, creator: user)
+    create(:laboratory, patient: patient_6, result: 'positive', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 24),
+                        report: DateTime.new(2021, 3, 26))
+    create(:laboratory, patient: patient_6, result: 'indeterminate', lab_type: 'Antigen', specimen_collection: DateTime.new(2021, 3, 24),
+                        report: DateTime.new(2021, 3, 26))
+    create(:laboratory, patient: patient_6, result: 'positive', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 25),
+                        report: DateTime.new(2021, 3, 26))
+    create(:laboratory, patient: patient_6, result: 'positive', lab_type: 'PCR', specimen_collection: DateTime.new(2021, 3, 24),
+                        report: DateTime.new(2021, 3, 25))
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filter_option_1 = { filterOption: {},
+                        value: [{ name: 'result', value: 'positive' }, { name: 'lab-type', value: 'PCR' },
+                                { name: 'specimen-collection', value: { when: 'before', date: '2021-03-25' } },
+                                { name: 'report', value: { when: 'after', date: '2021-03-25' } }] }
+    filter_option_2 = { filterOption: {},
+                        value: [{ name: 'result', value: 'indeterminate' }, { name: 'lab-type', value: 'Antigen' },
+                                { name: 'specimen-collection', value: { when: 'before', date: '2021-03-25' } },
+                                { name: 'report', value: { when: 'after', date: '2021-03-25' } }] }
+    filter_option_1[:filterOption]['name'] = 'lab-result'
+    filter_option_2[:filterOption]['name'] = 'lab-result'
+    filters = [filter_option_1, filter_option_2]
+    tz_offset = 300
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_6]
     assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
   end
 end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1055](https://tracker.codev.mitre.org/browse/SARAALERT-1055)

Adds support for filtering monitorees by different lab result fields (result, test type, collection date and report date).  This included adding support for a new advanced filter type, "multi-select".  See the JIRA ticket for mockups for the type.  The multi type is intended to support multiple fields using an "and".  It does not allow for the same field to be selected twice within the multi filter.

When testing, here is something to note.  When combining filters within one multi lab statement, a monitoree will be returned IF they have one lab that meets all of the fields.  For example...

This will return monitorees that have at least one positive PCR test

<img width="909" alt="Screen Shot 2021-04-14 at 6 53 49 PM" src="https://user-images.githubusercontent.com/35042815/114791139-fac51b00-9d53-11eb-807d-40362e1688da.png">

While this will return monitorees that have at least one positive test and at least one PCR test, but they do NOT need to be the same test

<img width="917" alt="Screen Shot 2021-04-14 at 6 54 12 PM" src="https://user-images.githubusercontent.com/35042815/114791181-103a4500-9d54-11eb-8395-bb25f1c3d0b7.png">

## (Feature) Demo/Screenshots
https://user-images.githubusercontent.com/35042815/114791026-bcc7f700-9d53-11eb-9527-6db2dbf12d16.mov

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`AdvancedFilter.js`
- Added new advanced filter type multi

`patient_query_helper.rb`
- Added backend support for filtering by labs

`user_filters_controller.rb`
- Updated permitted params when saving filters

`advancedFilterOptions.js`
- Added lab results filter option including all supported fields for the multi type

`patient_query_helper_test.rb`
- Added backend query tests for new lab results advanced filter

`AdvancedFilter.test.js`
- Added tests for multi type statement rendering, disabling, state updates, etc.

`mockFilters.js`
- Updated naming scheme for mock filters to make more sense when navigating the test file
- Added a lab results mock to this file

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@holmesie  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@timwongj  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@DPC15038   :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
