### PR TITLE
SARAALERT-1432: Refactor API Scopes

### DIFF
--- a/app/controllers/application_api_controller.rb
+++ b/app/controllers/application_api_controller.rb
@@ -3,6 +3,16 @@
 # ApplicationAPIController: defines methods useful for all API controllers
 class ApplicationApiController < ActionController::API
   include ActionController::MimeResponds
+
+  PATIENT_READ_SCOPES = %i[user/Patient.read user/Patient.* system/Patient.read system/Patient.*].freeze
+  PATIENT_WRITE_SCOPES = %i[user/Patient.write user/Patient.* system/Patient.write system/Patient.*].freeze
+  RELATED_PERSON_READ_SCOPES = %i[user/RelatedPerson.read user/RelatedPerson.* system/RelatedPerson.read system/RelatedPerson.*].freeze
+  RELATED_PERSON_WRITE_SCOPES = %i[user/RelatedPerson.write user/RelatedPerson.* system/RelatedPerson.write system/RelatedPerson.*].freeze
+  IMMUNIZATION_READ_SCOPES = %i[user/Immunization.read user/Immunization.* system/Immunization.read system/Immunization.*].freeze
+  IMMUNIZATION_WRITE_SCOPES = %i[user/Immunization.write user/Immunization.* system/Immunization.write system/Immunization.*].freeze
+  OBSERVATION_READ_SCOPES = %i[user/Observation.read system/Observation.read].freeze
+  QUESTIONNAIRE_RESPONSE_READ_SCOPES = %i[user/QuestionnaireResponse.read system/QuestionnaireResponse.read].freeze
+
   # Generic 401 unauthorized
   def status_unauthorized
     respond_to do |format|

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -7,15 +7,6 @@ class Fhir::R4::ApiController < ApplicationApiController
   include FhirHelper
   include ActionController::MimeResponds
 
