### PR TITLE
errored_report_reminder -> unsuccessful_report_reminder

### DIFF
--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -206,7 +206,7 @@ class PatientMailer < ApplicationMailer
   end
 
   def add_fail_history_blank_field(patient, type)
-    History.errored_report_reminder(patient: patient,
+    History.unsuccessful_report_reminder(patient: patient,
                                     comment: "Sara Alert could not send a report reminder to this monitoree via \
                                      #{patient.preferred_contact_method}, because the monitoree #{type} was blank.")
   end

--- a/app/mailers/twilio_sender.rb
+++ b/app/mailers/twilio_sender.rb
@@ -120,6 +120,6 @@ class TwilioSender
              # If errored contact was for a particular dependent ie: weblink assessment
              [patient, patient&.responder]
            end
-    History.errored_report_reminder_group_of_patients(patients: pats, error_message: error_message)
+    History.unsuccessful_report_reminder_group_of_patients(patients: pats, error_message: error_message)
   end
 end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -18,7 +18,7 @@ class History < ApplicationRecord
     reports_reviewed: 'Reports Reviewed',
     report_reviewed: 'Report Reviewed',
     report_reminder: 'Report Reminder',
-    errored_report_reminder: 'Unsuccessful Report Reminder',
+    unsuccessful_report_reminder: 'Unsuccessful Report Reminder',
     report_note: 'Report Note',
     lab_result: 'Lab Result',
     lab_result_edit: 'Lab Result Edit',
@@ -124,7 +124,7 @@ class History < ApplicationRecord
       .where(history_type: [HISTORY_TYPES[:reports_reviewed], HISTORY_TYPES[:report_reviewed]])
   }
 
-  def self.errored_report_reminder_group_of_patients(patients: nil, created_by: 'Sara Alert System', comment: 'Failed Contact Attempt', error_message: nil)
+  def self.unsuccessful_report_reminder_group_of_patients(patients: nil, created_by: 'Sara Alert System', comment: 'Failed Contact Attempt', error_message: nil)
     histories = []
     patients.uniq.each do |pat|
       if pat.responder == pat
@@ -140,7 +140,7 @@ class History < ApplicationRecord
                 else
                   "Sara Alert attempted to call #{recipient} at #{responder.primary_telephone}, but the call could not be completed.#{details}"
                 end
-      histories << History.new(created_by: created_by, comment: comment, patient_id: pat.id, history_type: HISTORY_TYPES[:errored_report_reminder])
+      histories << History.new(created_by: created_by, comment: comment, patient_id: pat.id, history_type: HISTORY_TYPES[:unsuccessful_report_reminder])
     end
     History.import! histories
   end
@@ -182,8 +182,8 @@ class History < ApplicationRecord
                    comment)
   end
 
-  def self.errored_report_reminder(patient: nil, created_by: 'Sara Alert System', comment: 'Unsuccessful report reminder.')
-    create_history(patient, created_by, HISTORY_TYPES[:errored_report_reminder], comment)
+  def self.unsuccessful_report_reminder(patient: nil, created_by: 'Sara Alert System', comment: 'Unsuccessful report reminder.')
+    create_history(patient, created_by, HISTORY_TYPES[:unsuccessful_report_reminder], comment)
   end
 
   def self.vaccination(patient: nil, created_by: 'Sara Alert System', comment: 'User added a new vaccination.')


### PR DESCRIPTION
History types in frontend are filtered by humanized HISTORY_TYPES keys -- the 'Unsuccessful Report Reminder' history type key did not match the value text.

# Checklists

**Submitter:**
- [ ] This PR describes why these changes were made.
- [ ] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA ticket reference.
- [ ] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary

