### PR TITLE
Remove COV-19 specific advanced filters

### DIFF
--- a/app/javascript/data/advancedFilterOptions.js
+++ b/app/javascript/data/advancedFilterOptions.js
@@ -64,23 +64,23 @@ export const advancedFilterOptions = [
     tooltip:
       'This filter will return monitorees that have texted “STOP” in response to a Sara Alert text message and cannot receive messages through SMS Preferred Reporting Methods until they text "START".'
   },
-  {
-    name: 'seven-day-quarantine',
-    title: 'Candidate to Reduce Quarantine after 7 Days (Boolean)',
-    description:
-      'All asymptomatic records that meet CDC criteria to end quarantine after Day 7 (based on last date of exposure and most recent lab result)',
-    type: 'boolean',
-    tooltip:
-      'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.'
-  },
-  {
-    name: 'ten-day-quarantine',
-    title: 'Candidate to Reduce Quarantine after 10 Days (Boolean)',
-    description: 'All asymptomatic records that meet CDC criteria to end quarantine after Day 10 (based on last date of exposure)',
-    type: 'boolean',
-    tooltip:
-      'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.'
-  },
+  // {
+  //   name: 'seven-day-quarantine',
+  //   title: 'Candidate to Reduce Quarantine after 7 Days (Boolean)',
+  //   description:
+  //     'All asymptomatic records that meet CDC criteria to end quarantine after Day 7 (based on last date of exposure and most recent lab result)',
+  //   type: 'boolean',
+  //   tooltip:
+  //     'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.'
+  // },
+  // {
+  //   name: 'ten-day-quarantine',
+  //   title: 'Candidate to Reduce Quarantine after 10 Days (Boolean)',
+  //   description: 'All asymptomatic records that meet CDC criteria to end quarantine after Day 10 (based on last date of exposure)',
+  //   type: 'boolean',
+  //   tooltip:
+  //     'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.'
+  // },
 
   /* SEARCH FILTER OPTIONS */
   {


### PR DESCRIPTION
# Description
Removes the "Candidate to Reduce Quarantine" filters which are specific to COVID-19.

## (Bugfix) How to Replicate
When selecting advanced filter options, `Candidate to Reduce Quarantine after 7 Days (Boolean)` and `Candidate to Reduce Quarantine after 10 Days (Boolean)` still appear which are COVID specific. 

## Important Changes

`advancedFilterOptions.js`
- Commented out COVID-19 specific filters.

# Checklists

**Submitter:**
- [X] This PR describes why these changes were made.
- [X] This PR is into the correct branch.
- [X] This PR includes the correct JIRA ticket reference. (N/A)
- [X] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [X] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced. (N/A)
- [X] Tests are included and test edge cases (N/A)
- [X] Tests have been run locally and pass (remember to update Gemfile when applicable) (N/A)
- [X] Test fixtures updated and documented as necessary (N/A)


@DPC15038 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
