### PR TITLE
Hotfix: fixed typo in translations

### DIFF
--- a/config/locales/spa-pr.yml
+++ b/config/locales/spa-pr.yml
@@ -79,7 +79,7 @@ spa-pr:
       title: 'Reporte diario'
       bool-title: 'Por favor, seleccione los síntomas que está sintiendo actualmente.'
       submit: 'Enviar'
-      thank-you: '"¡Gracias por completar su informe diario!'
+      thank-you: '¡Gracias por completar su informe diario!'
       instruction1: 'Si Usted no reportó ningún síntoma, por favor siga las recomendaciones provistas por su departamento de salud local.'
       instruction2: 'Si Usted reportó algún síntoma, su departamento de salud local se comunicará pronto con Usted. Si tiene alguna inquietud inmediata, llame a su proveedor médico o al departamento de salud local. Evite el contacto cercano con otras personas y quédese en casa por favor.'
       instruction3: 'Si tiene una emergencia médica, por favor llame al 911 e infórmeles que el departamento de salud lo está monitoreando.'

--- a/config/locales/spa.yml
+++ b/config/locales/spa.yml
@@ -79,7 +79,7 @@ spa:
       title: 'Reporte diario'
       bool-title: 'Por favor, seleccione los síntomas que está sintiendo actualmente.'
       submit: 'Enviar'
-      thank-you: '"¡Gracias por completar su informe diario!'
+      thank-you: '¡Gracias por completar su informe diario!'
       instruction1: 'Si Usted no reportó ningún síntoma, por favor siga las recomendaciones proveídas por su departamento de salud local.'
       instruction2: 'Si Usted reportó algún síntoma, su departamento de salud local se comunicará pronto con Usted. Si tiene alguna inquietud inmediata, llame a su proveedor médico o al departamento de salud local. Evite el contacto cercano con otras personas y quédese en casa por favor.'
       instruction3: 'Si tiene una emergencia médica, por favor llame al 911 e infórmeles que el departamento de salud lo está monitoreando.'


### PR DESCRIPTION
There was a typo in the translations. An extra quote had been added to the thank you messages for the Spanish translations. 

This PR ONLY fixes the translations themselves. A test-linting PR will go up later today that addresses the incorrect quotes in the test files.