### PR TITLE
SARAALERT-1357: Prevent users from adding dependents to a dependent record

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -98,17 +98,6 @@ class PatientsController < ApplicationController
   def create
     redirect_to(root_url) && return unless current_user.can_create_patient? || current_user.can_import?
 
-    # ----- Error Checking -----
-
-    # Check if patient's responder is a dependent in a household
-    if params.permit(:responder_id)[:responder_id]
-      responder = current_user.get_patient(params.permit(:responder_id)[:responder_id])
-      unless responder.responder_id == responder.id
-        error_message = 'Add new household member failed: responder is a dependent in a household.'
-        render(json: { error: error_message }, status: :bad_request) && return
-      end
-    end
-
     # Check for potential duplicate
     unless params[:bypass_duplicate]
       duplicate_data = current_user.viewable_patients.duplicate_data_detection(allowed_params)

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -98,6 +98,17 @@ class PatientsController < ApplicationController
   def create
     redirect_to(root_url) && return unless current_user.can_create_patient? || current_user.can_import?
 
+    # ----- Error Checking -----
+
+    # Check if patient's responder is a dependent in a household
+    if params.permit(:responder_id)[:responder_id]
+      responder = current_user.get_patient(params.permit(:responder_id)[:responder_id])
+      unless responder.responder_id == responder.id
+        error_message = 'Add new household member failed: responder is a dependent in a household.'
+        render(json: { error: error_message }, status: :bad_request) && return
+      end
+    end
+
     # Check for potential duplicate
     unless params[:bypass_duplicate]
       duplicate_data = current_user.viewable_patients.duplicate_data_detection(allowed_params)

--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -166,7 +166,7 @@ class Enrollment extends React.Component {
         }
       })
       .catch(err => {
-        reportError(err);
+        reportError(err?.response?.data?.error ? err.response.data.error : err, false);
       });
   };
 

--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -166,7 +166,7 @@ class Enrollment extends React.Component {
         }
       })
       .catch(err => {
-        reportError(err?.response?.data?.error ? err.response.data.error : err, false);
+        reportError(err);
       });
   };
 

--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -79,7 +79,7 @@ class Enrollment extends React.Component {
       window.onbeforeunload = () => {
         return 'All progress will be lost. Are you sure?';
       };
-      reenableButtons(true, true);
+      reenableButtons();
     }
   };
 
@@ -167,7 +167,6 @@ class Enrollment extends React.Component {
       })
       .catch(err => {
         reportError(err?.response?.data?.error ? err.response.data.error : err, false);
-        reenableButtons(true, false);
       });
   };
 

--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -57,7 +57,7 @@ class Enrollment extends React.Component {
     });
   }, 1000);
 
