### PR TITLE
SARAALERT-1294: new isolation icon

### DIFF
--- a/app/javascript/components/public_health/PublicHealthHeader.js
+++ b/app/javascript/components/public_health/PublicHealthHeader.js
@@ -201,7 +201,7 @@ class PublicHealthHeader extends React.Component {
             {this.state.counts.exposure !== undefined && <span id="exposureCount">({this.state.counts.exposure})</span>}
           </Button>
           <Button variant={this.props.workflow === 'isolation' ? 'primary' : 'outline-primary'} href={`${window.BASE_PATH}/public_health/isolation`}>
-            <i className="fas fa-house-user"></i> Isolation Monitoring{' '}
+            <i className="fas fa-street-view"></i> Isolation Monitoring{' '}
             {this.state.counts.isolation !== undefined && <span id="isolationCount">({this.state.counts.isolation})</span>}
           </Button>
         </ButtonGroup>


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1294](https://tracker.codev.mitre.org/browse/SARAALERT-1294)

Update the icon for isolation. 

## (Feature) Demo/Screenshots
![image](https://user-images.githubusercontent.com/7842704/115608315-1bd9be80-a2b4-11eb-9fd8-c921e85ca426.png)

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@sgober  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@DPC15038  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie   :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] N/A The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] N/A If applicable, you have tested changes against a large database, and considered possible performance regressions