-  PATIENT_READ_SCOPES = %i[user/Patient.read user/Patient.* system/Patient.read system/Patient.*].freeze
-  PATIENT_WRITE_SCOPES = %i[user/Patient.write user/Patient.* system/Patient.write system/Patient.*].freeze
-  RELATED_PERSON_READ_SCOPES = %i[user/RelatedPerson.read user/RelatedPerson.* system/RelatedPerson.read system/RelatedPerson.*].freeze
-  RELATED_PERSON_WRITE_SCOPES = %i[user/RelatedPerson.write user/RelatedPerson.* system/RelatedPerson.write system/RelatedPerson.*].freeze
-  IMMUNIZATION_READ_SCOPES = %i[user/Immunization.read user/Immunization.* system/Immunization.read system/Immunization.*].freeze
-  IMMUNIZATION_WRITE_SCOPES = %i[user/Immunization.write user/Immunization.* system/Immunization.write system/Immunization.*].freeze
-  OBSERVATION_READ_SCOPES = %i[user/Observation.read system/Observation.read].freeze
-  QUESTIONNAIRE_RESPONSE_READ_SCOPES = %i[user/QuestionnaireResponse.read system/QuestionnaireResponse.read].freeze
-
   before_action :cors_headers
   before_action only: %i[create update] do
     doorkeeper_authorize!(

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -5,6 +5,17 @@
 class Fhir::R4::ApiController < ApplicationApiController
   include ValidationHelper
   include FhirHelper
+  include ActionController::MimeResponds
+
+  PATIENT_READ_SCOPES = %i[user/Patient.read user/Patient.* system/Patient.read system/Patient.*].freeze
+  PATIENT_WRITE_SCOPES = %i[user/Patient.write user/Patient.* system/Patient.write system/Patient.*].freeze
+  RELATED_PERSON_READ_SCOPES = %i[user/RelatedPerson.read user/RelatedPerson.* system/RelatedPerson.read system/RelatedPerson.*].freeze
+  RELATED_PERSON_WRITE_SCOPES = %i[user/RelatedPerson.write user/RelatedPerson.* system/RelatedPerson.write system/RelatedPerson.*].freeze
+  IMMUNIZATION_READ_SCOPES = %i[user/Immunization.read user/Immunization.* system/Immunization.read system/Immunization.*].freeze
+  IMMUNIZATION_WRITE_SCOPES = %i[user/Immunization.write user/Immunization.* system/Immunization.write system/Immunization.*].freeze
+  OBSERVATION_READ_SCOPES = %i[user/Observation.read system/Observation.read].freeze
+  QUESTIONNAIRE_RESPONSE_READ_SCOPES = %i[user/QuestionnaireResponse.read system/QuestionnaireResponse.read].freeze
+
   before_action :cors_headers
   before_action only: %i[create update] do
     doorkeeper_authorize!(
@@ -987,15 +998,6 @@ class Fhir::R4::ApiController < ApplicationApiController
       end
     end
   end
-
-  PATIENT_READ_SCOPES = %i[user/Patient.read user/Patient.* system/Patient.read system/Patient.*].freeze
-  PATIENT_WRITE_SCOPES = %i[user/Patient.write user/Patient.* system/Patient.write system/Patient.*].freeze
-  RELATED_PERSON_READ_SCOPES = %i[user/RelatedPerson.read user/RelatedPerson.* system/RelatedPerson.read system/RelatedPerson.*].freeze
-  RELATED_PERSON_WRITE_SCOPES = %i[user/RelatedPerson.write user/RelatedPerson.* system/RelatedPerson.write system/RelatedPerson.*].freeze
-  IMMUNIZATION_READ_SCOPES = %i[user/Immunization.read user/Immunization.* system/Immunization.read system/Immunization.*].freeze
-  IMMUNIZATION_WRITE_SCOPES = %i[user/Immunization.write user/Immunization.* system/Immunization.write system/Immunization.*].freeze
-  OBSERVATION_READ_SCOPES = %i[user/Observation.read system/Observation.read].freeze
-  QUESTIONNAIRE_RESPONSE_READ_SCOPES = %i[user/QuestionnaireResponse.read system/QuestionnaireResponse.read].freeze
 
   # Allow cross-origin requests
   def cors_headers

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 # ApiController: API for interacting with Sara Alert
 class Fhir::R4::ApiController < ApplicationApiController
   include ValidationHelper
@@ -997,4 +996,3 @@ class Fhir::R4::ApiController < ApplicationApiController
     headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE, OPTIONS'
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -8,18 +8,18 @@ class Fhir::R4::ApiController < ApplicationApiController
   before_action :cors_headers
   before_action only: %i[create update] do
     doorkeeper_authorize!(
-      *patient_write_scopes,
-      *related_person_write_scopes,
-      *immunization_write_scopes
+      *PATIENT_WRITE_SCOPES,
+      *RELATED_PERSON_WRITE_SCOPES,
+      *IMMUNIZATION_WRITE_SCOPES
     )
   end
   before_action only: %i[show search] do
     doorkeeper_authorize!(
-      *patient_read_scopes,
-      *related_person_read_scopes,
-      *immunization_read_scopes,
-      *observation_read_scopes,
-      *questionnaire_response_read_scopes
+      *PATIENT_READ_SCOPES,
+      *RELATED_PERSON_READ_SCOPES,
+      *IMMUNIZATION_READ_SCOPES,
+      *OBSERVATION_READ_SCOPES,
+      *QUESTIONNAIRE_RESPONSE_READ_SCOPES
     )
   end
   before_action :check_client_type
@@ -36,23 +36,23 @@ class Fhir::R4::ApiController < ApplicationApiController
     resource_type = params.permit(:resource_type)[:resource_type]&.downcase
     case resource_type
     when 'patient'
-      return if doorkeeper_authorize!(*patient_read_scopes)
+      return if doorkeeper_authorize!(*PATIENT_READ_SCOPES)
 
       resource = get_patient(params.permit(:id)[:id])
     when 'observation'
-      return if doorkeeper_authorize!(*observation_read_scopes)
+      return if doorkeeper_authorize!(*OBSERVATION_READ_SCOPES)
 
       resource = get_record(Laboratory, params.permit(:id)[:id])
     when 'questionnaireresponse'
-      return if doorkeeper_authorize!(*questionnaire_response_read_scopes)
+      return if doorkeeper_authorize!(*QUESTIONNAIRE_RESPONSE_READ_SCOPES)
 
       resource = get_record(Assessment, params.permit(:id)[:id])
     when 'relatedperson'
-      return if doorkeeper_authorize!(*related_person_read_scopes)
+      return if doorkeeper_authorize!(*RELATED_PERSON_READ_SCOPES)
 
       resource = get_record(CloseContact, params.permit(:id)[:id])
     when 'immunization'
-      return if doorkeeper_authorize!(*immunization_read_scopes)
+      return if doorkeeper_authorize!(*IMMUNIZATION_READ_SCOPES)
 
       resource = get_record(Vaccine, params.permit(:id)[:id])
     else
@@ -87,7 +87,7 @@ class Fhir::R4::ApiController < ApplicationApiController
     resource_type = params.permit(:resource_type)[:resource_type]&.downcase
     case resource_type
     when 'patient'
-      return if doorkeeper_authorize!(*patient_write_scopes)
+      return if doorkeeper_authorize!(*PATIENT_WRITE_SCOPES)
 
       # Get the patient that needs to be updated
       patient = get_patient(params.permit(:id)[:id])
@@ -136,7 +136,7 @@ class Fhir::R4::ApiController < ApplicationApiController
 
       status_ok(patient.as_fhir) && return
     when 'relatedperson'
-      return if doorkeeper_authorize!(*related_person_write_scopes)
+      return if doorkeeper_authorize!(*RELATED_PERSON_WRITE_SCOPES)
 
       # Get the CloseContact that needs to be updated
       close_contact = get_record(CloseContact, params.permit(:id)[:id])
@@ -172,7 +172,7 @@ class Fhir::R4::ApiController < ApplicationApiController
       end
       status_ok(close_contact.as_fhir) && return
     when 'immunization'
-      return if doorkeeper_authorize!(*immunization_write_scopes)
+      return if doorkeeper_authorize!(*IMMUNIZATION_WRITE_SCOPES)
 
       # Get the Vaccine that needs to be updated
       vaccine = get_record(Vaccine, params.permit(:id)[:id])
@@ -254,7 +254,7 @@ class Fhir::R4::ApiController < ApplicationApiController
     resource_type = params.permit(:resource_type)[:resource_type]&.downcase
     case resource_type
     when 'patient'
-      return if doorkeeper_authorize!(*patient_write_scopes)
+      return if doorkeeper_authorize!(*PATIENT_WRITE_SCOPES)
 
       # Construct a Sara Alert Patient
       # fhir_map is of the form:
@@ -306,7 +306,7 @@ class Fhir::R4::ApiController < ApplicationApiController
       # Send enrollment notification only to responders
       resource.send_enrollment_notification if resource.self_reporter_or_proxy?
     when 'relatedperson'
-      return if doorkeeper_authorize!(*related_person_write_scopes)
+      return if doorkeeper_authorize!(*RELATED_PERSON_WRITE_SCOPES)
 
       fhir_map = close_contact_from_fhir(contents)
       vals = fhir_map.transform_values { |v| v[:value] }
@@ -324,7 +324,7 @@ class Fhir::R4::ApiController < ApplicationApiController
                               comment: "New close contact added via API (ID: #{resource.id}).")
       end
     when 'immunization'
-      return if doorkeeper_authorize!(*immunization_write_scopes)
+      return if doorkeeper_authorize!(*IMMUNIZATION_WRITE_SCOPES)
 
       fhir_map = vaccine_from_fhir(contents)
       vals = fhir_map.transform_values { |v| v[:value] }
@@ -362,27 +362,27 @@ class Fhir::R4::ApiController < ApplicationApiController
                                  '_count', '_id', 'patient')
     case resource_type
     when 'patient'
