### PR TITLE
Remove workflow change data from monitoree flow table in analytics

### DIFF
--- a/app/javascript/components/analytics/widgets/MonitoreeFlow.js
+++ b/app/javascript/components/analytics/widgets/MonitoreeFlow.js
@@ -17,15 +17,8 @@ class MonitoreeFlow extends React.Component {
         let thisTimeFrameData = props.stats.monitoree_snapshots.find(
           monitoree_snapshot => monitoree_snapshot.status === workflow && monitoree_snapshot.time_frame === time_frame
         );
-        let exposure = workflow === 'Exposure';
-        let inTotal =
-          thisTimeFrameData?.new_enrollments +
-          thisTimeFrameData?.transferred_in +
-          (exposure ? thisTimeFrameData?.isolation_to_exposure : thisTimeFrameData?.exposure_to_isolation);
-        let outTotal =
-          thisTimeFrameData?.closed +
-          thisTimeFrameData?.transferred_out +
-          (exposure ? thisTimeFrameData?.exposure_to_isolation : thisTimeFrameData?.isolation_to_exposure);
+        let inTotal = thisTimeFrameData?.new_enrollments + thisTimeFrameData?.transferred_in;
+        let outTotal = thisTimeFrameData?.closed + thisTimeFrameData?.transferred_out;
         return {
           time_frame,
           new_enrollments: {
@@ -44,21 +37,12 @@ class MonitoreeFlow extends React.Component {
             value: thisTimeFrameData?.transferred_out || 0,
             percentage: formatPercentage(thisTimeFrameData?.transferred_out, outTotal),
           },
-          exposure_to_isolation: {
-            value: thisTimeFrameData?.exposure_to_isolation || 0,
-            percentage: formatPercentage(thisTimeFrameData?.exposure_to_isolation, exposure ? outTotal : inTotal),
-          },
-          isolation_to_exposure: {
-            value: thisTimeFrameData?.isolation_to_exposure || 0,
-            percentage: formatPercentage(thisTimeFrameData?.isolation_to_exposure, exposure ? inTotal : outTotal),
-          },
         };
       });
     });
   }
 
   renderWorkflowTable(data, index) {
-    let oppositeWorkflow = _.upperCase(WORKFLOWS[Number(index == 0 ? 1 : 0)]);
     return (
       <Col lg="12" key={index} className="pb-3">
         <table className="analytics-table">
@@ -102,17 +86,6 @@ class MonitoreeFlow extends React.Component {
                 </td>
               ))}
             </tr>
-            <tr className="analytics-zebra-bg">
-              <td className="text-right">FROM {oppositeWorkflow} WORKFLOW</td>
-              {data.map((x, index) => (
-                <td key={index}>
-                  <div>{oppositeWorkflow === 'ISOLATION' ? x.isolation_to_exposure.value : x.exposure_to_isolation.value}</div>
-                  <span className="analytics-percentage">
-                    {` (${oppositeWorkflow === 'ISOLATION' ? x.isolation_to_exposure.percentage : x.exposure_to_isolation.percentage})`}
-                  </span>
-                </td>
-              ))}
-            </tr>
             <tr style={{ height: '25px' }}>
               <td className="font-weight-bold text-left analytics-mf-subheader align-bottom">
                 <u>OUTGOING</u>
@@ -133,17 +106,6 @@ class MonitoreeFlow extends React.Component {
                 <td key={index}>
                   <div>{x.transferred_out.value}</div>
                   <span className="analytics-percentage"> {`(${x.transferred_out.percentage})`}</span>
-                </td>
-              ))}
-            </tr>
-            <tr className="analytics-zebra-bg">
-              <td className="text-right">TO {oppositeWorkflow} WORKFLOW</td>
-              {data.map((x, index) => (
-                <td key={index}>
-                  <div>{oppositeWorkflow === 'ISOLATION' ? x.exposure_to_isolation.value : x.isolation_to_exposure.value}</div>
-                  <span className="analytics-percentage">
-                    {` (${oppositeWorkflow === 'ISOLATION' ? x.exposure_to_isolation.percentage : x.isolation_to_exposure.percentage})`}
-                  </span>
                 </td>
               ))}
             </tr>

--- a/app/javascript/tests/analytics/widgets/MonitoreeFlow.test.js
+++ b/app/javascript/tests/analytics/widgets/MonitoreeFlow.test.js
@@ -5,18 +5,14 @@ import MonitoreeFlow from '../../../components/analytics/widgets/MonitoreeFlow';
 import mockAnalytics from '../../mocks/mockAnalytics';
 
 const monitoreeFlowTableHeaders = ['Last 24 Hours  n (col %)', 'Last 7 Days  n (col %)', 'Last 14 Days  n (col %)', 'Total  n (col %)'];
