### PR TITLE
SARAALERT-1452 Add a "Monitoring Complete Message Sent" History Item

### DIFF
--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -192,6 +192,7 @@ class PatientMailer < ApplicationMailer
     mail(to: patient.email&.strip, subject: I18n.t('assessments.email.closed.subject', locale: @lang)) do |format|
       format.html { render layout: 'main_mailer' }
     end
+    History.monitoring_complete_message_sent(patient: patient)
   end
 
   private

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -29,7 +29,8 @@ class History < ApplicationRecord
     close_contact_edit: 'Close Contact Edit',
     contact_attempt: 'Contact Attempt',
     welcome_message_sent: 'Welcome Message Sent',
-    record_automatically_closed: 'Record Automatically Closed'
+    record_automatically_closed: 'Record Automatically Closed',
+    monitoring_complete_message_sent: 'Monitoring Complete Message Sent'
   }.freeze
 
   columns.each do |column|
@@ -227,6 +228,10 @@ class History < ApplicationRecord
 
   def self.record_automatically_closed(patient: nil, created_by: 'Sara Alert System', comment: 'Monitoree has completed monitoring.')
     create_history(patient, created_by, HISTORY_TYPES[:record_automatically_closed], comment)
+  end
+
+  def self.monitoring_complete_message_sent(patient: nil, created_by: 'Sara Alert System', comment: 'Monitoring Complete message was sent.')
+    create_history(patient, created_by, HISTORY_TYPES[:monitoring_complete_message_sent], comment)
   end
 
   def self.monitoring_status(history)

--- a/test/jobs/close_patients_job_test.rb
+++ b/test/jobs/close_patients_job_test.rb
@@ -125,6 +125,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
     close_email = ActionMailer::Base.deliveries[-2]
     assert_includes(close_email.to_s, 'Sara Alert Reporting Complete')
     assert_equal(close_email.to[0], patient.email)
+    assert_contains_history(patient, 'Monitoring Complete message was sent.')
   end
 
   test 'sends an admin email with all closed monitorees' do

--- a/test/mailers/patient_mailer_test.rb
+++ b/test/mailers/patient_mailer_test.rb
@@ -563,5 +563,6 @@ class PatientMailerTest < ActionMailer::TestCase
     assert_includes email_body, I18n.t('assessments.email.closed.dear', locale: @patient.primary_language)
     assert_includes email_body, I18n.t('assessments.email.closed.thank-you', locale: @patient.primary_language)
     assert_includes email_body, I18n.t('assessments.email.closed.footer', locale: @patient.primary_language)
+    assert_contains_history(@patient, 'Monitoring Complete message was sent.')
   end
 end

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -14,6 +14,19 @@ class ActiveSupport::TestCase
     Sidekiq::Worker.clear_all
   end
 
+  def assert_contains_history(patient, history_comment_substring)
+    patient.histories.each do |history|
+      return if history.comment.include? history_comment_substring # rubocop:disable Lint/NonLocalExitFromIterator
+    end
+    assert false, "Expected patient to have a history that contains: #{history_comment_substring}"
+  end
+
+  def assert_not_contains_history(patient, history_comment_substring)
+    patient.histories.each do |history|
+      assert false, "Expected patient to NOT have a history that contains: #{history_comment_substring}" if history.comment.include? history_comment_substring
+    end
+  end
+
   # Make corrections for the edge of DST.
   #
   # NOTE: One main assumption of this function is that `time` will only ever


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1452](https://tracker.codev.mitre.org/browse/SARAALERT-1452)

Add a "Monitoring Complete Message Sent" History Item
    
New history item type has been added called "Monitoring Complete Message Sent" and is created upon sending a monitoring complete email to a patient.

Testing out the UI portion:
- add `byebug` statement to end of `PatientMailer#closed_email` right before history creation
- start sidekiq for mailers `bundle exec sidekiq -q mailers`
- starts `rails c` and force some patients to be close eligible (and add emails to them)
```
Patient.limit(500).update_all(
    isolation: false,
    continuous_exposure: false,
    latest_assessment_at: DateTime.now,
    symptom_onset: nil,
    public_health_action: 'None',
    purged: false,
    monitoring: true,
    created_at: 100.days.ago, 
    email: 'test@example.com',
    last_date_of_exposure: 100.days.ago
)
ClosePatientsJob.perform_now
```
- Capture patient ID in sidekiq byebug and continue
- Navigate to patient page in web browser
- Verify that the history was correctly made

## (Feature) Demo/Screenshots

![Screen Shot 2021-05-11 at 8 31 12 AM](https://user-images.githubusercontent.com/24628687/117833057-41af0f00-b233-11eb-868a-be2c18c2a300.png)

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/mailers/patient_mailer.rb`
- Create new history item upon sending closed notification email

`app/models/history.rb`
- Add new history and update `HISTORY_TYPES` hash

`test/jobs/close_patients_job_test.rb`
- Add test to verify that new history was made

`test/mailers/patient_mailer_test.rb`
- Add test to verify that new history was made

`test/test_case.rb`
- Added history assertion helpers for patients

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@Bialogs  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
