### PR TITLE
SARAALERT-1386: Fix address validation

### DIFF
--- a/app/javascript/components/enrollment/steps/Address.js
+++ b/app/javascript/components/enrollment/steps/Address.js
@@ -87,6 +87,13 @@ class Address extends React.Component {
           });
         })
         .catch(err => {
+          // Even though domestic is invalid, if foreign is valid, still move on, otherwise show
+          // errors for current (domestic) tab
+          schemaForeign.validate(this.state.current.patient, { abortEarly: false }).then(() => {
+            self.setState({ errors: {} }, () => {
+              callback();
+            });
+          });
           // Validation errors, update state to display to user
           if (err && err.inner) {
             let issues = {};
@@ -106,6 +113,13 @@ class Address extends React.Component {
           });
         })
         .catch(err => {
+          // Even though foreign is invalid, if domestic is valid, still move on, otherwise show
+          // errors for current (foreign) tab
+          schemaDomestic.validate(this.state.current.patient, { abortEarly: false }).then(() => {
+            self.setState({ errors: {} }, () => {
+              callback();
+            });
+          });
           // Validation errors, update state to display to user
           if (err && err.inner) {
             let issues = {};

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -73,11 +73,6 @@ class Patient < ApplicationRecord
     validates required_field, on: :api, presence: { message: 'is required' }
   end
 
-  validates :address_state,
-            on: :api,
-            presence: { message: "is required unless a 'Foreign Address Country' is specified" },
-            unless: -> { foreign_address_country.present? }
-
   validates :symptom_onset,
             on: :api,
             presence: { message: "is required when 'Isolation' is 'true'" },
@@ -103,6 +98,7 @@ class Patient < ApplicationRecord
 
   validates_with PrimaryContactValidator, on: %i[api import]
   validates_with RaceValidator, on: %i[api import]
+  validates_with RequiredAddressValidator, on: :api
 
   # NOTE: Commented out until additional testing
   # validates_with PatientDateValidator

--- a/app/models/required_address_validator.rb
+++ b/app/models/required_address_validator.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Validates that either an address_state or a foreign_address_country is present
+class RequiredAddressValidator < ActiveModel::Validator
+  def validate(record)
+    record.errors.add(:base, "One of 'State' or 'Foreign Address Country' is required") if record.address_state.blank? && record.foreign_address_country.blank?
+  end
+end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -1904,18 +1904,26 @@ class PatientTest < ActiveSupport::TestCase
     assert patient.valid?
   end
 
-  test 'validates address_state is required unless foreign_address_country in api context' do
+  test 'validates one of address_state or foreign_address_country is required in api context' do
     patient = valid_patient
 
+    patient.address_state = 'Ohio'
+    patient.foreign_address_country = nil
+    assert patient.valid?(:api)
+
+    patient.foreign_address_country = 'UK'
+    patient.address_state = nil
+    assert patient.valid?(:api)
+
+    patient.foreign_address_country = 'UK'
+    patient.address_state = 'Ohio'
     assert patient.valid?(:api)
 
     patient.address_state = nil
+    patient.foreign_address_country = nil
     assert_not patient.valid?(:api)
     assert patient.valid?(:import)
     assert patient.valid?
-
-    patient.foreign_address_country = 'UK'
-    assert patient.valid?(:api)
   end
 
   test 'validates date_of_birth is required in api context' do


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1386](https://tracker.codev.mitre.org/browse/SARAALERT-1386)

This PR tweaks the address validation in the UI so that as long as one tab (USA or foreign) is valid, the user may proceed (even if it isn't the tab currently being viewed). Then the PR also updates the address validation in the API so that it matches this behavior.

## How to Replicate
I don't think the way it worked before was so much a bug, but here is how you could replicate it on 1.30.0:
1. Entry in an address with all required fields in the "Home Address Within USA" tab, then switch to the "Home Address Outside USA (Foreign)" tab.
2. Click "Next", and you will see errors about required elements on the "Home Address Outside USA (Foreign)" tab. Reversing the order of the tabs, this works the same way.

On this branch, after step 2, instead of seeing errors, you should just go to the next page, since the address tab you are not viewing has all required fields, so at least one address is fully present.

## Important Changes

`Address.js`
- Refactored validation so that if the schema for the current tab fails, but the schema for the other tab succeeds, we still go on to the next page. If both schemas fail, we still display errors for the current tab. If the schema for the current tab validates, then we just move on to the next page without checking the schema for the other tab.

`patient.rb`
- Replaced validation on `address_state` with a custom validator.

`required_address_validator.rb`
- Defined a custom validator for use on the Patient model which requires that at least one of `address_state` or `foreign_address_country` is present. It is expected that the API validation is more permissive than the UI validation, this PR is not meant to change that, so we only require one of these two fields. This validator actually works the same as the non-custom validation removed from `patient.rb`, but it is more readable and clear, and it is better for us to place the error on `base` than `address_state`.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@DPC15038 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@dubem7 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
