### PR TITLE
SARAALERT-1449: Purge job diagnostic email

### DIFF
--- a/app/jobs/purge_job.rb
+++ b/app/jobs/purge_job.rb
@@ -9,6 +9,7 @@ class PurgeJob < ApplicationJob
       start_time: DateTime.now
     }
     eligible = Patient.purge_eligible
+    # Change to hash
     purged = []
     not_purged = []
     job_info[:eligible] = eligible.count

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -12,10 +12,11 @@ class UserMailer < ApplicationMailer
     mail(to: ADMIN_OPTIONS['job_run_email'], subject: "Sara Alert Send Assessments Job Results (#{ActionMailer::Base.default_url_options[:host]})")
   end
 
-  def purge_job_email(purged, not_purged, eligible)
-    @purged = purged
-    @not_purged = not_purged
-    @eligible = eligible
+  def purge_job_email(monitorees, batch_info, job_info)
+    @purged = monitorees.reject { |m| m[:reason].present? }
+    @not_purged = monitorees.select { |m| m[:reason].present? }
+    @batch_info = batch_info
+    @job_info = job_info
     mail(to: ADMIN_OPTIONS['job_run_email'], subject: "Sara Alert Purge Job Results (#{ActionMailer::Base.default_url_options[:host]})")
   end
 

--- a/app/views/user_mailer/_purge_job_email_failure.html.erb
+++ b/app/views/user_mailer/_purge_job_email_failure.html.erb
@@ -1,0 +1,10 @@
+<h2>
+  Not Purged
+</h2>
+<br />
+ID
+<br />
+<% @not_purged.each do |monitoree| %>
+  <%= monitoree[:id] %>, <%= monitoree[:reason] %>
+  <br />
+<% end %>

--- a/app/views/user_mailer/_purge_job_email_success.html.erb
+++ b/app/views/user_mailer/_purge_job_email_success.html.erb
@@ -1,0 +1,10 @@
+<h2>
+  Purged
+</h2>
+<br />
+ID
+<br />
+<% @purged.each do |monitoree| %>
+  <%= monitoree[:id] %>
+  <br />
+<% end %>

--- a/app/views/user_mailer/purge_job_email.html.erb
+++ b/app/views/user_mailer/purge_job_email.html.erb
@@ -2,33 +2,23 @@
   Sara Alert Purge Job Results (<%= ActionMailer::Base.default_url_options[:host] %>)
 </h1>
 <h2>
-  <%= DateTime.now.in_time_zone('Eastern Time (US & Canada)') %>
+  Job Started: <%= @job_info[:start_time] %>
 </h2>
-<br />
-Total eligible for purge at runtime: <%= @eligible %>
-<br />
-Purged during this job run: <b><%= @purged.count %></b>
-<br />
-Not purged during this job run (due to exceptions): <b><%= @not_purged.count %></b>
-<br />
 <h2>
-  Purged
+  Job Ended: <%= @job_info[:end_time] %>
 </h2>
+<hr />
+Total eligible for purge at runtime: <%= @job_info[:eligible] %>
 <br />
-ID
+<p>Purged during this job run: <%= @job_info[:purged_count] %></p>
+<p>Not purged during this job run: <b><%= @job_info[:not_purged_count] %></b></p>
 <br />
-<% @purged.each do |p| %>
-  <%= p[:id] %>
-  <br />
+Message: <%= @batch_info[:current]%> of <%= @batch_info[:total] %>
+<hr />
+<% unless @job_info[:purged_count].zero? %>
+  <%= render partial: 'purge_job_email_success' %>
 <% end %>
 <br />
-<h2>
-  Not Purged
-</h2>
-<br />
-ID, Reason
-<br />
-<% @not_purged.each do |np| %>
-  <%= np[:id] %>, <%= np[:reason] %>
-  <br />
+<% unless @job_info[:not_purged_count].zero? %>
+  <%= render partial: 'purge_job_email_failure' %>
 <% end %>

--- a/config/sara/sara.yml
+++ b/config/sara/sara.yml
@@ -43,6 +43,10 @@ sentry_url: <%= ENV["SENTRY_URL"] || '' %>
 # Address to send job run results
 job_run_email: <%= ENV["JOB_RUN_EMAIL"] || '' %>
 
