### PR TITLE
SARAALERT-1338: Filter name modal clearing bug

### DIFF
--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -55,10 +55,51 @@ class AdvancedFilter extends React.Component {
   }
 
   /**
+   * Get a local storage value
+   * @param {String} key - relevant local storage key
+   */
+  getLocalStorage = key => {
+    // It's rare this is needed, but we want to make sure we won't fail on Firefox's NS_ERROR_FILE_CORRUPTED
+    try {
+      return localStorage.getItem(key);
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
+  };
+
+  /**
+   * Set a local storage value
+   * @param {String} key - relevant local storage key
+   * @param {String} value - value to set
+   */
+  setLocalStorage = (key, value) => {
+    // It's rare this is needed, but we want to make sure we won't fail on Firefox's NS_ERROR_FILE_CORRUPTED
+    try {
+      localStorage.setItem(key, value);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  /**
+   * Remove a local storage value
+   * @param {String} key - relevant local storage key
+   */
+  removeLocalStorage = key => {
+    // It's rare this is needed, but we want to make sure we won't fail on Firefox's NS_ERROR_FILE_CORRUPTED
+    try {
+      localStorage.removeItem(key);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  /**
    * Start a new filter
    */
   newFilter = () => {
-    this.setState({ activeFilterOptions: [], showAdvancedFilterModal: true, activeFilter: null, applied: false }, () => {
+    this.setState({ activeFilterOptions: [], showAdvancedFilterModal: true, activeFilter: null, applied: false, filterName: null }, () => {
       this.addStatement();
     });
   };
@@ -1080,7 +1121,7 @@ class AdvancedFilter extends React.Component {
         centered
         className="advanced-filter-modal-container"
         onHide={() => {
-          this.setState({ showFilterNameModal: false });
+          this.setState({ showFilterNameModal: false, showAdvancedFilterModal: true, filterName: null });
         }}>
         <Modal.Header>
           <Modal.Title>Filter Name</Modal.Title>
@@ -1119,47 +1160,6 @@ class AdvancedFilter extends React.Component {
         </Modal.Footer>
       </Modal>
     );
-  };
-
-  /**
-   * Get a local storage value
-   * @param {String} key - relevant local storage key
-   */
-  getLocalStorage = key => {
-    // It's rare this is needed, but we want to make sure we won't fail on Firefox's NS_ERROR_FILE_CORRUPTED
-    try {
-      return localStorage.getItem(key);
-    } catch (error) {
-      console.error(error);
-      return null;
-    }
-  };
-
-  /**
-   * Set a local storage value
-   * @param {String} key - relevant local storage key
-   * @param {String} value - value to set
-   */
-  setLocalStorage = (key, value) => {
-    // It's rare this is needed, but we want to make sure we won't fail on Firefox's NS_ERROR_FILE_CORRUPTED
-    try {
-      localStorage.setItem(key, value);
-    } catch (error) {
-      console.error(error);
-    }
-  };
-
-  /**
-   * Remove a local storage value
-   * @param {String} key - relevant local storage key
-   */
-  removeLocalStorage = key => {
-    // It's rare this is needed, but we want to make sure we won't fail on Firefox's NS_ERROR_FILE_CORRUPTED
-    try {
-      localStorage.removeItem(key);
-    } catch (error) {
-      console.error(error);
-    }
   };
 
   render() {

--- a/app/javascript/tests/public_health/query/AdvancedFilter.test.js
+++ b/app/javascript/tests/public_health/query/AdvancedFilter.test.js
@@ -881,6 +881,22 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find('#filter-name-input').prop('value')).toEqual('');
   });
 
+  it('Filter name is cleared when saving a new filter', () => {
+    const wrapper = getWrapper();
+    wrapper.find(Button).simulate('click');
+    wrapper.find('#advanced-filter-save').simulate('click');
+    expect(wrapper.state('filterName')).toEqual(null);
+    wrapper.find('#filter-name-input').simulate('change', { target: { value: 'some filter name' } });
+    expect(wrapper.state('filterName')).toEqual('some filter name');
+    wrapper.find('#filter-name-save').simulate('click');
+    expect(wrapper.state('filterName')).toEqual('some filter name');
+    wrapper.find('#advanced-filter-cancel').simulate('click');
+    expect(wrapper.state('filterName')).toEqual('some filter name');
+    wrapper.find(Dropdown.Item).simulate('click');
+    wrapper.find('#advanced-filter-save').simulate('click');
+    expect(wrapper.state('filterName')).toEqual(null);
+  });
+
   it('Opening Filter Name modal and clicking "Cancel" button maintains advanced filter modal state', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1338](https://tracker.codev.mitre.org/browse/SARAALERT-1338)

When you want to create multiple filters and save them, the name you used to save the previous filter seems to be automatically populated when you try to save the next one. 

## (Bugfix) How to Replicate
1. Create and save an advanced filter with a name
2. Click the "Apply" button
3. In the dropdown, click the new filter button
4. Click the "Save" button
5. Notice the name modal is pre-filled with the name of the last advanced filter

## (Bugfix) Solution
When the new filter button is clicked, insure filterName is cleared

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`AdvancedFilter.js`
- When the new filter button is clicked, clear filterName
- Added cancel button functionality to the onHide method of the filter name modal
- Moved storage methods out of the render methods to the top of the file

`AdvancedFilter.test.js`
- Added unit test for this specifc bug case to prevent in the future


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@holmesie :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@dubem7 :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@hackrm :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] **N/A** If applicable, you have tested changes against a large database, and considered possible performance regressions
