### PR TITLE
SARAALERT-1385 Close inactive patient records automatically

### DIFF
--- a/app/helpers/validation_helper.rb
+++ b/app/helpers/validation_helper.rb
@@ -105,8 +105,13 @@ module ValidationHelper # rubocop:todo Metrics/ModuleLength
   }.freeze
 
   SYSTEM_SELECTABLE_MONITORING_REASONS = [
-    'Enrolled more than 14 days after last date of exposure (system)', 'Enrolled more than 10 days after last date of exposure (system)',
-    'Enrolled on last day of monitoring period (system)', 'Completed Monitoring (system)', '', nil
+    'Enrolled more than 14 days after last date of exposure (system)',
+    'Enrolled more than 10 days after last date of exposure (system)',
+    'Enrolled on last day of monitoring period (system)',
+    'Completed Monitoring (system)',
+    'No record activity for 30 days (system)',
+    '',
+    nil
   ].freeze
 
   VALID_PATIENT_ENUMS = {

--- a/app/jobs/close_patients_job.rb
+++ b/app/jobs/close_patients_job.rb
@@ -25,6 +25,8 @@ class ClosePatientsJob < ApplicationJob
             ((patient.last_date_of_exposure.beginning_of_day + ADMIN_OPTIONS['monitoring_period_days'].days) == patient.created_at.beginning_of_day)
         # If the patient was enrolled on their last day of monitoring based on their last date of exposure, specify special reason for closure
         patient[:monitoring_reason] = 'Enrolled on last day of monitoring period (system)'
+      elsif patient.updated_at <= 30.days.ago
+        patient[:monitoring_reason] = 'No record activity for 30 days (system)'
       else
         # Otherwise, normal reason for closure
         patient[:monitoring_reason] = 'Completed Monitoring (system)'

--- a/performance/benchmarks/close_patients_job_benchmark.rb
+++ b/performance/benchmarks/close_patients_job_benchmark.rb
@@ -3,14 +3,18 @@
 require_relative '../../config/environment'
 require_relative '../benchmark'
 
-# Time Threshold: 8 minutes
+# Time Threshold: 10 minutes
 # Setup: Changes many patients to be close_eligible
 benchmark(
   name: 'ClosePatientsJob',
-  time_threshold: 18 * 60,
+  time_threshold: 10 * 60,
   setup: proc {
     puts 'updating patients'
     max_num_to_close = 20_000
+    # Due to the `no_recent_activity` criteria of the close_eligible scope
+    # it is necessary to change the updated_at of all patients so that
+    # we do not go over `max_num_to_close`
+    Patient.update_all(updated_at: Time.now)
     Patient.limit(max_num_to_close).update_all(
       isolation: false,
       continuous_exposure: false,

--- a/performance/benchmarks/close_patients_job_benchmark.rb
+++ b/performance/benchmarks/close_patients_job_benchmark.rb
@@ -7,7 +7,7 @@ require_relative '../benchmark'
 # Setup: Changes many patients to be close_eligible
 benchmark(
   name: 'ClosePatientsJob',
-  time_threshold: 8 * 60,
+  time_threshold: 18 * 60,
   setup: proc {
     puts 'updating patients'
     max_num_to_close = 20_000

--- a/performance/benchmarks/micro_benchmarks.rb
+++ b/performance/benchmarks/micro_benchmarks.rb
@@ -83,6 +83,10 @@ micro_results << benchmark(
   setup: proc {
     puts 'updating patients'
     max_num_to_close = 20_000
+    # Due to the `no_recent_activity` criteria of the close_eligible scope
+    # it is necessary to change the updated_at of all patients so that
+    # we do not go over `max_num_to_close`
+    Patient.update_all(updated_at: Time.now)
     Patient.limit(max_num_to_close).update_all(
       isolation: false,
       continuous_exposure: false,

--- a/test/jobs/close_patients_job_test.rb
+++ b/test/jobs/close_patients_job_test.rb
@@ -121,11 +121,11 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
                      email: 'testpatient@example.com')
 
     ClosePatientsJob.perform_now
-    assert_equal(ActionMailer::Base.deliveries.count, 2)
+    assert_not_nil(ActionMailer::Base.deliveries.find { |d| d.to.include? 'test@test.com' })
     closed_email = ActionMailer::Base.deliveries.find { |d| d.to.include? 'testpatient@example.com' }
     assert_not_nil closed_email
-    assert_includes(close_email.to_s, 'Sara Alert Reporting Complete')
-    assert_equal(close_email.to[0], patient.email)
+    assert_includes(closed_email.to_s, 'Sara Alert Reporting Complete')
+    assert_equal(closed_email.to[0], patient.email)
     assert_contains_history(patient, 'Monitoring Complete message was sent.')
   end
 


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1385](https://tracker.codev.mitre.org/browse/SARAALERT-1385)

Patient records in the non-reporting line list in the exposure workflow that have not been updated for 30+ days can now be automatically closed by the close_patients_job.

Added helper scope for :no_recent_activity
Added helper scope as or clause in close_eligible
Added new valid system-set monitoring reason 'No record activity for 30 days (system)'
Added logic for new monitoring reason in close_patients_job
Added relevant tests for new functionality

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/helpers/validation_helper.rb`
- Added new valid option `No record activity for 30 days (system)`
- Nicer formatting of list

`app/jobs/close_patients_job.rb`
- Added logic for setting the new `No record activity for 30 days (system)` monitoring reason

`app/models/patient.rb`
- Added `no_recent_activity` helper scope
- Included `no_recent_activity` scope in `close_eligible` scope's logic as an OR clause

`test/jobs/close_patients_job_test.rb`
- Added test for inactive patient close
- Improved test that searches for email delivery

`test/models/patient_test.rb`
- Added test for `no_recent_activity` and new relevant test for `close_eligible`


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@Bialogs  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
