### PR TITLE
SARAALERT-1229: Vaccine Advanced Filter

### DIFF
--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -239,6 +239,8 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
       case filter[:filterOption]['name']
       when 'lab-result'
         patients = advanced_filter_lab_result(patients, filter)
+      when 'vaccination'
+        patients = advanced_filter_vaccines(patients, filter)
       when 'sent-today'
         patients = if filter[:value].present?
                      patients.where('last_assessment_reminder_sent >= ?', 24.hours.ago)
@@ -505,6 +507,36 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     end
 
     patients.where(id: labs)
+  end
+
+  def advanced_filter_vaccines(patients, filter)
+    vaccines = patients.joins(:vaccines)
+    filter[:value].each do |field|
+      case field[:name]
+      when 'vaccine-group'
+        vaccines = vaccines.where('vaccines.group_name = ?', field[:value])
+      when 'product-name'
+        vaccines = vaccines.where('vaccines.product_name = ?', field[:value])
+      when 'administration-date'
+        case field[:value][:when]
+        when 'before'
+          vaccines = vaccines.where('vaccines.administration_date < ?', field[:value][:date])
+        when 'after'
+          vaccines = vaccines.where('vaccines.administration_date > ?', field[:value][:date])
+        end
+      when 'dose-number'
+        if field[:value].blank?
+          vaccines = vaccines.where('vaccines.dose_number IS NULL')
+                             .or(
+                               vaccines.where('vaccines.dose_number = ?', '')
+                             )
+        else
+          vaccines = vaccines.where('vaccines.dose_number = ?', field[:value])
+        end
+      end
+    end
+
+    patients.where(id: vaccines)
   end
 
   # Filter patients by a set time range for the given field

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -525,14 +525,14 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
           vaccines = vaccines.where('vaccines.administration_date > ?', field[:value][:date])
         end
       when 'dose-number'
-        if field[:value].blank?
-          vaccines = vaccines.where('vaccines.dose_number IS NULL')
+        vaccines = if field[:value].blank?
+                     vaccines.where('vaccines.dose_number IS NULL')
                              .or(
                                vaccines.where('vaccines.dose_number = ?', '')
                              )
-        else
-          vaccines = vaccines.where('vaccines.dose_number = ?', field[:value])
-        end
+                   else
+                     vaccines.where('vaccines.dose_number = ?', field[:value])
+                   end
       end
     end
 

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -1171,7 +1171,7 @@ class AdvancedFilter extends React.Component {
                     type="dark"
                     effect="solid"
                     className="tooltip-container">
-                    <span>Select to add multiple Lab Result search criteria.</span>
+                    <span>Select to add multiple {filter.title.replace(' (Multi-select)', '')} search criteria.</span>
                   </ReactTooltip>
                 </React.Fragment>
               )}

--- a/app/javascript/data/advancedFilterOptions.js
+++ b/app/javascript/data/advancedFilterOptions.js
@@ -289,5 +289,37 @@ export const advancedFilterOptions = [
         type: 'date'
       }
     ]
+  },
+  {
+    name: 'vaccination',
+    title: 'Vaccination (Multi-select)',
+    description: 'Monitorees with specified Vaccination criteria',
+    type: 'multi',
+    tooltip: 'Returns records that contain at least one Vaccination entry that meets all user-specified criteria (e.g., searching for a specific Vaccination Product Name and Administration Date will only return records containing at least one Vaccination entry with matching values in both fields).',
+    fields: [
+      {
+        name: 'vaccine-group',
+        title: 'vaccine group',
+        type: 'select',
+        options: ['COVID-19']
+      },
+      {
+        name: 'product-name',
+        title: 'product name',
+        type: 'select',
+        options: ['Moderna COVID-19 Vaccine', 'Pfizer-BioNTech COVID-19 Vaccine', 'Janssen (J&J) COVID-19 Vaccine', 'Unknown']
+      },
+      {
+        name: 'administration-date',
+        title: 'administration date',
+        type: 'date'
+      },
+      {
+        name: 'dose-number',
+        title: 'dose number',
+        type: 'select',
+        options: ['', '1', '2', 'Unknown']
+      }
+    ]
   }
 ]

--- a/test/helpers/patient_query_helper_test.rb
+++ b/test/helpers/patient_query_helper_test.rb
@@ -3,7 +3,7 @@
 require 'test_case'
 
 class PatientQueryHelperTest < ActionView::TestCase