-const exposureNewEnrollmentValues = [ '54 (88.5%)', '164 (85.9%)', '192 (83.5%)', '223 (68.8%)' ];
-const exposureTransferredInValues = [ '7 (11.5%)', '21 (11.0%)', '22 (9.6%)', '25 (7.7%)' ];
-const exposureFromIsolationValues = [ '0 (None)', '6 (3.1%)', '16 (7.0%)', '76 (23.5%)' ];
-const exposureClosedValues = [ '4 (28.6%)', '11 (22.0%)', '12 (13.6%)', '15 (8.3%)' ];
-const exposureTransferredOutValues = [ '8 (57.1%)', '18 (36.0%)', '20 (22.7%)', '27 (15.0%)' ];
-const exposureToIsolationValues = [ '2 (14.3%)', '21 (42.0%)', '56 (63.6%)', '138 (76.7%)' ];
-const isolationNewEnrollmentValues = [ '39 (86.7%)', '100 (72.5%)', '171 (69.5%)', '195 (54.9%)' ];
-const isolationTransferredInValues = [ '4 (8.9%)', '17 (12.3%)', '19 (7.7%)', '22 (6.2%)' ];
-const isolationFromExposureValues = [ '2 (4.4%)', '21 (15.2%)', '56 (22.8%)', '138 (38.9%)' ];
-const isolationClosedValues = [ '2 (28.6%)', '4 (14.3%)', '6 (13.6%)', '7 (6.5%)' ];
-const isolationTransferredOutValues = [ '5 (71.4%)', '18 (64.3%)', '22 (50.0%)', '25 (23.1%)' ];
-const isolationToExposureValues = [ '0 (None)', '6 (21.4%)', '16 (36.4%)', '76 (70.4%)' ];
+const exposureNewEnrollmentValues = [ '54 (88.5%)', '164 (88.6%)', '192 (89.7%)', '223 (89.9%)' ];
+const exposureTransferredInValues = [ '7 (11.5%)', '21 (11.4%)', '22 (10.3%)', '25 (10.1%)' ];
+const exposureClosedValues = [ '4 (33.3%)', '11 (37.9%)', '12 (37.5%)', '15 (35.7%)' ];
+const exposureTransferredOutValues = [ '8 (66.7%)', '18 (62.1%)', '20 (62.5%)', '27 (64.3%)' ];
+const isolationNewEnrollmentValues = [ '39 (90.7%)', '100 (85.5%)', '171 (90.0%)', '195 (89.9%)' ];
+const isolationTransferredInValues = [ '4 (9.3%)', '17 (14.5%)', '19 (10.0%)', '22 (10.1%)' ];
+const isolationClosedValues = [ '2 (28.6%)', '4 (18.2%)', '6 (21.4%)', '7 (21.9%)' ];
+const isolationTransferredOutValues = [ '5 (71.4%)', '18 (81.8%)', '22 (78.6%)', '25 (78.1%)' ];
 
 function getWrapper() {
   return shallow(<MonitoreeFlow stats={mockAnalytics}/>);
@@ -50,49 +46,33 @@ describe('MonitoreeFlow', () => {
     exposureTransferredInValues.forEach(function(value, index) {
       expect(tableBody.find('tr').at(3).find('td').at(index+1).text()).toEqual(String(value));
     });
-    expect(tableBody.find('tr').at(4).find('td').first().text()).toEqual('FROM ISOLATION WORKFLOW');
-    exposureFromIsolationValues.forEach(function(value, index) {
-      expect(tableBody.find('tr').at(4).find('td').at(index+1).text()).toEqual(String(value));
-    });
-    expect(tableBody.find('tr').at(5).text()).toEqual('OUTGOING');
-    expect(tableBody.find('tr').at(6).find('td').first().text()).toEqual('CLOSED');
+    expect(tableBody.find('tr').at(4).text()).toEqual('OUTGOING');
+    expect(tableBody.find('tr').at(5).find('td').first().text()).toEqual('CLOSED');
     exposureClosedValues.forEach(function(value, index) {
+      expect(tableBody.find('tr').at(5).find('td').at(index+1).text()).toEqual(String(value));
+    });
+    expect(tableBody.find('tr').at(6).find('td').first().text()).toEqual('TRANSFERRED OUT');
+    exposureTransferredOutValues.forEach(function(value, index) {
       expect(tableBody.find('tr').at(6).find('td').at(index+1).text()).toEqual(String(value));
     });
-    expect(tableBody.find('tr').at(7).find('td').first().text()).toEqual('TRANSFERRED OUT');
-    exposureTransferredOutValues.forEach(function(value, index) {
-      expect(tableBody.find('tr').at(7).find('td').at(index+1).text()).toEqual(String(value));
-    });
-    expect(tableBody.find('tr').at(8).find('td').first().text()).toEqual('TO ISOLATION WORKFLOW');
-    exposureToIsolationValues.forEach(function(value, index) {
-      expect(tableBody.find('tr').at(8).find('td').at(index+1).text()).toEqual(String(value));
-    });
-    expect(tableBody.find('tr').at(9).text()).toEqual('ISOLATION WORKFLOW');
-    expect(tableBody.find('tr').at(10).text()).toEqual('INCOMING');
-    expect(tableBody.find('tr').at(11).find('td').first().text()).toEqual('NEW ENROLLMENTS');
+    expect(tableBody.find('tr').at(7).text()).toEqual('ISOLATION WORKFLOW');
+    expect(tableBody.find('tr').at(8).text()).toEqual('INCOMING');
+    expect(tableBody.find('tr').at(9).find('td').first().text()).toEqual('NEW ENROLLMENTS');
     isolationNewEnrollmentValues.forEach(function(value, index) {
-      expect(tableBody.find('tr').at(11).find('td').at(index+1).text()).toEqual(String(value));
+      expect(tableBody.find('tr').at(9).find('td').at(index+1).text()).toEqual(String(value));
     });
-    expect(tableBody.find('tr').at(12).find('td').first().text()).toEqual('TRANSFERRED IN');
+    expect(tableBody.find('tr').at(10).find('td').first().text()).toEqual('TRANSFERRED IN');
     isolationTransferredInValues.forEach(function(value, index) {
+      expect(tableBody.find('tr').at(10).find('td').at(index+1).text()).toEqual(String(value));
+    });
+    expect(tableBody.find('tr').at(11).text()).toEqual('OUTGOING');
+    expect(tableBody.find('tr').at(12).find('td').first().text()).toEqual('CLOSED');
+    isolationClosedValues.forEach(function(value, index) {
       expect(tableBody.find('tr').at(12).find('td').at(index+1).text()).toEqual(String(value));
     });
-    expect(tableBody.find('tr').at(13).find('td').first().text()).toEqual('FROM EXPOSURE WORKFLOW');
-    isolationFromExposureValues.forEach(function(value, index) {
-      expect(tableBody.find('tr').at(13).find('td').at(index+1).text()).toEqual(String(value));
-    });
-    expect(tableBody.find('tr').at(14).text()).toEqual('OUTGOING');
-    expect(tableBody.find('tr').at(15).find('td').first().text()).toEqual('CLOSED');
-    isolationClosedValues.forEach(function(value, index) {
-      expect(tableBody.find('tr').at(15).find('td').at(index+1).text()).toEqual(String(value));
-    });
-    expect(tableBody.find('tr').at(16).find('td').first().text()).toEqual('TRANSFERRED OUT');
+    expect(tableBody.find('tr').at(13).find('td').first().text()).toEqual('TRANSFERRED OUT');
     isolationTransferredOutValues.forEach(function(value, index) {
-      expect(tableBody.find('tr').at(16).find('td').at(index+1).text()).toEqual(String(value));
-    });
-    expect(tableBody.find('tr').at(17).find('td').first().text()).toEqual('TO EXPOSURE WORKFLOW');
-    isolationToExposureValues.forEach(function(value, index) {
-      expect(tableBody.find('tr').at(17).find('td').at(index+1).text()).toEqual(String(value));
+      expect(tableBody.find('tr').at(13).find('td').at(index+1).text()).toEqual(String(value));
     });
   });
 });

