### PR TITLE
Temporarily revert first positive lab changes

### DIFF
--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -262,7 +262,8 @@ class Exposure extends React.Component {
               .toDate(),
             'Date can not be more than 30 days in the future.'
           )
-          .required('Please enter a Symptom Onset Date OR select No Reported Symptoms and enter a first positive lab result')
+          .required('Please enter a Symptom Onset Date') // NOTE: replace this line with the commented out line below when first positive lab is enabled
+          // .required('Please enter a Symptom Onset Date OR select No Reported Symptoms and enter a first positive lab result')
           .nullable(),
         no_reported_symptoms: yup.bool().nullable(),
       });
@@ -405,7 +406,7 @@ class Exposure extends React.Component {
               {this.state.errors['case_status']}
             </Form.Control.Feedback>
           </Form.Group>
-          <Form.Group as={Col} lg={{ span: 8, order: 3 }} className="mb-0"></Form.Group>
+          {/* <Form.Group as={Col} lg={{ span: 8, order: 3 }} className="mb-0"></Form.Group>
           <Form.Group
             as={Col}
             lg={{ span: 8, order: 4 }}
@@ -493,8 +494,9 @@ class Exposure extends React.Component {
                 </Form.Control.Feedback>
               </div>
             )}
-          </Form.Group>
+          </Form.Group> */}
         </Form.Row>
+        <div className="py-1" /> {/* NOTE: Remove this extra padding when first positive lab is enabled */}
         <Form.Row>
           <Form.Group as={Col} md="24" className="mb-2">
             <Form.Label htmlFor="exposure_notes" className="nav-input-label ml-1">

--- a/app/javascript/components/patient/Patient.js
+++ b/app/javascript/components/patient/Patient.js
@@ -652,7 +652,8 @@ class Patient extends React.Component {
                       <b>Symptom Onset: </b>
                       <span>
                         {this.props.details.symptom_onset ? moment(this.props.details.symptom_onset, 'YYYY-MM-DD').format('MM/DD/YYYY') : '--'}
-                        {/* : 'No symptoms reported'} */} {/* NOTE: Replace the above line with this when first positive lab is enabled */}
+                        {/* : 'No symptoms reported'} */}
+                        {/* NOTE: Replace the above line with this when first positive lab is enabled */}
                       </span>
                     </div>
                   </div>

--- a/app/javascript/components/patient/Patient.js
+++ b/app/javascript/components/patient/Patient.js
@@ -651,9 +651,8 @@ class Patient extends React.Component {
                     <div>
                       <b>Symptom Onset: </b>
                       <span>
-                        {this.props.details.symptom_onset
-                          ? moment(this.props.details.symptom_onset, 'YYYY-MM-DD').format('MM/DD/YYYY')
-                          : 'No symptoms reported'}
+                        {this.props.details.symptom_onset ? moment(this.props.details.symptom_onset, 'YYYY-MM-DD').format('MM/DD/YYYY') : '--'}
+                        {/* : 'No symptoms reported'} */} {/* NOTE: Replace the above line with this when first positive lab is enabled */}
                       </span>
                     </div>
                   </div>

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -484,7 +484,9 @@ class PatientsTable extends React.Component {
   };
 
   formatSymptomOnset = data => {
-    return data?.value ? formatDate(data.value) : 'None reported';
+    return data?.value ? formatDate(data.value) : '';
+    // NOTE: Replace the above line with the line below when first positive lab is enabled
+    // return data?.value ? formatDate(data.value) : 'None reported';
   };
 
   formatLatestReport = data => {

--- a/app/lib/import_export_constants.rb
+++ b/app/lib/import_export_constants.rb
@@ -270,7 +270,8 @@ module ImportExportConstants # rubocop:todo Metrics/ModuleLength
     continuous_exposure: 'Continuous Exposure',
     symptom_onset: 'Symptom Onset Date',
     symptom_onset_defined_by: 'Symptom Onset Defined By',
-    no_reported_symptoms: 'No Reported Symptoms',
+    # NOTE: uncomment when first positive lab is enabled
+    # no_reported_symptoms: 'No Reported Symptoms',
     extended_isolation: 'Extended Isolation Date',
     end_of_monitoring: 'End of Monitoring',
     closed_at: 'Closure Date',
@@ -473,8 +474,12 @@ module ImportExportConstants # rubocop:todo Metrics/ModuleLength
               rct_node(:patients, 'Linelist Info', %i[workflow status]),
               rct_node(:patients, 'Monitoring Actions', %i[monitoring_status exposure_risk_assessment monitoring_plan case_status public_health_action
                                                            jurisdiction_path jurisdiction_name assigned_user]),
-              rct_node(:patients, 'Monitoring Period', %i[last_date_of_exposure continuous_exposure symptom_onset symptom_onset_defined_by no_reported_symptoms
-                                                          extended_isolation end_of_monitoring closed_at monitoring_reason expected_purge_ts]),
+              # NOTE: uncomment when first positive lab is enabled
+              # rct_node(:patients, 'Monitoring Period', %i[last_date_of_exposure continuous_exposure symptom_onset symptom_onset_defined_by
+              #                                             no_reported_symptoms extended_isolation end_of_monitoring closed_at monitoring_reason
+              #                                             expected_purge_ts]),
+              rct_node(:patients, 'Monitoring Period', %i[last_date_of_exposure continuous_exposure symptom_onset symptom_onset_defined_by extended_isolation
+                                                          end_of_monitoring closed_at monitoring_reason expected_purge_ts]),
               rct_node(:patients, 'Reporting Info', %i[responder_id head_of_household pause_notifications last_assessment_reminder_sent])
             ]
           }

--- a/test/system/roles/enroller/enroller_enrollment_test.rb
+++ b/test/system/roles/enroller/enroller_enrollment_test.rb
@@ -25,9 +25,10 @@ class EnrollerEnrollmentTest < ApplicationSystemTestCase
     @@enroller_test_helper.enroll_monitoree('locals2c4_enroller', 'monitoree_17')
   end
 
-  test 'enroll case with first positive lab' do
-    @@enroller_test_helper.enroll_monitoree('locals1c1_enroller', 'monitoree_18')
-  end
+  # NOTE: Uncomment after first positive lab is enabled
+  # test 'enroll case with first positive lab' do
+  #   @@enroller_test_helper.enroll_monitoree('locals1c1_enroller', 'monitoree_18')
+  # end
 
   test 'enroll monitoree with jurisdiction within hierarchy' do
     @@enroller_test_helper.enroll_monitoree('state1_enroller', 'monitoree_5')

--- a/test/system/roles/enroller/enrollment/form_validator.rb
+++ b/test/system/roles/enroller/enrollment/form_validator.rb
@@ -128,23 +128,25 @@ class EnrollmentFormValidator < ApplicationSystemTestCase
     @@system_test_utils.wait_for_enrollment_page_transition
     click_on 'edit-potential_exposure_information-btn'
     click_on 'Next'
-    verify_text_displayed('Please enter a Symptom Onset Date OR select No Reported Symptoms and enter a first positive lab result')
+    verify_text_displayed('Please enter a Symptom Onset Date')
+    # verify_text_displayed('Please enter a Symptom Onset Date OR select No Reported Symptoms and enter a first positive lab result')
     fill_in 'symptom_onset', with: 3.days.ago.strftime('%m/%d/%Y')
     fill_in 'jurisdiction_id', with: '' # clear out jurisdiction to so that there is at least one validation error
     click_on 'Next'
-    verify_text_not_displayed('Please enter a Symptom Onset Date OR select No Reported Symptoms and enter a first positive lab result')
-    page.find('label', text: 'NO REPORTED SYMPTOMS').click
-    click_on 'Next'
-    verify_text_not_displayed('Please enter a Symptom Onset Date OR select No Reported Symptoms and enter a first positive lab result')
-    fill_in 'jurisdiction_id', with: 'USA, State 1, County 1'
-    click_on 'Next'
-    verify_text_displayed('Please enter a lab result')
-    click_on 'Enter Lab Result'
-    assert page.has_button?('Create', disabled: true)
-    fill_in 'specimen_collection', with: 2.days.ago.strftime('%m/%d/%Y')
-    click_on 'Create'
-    click_on 'Next'
-    verify_text_not_displayed('Please enter a lab result')
+    verify_text_not_displayed('Please enter a Symptom Onset Date')
+    # verify_text_not_displayed('Please enter a Symptom Onset Date OR select No Reported Symptoms and enter a first positive lab result')
+    # page.find('label', text: 'NO REPORTED SYMPTOMS').click
+    # click_on 'Next'
+    # verify_text_not_displayed('Please enter a Symptom Onset Date OR select No Reported Symptoms and enter a first positive lab result')
+    # fill_in 'jurisdiction_id', with: 'USA, State 1, County 1'
+    # click_on 'Next'
+    # verify_text_displayed('Please enter a lab result')
+    # click_on 'Enter Lab Result'
+    # assert page.has_button?('Create', disabled: true)
+    # fill_in 'specimen_collection', with: 2.days.ago.strftime('%m/%d/%Y')
+    # click_on 'Create'
+    # click_on 'Next'
+    # verify_text_not_displayed('Please enter a lab result')
   end
 
   def verify_text_displayed(text)


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-562

This PR temporarily reverts the changes introduced in 562 for adding first positive lab to enrollment

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