-  # BOOLEAN ADVANCED FILTER QUERIES
+  # --- BOOLEAN ADVANCED FILTER QUERIES --- #
 
   test 'advanced filter blocked sms properly filters those with blocked numbers' do
     Patient.destroy_all
@@ -33,7 +33,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
   end
 
-  # SEARCH ADVANCED FILTER QUERIES
+  # --- SEARCH ADVANCED FILTER QUERIES --- #
 
   test 'advanced filter close contact with known case id exact match single value' do
     Patient.destroy_all
@@ -138,7 +138,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
   end
 
-  # MULTI ADVANCED FILTER QUERIES
+  # --- MULTI ADVANCED FILTER QUERIES --- #
 
   test 'advanced filter laboratory single filter option results' do
     Patient.destroy_all
@@ -436,6 +436,364 @@ class PatientQueryHelperTest < ActionView::TestCase
     tz_offset = 300
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_6]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter vaccination single filter option vaccine group' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_1, group_name: 'COVID-19')
+    create(:vaccine, patient: patient_1, group_name: 'COVID-19')
+    patient_2 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_2, group_name: 'COVID-19')
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filters = [{ filterOption: {}, value: [{ name: 'vaccine-group', value: 'COVID-19' }] }]
+    filters[0][:filterOption]['name'] = 'vaccination'
+    tz_offset = 300
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter vaccination single filter option product name' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_1, product_name: 'Moderna COVID-19 Vaccine')
+    create(:vaccine, patient: patient_1, product_name: 'Pfizer-BioNTech COVID-19 Vaccine')
+    patient_2 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_2, product_name: 'Janssen (J&J) COVID-19 Vaccine')
+    patient_3 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_3, product_name: 'Moderna COVID-19 Vaccine')
+    patient_4 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_4, product_name: 'Unknown')
+    patient_5 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_5, product_name: 'Pfizer-BioNTech COVID-19 Vaccine')
+    create(:vaccine, patient: patient_5, product_name: 'Pfizer-BioNTech COVID-19 Vaccine')
+    patient_6 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_6, product_name: 'Moderna COVID-19 Vaccine')
+    create(:vaccine, patient: patient_6, product_name: 'Moderna COVID-19 Vaccine')
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filters = [{ filterOption: {}, value: [{ name: 'product-name', value: 'Moderna COVID-19 Vaccine' }] }]
+    filters[0][:filterOption]['name'] = 'vaccination'
+    tz_offset = 300
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_3, patient_6]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter vaccination single filter option administration date before' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_1, administration_date: DateTime.new(2021, 3, 1))
+    create(:vaccine, patient: patient_1, administration_date: DateTime.new(2021, 4, 1))
+    patient_2 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_2, administration_date: DateTime.new(2021, 3, 24))
+    patient_3 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_3, administration_date: DateTime.new(2021, 3, 25))
+    patient_4 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_4, administration_date: DateTime.new(2021, 3, 26))
+    patient_5 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_5, administration_date: DateTime.new(2021, 3, 1))
+    create(:vaccine, patient: patient_5, administration_date: DateTime.new(2021, 3, 15))
+    patient_6 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_6, administration_date: DateTime.new(2021, 4, 1))
+    create(:vaccine, patient: patient_6, administration_date: DateTime.new(2021, 4, 3))
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filters = [{ filterOption: {}, value: [{ name: 'administration-date', value: { when: 'before', date: '2021-03-25' } }] }]
+    filters[0][:filterOption]['name'] = 'vaccination'
+    tz_offset = 300
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2, patient_5]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter vaccination single filter option administration date after' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_1, administration_date: DateTime.new(2021, 3, 1))
+    create(:vaccine, patient: patient_1, administration_date: DateTime.new(2021, 4, 1))
+    patient_2 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_2, administration_date: DateTime.new(2021, 3, 24))
+    patient_3 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_3, administration_date: DateTime.new(2021, 3, 25))
+    patient_4 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_4, administration_date: DateTime.new(2021, 3, 26))
+    patient_5 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_5, administration_date: DateTime.new(2021, 3, 1))
+    create(:vaccine, patient: patient_5, administration_date: DateTime.new(2021, 3, 15))
+    patient_6 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_6, administration_date: DateTime.new(2021, 4, 1))
+    create(:vaccine, patient: patient_6, administration_date: DateTime.new(2021, 4, 3))
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filters = [{ filterOption: {}, value: [{ name: 'administration-date', value: { when: 'after', date: '2021-03-25' } }] }]
+    filters[0][:filterOption]['name'] = 'vaccination'
+    tz_offset = 300
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_4, patient_6]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter vaccination single filter option dose number blank' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_1, dose_number: '1')
+    create(:vaccine, patient: patient_1, dose_number: '2')
+    patient_2 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_2, dose_number: 'Unknown')
+    patient_3 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_3, dose_number: nil)
+    patient_4 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_4, dose_number: '')
+    patient_5 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_5, dose_number: '')
+    create(:vaccine, patient: patient_5, dose_number: nil)
+    patient_6 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_6, dose_number: '1')
+    create(:vaccine, patient: patient_6, dose_number: '')
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filters = [{ filterOption: {}, value: [{ name: 'dose-number', value: '' }] }]
+    filters[0][:filterOption]['name'] = 'vaccination'
+    tz_offset = 300
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_3, patient_4, patient_5, patient_6]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter vaccination single filter option dose number not blank' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_1, dose_number: '1')
+    create(:vaccine, patient: patient_1, dose_number: '2')
+    patient_2 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_2, dose_number: '1')
+    patient_3 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_3, dose_number: '')
+    patient_4 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_4, dose_number: 'Unknown')
+    patient_5 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_5, dose_number: '1')
+    create(:vaccine, patient: patient_5, dose_number: nil)
+    patient_6 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_6, dose_number: '1')
+    create(:vaccine, patient: patient_6, dose_number: '1')
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filters = [{ filterOption: {}, value: [{ name: 'dose-number', value: '1' }] }]
+    filters[0][:filterOption]['name'] = 'vaccination'
+    tz_offset = 300
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2, patient_5, patient_6]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter vaccination single filter option muliple values' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_1, product_name: 'Pfizer-BioNTech COVID-19 Vaccine', dose_number: '1')
+    create(:vaccine, patient: patient_1, product_name: 'Pfizer-BioNTech COVID-19 Vaccine', dose_number: '2')
+    patient_2 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_2, product_name: 'Pfizer-BioNTech COVID-19 Vaccine', dose_number: 'Unknown')
+    patient_3 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_3, product_name: 'Pfizer-BioNTech COVID-19 Vaccine', dose_number: nil)
+    patient_4 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_4, product_name: 'Janssen (J&J) COVID-19 Vaccine', dose_number: '1')
+    patient_5 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_5, product_name: 'Pfizer-BioNTech COVID-19 Vaccine', dose_number: '1')
+    create(:vaccine, patient: patient_5, product_name: 'Janssen (J&J) COVID-19 Vaccine', dose_number: '1')
+    create(:vaccine, patient: patient_5, product_name: 'Unknown', dose_number: 'Unknown')
+    create(:vaccine, patient: patient_5, product_name: 'Pfizer-BioNTech COVID-19 Vaccine', dose_number: '2')
+    patient_6 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_6, product_name: 'Moderna COVID-19 Vaccine', dose_number: '1')
+    create(:vaccine, patient: patient_6, product_name: 'Pfizer-BioNTech COVID-19 Vaccine', dose_number: '2')
+    patient_7 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_7, product_name: 'Pfizer-BioNTech COVID-19 Vaccine', dose_number: '1')
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filters = [{ filterOption: {}, value: [{ name: 'product-name', value: 'Pfizer-BioNTech COVID-19 Vaccine' }, { name: 'dose-number', value: '1' }] }]
+    filters[0][:filterOption]['name'] = 'vaccination'
+    tz_offset = 300
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_5, patient_7]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter vaccination single filter option all values' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_1, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 24), dose_number: '1')
+    create(:vaccine, patient: patient_1, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 4, 11), dose_number: '2')
+    patient_2 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_2, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 24), dose_number: 'Unknown')
+    patient_3 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_3, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 25), dose_number: '1')
+    patient_4 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_4, group_name: 'COVID-19', product_name: 'Janssen (J&J) COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 24), dose_number: '1')
+    patient_5 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_5, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 24), dose_number: '1')
+    create(:vaccine, patient: patient_5, group_name: 'COVID-19', product_name: 'Janssen (J&J) COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 24), dose_number: '1')
+    create(:vaccine, patient: patient_5, group_name: 'COVID-19', product_name: 'Unknown', administration_date: DateTime.new(2021, 3, 24),
+                     dose_number: 'Unknown')
+    create(:vaccine, patient: patient_5, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 4, 13), dose_number: '2')
+    patient_6 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_6, group_name: 'COVID-19', product_name: 'Moderna COVID-19 Vaccine', administration_date: DateTime.new(2021, 3, 24),
+                     dose_number: '1')
+    create(:vaccine, patient: patient_6, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 4, 11), dose_number: '2')
+    patient_7 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_7, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 24), dose_number: '1')
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filters = [{ filterOption: {},
+                 value: [{ name: 'vaccine-group', value: 'COVID-19' }, { name: 'product-name', value: 'Pfizer-BioNTech COVID-19 Vaccine' },
+                         { name: 'administration-date', value: { when: 'before', date: '2021-03-25' } },
+                         { name: 'dose-number', value: '1' }] }]
+    filters[0][:filterOption]['name'] = 'vaccination'
+    tz_offset = 300
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_5, patient_7]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter vaccination multiple filter options some values' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_1, product_name: 'Pfizer-BioNTech COVID-19 Vaccine', dose_number: '1')
+    create(:vaccine, patient: patient_1, product_name: 'Pfizer-BioNTech COVID-19 Vaccine', dose_number: '2')
+    patient_2 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_2, product_name: 'Pfizer-BioNTech COVID-19 Vaccine', dose_number: 'Unknown')
+    patient_3 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_3, product_name: 'Pfizer-BioNTech COVID-19 Vaccine', dose_number: nil)
+    patient_4 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_4, product_name: 'Janssen (J&J) COVID-19 Vaccine', dose_number: '1')
+    patient_5 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_5, product_name: 'Pfizer-BioNTech COVID-19 Vaccine', dose_number: '1')
+    create(:vaccine, patient: patient_5, product_name: 'Janssen (J&J) COVID-19 Vaccine', dose_number: '1')
+    create(:vaccine, patient: patient_5, product_name: 'Unknown', dose_number: 'Unknown')
+    create(:vaccine, patient: patient_5, product_name: 'Pfizer-BioNTech COVID-19 Vaccine', dose_number: '2')
+    patient_6 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_6, product_name: 'Moderna COVID-19 Vaccine', dose_number: '1')
+    create(:vaccine, patient: patient_6, product_name: 'Pfizer-BioNTech COVID-19 Vaccine', dose_number: '2')
+    patient_7 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_7, product_name: 'Pfizer-BioNTech COVID-19 Vaccine', dose_number: '1')
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filter_option_1 = { filterOption: {}, value: [{ name: 'product-name', value: 'Pfizer-BioNTech COVID-19 Vaccine' }, { name: 'dose-number', value: '1' }] }
+    filter_option_2 = { filterOption: {}, value: [{ name: 'product-name', value: 'Pfizer-BioNTech COVID-19 Vaccine' }, { name: 'dose-number', value: '2' }] }
+    filter_option_1[:filterOption]['name'] = 'vaccination'
+    filter_option_2[:filterOption]['name'] = 'vaccination'
+    filters = [filter_option_1, filter_option_2]
+    tz_offset = 300
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_5]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter vaccination multiple filter options all values' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_1, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 24), dose_number: '1')
+    create(:vaccine, patient: patient_1, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 4, 11), dose_number: '2')
+    patient_2 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_2, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 24), dose_number: '1')
+    patient_3 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_3, group_name: 'COVID-19', product_name: 'Unknown', administration_date: DateTime.new(2021, 3, 26),
+                     dose_number: 'Unknown')
+    patient_4 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_4, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 24), dose_number: '1')
+    create(:vaccine, patient: patient_4, group_name: 'COVID-19', product_name: 'Unknown', administration_date: DateTime.new(2021, 3, 26), dose_number: nil)
+    patient_5 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_5, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 25), dose_number: '1')
+    create(:vaccine, patient: patient_5, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 4, 18), dose_number: '2')
+    create(:vaccine, patient: patient_5, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 24), dose_number: 'Unknown')
+    create(:vaccine, patient: patient_5, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 24), dose_number: nil)
+    create(:vaccine, patient: patient_5, group_name: 'COVID-19', product_name: 'Moderna COVID-19 Vaccine', administration_date: DateTime.new(2021, 3, 25),
+                     dose_number: '1')
+    create(:vaccine, patient: patient_5, group_name: 'COVID-19', product_name: 'Unknown', administration_date: DateTime.new(2021, 3, 26), dose_number: nil)
+    patient_6 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_6, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 24), dose_number: '1')
+    create(:vaccine, patient: patient_6, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 26), dose_number: nil)
+    create(:vaccine, patient: patient_6, group_name: 'COVID-19', product_name: 'Unknown', administration_date: DateTime.new(2021, 3, 25), dose_number: nil)
+    create(:vaccine, patient: patient_6, group_name: 'COVID-19', product_name: 'Unknown', administration_date: DateTime.new(2021, 3, 5), dose_number: nil)
+    create(:vaccine, patient: patient_6, group_name: 'COVID-19', product_name: 'Unknown', administration_date: DateTime.new(2021, 3, 26), dose_number: '2')
+    patient_7 = create(:patient, creator: user)
+    create(:vaccine, patient: patient_7, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 24), dose_number: '1')
+    create(:vaccine, patient: patient_7, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 25), dose_number: '1')
+    create(:vaccine, patient: patient_7, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 4, 18), dose_number: '2')
+    create(:vaccine, patient: patient_7, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 24), dose_number: 'Unknown')
+    create(:vaccine, patient: patient_7, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 24), dose_number: nil)
+    create(:vaccine, patient: patient_7, group_name: 'COVID-19', product_name: 'Moderna COVID-19 Vaccine', administration_date: DateTime.new(2021, 3, 25),
+                     dose_number: '1')
+    create(:vaccine, patient: patient_7, group_name: 'COVID-19', product_name: 'Pfizer-BioNTech COVID-19 Vaccine',
+                     administration_date: DateTime.new(2021, 3, 26), dose_number: nil)
+    create(:vaccine, patient: patient_7, group_name: 'COVID-19', product_name: 'Unknown', administration_date: DateTime.new(2021, 3, 25), dose_number: nil)
+    create(:vaccine, patient: patient_7, group_name: 'COVID-19', product_name: 'Unknown', administration_date: DateTime.new(2021, 3, 5), dose_number: nil)
+    create(:vaccine, patient: patient_7, group_name: 'COVID-19', product_name: 'Unknown', administration_date: DateTime.new(2021, 3, 26), dose_number: '2')
+    create(:vaccine, patient: patient_7, group_name: 'COVID-19', product_name: 'Unknown', administration_date: DateTime.new(2021, 3, 26), dose_number: '')
+    create(:patient, creator: user)
+
+    patients = Patient.all
+    filter_option_1 = { filterOption: {},
+                        value: [{ name: 'vaccine-group', value: 'COVID-19' }, { name: 'product-name', value: 'Pfizer-BioNTech COVID-19 Vaccine' },
+                                { name: 'administration-date', value: { when: 'before', date: '2021-03-25' } },
+                                { name: 'dose-number', value: '1' }] }
+    filter_option_2 = { filterOption: {},
+                        value: [{ name: 'vaccine-group', value: 'COVID-19' }, { name: 'product-name', value: 'Unknown' },
+                                { name: 'administration-date', value: { when: 'after', date: '2021-03-25' } },
+                                { name: 'dose-number', value: '' }] }
+    filter_option_1[:filterOption]['name'] = 'vaccination'
+    filter_option_2[:filterOption]['name'] = 'vaccination'
+    filters = [filter_option_1, filter_option_2]
+    tz_offset = 300
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_4, patient_7]
     assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
   end
 end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1229](https://tracker.codev.mitre.org/browse/SARAALERT-1229)

Allow users to filter records by vaccine history using the following fields: Administration Date, Dose Number, Product Name, and Vaccine Group

## (Feature) Demo/Screenshots
![Screen Shot 2021-05-17 at 11 27 35 AM](https://user-images.githubusercontent.com/35042815/118515060-06b14d80-b703-11eb-9f56-8ffe98b3e760.png)

![Screen Shot 2021-05-17 at 11 27 43 AM](https://user-images.githubusercontent.com/35042815/118515076-09ac3e00-b703-11eb-8c4c-8d726c346552.png)

![Screen Shot 2021-05-17 at 11 27 53 AM](https://user-images.githubusercontent.com/35042815/118515082-0c0e9800-b703-11eb-96a1-0f03962ef6de.png)

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`patient_query_helper.rb`
- Added support for filtering by multiple vaccine fields to the backend (these are very similar to the ones for the lab multi advanced filter)

`patient_query_helper_test.rb`
- Added backend query tests for the multi vaccine advanced filter (again, very similar to how the lab multi advanced filter is done)

`advancedFilterOptions.js`
- Added vaccine filter option to list of advanced filters
- This is all that is needed to populate the front end, YAY!


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@tstrass :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@timwongj :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@DPC15038 :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
