### PR TITLE
Benchmark modes

### DIFF
--- a/performance/benchmarks/micro_benchmarks.rb
+++ b/performance/benchmarks/micro_benchmarks.rb
@@ -14,6 +14,7 @@ micro_results = []
 micro_results << benchmark(
   name: 'PatientCountBaseline',
   time_threshold: 15,
+  mode: :real,
   no_exit: true
 ) { Patient.count }
 
@@ -26,6 +27,7 @@ micro_results << benchmark(
   name: 'PatientReminderEligible',
   time_threshold: 7,
   no_exit: true,
+  mode: :real,
   setup: proc { Timecop.travel(Time.now.utc.change(hour: 18)) },
   teardown: proc { Timecop.return }
 ) { Patient.reminder_eligible.count }
@@ -77,6 +79,7 @@ micro_results << benchmark(
   name: 'PatientCloseEligible',
   time_threshold: 7,
   no_exit: true,
+  mode: :real,
   setup: proc {
     puts 'updating patients'
     max_num_to_close = 20_000


### PR DESCRIPTION
 Description
Jira Ticket: SARAALERT-NONE

These changes allow benchmarks to specify the mode of measurement (total, user, system, real). The default is still total, but with benchmarks that are heavily or completely measuring SQL queries it is more useful to measure real time since the time spent waiting for queries is not included in total time.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@Bialogs  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