+# Number of monitorees to be included in a single job run result email
+# Too many will cause the email to be too large and throw an SMTPError
+job_run_email_group_size: <%= ENV["JOB_RUN_EMAIL_GROUP_SIZE"] || 50000 %>
+
 # Maximum number of allowed user saved filters
 max_user_filters: <%= ENV["MAX_USER_FILTERS"] || 150 %>
 

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -5,6 +5,11 @@ require 'test_case'
 class UserMailerTest < ActionMailer::TestCase
   def setup
     @user = create(:user)
+    ADMIN_OPTIONS['job_run_email'] = 'test@test.com'
+  end
+
+  def teardown
+    ADMIN_OPTIONS['job_run_email'] = nil
   end
 
   test 'download email no lookups' do
@@ -14,5 +19,76 @@ class UserMailerTest < ActionMailer::TestCase
     assert_not(ActionMailer::Base.deliveries.empty?)
     assert_includes(email_body, 'Export Label')
     assert_includes(email_body, 'no monitorees or monitoree data matched the selected export criteria')
+  end
+
+  test 'purge_job email with all purged monitorees' do
+    email = UserMailer.purge_job_email(
+      [{ id: 9999 }],
+      { current: 1, total: 1 },
+      {
+        start_time: 2.minute.ago,
+        end_time: 1.minute.ago,
+        not_purged_count: 0,
+        purged_count: 1
+      }
+    ).deliver_now
+    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    assert_not(ActionMailer::Base.deliveries.empty?)
+    assert_includes(email_body, 'Purged during this job run: 1')
+    assert_includes(email_body, '9999')
+  end
+
+  test 'purge_job email with all non purged monitorees' do
+    email = UserMailer.purge_job_email(
+      [{ id: 9999, reason: 'StandardError' }],
+      { current: 1, total: 1 },
+      {
+        start_time: 2.minute.ago,
+        end_time: 1.minute.ago,
+        not_purged_count: 1,
+        purged_count: 0
+      }
+    ).deliver_now
+    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    assert_not(ActionMailer::Base.deliveries.empty?)
+    assert_includes(email_body, 'Purged during this job run: 0')
+    assert_includes(email_body, 'Not purged during this job run: 1')
+    assert_includes(email_body, '9999, StandardError')
+  end
+
+  test 'purge_job email with no purged or non purged monitorees' do
+    email = UserMailer.purge_job_email(
+      [],
+      { current: 1, total: 1 },
+      {
+        start_time: 2.minute.ago,
+        end_time: 1.minute.ago,
+        not_purged_count: 0,
+        purged_count: 0
+      }
+    ).deliver_now
+    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    assert_not(ActionMailer::Base.deliveries.empty?)
+    assert_includes(email_body, 'Purged during this job run: 0')
+    assert_includes(email_body, 'Not purged during this job run: 0')
+  end
+
+  test 'purge_job email with purged and non purged monitorees' do
+    email = UserMailer.purge_job_email(
+      [{ id: 9998 }, { id: 9999, reason: 'StandardError' }],
+      { current: 1, total: 1 },
+      {
+        start_time: 2.minute.ago,
+        end_time: 1.minute.ago,
+        not_purged_count: 1,
+        purged_count: 1
+      }
+    ).deliver_now
+    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    assert_not(ActionMailer::Base.deliveries.empty?)
+    assert_includes(email_body, 'Purged during this job run: 1')
+    assert_includes(email_body, 'Not purged during this job run: 1')
+    assert_includes(email_body, '9998')
+    assert_includes(email_body, '9999, StandardError')
   end
 end


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1449

Updates the PurgeJob to send emails in batches.
Includes additional diagnostic info.

## (Feature) Demo/Screenshots
Nothing purged / no errors
<img width="615" alt="Screen Shot 2021-05-14 at 14 25 41" src="https://user-images.githubusercontent.com/3009651/118333297-4e946280-b4c0-11eb-82c5-2c84fed544e1.png">

With data
<img width="600" alt="Screen Shot 2021-05-14 at 14 33 45" src="https://user-images.githubusercontent.com/3009651/118333915-6f10ec80-b4c1-11eb-9dca-82bad583b5f7.png">

## (Bugfix) How to Replicate
Send an email to our email server in excess of 170k lines and receive an STMPError.

## (Bugfix) Solution
Send multiple emails so we do not hit this upper limit.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`purge_job.rb`
- Batching logic

`purge_job_test.rb`
- Tests for batching

`sara.yml`
- Add batch size config 

`purge_job_email.html.erb`
- Logic updates
- Break out into partial for purged/not_purged
- Include new job information
- Formatting improvements

`user_mailer_test.rb`
- Updated tests for different cases

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@timwongj:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@jkufro:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
