### PR TITLE
BUGFIX: Export and assessments symptom label bug

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -195,7 +195,7 @@ class AssessmentsController < ApplicationController
 
         new_val = reported_symptoms[symptom[:name]][:value]
         old_val = symptom.value
-        next if new_val&.to_s == old_val&.to_s
+        next if new_val == old_val
 
         case symptom.type
         when 'BoolSymptom'

--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -181,7 +181,7 @@ class AssessmentsController < ApplicationController
 
     assessment = Assessment.find_by(id: params.permit(:id)[:id])
     reported_symptoms_array = params.permit({ symptoms: %i[name value type label notes required] }).to_h['symptoms']
-    redirect_to(root_url) && return if reported_symptoms_array.map { |symptom| symptom[:name] }.include?(:nil)
+    redirect_to(root_url) && return if reported_symptoms_array.any? { |symptom| symptom[:name].nil? }
 
     valid_symptom_names = assessment.reported_condition&.threshold_condition&.symptoms&.pluck(:name)
     redirect_to(root_url) && return if valid_symptom_names.nil? || (reported_symptoms_array.map { |symptom| symptom[:name] } - valid_symptom_names).any?

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -198,7 +198,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
 
     # Nested querying by id is faster than joining patients to assessments to conditions to symptoms
     symptoms = Symptom.where(condition_id: ReportedCondition.where(assessment_id: Assessment.where(patient_id: patients.pluck(:id)).pluck(:id)).pluck(:id))
-    symptom_names_and_labels = symptoms.distinct.order(:label).pluck(:name, :label).transpose
+    symptom_names_and_labels = symptoms.where.not(name: nil).where.not(label: nil).distinct.order(:label).pluck(:name, :label).transpose
 
     # Empty symptoms check
     return [] unless symptom_names_and_labels.present?

--- a/test/fixtures/conditions.yml
+++ b/test/fixtures/conditions.yml
@@ -43,36 +43,43 @@ jurisdiction_7_threshold_condition:
 
 threshold_condition_1:
   id: 8
+  type: 'ThresholdCondition'
   threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1' + '2') %>
   created_at: <%= 50.days.ago %>
   updated_at: <%= 50.days.ago %>
 threshold_condition_2:
   id: 10
+  type: 'ThresholdCondition'
   threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 2' + '2') %>
   created_at: <%= 50.days.ago %>
   updated_at: <%= 50.days.ago %>
 threshold_condition_3:
   id: 12
+  type: 'ThresholdCondition'
   threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 2, County 3' + '3') %>
   created_at: <%= 50.days.ago %>
   updated_at: <%= 50.days.ago %>
 threshold_condition_4:
   id: 14
+  type: 'ThresholdCondition'
   threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 2, County 4' + '3') %>
   created_at: <%= 50.days.ago %>
   updated_at: <%= 50.days.ago %>
 threshold_condition_5:
   id: 16
+  type: 'ThresholdCondition'
   threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA' + '1') %>
   created_at: <%= 50.days.ago %>
   updated_at: <%= 50.days.ago %>
 threshold_condition_6:
   id: 25
+  type: 'ThresholdCondition'
   threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1, County 2' + '3') %>
   created_at: <%= 50.days.ago %>
   updated_at: <%= 50.days.ago %>
 threshold_condition_7:
   id: 44
+  type: 'ThresholdCondition'
   threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 1, County 1' + '3') %>
   created_at: <%= 50.days.ago %>
   updated_at: <%= 50.days.ago %>

--- a/test/fixtures/symptoms.yml
+++ b/test/fixtures/symptoms.yml
@@ -53,6 +53,25 @@ threshold_condition_1_difficulty_breathing_symptom:
   type: 'BoolSymptom'
   created_at: <%= 50.days.ago %>
   updated_at: <%= 50.days.ago %>
+threshold_condition_1_temperature_symptom:
+  id: 7
+  name: 'temperature'
+  label: 'Temperature'
+  int_value: 2
+  condition_id: 8
+  type: 'IntegerSymptom'
+  created_at: <%= 50.days.ago %>
+  updated_at: <%= 50.days.ago %>
+threshold_condition_1_pulse_ox_symptom:
+  id: 8
+  name: 'pulse-ox'
+  label: 'Pulse Ox'
+  float_value: 98.4
+  condition_id: 8
+  type: 'FloatSymptom'
+  created_at: <%= 50.days.ago %>
+  updated_at: <%= 50.days.ago %>
+
 threshold_condition_2_fever_symptom:
   id: 10
   name: 'fever'
@@ -268,6 +287,24 @@ patient_1_assessment_2_difficulty_breathing:
   bool_value: false
   condition_id: 1002
   type: 'BoolSymptom'
+  created_at: <%= 36.days.ago %>
+  updated_at: <%= 32.days.ago %>
+patient_1_assessment_2_temperature:
+  id: 10024
+  name: 'temperature'
+  label: 'Temperature'
+  int_value: 2
+  condition_id: 1002
+  type: 'IntegerSymptom'
+  created_at: <%= 36.days.ago %>
+  updated_at: <%= 32.days.ago %>
+patient_1_assessment_2_pulse_ox:
+  id: 10025
+  name: 'pulse-ox'
+  label: 'Pulse Ox'
+  float_value: 99.8
+  condition_id: 1002
+  type: 'FloatSymptom'
   created_at: <%= 36.days.ago %>
   updated_at: <%= 32.days.ago %>
 patient_2_assessment_1_fever:

--- a/test/system/roles/public_health/patient_page/reports_verifier.rb
+++ b/test/system/roles/public_health/patient_page/reports_verifier.rb
@@ -60,7 +60,7 @@ class PublicHealthPatientPageReportsVerifier < ApplicationSystemTestCase
         cell = cells[symptom_column_indexes[symptom[:name]]]
         value = symptom.value
         value = value == true ? 'Yes' : 'No' if symptom[:type] == 'BoolSymptom' && !value.nil?
-        assert_equal value || '', cell.text, "Symptom '#{symptom[:label]}' for assessment #{assessment[:id]}"
+        assert_equal value&.to_s || '', cell.text, "Symptom '#{symptom[:label]}' for assessment #{assessment[:id]}"
         assert_equal assessment.symptom_passes_threshold(symptom), cell.find('span')[:class].include?('concern'),
                      "'Symptomatic color' for symptom '#{symptom[:label]}' for assessment #{assessment[:id]}"
       end


### PR DESCRIPTION
# Description
Jira Ticket: N/A

This bug was initially discovered as an export bug caused by some symptoms having `nil` labels, which was a result of some recent assessment changes

## (Bugfix) How to Replicate

Before checking out this branch:

1) edit any assessment
2) query the assessments' symptoms and notice that the labels are missing

## (Bugfix) Solution

The [assessment performance PR](https://github.com/SaraAlert/SaraAlert/pull/806) changed what was being passed back to the controller upon assessment update (no longer includes the label) which was being relied on. This PR changes the way assessments are updated so that the symptom label/type for the update come from the original assessment and symptom from the threshold condition.

Also added `nil` checks to the symptom query for exports

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] **N/A** This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] **N/A** If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@mayerm94 :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