--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -377,8 +377,6 @@ class CacheAnalyticsJob < ApplicationJob
   def self.all_monitoree_snapshots(analytic_id, monitorees, subjur_ids)
     counts = []
     MONITOREE_SNAPSHOT_TIME_FRAMES.map do |time_frame|
-      e_to_i = monitorees.joins(:histories).merge(History.exposure_to_isolation.in_time_frame(time_frame)).size
-      i_to_e = monitorees.joins(:histories).merge(History.isolation_to_exposure.in_time_frame(time_frame)).size
       WORKFLOWS.map do |workflow|
         counts.append(MonitoreeSnapshot.new(
                         analytic_id: analytic_id,
@@ -402,8 +400,6 @@ class CacheAnalyticsJob < ApplicationJob
                                                  .where_assoc_exists(:patient, isolation: workflow == 'Isolation')
                                                  .in_time_frame(time_frame)
                                                  .size,
-                        exposure_to_isolation: e_to_i,
-                        isolation_to_exposure: i_to_e,
                         status: workflow
                       ))
       end


### PR DESCRIPTION
It was realized this didn't make sense in the table since the data
pertains to active monitorees only and not purged ones, while the
rest of the data in that table includes purged.

This is a temporary measure, and the workflow move data will be
included in the future elsewhere on the analytics page. For this
reason, the migration was left in.




Here is a [full (reverse) diff](https://github.com/SaraAlert/SaraAlert/compare/revert-374) of the changes of the changes that went in as a part of 374, for which the changes in this PR are a subset.