### PR TITLE
SARAALERT-767: Ability to delete/retire close contacts from the list

### DIFF
--- a/app/javascript/components/util/DeleteDialog.js
+++ b/app/javascript/components/util/DeleteDialog.js
@@ -48,7 +48,13 @@ class DeleteDialog extends React.Component {
             record&apos;s history export.
           </p>
           <p>Please select reason for deletion:</p>
-          <Form.Control as="select" className="form-control-md mb-3" id="delete_reason" onChange={this.handleReasonChange} defaultValue={-1}>
+          <Form.Control
+            as="select"
+            className="form-control-md mb-3"
+            id="delete_reason"
+            onChange={this.handleReasonChange}
+            defaultValue={-1}
+            aria-label="Delete reason select">
             <option disabled value={-1}>
               --
             </option>
@@ -65,6 +71,7 @@ class DeleteDialog extends React.Component {
                 maxLength={MAX_REASON_LENGTH}
                 className="form-square"
                 placeholder="Please enter additional information about the reason for deletion"
+                aria-label="Delete reason additional text input"
                 value={this.state.delete_reason_text}
                 onChange={this.handleTextChange}
               />

--- a/app/javascript/packs/stylesheets/layout.scss
+++ b/app/javascript/packs/stylesheets/layout.scss
@@ -24,7 +24,7 @@
 
 .character-limit-text {
   width: 100%;
-  font-size: 10px;
+  font-size: 12px;
   color: dimgray;
   font-style: italic;
   text-align: right;

--- a/app/javascript/tests/patient/close_contact/CloseContact.test.js
+++ b/app/javascript/tests/patient/close_contact/CloseContact.test.js
@@ -31,13 +31,14 @@ describe('CloseContact', () => {
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
     expect(emptyCCWrapper.find(Button).length).toEqual(1);
     expect(emptyCCWrapper.find(Button).at(0).text()).toContain('Add New Close Contact');
-    expect(emptyCCWrapper.state('showModal')).toBeFalsy();
+
+    expect(emptyCCWrapper.state('showCloseContactModal')).toBeFalsy();
     expect(emptyCCWrapper.state('first_name')).toEqual('');
     expect(emptyCCWrapper.state('last_name')).toEqual('');
     expect(emptyCCWrapper.state('primary_telephone')).toEqual('');
     expect(emptyCCWrapper.state('email')).toEqual('');
-    expect(emptyCCWrapper.state('last_date_of_exposure')).toEqual(null);
-    expect(emptyCCWrapper.state('assigned_user')).toEqual(null);
+    expect(emptyCCWrapper.state('cc_last_date_of_exposure')).toEqual(null);
+    expect(emptyCCWrapper.state('cc_assigned_user')).toEqual(null);
     expect(emptyCCWrapper.state('notes')).toEqual('');
     expect(emptyCCWrapper.state('enrolled_id')).toEqual(null);
     expect(emptyCCWrapper.state('contact_attempts')).toEqual(0);
@@ -45,47 +46,51 @@ describe('CloseContact', () => {
 
   it('Properly renders all main components for already existing enrolled close contact', () => {
     const alreadyExistingCCWrapper = getShallowWrapper(mockCloseContact2);
-    expect(alreadyExistingCCWrapper.find(Button).length).toEqual(3);
+    expect(alreadyExistingCCWrapper.find(Button).length).toEqual(4);
     expect(alreadyExistingCCWrapper.find(Button).at(0).text()).toContain('Edit');
     expect(alreadyExistingCCWrapper.find(Button).at(1).text()).toContain('Contact Attempt');
-    expect(alreadyExistingCCWrapper.find(Button).at(2).text()).toContain('View Record');
-    expect(alreadyExistingCCWrapper.state('showModal')).toBeFalsy();
+    expect(alreadyExistingCCWrapper.find(Button).at(2).text()).toContain('Delete');
+    expect(alreadyExistingCCWrapper.find(Button).at(3).text()).toContain('View Record');
+
+    expect(alreadyExistingCCWrapper.state('showCloseContactModal')).toBeFalsy();
     expect(alreadyExistingCCWrapper.state('first_name')).toEqual(mockCloseContact2.first_name || '');
     expect(alreadyExistingCCWrapper.state('last_name')).toEqual(mockCloseContact2.last_name || '');
     expect(alreadyExistingCCWrapper.state('primary_telephone')).toEqual(mockCloseContact2.primary_telephone || '');
     expect(alreadyExistingCCWrapper.state('email')).toEqual(mockCloseContact2.email || '');
-    expect(alreadyExistingCCWrapper.state('last_date_of_exposure')).toEqual(mockCloseContact2.last_date_of_exposure || null);
-    expect(alreadyExistingCCWrapper.state('assigned_user')).toEqual(mockCloseContact2.assigned_user || null);
+    expect(alreadyExistingCCWrapper.state('cc_last_date_of_exposure')).toEqual(mockCloseContact2.last_date_of_exposure || null);
+    expect(alreadyExistingCCWrapper.state('cc_assigned_user')).toEqual(mockCloseContact2.assigned_user || null);
     expect(alreadyExistingCCWrapper.state('notes')).toEqual(mockCloseContact2.notes || '');
     expect(alreadyExistingCCWrapper.state('contact_attempts')).toEqual(mockCloseContact2.contact_attempts || 0);
   });
 
   it('Properly renders all main components for already existing unenrolled close contact', () => {
     const alreadyExistingCCWrapper = getShallowWrapper(mockCloseContact3);
-    expect(alreadyExistingCCWrapper.find(Button).length).toEqual(3);
+    expect(alreadyExistingCCWrapper.find(Button).length).toEqual(4);
     expect(alreadyExistingCCWrapper.find(Button).at(0).text()).toContain('Edit');
     expect(alreadyExistingCCWrapper.find(Button).at(1).text()).toContain('Contact Attempt');
-    expect(alreadyExistingCCWrapper.find(Button).at(2).text()).toContain('Enroll');
-    expect(alreadyExistingCCWrapper.state('showModal')).toBeFalsy();
+    expect(alreadyExistingCCWrapper.find(Button).at(2).text()).toContain('Delete');
+    expect(alreadyExistingCCWrapper.find(Button).at(3).text()).toContain('Enroll');
+
+    expect(alreadyExistingCCWrapper.state('showCloseContactModal')).toBeFalsy();
     expect(alreadyExistingCCWrapper.state('first_name')).toEqual(mockCloseContact3.first_name || '');
     expect(alreadyExistingCCWrapper.state('last_name')).toEqual(mockCloseContact3.last_name || '');
     expect(alreadyExistingCCWrapper.state('primary_telephone')).toEqual(mockCloseContact3.primary_telephone || '');
     expect(alreadyExistingCCWrapper.state('email')).toEqual(mockCloseContact3.email || '');
-    expect(alreadyExistingCCWrapper.state('last_date_of_exposure')).toEqual(mockCloseContact3.last_date_of_exposure || null);
-    expect(alreadyExistingCCWrapper.state('assigned_user')).toEqual(mockCloseContact3.assigned_user || null);
+    expect(alreadyExistingCCWrapper.state('cc_last_date_of_exposure')).toEqual(mockCloseContact3.last_date_of_exposure || null);
+    expect(alreadyExistingCCWrapper.state('cc_assigned_user')).toEqual(mockCloseContact3.assigned_user || null);
     expect(alreadyExistingCCWrapper.state('notes')).toEqual(mockCloseContact3.notes || '');
     expect(alreadyExistingCCWrapper.state('contact_attempts')).toEqual(mockCloseContact3.contact_attempts || 0);
   });
 
   it('Properly renders the modal if button is clicked', () => {
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
-    expect(emptyCCWrapper.state('showModal')).toBeFalsy();
+    expect(emptyCCWrapper.state('showCloseContactModal')).toBeFalsy();
     expect(emptyCCWrapper.find(Button).at(0).text()).toContain('Add New Close Contact');
     emptyCCWrapper.find(Button).at(0).simulate('click');
-    expect(emptyCCWrapper.state('showModal')).toBeTruthy();
+    expect(emptyCCWrapper.state('showCloseContactModal')).toBeTruthy();
     expect(emptyCCWrapper.find(Modal.Header).exists()).toBeTruthy();
-    expect(emptyCCWrapper.find(Modal).find('.sr-only').text()).toEqual('Close Contact');
-    expect(emptyCCWrapper.find(Modal.Header).find('ModalTitle').text()).toEqual('Close Contact');
+    expect(emptyCCWrapper.find(Modal).find('.sr-only').text()).toEqual('Create Close Contact');
+    expect(emptyCCWrapper.find(Modal.Header).find('ModalTitle').text()).toEqual('Create Close Contact');
     expect(emptyCCWrapper.find(Modal.Body).exists()).toBeTruthy();
     // Using 'toContain' instead of 'toEqual' to avoid any whitespace issues
     expect(emptyCCWrapper.find(Modal.Body).find('Row').at(0).find(Form.Label).at(0).text()).toContain('First Name');
@@ -114,12 +119,12 @@ describe('CloseContact', () => {
   it('Can properly set fields when an empty close contact is used as a prop', () => {
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
     const handleChangeSpy = jest.spyOn(emptyCCWrapper.instance(), 'handleChange');
-    const handleDateChangeSpy = jest.spyOn(emptyCCWrapper.instance(), 'handleDateChange');
+    const handleLDEChangeSpy = jest.spyOn(emptyCCWrapper.instance(), 'handleLDEChange');
 
-    expect(emptyCCWrapper.state('showModal')).toBeFalsy();
+    expect(emptyCCWrapper.state('showCloseContactModal')).toBeFalsy();
     expect(emptyCCWrapper.find(Button).at(0).text()).toContain('Add New Close Contact');
     emptyCCWrapper.find(Button).at(0).simulate('click');
-    expect(emptyCCWrapper.state('showModal')).toBeTruthy();
+    expect(emptyCCWrapper.state('showCloseContactModal')).toBeTruthy();
 
     let value;
     value = testInputValues.find(x => x.field === 'first_name').value;
@@ -169,21 +174,21 @@ describe('CloseContact', () => {
     expect(emptyCCWrapper.state('email')).toEqual(value);
 
     value = testInputValues.find(x => x.field === 'last_date_of_exposure').value;
-    expect(emptyCCWrapper.state('last_date_of_exposure')).toBeFalsy();
+    expect(emptyCCWrapper.state('cc_last_date_of_exposure')).toBeFalsy();
     emptyCCWrapper.find(Modal.Body).find('Row').at(2).find('DateInput').simulate('change', value);
-    expect(handleDateChangeSpy).toHaveBeenCalled();
-    expect(emptyCCWrapper.state('last_date_of_exposure')).toEqual(value);
+    expect(handleLDEChangeSpy).toHaveBeenCalled();
+    expect(emptyCCWrapper.state('cc_last_date_of_exposure')).toEqual(value);
 
     value = testInputValues.find(x => x.field === 'assigned_user').value;
-    expect(emptyCCWrapper.state('assigned_user')).toBeFalsy();
+    expect(emptyCCWrapper.state('cc_assigned_user')).toBeFalsy();
     emptyCCWrapper
       .find(Modal.Body)
       .find('Row')
       .at(2)
       .find(Form.Control)
-      .simulate('change', { target: { id: 'assigned_user', value: value } });
+      .simulate('change', { target: { id: 'cc_assigned_user', value: value } });
     expect(handleChangeSpy).toHaveBeenCalled();
-    expect(emptyCCWrapper.state('assigned_user')).toEqual(value);
+    expect(emptyCCWrapper.state('cc_assigned_user')).toEqual(value);
 
     value = testInputValues.find(x => x.field === 'notes').value;
     expect(emptyCCWrapper.state('notes')).toBeFalsy();
@@ -208,10 +213,10 @@ describe('CloseContact', () => {
 
   it('Properly clears any values in the modal on close (when adding a new close contact)', () => {
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
-    expect(emptyCCWrapper.state('showModal')).toBeFalsy();
+    expect(emptyCCWrapper.state('showCloseContactModal')).toBeFalsy();
     expect(emptyCCWrapper.find(Button).at(0).text()).toContain('Add New Close Contact');
     emptyCCWrapper.find(Button).at(0).simulate('click');
-    expect(emptyCCWrapper.state('showModal')).toBeTruthy();
+    expect(emptyCCWrapper.state('showCloseContactModal')).toBeTruthy();
 
     let value;
     value = testInputValues.find(x => x.field === 'first_name').value;
@@ -252,7 +257,7 @@ describe('CloseContact', () => {
       .find('Row')
       .at(2)
       .find(Form.Control)
-      .simulate('change', { target: { id: 'assigned_user', value: value } });
+      .simulate('change', { target: { id: 'cc_assigned_user', value: value } });
     value = testInputValues.find(x => x.field === 'notes').value;
     emptyCCWrapper
       .find(Modal.Body)
@@ -263,21 +268,21 @@ describe('CloseContact', () => {
 
     emptyCCWrapper.find(Button).at(1).simulate('click');
     // Once the modal is closed, the values should default back to their nulled out original values
-    expect(emptyCCWrapper.state('showModal')).toBeFalsy();
+    expect(emptyCCWrapper.state('showCloseContactModal')).toBeFalsy();
     expect(emptyCCWrapper.state('first_name')).toEqual(mockCloseContact1.first_name || '');
     expect(emptyCCWrapper.state('last_name')).toEqual(mockCloseContact1.last_name || '');
     expect(emptyCCWrapper.state('primary_telephone')).toEqual(mockCloseContact1.primary_telephone || '');
     expect(emptyCCWrapper.state('email')).toEqual(mockCloseContact1.email || '');
-    expect(emptyCCWrapper.state('last_date_of_exposure')).toEqual(mockCloseContact1.last_date_of_exposure || null);
-    expect(emptyCCWrapper.state('assigned_user')).toEqual(mockCloseContact1.assigned_user || null);
+    expect(emptyCCWrapper.state('cc_last_date_of_exposure')).toEqual(mockCloseContact1.cc_last_date_of_exposure || null);
+    expect(emptyCCWrapper.state('cc_assigned_user')).toEqual(mockCloseContact1.assigned_user || null);
     expect(emptyCCWrapper.state('notes')).toEqual(mockCloseContact1.notes || '');
   });
 
   it('Properly resets any values in the modal to the default (when editing an existing close contact)', () => {
     const existingCCWrapper = getShallowWrapper(mockCloseContact2);
-    expect(existingCCWrapper.state('showModal')).toBeFalsy();
+    expect(existingCCWrapper.state('showCloseContactModal')).toBeFalsy();
     existingCCWrapper.find(Button).at(0).simulate('click');
-    expect(existingCCWrapper.state('showModal')).toBeTruthy();
+    expect(existingCCWrapper.state('showCloseContactModal')).toBeTruthy();
 
     let value;
     value = testInputValues.find(x => x.field === 'first_name').value;
@@ -318,7 +323,7 @@ describe('CloseContact', () => {
       .find('Row')
       .at(2)
       .find(Form.Control)
-      .simulate('change', { target: { id: 'assigned_user', value: value } });
+      .simulate('change', { target: { id: 'cc_assigned_user', value: value } });
     value = testInputValues.find(x => x.field === 'notes').value;
     existingCCWrapper
       .find(Modal.Body)
@@ -327,35 +332,35 @@ describe('CloseContact', () => {
       .find(Form.Control)
       .simulate('change', { target: { id: 'notes', value: value } });
 
-    existingCCWrapper.find(Button).at(3).simulate('click');
+    existingCCWrapper.find(Button).at(4).simulate('click');
     // Once the modal is closed, the values should default back to their nulled out original values
-    expect(existingCCWrapper.state('showModal')).toBeFalsy();
+    expect(existingCCWrapper.state('showCloseContactModal')).toBeFalsy();
     expect(existingCCWrapper.state('first_name')).toEqual(mockCloseContact2.first_name || '');
     expect(existingCCWrapper.state('last_name')).toEqual(mockCloseContact2.last_name || '');
     expect(existingCCWrapper.state('primary_telephone')).toEqual(mockCloseContact2.primary_telephone || '');
     expect(existingCCWrapper.state('email')).toEqual(mockCloseContact2.email || '');
-    expect(existingCCWrapper.state('last_date_of_exposure')).toEqual(mockCloseContact2.last_date_of_exposure || null);
-    expect(existingCCWrapper.state('assigned_user')).toEqual(mockCloseContact2.assigned_user || null);
+    expect(existingCCWrapper.state('cc_last_date_of_exposure')).toEqual(mockCloseContact2.last_date_of_exposure || null);
+    expect(existingCCWrapper.state('cc_assigned_user')).toEqual(mockCloseContact2.assigned_user || null);
     expect(existingCCWrapper.state('notes')).toEqual(mockCloseContact2.notes || '');
   });
 
-  it('Properly calls submit when the button is clicked', () => {
+  it('Properly calls handleCloseContactSubmit when the button is clicked', () => {
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
-    const submitSpy = jest.spyOn(emptyCCWrapper.instance(), 'submit');
+    const handleCloseContactSubmitSpy = jest.spyOn(emptyCCWrapper.instance(), 'handleCloseContactSubmit');
     expect(emptyCCWrapper.find(Button).at(0).text()).toContain('Add New Close Contact');
     emptyCCWrapper.find(Button).at(0).simulate('click');
     expect(emptyCCWrapper.find(Button).at(2).text()).toContain('Create');
-    emptyCCWrapper.find(Button).at(2).simulate('click'); //click submit
-    expect(submitSpy).toHaveBeenCalledTimes(1);
+    emptyCCWrapper.find(Button).at(2).simulate('click'); //click handleCloseContactSubmit
+    expect(handleCloseContactSubmitSpy).toHaveBeenCalledTimes(1);
   });
 
   it('Properly renders accurate count of characters remaining for notes field', () => {
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
     const testNoteString = 'The Strongest Avenger';
-    expect(emptyCCWrapper.state('showModal')).toBeFalsy();
+    expect(emptyCCWrapper.state('showCloseContactModal')).toBeFalsy();
     expect(emptyCCWrapper.find(Button).at(0).text()).toContain('Add New Close Contact');
     emptyCCWrapper.find(Button).at(0).simulate('click');
-    expect(emptyCCWrapper.state('showModal')).toBeTruthy();
+    expect(emptyCCWrapper.state('showCloseContactModal')).toBeTruthy();
     expect(emptyCCWrapper.find(Modal.Body).find('Row').at(3).find(Form.Label).text()).toContain('Notes');
     expect(emptyCCWrapper.find(Modal.Body).find('Row').at(3).find('.character-limit-text').text()).toContain('2000 characters remaining');
     emptyCCWrapper
@@ -370,7 +375,7 @@ describe('CloseContact', () => {
   it('Properly enables and disables the submit/create button when First Name and Phone is entered', () => {
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
 
-    expect(emptyCCWrapper.state('showModal')).toBeFalsy();
+    expect(emptyCCWrapper.state('showCloseContactModal')).toBeFalsy();
     expect(emptyCCWrapper.find(Button).at(0).text()).toContain('Add New Close Contact');
     emptyCCWrapper.find(Button).at(0).simulate('click');
 
@@ -414,7 +419,7 @@ describe('CloseContact', () => {
   it('Properly enables and disables the submit/create button when First Name and Email is entered', () => {
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
 
-    expect(emptyCCWrapper.state('showModal')).toBeFalsy();
+    expect(emptyCCWrapper.state('showCloseContactModal')).toBeFalsy();
     expect(emptyCCWrapper.find(Button).at(0).text()).toContain('Add New Close Contact');
     emptyCCWrapper.find(Button).at(0).simulate('click');
 
@@ -458,7 +463,7 @@ describe('CloseContact', () => {
   it('Properly enables and disables the submit/create button when Last Name and Phone is entered', () => {
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
 
-    expect(emptyCCWrapper.state('showModal')).toBeFalsy();
+    expect(emptyCCWrapper.state('showCloseContactModal')).toBeFalsy();
     expect(emptyCCWrapper.find(Button).at(0).text()).toContain('Add New Close Contact');
     emptyCCWrapper.find(Button).at(0).simulate('click');
 
@@ -502,7 +507,7 @@ describe('CloseContact', () => {
   it('Properly enables and disables the submit/create button when Last Name and Email is entered', () => {
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
 
-    expect(emptyCCWrapper.state('showModal')).toBeFalsy();
+    expect(emptyCCWrapper.state('showCloseContactModal')).toBeFalsy();
     expect(emptyCCWrapper.find(Button).at(0).text()).toContain('Add New Close Contact');
     emptyCCWrapper.find(Button).at(0).simulate('click');
 
@@ -546,7 +551,7 @@ describe('CloseContact', () => {
   it('Properly keeps the buttons disabled when all the required fields are not added', () => {
     const emptyCCWrapper = getShallowWrapper(mockCloseContact1);
 
-    expect(emptyCCWrapper.state('showModal')).toBeFalsy();
+    expect(emptyCCWrapper.state('showCloseContactModal')).toBeFalsy();
     expect(emptyCCWrapper.find(Button).at(0).text()).toContain('Add New Close Contact');
     emptyCCWrapper.find(Button).at(0).simulate('click');
     let value;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,7 @@ Rails.application.routes.draw do
 
   post '/close_contacts', to: 'close_contacts#create'
   post '/close_contacts/:id', to: 'close_contacts#update'
+  delete '/close_contacts/:id', to: 'close_contacts#destroy'
 
   get '/patients/:id/group', to: 'patients#new_group_member'
 

--- a/test/controllers/close_contacts_controller_test.rb
+++ b/test/controllers/close_contacts_controller_test.rb
@@ -1,0 +1,278 @@
+# frozen_string_literal: true
+
+require 'test_case'
+
+class CloseContactsControllerTest < ActionController::TestCase
+  def setup; end
+
+  def teardown; end
+
+  # --- BEFORE ACTION --- #
+
+  test 'before action: authenticate user' do
+    post :create, params: {}
+    assert_redirected_to(new_user_session_path)
+
+    put :update, params: { id: 'test' }
+    assert_redirected_to(new_user_session_path)
+
+    put :destroy, params: { id: 'test' }
+    assert_redirected_to(new_user_session_path)
+  end
+
+  test 'before action: check user can create' do
+    user = create(:enroller_user)
+    sign_in user
+
+    post :create, params: {}
+    assert_response(:forbidden)
+
+    sign_out user
+  end
+
+  test 'before action: check user can edit' do
+    user = create(:enroller_user)
+    sign_in user
+
+    put :update, params: { id: 'test' }
+    assert_response(:forbidden)
+
+    put :destroy, params: { id: 'test' }
+    assert_response(:forbidden)
+
+    sign_out user
+  end
+
+  test 'before action: check patient valid (patient exists)' do
+    user = create(:public_health_enroller_user)
+    sign_in user
+
+    post :create, params: { patient_id: 'test' }
+    assert_response(:bad_request)
+    assert_equal("Close Contact cannot be modified for unknown monitoree with ID: #{'test'.to_i}", JSON.parse(response.body)['error'])
+
+    put :update, params: { id: 'test', patient_id: 'test' }
+    assert_response(:bad_request)
+    assert_equal("Close Contact cannot be modified for unknown monitoree with ID: #{'test'.to_i}", JSON.parse(response.body)['error'])
+
+    put :destroy, params: { id: 'test', patient_id: 'test' }
+    assert_response(:bad_request)
+    assert_equal("Close Contact cannot be modified for unknown monitoree with ID: #{'test'.to_i}", JSON.parse(response.body)['error'])
+
+    sign_out user
+  end
+
+  test 'before action: check patient (current user can view patient)' do
+    user = create(:public_health_enroller_user)
+    user_2 = create(:public_health_enroller_user)
+    patient = create(:patient, creator: user_2)
+    sign_in user
+
+    post :create, params: { patient_id: patient.id }
+    assert_response(:forbidden)
+    assert_equal("User does not have access to Patient with ID: #{patient.id}", JSON.parse(response.body)['error'])
+
+    put :update, params: { id: 'test', patient_id: patient.id }
+    assert_response(:forbidden)
+    assert_equal("User does not have access to Patient with ID: #{patient.id}", JSON.parse(response.body)['error'])
+
+    put :destroy, params: { id: 'test', patient_id: patient.id }
+    assert_response(:forbidden)
+    assert_equal("User does not have access to Patient with ID: #{patient.id}", JSON.parse(response.body)['error'])
+
+    sign_out user
+  end
+
+  test 'before action: check close_contact' do
+    user = create(:public_health_enroller_user)
+    patient = create(:patient, creator: user)
+    sign_in user
+
+    put :update, params: { id: 'test', patient_id: patient.id }
+    assert_response(:bad_request)
+
+    put :destroy, params: { id: 'test', patient_id: patient.id }
+    assert_response(:bad_request)
+
+    sign_out user
+  end
+
+  # --- CREATE --- #
+
+  test 'create: creates new close contact and creates related history item' do
+    user = create(:public_health_enroller_user)
+    patient = create(:patient, creator: user)
+
+    sign_in user
+    first_name = 'test'
+    last_name = 'test'
+    email = 'email@test.com'
+    post :create, params: {
+      first_name: first_name,
+      last_name: last_name,
+      email: email,
+      patient_id: patient.id
+    }
+
+    assert_response(:success)
+    assert_equal(1, patient.close_contacts.count)
+    assert_equal(1, patient.histories.count)
+
+    close_contact = patient.close_contacts.first
+    assert_equal(first_name, close_contact[:first_name])
+    assert_equal(last_name, close_contact[:last_name])
+    assert_equal(email, close_contact[:email])
+
+    history = patient.histories.first
+    assert_equal(History::HISTORY_TYPES[:close_contact], history[:history_type])
+    assert_equal(user.email, history[:created_by])
+    assert_equal("User added a new close contact (ID: #{close_contact.id}).", history[:comment])
+
+    sign_out user
+  end
+
+  test 'create: handles failure on create and fires error' do
+    user = create(:public_health_enroller_user)
+    patient = create(:patient, creator: user)
+
+    allow_any_instance_of(CloseContact).to receive(:save).and_return(false)
+    sign_in user
+
+    first_name = 'test'
+    last_name = 'test'
+    email = 'email@test.com'
+    post :create, params: {
+      first_name: first_name,
+      last_name: last_name,
+      email: email,
+      patient_id: patient.id
+    }
+
+    assert_response(:bad_request)
+    assert_equal('Close Contact was unable to be created.', JSON.parse(response.body)['error'])
+    assert_equal(0, patient.close_contacts.count)
+    assert_equal(0, patient.histories.count)
+
+    sign_out user
+  end
+
+  # --- UPDATE --- #
+
+  test 'update: updates existing close contact and creates related history item' do
+    user = create(:public_health_enroller_user)
+    patient = create(:patient, creator: user)
+    close_contact = create(:close_contact, patient: patient, updated_at: 2.days.ago)
+
+    sign_in user
+    first_name = 'test'
+    last_name = 'test'
+    email = 'email@test.com'
+    put :update, params: {
+      id: close_contact.id,
+      first_name: first_name,
+      last_name: last_name,
+      email: email,
+      patient_id: patient.id
+    }
+
+    close_contact.reload
+    assert_response(:success)
+    assert_in_delta(Time.now, close_contact.updated_at, 1) # assert updated
+    assert_equal(1, patient.histories.count)
+
+    close_contact = CloseContact.find(close_contact.id)
+    assert_equal(first_name, close_contact[:first_name])
+    assert_equal(last_name, close_contact[:last_name])
+    assert_equal(email, close_contact[:email])
+
+    history = patient.histories.first
+    assert_equal(History::HISTORY_TYPES[:close_contact_edit], history[:history_type])
+    assert_equal(user.email, history[:created_by])
+    assert_equal("User edited a close contact (ID: #{close_contact.id}).", history[:comment])
+
+    sign_out user
+  end
+
+  test 'update: handles failure on update and fires error' do
+    user = create(:public_health_enroller_user)
+    patient = create(:patient, creator: user)
+    close_contact = create(:close_contact, patient: patient, updated_at: 2.days.ago)
+
+    allow_any_instance_of(CloseContact).to receive(:update).and_return(false)
+    sign_in user
+
+    first_name = 'test'
+    last_name = 'test'
+    email = 'email@test.com'
+    put :update, params: {
+      id: close_contact.id,
+      first_name: first_name,
+      last_name: last_name,
+      email: email,
+      patient_id: patient.id
+    }
+
+    assert_response(:bad_request)
+    assert_equal('Close Contact was unable to be updated.', JSON.parse(response.body)['error'])
+    assert_equal(1, patient.close_contacts.count)
+    assert_equal(0, patient.histories.count)
+    assert_equal(CloseContact.find(close_contact.id), close_contact)
+
+    sign_out user
+  end
+
+  # --- DESTROY --- #
+
+  test 'destroy: destroys existing close contact and creates related history item' do
+    user = create(:public_health_enroller_user)
+    patient = create(:patient, creator: user)
+    close_contact = create(:close_contact, patient: patient, first_name: 'test', last_name: 'test', updated_at: 2.days.ago)
+    delete_reason = 'some delete reason'
+
+    sign_in user
+    put :destroy, params: {
+      id: close_contact.id,
+      patient_id: patient.id,
+      delete_reason: delete_reason
+    }
+
+    assert_response(:success)
+    assert_equal(1, patient.histories.count)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      close_contact = CloseContact.find(close_contact.id)
+    end
+
+    history = patient.histories.first
+    assert_equal(History::HISTORY_TYPES[:close_contact_edit], history[:history_type])
+    assert_equal(user.email, history[:created_by])
+    assert_equal("User deleted a close contact (ID: #{close_contact.id}, Name: #{close_contact.first_name} #{close_contact.last_name}"\
+      "). Reason: #{delete_reason}.", history[:comment])
+
+    sign_out user
+  end
+
+  test 'delete: handles failure on delete and fires error' do
+    user = create(:public_health_enroller_user)
+    patient = create(:patient, creator: user)
+    close_contact = create(:close_contact, patient: patient, updated_at: 2.days.ago)
+    delete_reason = 'some delete reason'
+
+    allow_any_instance_of(CloseContact).to receive(:destroy).and_return(false)
+    sign_in user
+
+    put :destroy, params: {
+      id: close_contact.id,
+      patient_id: patient.id,
+      delete_reason: delete_reason
+    }
+
+    assert_response(:bad_request)
+    assert_equal('Close Contact was unable to be deleted.', JSON.parse(response.body)['error'])
+    assert_equal(1, patient.close_contacts.count)
+    assert_equal(0, patient.histories.count)
+    assert_equal(CloseContact.find(close_contact.id), close_contact)
+
+    sign_out user
+  end
+end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-767](https://tracker.codev.mitre.org/browse/SARAALERT-767)

Adds the ability for users to delete close contact records from patients. 

## (Feature) Demo/Screenshots

<img width="1021" alt="Screen Shot 2021-04-26 at 6 56 18 PM" src="https://user-images.githubusercontent.com/16108095/116161083-24b9fe00-a6c1-11eb-9d5b-74846a16d0cf.png">
<img width="1631" alt="Screen Shot 2021-04-26 at 6 56 14 PM" src="https://user-images.githubusercontent.com/16108095/116161077-2257a400-a6c1-11eb-823c-9370a9144260.png">

## Important Changes
app/controllers/close_contacts_controller.rb
- adds the delete method, with some very basic authentication. 
app/javascript/components/patient/close_contact/CloseContact.js
- adds front-end functionality to delete close contacts from the patient view, with a warning prompt. 
app/config/routes.rb
- adds a route for the delete method in the controller so the front-end can interact with the db. 

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@sgober :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@timwongj :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
