### PR TITLE
set activestorage route prefix to /files 

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,6 +33,7 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :development
   config.active_storage.resolve_model_to_route = :rails_storage_proxy
+  config.active_storage.routes_prefix = '/files'
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,6 +47,8 @@ Rails.application.configure do
   # Override allows using the local filesystem for demo/staging
   config.active_storage.service = ActiveModel::Type::Boolean.new.cast(ENV["SARA_ALERT_REPORT_MODE"]) ? nil : ENV['ACTIVE_STORAGE_DRIVER']&.to_sym
   config.active_storage.resolve_model_to_route = :rails_storage_proxy
+  config.active_storage.routes_prefix = '/files'
+
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,6 +40,7 @@ Rails.application.configure do
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
   config.active_storage.resolve_model_to_route = :rails_storage_proxy
+  config.active_storage.routes_prefix = '/files'
 
   config.action_mailer.perform_caching = false
 


### PR DESCRIPTION
set activestorage route prefix to /files  to avoid routing to the assessment container
