### PR TITLE
SARAALERT-1438: Adds 'Notes' to the Admin Panel Audit Modal

### DIFF
--- a/app/javascript/components/admin/AdminTable.js
+++ b/app/javascript/components/admin/AdminTable.js
@@ -20,7 +20,7 @@ class AdminTable extends React.Component {
       table: {
         colData: [
           { label: 'Id', field: 'id', isSortable: true },
-          { label: 'Email', field: 'email', className: 'wrap', isSortable: true },
+          { label: 'Email', field: 'email', className: 'wrap-words', isSortable: true },
           { label: 'Jurisdiction', field: 'jurisdiction_path', isSortable: true },
           { label: 'Role', field: 'role_title', isSortable: false },
           { label: 'Status', field: 'is_locked', isSortable: false, options: { true: 'Locked', false: 'Unlocked' } },

--- a/app/javascript/components/admin/AuditModal.js
+++ b/app/javascript/components/admin/AuditModal.js
@@ -15,8 +15,8 @@ class AuditModal extends React.Component {
     this.state = {
       table: {
         colData: [
-          { label: 'Triggered by', field: 'user', className: 'wrap', isSortable: true, colWidth: '30%' },
-          { label: 'Action', field: 'change', className: 'wrap', filter: this.formatChange, isSortable: false, colWidth: '60%' },
+          { label: 'Triggered by', field: 'user', className: 'wrap-words', isSortable: true, colWidth: '30%' },
+          { label: 'Action', field: 'change', className: 'wrap-words', filter: this.formatChange, isSortable: false, colWidth: '60%' },
           { label: 'Timestamp', field: 'timestamp', filter: formatTimestamp, isSortable: true, colWidth: '10%' },
         ],
         rowData: [],
@@ -138,6 +138,22 @@ class AuditModal extends React.Component {
           return (
             <span>
               <b>Account Status</b>: {change.details[0] ? 'Unlocked' : 'Locked'}
+            </span>
+          );
+        }
+      case 'notes':
+        // Generic audit message in case before & after values not provided
+        if (!change.details || !Array.isArray(change.details) || !change.details.length) {
+          return (
+            <span>
+              <b>Notes</b>: Updated
+            </span>
+          );
+          // More detailed audit message when before & after values provided
+        } else {
+          return (
+            <span>
+              <b>Notes</b>: Changed from &quot;{change.details[0]}&quot; to &quot;{change.details[1]}&quot;
             </span>
           );
         }

--- a/app/javascript/components/admin/UserModal.js
+++ b/app/javascript/components/admin/UserModal.js
@@ -5,6 +5,8 @@ import Select from 'react-select';
 import _ from 'lodash';
 import { cursorPointerStyle } from '../../packs/stylesheets/ReactSelectStyling';
 
+const MAX_NOTES_LENGTH = 2000;
+
 class UserModal extends React.Component {
   constructor(props) {
     super(props);
@@ -146,11 +148,11 @@ class UserModal extends React.Component {
                   rows="5"
                   className="form-square"
                   value={this.state.notes}
-                  maxLength="5000"
+                  maxLength={MAX_NOTES_LENGTH}
                   onChange={this.handleChange}
                 />
               </InputGroup>
-              <Form.Label className="notes-character-limit"> {5000 - this.state.notes.length} characters remaining </Form.Label>
+              <Form.Label className="notes-character-limit"> {MAX_NOTES_LENGTH - this.state.notes.length} characters remaining </Form.Label>
             </Form.Group>
           </Form>
         </Modal.Body>

--- a/app/javascript/components/analytics/widgets/Demographics.js
+++ b/app/javascript/components/analytics/widgets/Demographics.js
@@ -139,16 +139,16 @@ class Demographics extends React.Component {
                 <th>Total</th>
               </tr>
             </thead>
-            {_.initial(AGEGROUPS).map((val, index1) => (
-              <tbody key={`workflow-table-${index1}`}>
-                <tr className={index1 % 2 ? '' : 'analytics-zebra-bg'}>
+            <tbody>
+              {_.initial(AGEGROUPS).map((val, index1) => (
+                <tr key={`workflow-table-${index1}`} className={index1 % 2 ? '' : 'analytics-zebra-bg'}>
                   <td className="font-weight-bold"> {val} </td>
                   {this.ageData[Number(index1)].map((data, subIndex1) => (
                     <td key={subIndex1}> {data} </td>
                   ))}
                 </tr>
-              </tbody>
-            ))}
+              ))}
+            </tbody>
           </table>
           {this.hasFakeBirthdateData && (
             <div className="text-secondary fake-demographic-text mb-3">
@@ -172,16 +172,16 @@ class Demographics extends React.Component {
                 <th>Total</th>
               </tr>
             </thead>
-            {RACES.map((val, index4) => (
-              <tbody key={`workflow-table-${index4}`}>
-                <tr className={index4 % 2 ? '' : 'analytics-zebra-bg'}>
+            <tbody>
+              {RACES.map((val, index4) => (
+                <tr key={`workflow-table-${index4}`} className={index4 % 2 ? '' : 'analytics-zebra-bg'}>
                   <td className="font-weight-bold"> {val} </td>
                   {this.raceData[Number(index4)].map((data, subIndex4) => (
                     <td key={subIndex4}> {data} </td>
                   ))}
                 </tr>
-              </tbody>
-            ))}
+              ))}
+            </tbody>
           </table>
         </Col>
         <Col md="12">
@@ -199,16 +199,16 @@ class Demographics extends React.Component {
                 <th>Total</th>
               </tr>
             </thead>
-            {SEXES.map((val, index2) => (
-              <tbody key={`workflow-table-${index2}`}>
-                <tr className={index2 % 2 ? '' : 'analytics-zebra-bg'}>
+            <tbody>
+              {SEXES.map((val, index2) => (
+                <tr key={`workflow-table-${index2}`} className={index2 % 2 ? '' : 'analytics-zebra-bg'}>
                   <td className="font-weight-bold"> {val} </td>
                   {this.sexData[Number(index2)].map((data, subIndex2) => (
                     <td key={subIndex2}> {data} </td>
                   ))}
                 </tr>
-              </tbody>
-            ))}
+              ))}
+            </tbody>
           </table>
           <div className="text-left mt-3 mb-n1 h4">Ethnicity</div>
           <table className="analytics-table">
@@ -224,16 +224,16 @@ class Demographics extends React.Component {
                 <th>Total</th>
               </tr>
             </thead>
-            {ETHNICITIES.map((val, index3) => (
-              <tbody key={`workflow-table-${index3}`}>
-                <tr className={index3 % 2 ? '' : 'analytics-zebra-bg'}>
+            <tbody>
+              {ETHNICITIES.map((val, index3) => (
+                <tr key={`workflow-table-${index3}`} className={index3 % 2 ? '' : 'analytics-zebra-bg'}>
                   <td className="font-weight-bold"> {val} </td>
                   {this.ethnicityData[Number(index3)].map((data, subIndex3) => (
                     <td key={subIndex3}> {data} </td>
                   ))}
                 </tr>
-              </tbody>
-            ))}
+              ))}
+            </tbody>
           </table>
         </Col>
         <Col md="12">
@@ -253,16 +253,16 @@ class Demographics extends React.Component {
                     <th>Total</th>
                   </tr>
                 </thead>
-                {SEXUAL_ORIENTATIONS.map((val, index5) => (
-                  <tbody key={`workflow-table-${index5}`}>
-                    <tr className={index5 % 2 ? '' : 'analytics-zebra-bg'}>
+                <tbody>
+                  {SEXUAL_ORIENTATIONS.map((val, index5) => (
+                    <tr key={`workflow-table-${index5}`} className={index5 % 2 ? '' : 'analytics-zebra-bg'}>
                       <td className="font-weight-bold"> {val} </td>
                       {this.soData[Number(index5)].map((data, subIndex5) => (
                         <td key={subIndex5}> {data} </td>
                       ))}
                     </tr>
-                  </tbody>
-                ))}
+                  ))}
+                </tbody>
               </table>
             </div>
           )}

--- a/app/javascript/components/patient/close_contact/CloseContact.js
+++ b/app/javascript/components/patient/close_contact/CloseContact.js
@@ -17,6 +17,8 @@ import InfoTooltip from '../../util/InfoTooltip';
 import PhoneInput from '../../util/PhoneInput';
 import reportError from '../../util/ReportError';
 
+const MAX_NOTES_LENGTH = 2000;
+
 class CloseContact extends React.Component {
   constructor(props) {
     super(props);
@@ -252,10 +254,10 @@ class CloseContact extends React.Component {
                 className="form-square"
                 value={this.state.notes || ''}
                 placeholder={this.closeContactNotePlaceholder}
-                maxLength="2000"
+                maxLength={MAX_NOTES_LENGTH}
                 onChange={this.handleChange}
               />
-              <Form.Label className="notes-character-limit"> {2000 - this.state.notes.length} characters remaining </Form.Label>
+              <Form.Label className="notes-character-limit"> {MAX_NOTES_LENGTH - this.state.notes.length} characters remaining </Form.Label>
               <Form.Control.Feedback className="d-block" type="invalid">
                 {this.state.errors['notes']}
               </Form.Control.Feedback>

--- a/app/javascript/components/patient/vaccines/VaccineModal.js
+++ b/app/javascript/components/patient/vaccines/VaccineModal.js
@@ -9,6 +9,8 @@ import { vaccineModalSelectStyling } from '../../../packs/stylesheets/ReactSelec
 
 import DateInput from '../../util/DateInput';
 
+const MAX_NOTES_LENGTH = 2000;
+
 class VaccineModal extends React.Component {
   constructor(props) {
     super(props);
@@ -22,7 +24,7 @@ class VaccineModal extends React.Component {
         : null,
       administration_date: this.props.currentVaccineData?.administration_date,
       dose_number: this.props.currentVaccineData?.dose_number,
-      notes: this.props.currentVaccineData?.notes,
+      notes: this.props.currentVaccineData?.notes || '',
       // Sorting so that the blank option shows up at the top
       sorted_dose_number_options: this.props.dose_number_options ? this.props.dose_number_options.sort() : [],
     };
@@ -186,12 +188,12 @@ class VaccineModal extends React.Component {
                   as="textarea"
                   rows="5"
                   className="form-square"
-                  value={this.state.notes || ''}
+                  value={this.state.notes}
                   placeholder={'Enter any additional information about this vaccination...'}
-                  maxLength="2000"
+                  maxLength={MAX_NOTES_LENGTH}
                   onChange={this.handleNotesChange}
                 />
-                <Form.Label className="notes-character-limit"> {this.state.notes ? 2000 - this.state.notes.length : 2000} characters remaining </Form.Label>
+                <Form.Label className="notes-character-limit"> {MAX_NOTES_LENGTH - this.state.notes.length} characters remaining </Form.Label>
               </Form.Group>
             </Row>
           </Form>

--- a/app/javascript/packs/stylesheets/bootstrap.scss
+++ b/app/javascript/packs/stylesheets/bootstrap.scss
@@ -36,11 +36,11 @@ body {
 }
 
 .btn.btn-circle {
-  width: 30px; 
-  height: 30px; 
-  padding: 2px 5px; 
-  border-radius: 15px !important; 
-  text-align: center; 
+  width: 30px;
+  height: 30px;
+  padding: 2px 5px;
+  border-radius: 15px !important;
+  text-align: center;
 }
 
 .react-datepicker-popper {
@@ -287,6 +287,11 @@ select.form-control {
   justify-content: unset;
 }
 
-.wrap {
+// Use this class to correctly word-break elements across all browsers
+.wrap-words {
+  // This somewhat hacky solution causes things to wrap on all browsers
+  // Not all browsers have these defined. The browser will select the ones it has defined
+  // This has been tested on Safari, IE11, MSEdge, Chrome, and Firefox and it behaves as expected
   word-break: break-all;
+  word-break: break-word;
 }

--- a/app/javascript/packs/stylesheets/layout.scss
+++ b/app/javascript/packs/stylesheets/layout.scss
@@ -26,11 +26,3 @@
 .header-brand-text {
   font-size: 20px !important;
 }
-
-.cc-notes-wrap {
-  // This somewhat hacky solution causes things to wrap on all browsers
-  // Not all browsers have these defined. The browser will select the ones it has defined
-  // This has been tested on Safari, IE11, MSEdge, Chrome, and Firefox and it behaves as expected
-  word-break: break-all;
-  word-break: break-word;
-}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@
 # User: user model
 class User < ApplicationRecord
   audited only: %i[locked_at jurisdiction_id created_at api_enabled role email authy_enabled
-                   force_password_change last_sign_in_with_authy], max_audits: 1000
+                   force_password_change last_sign_in_with_authy notes], max_audits: 1000
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -172,7 +172,7 @@
           <td><%= cc.assigned_user %></td>
           <td><%= cc.contact_attempts || 0 %></td>
           <td><%= cc.enrolled_id ? 'Yes' : 'No' %> </td>
-          <td class="cc-notes-wrap"><%= cc.notes && cc.notes.length > 500 + 3 ? (cc.notes[0..500] + '...') : cc.notes %></td>
+          <td class="wrap-words"><%= cc.notes && cc.notes.length > 500 + 3 ? (cc.notes[0..500] + '...') : cc.notes %></td>
         </tr>
         <% end -%>
       </tbody>


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1438

This Pull Request does 4 main things:
1. Tracks any changes to the Notes field in the Admin Page and displays them in the Audit Modal
2. Combines some `word-wrap` CSS that had been duplicated.
3. Fixes an issue with too many `<tbody>`s in the Analytics
4. Makes the length and syntax of notes constant (the VaccineModal was doing it slightly different)


Number 1 is the only big thing. Fixes 2 through 4 are just small tweaks.

## (Feature) Demo/Screenshots
![image](https://user-images.githubusercontent.com/17532163/117205306-76e4d880-adbf-11eb-94b7-888cbe6b303f.png)

## Important Changes
`app/javascript/components/admin/AdminTable.js`
- Adds the back-end for the Notes Auditing

`app/javascript/components/admin/AuditModal.js`
- Adds front-end formatting for the Notes Auditing

`app/javascript/components/admin/UserModal.js` and `app/javascript/components/patient/close_contact/CloseContact.js`
- Formats Max Notes Length in similar manner for consistency

`app/javascript/packs/stylesheets/bootstrap.scss`
- Combines duplicate CSS

`app/javascript/components/analytics/widgets/Demographics.js`
- Fixes incorrect use of <tbody> within loop.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@Bialogs 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie  
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ngfreiter 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
