### PR TITLE
SARAALERT-1440: Improve analytics page initial loading time

### DIFF
--- a/app/javascript/components/analytics/widgets/GeographicSummary.js
+++ b/app/javascript/components/analytics/widgets/GeographicSummary.js
@@ -28,7 +28,7 @@ class GeographicSummary extends React.Component {
         this.setState({
           analyticsData,
           jurisdictionsPermittedToView: this.obtainJurisdictionsPermittedToView(response.data.monitoree_maps, maxDaysOfHistory),
-          jurisdictions_not_in_use: this.obtainJurisdictionsNotInUse(response.data.monitoree_maps, maxDaysOfHistory),
+          jurisdictionsNotInUse: this.obtainJurisdictionsNotInUse(response.data.monitoree_maps, maxDaysOfHistory),
           selectedDateIndex: maxDaysOfHistory - 1,
           showBackButton: false,
           jurisdictionToShow: {
@@ -326,7 +326,7 @@ class GeographicSummary extends React.Component {
                   mapObject={this.state.mapObject}
                   handleJurisdictionChange={this.handleJurisdictionChange}
                   decrementSpinnerCount={this.decrementSpinnerCount}
-                  jurisdictionsNotInUse={this.state.jurisdictions_not_in_use}
+                  jurisdictionsNotInUse={this.state.jurisdictionsNotInUse}
                   jurisdictionsPermittedToView={this.state.jurisdictionsPermittedToView}
                 />
               </Col>
@@ -339,7 +339,7 @@ class GeographicSummary extends React.Component {
                   mapObject={this.state.mapObject}
                   handleJurisdictionChange={this.handleJurisdictionChange}
                   decrementSpinnerCount={this.decrementSpinnerCount}
-                  jurisdictionsNotInUse={this.state.jurisdictions_not_in_use}
+                  jurisdictionsNotInUse={this.state.jurisdictionsNotInUse}
                   jurisdictionsPermittedToView={this.state.jurisdictionsPermittedToView}
                 />
               </Col>

--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -330,10 +330,10 @@ class CacheAnalyticsJob < ApplicationJob
   def self.monitoree_counts_by_last_exposure_month(analytic_id, monitorees)
     counts = []
     exposure_months = <<-SQL
-      DATE_FORMAT(last_date_of_exposure ,'%Y-%m-01')
+      DATE_FORMAT(last_date_of_exposure, '%Y-%m-01')
     SQL
     symptom_onset_months = <<-SQL
-      DATE_FORMAT(symptom_onset ,'%Y-%m-01')
+      DATE_FORMAT(symptom_onset, '%Y-%m-01')
     SQL
 
     monitorees.where(isolation: false)

--- a/app/views/analytics/index.html.erb
+++ b/app/views/analytics/index.html.erb
@@ -6,6 +6,6 @@
   <%= react_component('analytics/EnrollerAnalytics', { current_user: current_user, stats: @stats }) %>
 <% end %>
 
-<% if current_user.can_view_epi_analytics? %>
+<% if @can_view_epi_analytics %>
   <%= react_component('analytics/PublicHealthAnalytics', { current_user: current_user, stats: @stats }) %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,7 +103,7 @@ Rails.application.routes.draw do
   end
 
   resources :vaccines, only: [:index, :create, :update]
-  
+
   resources :user_filters, only: [:index, :create, :update, :destroy]
 
   resources :user_export_presets, only: [:index, :create, :update, :destroy]
@@ -133,6 +133,7 @@ Rails.application.routes.draw do
   get '/public_health/patients/counts/:workflow/:tab', to: 'public_health#tab_counts', as: :tab_counts
 
   get '/analytics', to: 'analytics#index', as: :analytics
+  get '/analytics/monitoree_maps', to: 'analytics#monitoree_maps', as: :monitoree_maps
   get '/county_level_maps/:mapFile', to: 'analytics#clm_geo_json'
 
   # Errors

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -239,7 +239,7 @@ desc 'Backup the database'
     end
 
     # Cache analytics
-    demo_cache_analytics(beginning_of_day, cache_analytics)
+    demo_cache_analytics(beginning_of_day) if cache_analytics
   end
 
   def demo_populate_patients(beginning_of_day, num_patients_today, days_ago, jurisdictions, assigned_users, case_ids, counties)
@@ -970,16 +970,15 @@ desc 'Backup the database'
     SQL
   end
 
-  def demo_cache_analytics(beginning_of_day, cache_analytics)
+  def demo_cache_analytics(beginning_of_day)
     printf("Caching analytics...")
-    if cache_analytics || (day + 1) == days
-      Rake::Task["analytics:cache_current_analytics"].reenable
-      Rake::Task["analytics:cache_current_analytics"].invoke
-      # Add time onto update time for more realistic reports
-      t = Time.now
-      date_time_update = DateTime.new(beginning_of_day.year, beginning_of_day.month, beginning_of_day.day, t.hour, t.min, t.sec, t.zone)
-      Analytic.where('created_at > ?', 1.hour.ago).update_all(created_at: date_time_update, updated_at: date_time_update)
-    end
+    Rake::Task["analytics:cache_current_analytics"].reenable
+    Rake::Task["analytics:cache_current_analytics"].invoke
+    # Add time onto update time for more realistic reports
+    Analytic.where('created_at > ?', 1.hour.ago).update_all(created_at: beginning_of_day, updated_at: beginning_of_day)
+    MonitoreeCount.where('created_at > ?', 1.hour.ago).update_all(created_at: beginning_of_day, updated_at: beginning_of_day)
+    MonitoreeSnapshot.where('created_at > ?', 1.hour.ago).update_all(created_at: beginning_of_day, updated_at: beginning_of_day)
+    MonitoreeMap.where('created_at > ?', 1.hour.ago).update_all(created_at: beginning_of_day, updated_at: beginning_of_day)
     printf(" done.\n")
   end
 


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1440](https://tracker.codev.mitre.org/browse/SARAALERT-1440)

Currently the analytics page takes a while to complete its initial page load because it takes a while to query and load all the `monitoree_maps` data, which prevents anything on the page from loading until it's completed. This PR includes changes to dynamically load `monitoree_maps` data once the analytics component is mounted that way the initial load time is way faster as well as slight improvements to query `monitoree_maps` more efficiently.

NOTE: This PR is currently targeted towards the `demo_script_households` branch because it includes those changes to `demo.rake`, once that PR is merged, this branch will be targeted to `1.28.0`

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/controllers/analytics_controller.rb`
- Move `monitoree_maps` query to new method under new route

`app/javascript/components/analytics/widgets/GeographicSummary.js`
- Dynamically load `monitoree_maps` after component is mounted

`lib/tasks/demo.rake`
- Analytics were not actually being cached during demo script, this fixes it

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@DPC15038 :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
