### PR TITLE
SARAALERT-1471: Fix bug with unauthorized request to PHDC export endpoint

### DIFF
--- a/app/controllers/application_api_controller.rb
+++ b/app/controllers/application_api_controller.rb
@@ -47,4 +47,6 @@ class ApplicationApiController < ActionController::API
       format.any { head :not_found }
     end
   end
+
+  class ClientError < StandardError; end
 end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1471](https://tracker.codev.mitre.org/browse/SARAALERT-1471)

When an unauthorized application made a request to the `nbs/patient` endpoint, we were incorrectly responding with a 500 error, since we were double `respond_to`ing. One `respond_to` came from `doorkeeper_authorize!`, and then we would also run `status_unauthorized`, causing a server error. This PR fixes that bug.

## How to Replicate
Make a request to `nbs/patients` without any authorization token. You should get a 500 response, instead of the expected 401.

## Solution
To fix this, we now raise a `ClientError` whenever there is some sort of error status that is using `respond_to`, this halts execution, and the error is rescued (but nothing is done with it, since the status is already set).

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`api_export_controller.rb`
- Raise `ClientError` when we are setting the various error statuses, and then add a `rescue_from` block that rescues such errors. 

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] (N/A) If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@Bialogs 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