-      return if doorkeeper_authorize!(*patient_read_scopes)
+      return if doorkeeper_authorize!(*PATIENT_READ_SCOPES)
 
       resources = search_patients(search_params)
       resource_type = 'Patient'
     when 'observation'
-      return if doorkeeper_authorize!(*observation_read_scopes)
+      return if doorkeeper_authorize!(*OBSERVATION_READ_SCOPES)
 
       resources = search_laboratories(search_params) || []
       resource_type = 'Observation'
     when 'questionnaireresponse'
-      return if doorkeeper_authorize!(*questionnaire_response_read_scopes)
+      return if doorkeeper_authorize!(*QUESTIONNAIRE_RESPONSE_READ_SCOPES)
 
       resources = search_assessments(search_params) || []
       resource_type = 'QuestionnaireResponse'
     when 'relatedperson'
-      return if doorkeeper_authorize!(*related_person_read_scopes)
+      return if doorkeeper_authorize!(*RELATED_PERSON_READ_SCOPES)
 
       resources = search_close_contacts(search_params) || []
       resource_type = 'RelatedPerson'
     when 'immunization'
-      return if doorkeeper_authorize!(*immunization_read_scopes)
+      return if doorkeeper_authorize!(*IMMUNIZATION_READ_SCOPES)
 
       resources = search_vaccines(search_params) || []
       resource_type = 'Immunization'
