### PR TITLE
SARAALERT-1344: Converts language back to display code for export

### DIFF
--- a/app/javascript/components/patient/Patient.js
+++ b/app/javascript/components/patient/Patient.js
@@ -34,7 +34,8 @@ class Patient extends React.Component {
   componentDidUpdate(nextProps, prevState) {
     // The way that Enrollment is structured, this Patient component is not re-mounted when reviewing a Patient
     // We need to update the `primaryLanguageDisplayName`. We reset `primary_language` below to break out of the
-    // infinite loop that not resetting it will cause.
+    // infinite loop that not resetting it will cause. You cannot use `getDerivedStateFromProps` here due to the
+    // async nature of convertLanguageCodesToNames()
     if (nextProps.details?.primary_language !== prevState.details?.primary_language) {
       convertLanguageCodesToNames([nextProps.details?.primary_language], this.props.authenticity_token, res => {
         this.setState({

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -301,6 +301,8 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
       patient_details[:expected_purge_ts] = patient.expected_purge_date_exp if fields.include?(:expected_purge_ts)
       patient_details[:full_status] = patient.status&.to_s&.humanize&.downcase if fields.include?(:full_status)
       patient_details[:status] = patient.status&.to_s&.humanize&.downcase&.sub('exposure ', '')&.sub('isolation ', '') if fields.include?(:status)
+      patient_details[:primary_language] = Languages.translate_code_to_display(patient.primary_language)
+      patient_details[:secondary_language] = Languages.translate_code_to_display(patient.secondary_language)
 
       # populate creator if requested
       patient_details[:creator] = patients_creators[patient.creator_id] if fields.include?(:creator)

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -13,6 +13,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
   include HistoryQueryHelper
   include Utils
   include ExcelSanitizer
+  include Languages
 
   # Writes export data to file(s)
   def write_export_data_to_files(config, patients, outer_batch_size, inner_batch_size)
@@ -289,6 +290,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
       (fields & PATIENT_FIELD_TYPES[:phones]).each { |field| patient_details[field] = format_phone_number(patient[field]) }
       (fields & (PATIENT_FIELD_TYPES[:numbers] + PATIENT_FIELD_TYPES[:timestamps])).each { |field| patient_details[field] = patient[field] }
       (fields & (PATIENT_FIELD_TYPES[:booleans] + PATIENT_FIELD_TYPES[:races])).each { |field| patient_details[field] = patient[field] || false }
+      (fields & PATIENT_FIELD_TYPES[:languages]).each { |field| patient_details[field] = Languages.translate_code_to_display(patient[field]) }
 
       # populate computed fields
       patient_details[:name] = patient.displayed_name if fields.include?(:name)
@@ -301,8 +303,6 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
       patient_details[:expected_purge_ts] = patient.expected_purge_date_exp if fields.include?(:expected_purge_ts)
       patient_details[:full_status] = patient.status&.to_s&.humanize&.downcase if fields.include?(:full_status)
       patient_details[:status] = patient.status&.to_s&.humanize&.downcase&.sub('exposure ', '')&.sub('isolation ', '') if fields.include?(:status)
-      patient_details[:primary_language] = Languages.translate_code_to_display(patient.primary_language)
-      patient_details[:secondary_language] = Languages.translate_code_to_display(patient.secondary_language)
 
       # populate creator if requested
       patient_details[:creator] = patients_creators[patient.creator_id] if fields.include?(:creator)

--- a/app/lib/import_export_constants.rb
+++ b/app/lib/import_export_constants.rb
@@ -138,6 +138,7 @@ module ImportExportConstants # rubocop:todo Metrics/ModuleLength
                  member_of_a_common_exposure_cohort head_of_household pause_notifications],
     races: %i[white black_or_african_american american_indian_or_alaska_native asian native_hawaiian_or_other_pacific_islander race_other race_unknown
               race_refused_to_answer],
+    languages: %i[primary_language secondary_language],
     alternative_identifiers: %i[user_defined_id_statelocal user_defined_id_cdc user_defined_id_nndss],
     lab_fields: %i[lab_1_type lab_1_specimen_collection lab_1_report lab_1_result lab_2_type lab_2_specimen_collection lab_2_report lab_2_result]
   }.freeze

--- a/app/lib/languages.rb
+++ b/app/lib/languages.rb
@@ -34,7 +34,7 @@ module Languages
   # PARAM: 'eng', 'spa', 'fra'
   # RETURN VALUE: 'English', 'Spanish', 'French'
   def self.translate_code_to_display(lang)
-    Languages.all_languages[lang&.to_sym]&.[](:display)
+    Languages.all_languages.dig(lang&.to_sym, :display)
   end
 
   # This function will attempt to match the input to a language in the system

--- a/app/lib/languages.rb
+++ b/app/lib/languages.rb
@@ -29,6 +29,14 @@ module Languages
     matched_val ? matched_val.to_s : lang
   end
 
+  # Given an 3-letter iso code, return the Language Display name for that language
+  # Function will return nil for nil (or unmatchable)
+  # PARAM: 'eng', 'spa', 'fra'
+  # RETURN VALUE: 'English', 'Spanish', 'French'
+  def self.translate_code_to_display(lang)
+    Languages.all_languages[lang&.to_sym]&.[](:display)
+  end
+
   # This function will attempt to match the input to a language in the system
   # PARAM: `lang` can be a three-letter iso-639-2t code, a two-letter iso-639-1 code, or the name (not case sensitive)
   # PARAM EXAMPLES: 'eng', 'en', 'English', 'ENGLISH' <-- All will map to 'eng'

--- a/test/lib/languages_test.rb
+++ b/test/lib/languages_test.rb
@@ -34,6 +34,19 @@ class LanguagesTest < ActiveSupport::TestCase
     assert_nil(Languages.normalize_and_get_language_code(:en))
   end
 
+  test 'translate code to display string' do
+    assert_equal(Languages.translate_code_to_display('eng'), 'English')
+    assert_equal(Languages.translate_code_to_display('fra'), 'French')
+    assert_equal(Languages.translate_code_to_display('isl'), 'Icelandic')
+
+    assert_equal(Languages.translate_code_to_display(:ita), 'Italian')
+    assert_equal(Languages.translate_code_to_display(:cha), 'Chamorro')
+    assert_equal(Languages.translate_code_to_display(:ase), 'American Sign Language')
+
+    assert_nil(Languages.translate_code_to_display('INVALID LANGUAGE'))
+    assert_nil(Languages.translate_code_to_display(nil))
+  end
+
   test 'normalize_and_get_language_code 2-letter-code' do
     assert_equal(:eng, Languages.normalize_and_get_language_code('en'))
     assert_equal(:'spa-pr', Languages.normalize_and_get_language_code('es-PR'))

--- a/test/system/roles/public_health/dashboard/export_verifier.rb
+++ b/test/system/roles/public_health/dashboard/export_verifier.rb
@@ -7,6 +7,7 @@ require_relative '../../../lib/system_test_utils'
 
 class PublicHealthMonitoringExportVerifier < ApplicationSystemTestCase
   include ImportExport
+  include Languages
   @@system_test_utils = SystemTestUtils.new(nil)
 
   DOWNLOAD_TIMEOUT = 5
@@ -169,6 +170,8 @@ class PublicHealthMonitoringExportVerifier < ApplicationSystemTestCase
           assert_equal(patient.status&.to_s&.humanize&.downcase, cell_value, "For field: #{field} (row #{row + 1})")
         elsif %i[primary_telephone secondary_telephone].include?(field)
           assert_equal(format_phone_number(details[field]).to_s, cell_value || '', "For field: #{field} (row #{row + 1})")
+        elsif %i[primary_language secondary_language].include?(field)
+          assert_equal(Languages.translate_code_to_display(details[field]).to_s, cell_value || '', "For field: #{field} (row #{row + 1})")
         else
           assert_equal(details[field].to_s, cell_value || '', "For field: #{field} (row #{row + 1})")
         end
@@ -190,6 +193,8 @@ class PublicHealthMonitoringExportVerifier < ApplicationSystemTestCase
           assert_equal(patient.status&.to_s&.humanize&.downcase, cell_value, "For field: #{field} in Monitorees List (row #{row + 1})")
         elsif %i[primary_telephone secondary_telephone].include?(field)
           assert_equal(format_phone_number(details[field]).to_s, cell_value || '', "For field: #{field} in Monitorees List (row #{row + 1})")
+        elsif %i[primary_language secondary_language].include?(field)
+          assert_equal(Languages.translate_code_to_display(details[field]).to_s, cell_value || '', "For field: #{field} in Monitorees List (row #{row + 1})")
         else
           assert_equal(details[field].to_s, cell_value || '', "For field: #{field} in Monitorees List (row #{row + 1})")
         end
@@ -348,6 +353,9 @@ class PublicHealthMonitoringExportVerifier < ApplicationSystemTestCase
                        "For field: #{field} in Monitorees List (row #{row + 1})")
         elsif %i[primary_telephone secondary_telephone].include?(field)
           assert_equal(format_phone_number(patient_details[field]).to_s, cell_value || '', "For field: #{field} in Monitorees List (row #{row + 1})")
+        elsif %i[primary_language secondary_language].include?(field)
+          assert_equal(Languages.translate_code_to_display(patient_details[field]).to_s, cell_value || '',
+                       "For field: #{field} in Monitorees List (row #{row + 1})")
         elsif field == :creator
           responder_email = User.find(patient.creator_id).email
           assert_equal(responder_email, cell_value, "For field: #{field} in Monitorees List (row #{row + 1})")


### PR DESCRIPTION
This PR translates the three-letter language codes on the Patient into Display names for Export.