### PR TITLE
1448-filters out the empty string from the country of exposure analytis

### DIFF
--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -256,7 +256,7 @@ class CacheAnalyticsJob < ApplicationJob
   def self.monitoree_counts_by_exposure_country(analytic_id, monitorees)
     counts = []
     exposure_countries = monitorees.monitoring_active(true)
-                                   .where.not(potential_exposure_country: nil)
+                                   .where.not(potential_exposure_country: [nil, ''])
                                    .group(:potential_exposure_country)
                                    .order(count_potential_exposure_country: :desc)
                                    .order(:potential_exposure_country)


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1448
This ticket filters out any values in the Analytics where `potential_exposure_country` is `''`. Previously, only `nil` values were filtered out.