@@ -422,11 +422,11 @@ class Fhir::R4::ApiController < ApplicationApiController
   # GET /fhir/r4/Patient/[:id]/$everything
   def all
     # Require all scopes for all five resources
-    return if doorkeeper_authorize!(*patient_read_scopes)
-    return if doorkeeper_authorize!(*observation_read_scopes)
-    return if doorkeeper_authorize!(*questionnaire_response_read_scopes)
-    return if doorkeeper_authorize!(*related_person_read_scopes)
-    return if doorkeeper_authorize!(*immunization_read_scopes)
+    return if doorkeeper_authorize!(*PATIENT_READ_SCOPES)
+    return if doorkeeper_authorize!(*OBSERVATION_READ_SCOPES)
+    return if doorkeeper_authorize!(*QUESTIONNAIRE_RESPONSE_READ_SCOPES)
+    return if doorkeeper_authorize!(*RELATED_PERSON_READ_SCOPES)
+    return if doorkeeper_authorize!(*IMMUNIZATION_READ_SCOPES)
 
     status_not_acceptable && return unless accept_header?
 
@@ -988,37 +988,14 @@ class Fhir::R4::ApiController < ApplicationApiController
     end
   end
 
-  def patient_read_scopes
-    %i[user/Patient.read user/Patient.* system/Patient.read system/Patient.*]
-  end
-
-  def patient_write_scopes
-    %i[user/Patient.write user/Patient.* system/Patient.write system/Patient.*]
-  end
-
-  def related_person_read_scopes
-    %i[user/RelatedPerson.read user/RelatedPerson.* system/RelatedPerson.read system/RelatedPerson.*]
-  end
-
-  def related_person_write_scopes
-    %i[user/RelatedPerson.write user/RelatedPerson.* system/RelatedPerson.write system/RelatedPerson.*]
-  end
-
-  def immunization_read_scopes
-    %i[user/Immunization.read user/Immunization.* system/Immunization.read system/Immunization.*]
-  end
-
-  def immunization_write_scopes
-    %i[user/Immunization.write user/Immunization.* system/Immunization.write system/Immunization.*]
-  end
-
-  def observation_read_scopes
-    %i[user/Observation.read system/Observation.read]
-  end
-
-  def questionnaire_response_read_scopes
-    %i[user/QuestionnaireResponse.read system/QuestionnaireResponse.read]
-  end
+  PATIENT_READ_SCOPES = %i[user/Patient.read user/Patient.* system/Patient.read system/Patient.*].freeze
+  PATIENT_WRITE_SCOPES = %i[user/Patient.write user/Patient.* system/Patient.write system/Patient.*].freeze
+  RELATED_PERSON_READ_SCOPES = %i[user/RelatedPerson.read user/RelatedPerson.* system/RelatedPerson.read system/RelatedPerson.*].freeze
+  RELATED_PERSON_WRITE_SCOPES = %i[user/RelatedPerson.write user/RelatedPerson.* system/RelatedPerson.write system/RelatedPerson.*].freeze
+  IMMUNIZATION_READ_SCOPES = %i[user/Immunization.read user/Immunization.* system/Immunization.read system/Immunization.*].freeze
+  IMMUNIZATION_WRITE_SCOPES = %i[user/Immunization.write user/Immunization.* system/Immunization.write system/Immunization.*].freeze
+  OBSERVATION_READ_SCOPES = %i[user/Observation.read system/Observation.read].freeze
+  QUESTIONNAIRE_RESPONSE_READ_SCOPES = %i[user/QuestionnaireResponse.read system/QuestionnaireResponse.read].freeze
 
   # Allow cross-origin requests
   def cors_headers


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1432](https://tracker.codev.mitre.org/browse/SARAALERT-1432)

This PR refactors how we handle checking scopes in the API so that we don't explicitly list out all the scopes every single time we authorize. Since certain scopes are always grouped together (for example, we don't have any cases where it would make sense for someone to be allowed only the `system/Patient.read` scope but not the `system/Patient.*` scope), this PR groups those scopes together and uses those groupings when authorizing. This came out of this [comment](https://github.com/SaraAlert/SaraAlert/pull/797#discussion_r609973264) by @dubem7.  

## Important Changes
`api_controller.rb`
- Refactor listing of scopes in `doorkeeper_authorize!` calls.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@dubem7 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ashankland 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
