### PR TITLE
SARAALERT-1186: Notify a user of an export that had no patients matching export criteria

### DIFF
--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -27,7 +27,6 @@ class ExportJob < ApplicationJob
     # Construct export
     patients = patients_by_query(user, data.dig(:patients, :query) || {})
     files = write_export_data_to_files(config, patients, OUTER_BATCH_SIZE, INNER_BATCH_SIZE)
-    return unless files.present?
 
     # Sort files by filename so that they are grouped together accordingly after batching
     files = files.sort_by { |file| file[:filename] }

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -143,6 +143,9 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
           files << save_file(config, file)
         end
       else
+        # Do not create a file for an export that only has headers.
+        next if last_row_nums.values.all?(&:zero?)
+
         file = { filename: build_export_filename(config, nil, outer_batch_index, false), content: Base64.encode64(workbook.read_string) }
         files << save_file(config, file)
       end

--- a/app/views/user_mailer/download_email.html.erb
+++ b/app/views/user_mailer/download_email.html.erb
@@ -1,20 +1,26 @@
 <% content_for :body do %>
-  <p>Your requested export of &quot;<b><%= @export_label %></b>&quot; is now ready.<p>
-      Please note that this export link is one-time use only. The system will delete a stored export file either once you've downloaded that file or whenever stored files are purged on Saturdays, whichever comes first. Once the file is deleted, it will no longer be accessible.
+  <% if @lookups.empty? %>
+    <p>
+      Your request for export of &quot;<b><%= @export_label %></b>&quot; was received but no monitorees or monitoree data matched the selected export criteria. Therefore, no export file is available for download.
+    </p>
+  <% else %>
+    <p>
+      Your requested export of &quot;<b><%= @export_label %></b>&quot; is now ready.
+    </p>
+    Please note that this export link is one-time use only. The system will delete a stored export file either once you've downloaded that file or whenever stored files are purged on Saturdays, whichever comes first. Once the file is deleted, it will no longer be accessible.
     These downloads will be invalid if you attempt another export of this type before retrieving the file(s). Exports will not work if forwarded to another user. You must be logged into Sara Alert to access exports.
     <br />
     <br />
     If your export exceeded <%= number_with_delimiter(@batch_size) %> records, you will see separate files below with each containing data for no more than <%= number_with_delimiter(@batch_size) %> monitorees.
     Each file (e.g., monitorees, assessments, etc) belonging to the same batch will have the same number at the end of the filename.
-  </p>
-  </p>
-  <% @lookups.each do |lookup| %>
-  <%= render partial: 'main_mailer/responsive_button', locals: { link: export_download_url(lookup: lookup[:lookup]), text: "Click here to download #{lookup[:filename]}" } %>
-  <br />
+    <% @lookups.each do |lookup| %>
+      <%= render partial: 'main_mailer/responsive_button', locals: { link: export_download_url(lookup: lookup[:lookup]), text: "Click here to download #{lookup[:filename]}" } %>
+      <br />
+    <% end %>
   <% end %>
-  <% end %>
+<% end %>
 
-  <% content_for :footer do %>
+<% content_for :footer do %>
   <p>
     This notification was sent by the Sara Alert system. If you wish to stop receiving these notifications or believe that it was a mistake, please contact the help desk.
   </p>

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'test_case'
+
+class UserMailerTest < ActionMailer::TestCase
+  def setup
+    @user = create(:user)
+  end
+
+  test 'download email no lookups' do
+    # When no monitorees match export criteria lookups = []
+    email = UserMailer.download_email(@user, 'Export Label', [], 10_000).deliver_now
+    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    assert_not(ActionMailer::Base.deliveries.empty?)
+    assert_includes(email_body, 'Export Label')
+    assert_includes(email_body, 'no monitorees or monitoree data matched the selected export criteria')
+  end
+end


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1186

If there are no valid patients for an export (such as with purge eligible), the user will be confused because the export starts and finishes successfully but no email is sent letting the user know that nothing was actually available to export.

If there are valid patients for an export, but all selected patients do not have any data (such as a group of patients that all do not have lab results) and the user requests that only lab results be exported, they will get an email notifying them that nothing was available to export.

This PR will send an email notifying users that the export did not have any patients available.

## (Feature) Demo/Screenshots
<img width="622" alt="Screen Shot 2021-05-03 at 16 26 44" src="https://user-images.githubusercontent.com/3009651/116945465-90a1e680-ac2c-11eb-989b-e2a752670d7f.png">



## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`export_job.rb`
- Remove return statement blocking empty exports from sending an email.

`import_export.rb`
- Check if the worksheet only has headers. If it does, do not create a file for it.

`download_email.html.erb`
- Add logic and text for empty export.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@ngfreiter  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