-  handleConfirmDuplicate = async (data, groupMember, message, reenableSubmit, confirmText) => {
+  handleConfirmDuplicate = async (data, groupMember, message, reenableButtons, confirmText) => {
     if (await confirmDialog(confirmText)) {
       data['bypass_duplicate'] = true;
       axios({
@@ -79,11 +79,11 @@ class Enrollment extends React.Component {
       window.onbeforeunload = () => {
         return 'All progress will be lost. Are you sure?';
       };
-      reenableSubmit();
+      reenableButtons(true, true);
     }
   };
 
-  submit = (_event, groupMember, reenableSubmit) => {
+  submit = (_event, groupMember, reenableButtons) => {
     window.onbeforeunload = null;
     axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
 
@@ -155,7 +155,7 @@ class Enrollment extends React.Component {
           text += ` Are you sure you want to enroll this ${patientType}?`;
 
           // Duplicate, ask if want to continue with create
-          this.handleConfirmDuplicate(data, groupMember, message, reenableSubmit, text);
+          this.handleConfirmDuplicate(data, groupMember, message, reenableButtons, text);
         } else {
           // Success, inform user and redirect to home
           toast.success(message, {
@@ -167,6 +167,7 @@ class Enrollment extends React.Component {
       })
       .catch(err => {
         reportError(err?.response?.data?.error ? err.response.data.error : err, false);
+        reenableButtons(true, false);
       });
   };
 

--- a/app/javascript/components/enrollment/steps/Review.js
+++ b/app/javascript/components/enrollment/steps/Review.js
@@ -7,18 +7,18 @@ import Patient from '../../patient/Patient';
 class Review extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { submitDisabled: false, cancelDisabled: false, showGroupAddNotification: false };
+    this.state = { disabled: false, showGroupAddNotification: false };
   }
 
   submit = (event, groupMember) => {
     // Update state before submitting data so submit button disables when clicked to prevent multiple submissions.
-    this.setState({ submitDisabled: true, cancelDisabled: true }, () => {
+    this.setState({ disabled: true }, () => {
       this.props.submit(event, groupMember, this.reenableButtons);
     });
   };
 
-  reenableButtons = (submitDisabled, cancelDisabled) => {
-    this.setState({ submitDisabled, cancelDisabled });
+  reenableButtons = () => {
+    this.setState({ disabled: false });
   };
 
   toggleGroupAddNotification = () => {
@@ -82,7 +82,7 @@ class Review extends React.Component {
                 variant="secondary"
                 size="lg"
                 className="float-right btn-square px-5"
-                disabled={this.state.cancelDisabled}
+                disabled={this.state.disabled}
                 onClick={() => {
                   window.history.back();
                 }}>
@@ -94,7 +94,7 @@ class Review extends React.Component {
                 variant="primary"
                 size="lg"
                 className="float-right btn-square px-5 mr-4"
-                disabled={this.state.submitDisabled}
+                disabled={this.state.disabled}
                 onClick={this.submit}>
                 Finish
               </Button>
@@ -104,7 +104,7 @@ class Review extends React.Component {
                 variant="primary"
                 size="lg"
                 className="float-right btn-square px-5 mr-4"
-                disabled={this.state.submitDisabled}
+                disabled={this.state.disabled}
                 onClick={this.toggleGroupAddNotification}>
                 Finish and Add a Household Member
               </Button>

--- a/app/javascript/components/enrollment/steps/Review.js
+++ b/app/javascript/components/enrollment/steps/Review.js
@@ -7,18 +7,18 @@ import Patient from '../../patient/Patient';
 class Review extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { submitDisabled: false, showGroupAddNotification: false };
+    this.state = { submitDisabled: false, cancelDisabled: false, showGroupAddNotification: false };
   }
 
   submit = (event, groupMember) => {
     // Update state before submitting data so submit button disables when clicked to prevent multiple submissions.
-    this.setState({ submitDisabled: true }, () => {
-      this.props.submit(event, groupMember, this.reenableSubmit);
+    this.setState({ submitDisabled: true, cancelDisabled: true }, () => {
+      this.props.submit(event, groupMember, this.reenableButtons);
     });
   };
 
-  reenableSubmit = () => {
-    this.setState({ submitDisabled: false });
+  reenableButtons = (submitDisabled, cancelDisabled) => {
+    this.setState({ submitDisabled, cancelDisabled });
   };
 
   toggleGroupAddNotification = () => {
@@ -82,7 +82,7 @@ class Review extends React.Component {
                 variant="secondary"
                 size="lg"
                 className="float-right btn-square px-5"
-                disabled={this.state.submitDisabled}
+                disabled={this.state.cancelDisabled}
                 onClick={() => {
                   window.history.back();
                 }}>
@@ -90,7 +90,12 @@ class Review extends React.Component {
               </Button>
             )}
             {this.props.submit && (
-              <Button variant="primary" size="lg" className="float-right btn-square px-5 mr-4" disabled={this.state.submitDisabled} onClick={this.submit}>
+              <Button
+                variant="primary"
+                size="lg"
+                className="float-right btn-square px-5 mr-4"
+                disabled={this.state.submitDisabled}
+                onClick={this.submit}>
                 Finish
               </Button>
             )}

--- a/app/javascript/components/enrollment/steps/Review.js
+++ b/app/javascript/components/enrollment/steps/Review.js
@@ -28,11 +28,11 @@ class Review extends React.Component {
     });
   };
 
-  createModal(title, toggle, submit) {
+  createModal() {
     return (
-      <Modal size="lg" show centered onHide={toggle}>
+      <Modal size="lg" show centered onHide={this.toggleGroupAddNotification}>
         <Modal.Header>
-          <Modal.Title>{title}</Modal.Title>
+          <Modal.Title>Enroll Household Members</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <p>
@@ -46,10 +46,10 @@ class Review extends React.Component {
           </p>
         </Modal.Body>
         <Modal.Footer>
-          <Button variant="secondary btn-square" onClick={toggle}>
+          <Button variant="secondary btn-square" onClick={this.toggleGroupAddNotification}>
             Cancel
           </Button>
-          <Button variant="primary btn-square" onClick={submit}>
+          <Button variant="primary btn-square" onClick={event => this.submit(event, true)}>
             Continue
           </Button>
         </Modal.Footer>
@@ -94,7 +94,7 @@ class Review extends React.Component {
                 Finish
               </Button>
             )}
-            {this.props.submit && this.props.currentState.responder_id === this.props.currentState.id && this.props.canAddGroup && (
+            {this.props.submit && this.props.currentState.patient.responder_id === this.props.currentState.patient.id && this.props.canAddGroup && (
               <Button
                 variant="primary"
                 size="lg"
@@ -106,8 +106,7 @@ class Review extends React.Component {
             )}
           </Card.Body>
         </Card>
-        {this.state.showGroupAddNotification &&
-          this.createModal('Enroll Household Members', this.toggleGroupAddNotification, event => this.submit(event, true))}
+        {this.state.showGroupAddNotification && this.createModal()}
       </React.Fragment>
     );
   }


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1357](https://tracker.codev.mitre.org/browse/SARAALERT-1357)

If two users are editing a record at once, and one of them opens the model to add a dependent to the record, and another one adds that record as a dependent, then the first user may be able to enroll a dependent on a dependent record. In addition, this fixes a bug where the "Finish and Add a Household Member" button is displayed for a dependent when it should not be.

## (Bugfix) How to Replicate
There are two ways to replicate this bug, one for a HoH and one for an individual

HoH:
1. Open up two tabs of Sara Alert with the same HoH details displayed in each
2. In one tab, open up the Change HoH modal.  Select a dependent but **DO NOT SUBMIT**
3. In the other tab, click the "Enroll Household Member" button
4. Step through the enrollment wizard filling in necessary fields
5. When you get to the review page, **STOP**
6. Go back to the other tab and submit the change HoH
7. Then come back to the tab with the enrollment, and click the finish button

Individual:
1. Open up two tabs of Sara Alert with the same individual details displayed in each
2. In one tab, open up the Move to Household modal. **DON'T SELECT ANYTHING YET**
3. In the other tab, click the "Enroll Household Member" button
4. Step through the enrollment wizard filling in necessary fields
5. When you get to the review page, **STOP**
6. Go back to the other tab and select a HoH for the individual
7. Then come back to the tab with the enrollment, and click the finish button

For both of these cases, this will allow you to create a new household member as the dependent of a househould, which should not be allowed.  However, if you do it in the opposite order (enroll new household member THEN move to household/change hoh), the move/change will be prevented because there is already error handling for that.

## (Bugfix) Solution
Insert description for the solution this PR implements to address the bug.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`patients_controller.rb`
- Added error checking when creating a new monitoree.  If the responder for the monitoree is already a dependent in a household (i.e. responder_id != id), fire an error and prevent the monitoree from being created

`Enrollment.js`
- Ensure the error message is displayed in the red box at the top of the screen

`Review.js`
- Fixed a bug where the "Finish and Add a Household Member" was being displayed for a dependent, when it should not be
- Refactored some unnecessary code


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@tstrass :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@hackrm :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] **N/A** The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] **N/A** If applicable, you have tested changes against a large database, and considered possible performance regressions


@dubem7 :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] **N/A** If applicable, you have tested changes against a large database, and considered possible performance regressions