### PR TITLE
SARAALERT-1053: Hide fields in isolation

### DIFF
--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
-import { Spinner, Table, Form, InputGroup } from 'react-bootstrap';
+import { Col, Form, InputGroup, Row, Spinner, Table } from 'react-bootstrap';
 import ReactPaginate from 'react-paginate';
 import ReactTooltip from 'react-tooltip';
 import InfoTooltip from '../util/InfoTooltip';
@@ -264,8 +264,8 @@ class CustomTable extends React.Component {
           </Table>
         </div>
         {this.props.showPagination && (
-          <div id="pagination-container" className="row-container">
-            <div className="left-container">
+          <Row id="pagination-container">
+            <Col className="mt-2">
               <div className="left-box-1">
                 <InputGroup>
                   <InputGroup.Prepend>
@@ -294,8 +294,8 @@ class CustomTable extends React.Component {
               <div className="left-box-2">
                 <span className="ml-0 ml-md-2 text-nowrap align-self-center">{`Displaying ${this.props.rowData.length} out of ${this.props.totalRows} rows.`}</span>
               </div>
-            </div>
-            <div className="right-container">
+            </Col>
+            <Col xs="auto" className="mt-2">
               {this.props.totalRows > 0 && (
                 <div style={{ float: 'right' }}>
                   <ReactPaginate
@@ -324,8 +324,8 @@ class CustomTable extends React.Component {
                   />
                 </div>
               )}
-            </div>
-          </div>
+            </Col>
+          </Row>
         )}
       </React.Fragment>
     );

--- a/app/javascript/components/patient/assessment/actions/ExtendedIsolation.js
+++ b/app/javascript/components/patient/assessment/actions/ExtendedIsolation.js
@@ -40,37 +40,26 @@ class ExtendedIsolation extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Col>
-          <Row className="reports-actions-title">
-            <Col>
-              <Form.Label className="nav-input-label">
-                EXTEND ISOLATION TO
-                <InfoTooltip tooltipTextKey="extendedIsolation" location="right"></InfoTooltip>
-              </Form.Label>
-            </Col>
-          </Row>
-          <Row>
-            <Col>
-              <DateInput
-                id="extended_isolation"
-                date={this.state.extended_isolation}
-                minDate={moment()
-                  .subtract(30, 'days')
-                  .format('YYYY-MM-DD')}
-                maxDate={moment()
-                  .add(30, 'days')
-                  .format('YYYY-MM-DD')}
-                onChange={date => this.setState({ extended_isolation: date, showExtendIsolationModal: true, reasoning: '' })}
-                placement="bottom"
-                customClass="form-control-lg"
-                ariaLabel="Extended Isolation to Date Input"
-                isClearable
-              />
-            </Col>
-          </Row>
-          <Row>
-            <Col></Col>
-          </Row>
+        <Col md={12} xl={8}>
+          <Form.Label className="nav-input-label">
+            EXTEND ISOLATION TO
+            <InfoTooltip tooltipTextKey="extendedIsolation" location="right"></InfoTooltip>
+          </Form.Label>
+          <DateInput
+            id="extended_isolation"
+            date={this.state.extended_isolation}
+            minDate={moment()
+              .subtract(30, 'days')
+              .format('YYYY-MM-DD')}
+            maxDate={moment()
+              .add(30, 'days')
+              .format('YYYY-MM-DD')}
+            onChange={date => this.setState({ extended_isolation: date, showExtendIsolationModal: true, reasoning: '' })}
+            placement="bottom"
+            customClass="form-control-lg"
+            ariaLabel="Extended Isolation to Date Input"
+            isClearable
+          />
         </Col>
         {this.state.showExtendIsolationModal && (
           <Modal

--- a/app/javascript/components/patient/assessment/actions/ExtendedIsolation.js
+++ b/app/javascript/components/patient/assessment/actions/ExtendedIsolation.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
-import { Button, Col, Form, Modal, Row } from 'react-bootstrap';
+import { Button, Col, Form, Modal } from 'react-bootstrap';
 import axios from 'axios';
 import moment from 'moment';
 

--- a/app/javascript/components/patient/assessment/actions/LastDateExposure.js
+++ b/app/javascript/components/patient/assessment/actions/LastDateExposure.js
@@ -203,35 +203,27 @@ class LastDateExposure extends React.Component {
         <Row>
           <SymptomOnset authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
           {!this.props.patient.isolation ? (
-            <>
-              <Form.Group as={Col} controlId="last_date_of_exposure">
-                <Row className="reports-actions-title">
-                  <Col>
-                    <Form.Label className="nav-input-label h6">
-                      LAST DATE OF EXPOSURE
-                      <InfoTooltip tooltipTextKey="lastDateOfExposure" location="right"></InfoTooltip>
-                    </Form.Label>
-                  </Col>
-                </Row>
-                <Row>
-                  <Col>
-                    <DateInput
-                      id="last_date_of_exposure"
-                      date={this.state.last_date_of_exposure}
-                      minDate={'2020-01-01'}
-                      maxDate={moment()
-                        .add(30, 'days')
-                        .format('YYYY-MM-DD')}
-                      onChange={this.openLastDateOfExposureModal}
-                      placement="top"
-                      customClass="form-control-lg"
-                      ariaLabel="Last Date of Exposure Input"
-                      isClearable
-                    />
-                  </Col>
-                </Row>
-                <Row className="pt-2">
-                  <Col>
+            <React.Fragment>
+              <Form.Group as={Col} md={8} controlId="last_date_of_exposure">
+                <Form.Label className="nav-input-label">
+                  LAST DATE OF EXPOSURE
+                  <InfoTooltip tooltipTextKey="lastDateOfExposure" location="right"></InfoTooltip>
+                </Form.Label>
+                <DateInput
+                  id="last_date_of_exposure"
+                  date={this.state.last_date_of_exposure}
+                  minDate={'2020-01-01'}
+                  maxDate={moment()
+                    .add(30, 'days')
+                    .format('YYYY-MM-DD')}
+                  onChange={this.openLastDateOfExposureModal}
+                  placement="top"
+                  customClass="form-control-lg"
+                  ariaLabel="Last Date of Exposure Input"
+                  isClearable
+                />
+                {/* <Row className="pt-2">
+                  <Col> */}
                     <OverlayTrigger
                       key="tooltip-ot-ce"
                       placement="left"
@@ -253,24 +245,15 @@ class LastDateExposure extends React.Component {
                       </span>
                     </OverlayTrigger>
                     <InfoTooltip tooltipTextKey="continuousExposure" location="right"></InfoTooltip>
-                  </Col>
-                </Row>
+                  {/* </Col>
+                </Row> */}
               </Form.Group>
-              <Col>
-                <Row className="reports-actions-title">
-                  <Col>
-                    <span className="nav-input-label">END OF MONITORING</span>
-                    <InfoTooltip getCustomText={this.endOfMonitoringTooltipText} location="right"></InfoTooltip>
-                  </Col>
-                </Row>
-                <Row>
-                  <Col>{this.formatEndOfMonitoringDate()}</Col>
-                </Row>
-                <Row>
-                  <Col></Col>
-                </Row>
+              <Col md={8}>
+                <span className="nav-input-label">END OF MONITORING</span>
+                <InfoTooltip getCustomText={this.endOfMonitoringTooltipText} location="right"></InfoTooltip>
+                <div>{this.formatEndOfMonitoringDate()}</div>
               </Col>
-            </>
+            </React.Fragment>
           ) : (
             <ExtendedIsolation authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
           )}

--- a/app/javascript/components/patient/assessment/actions/LastDateExposure.js
+++ b/app/javascript/components/patient/assessment/actions/LastDateExposure.js
@@ -202,77 +202,77 @@ class LastDateExposure extends React.Component {
           )}
         <Row>
           <SymptomOnset authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
-          {!this.props.patient.isolation && (
-            <Form.Group as={Col} controlId="last_date_of_exposure">
-              <Row className="reports-actions-title">
-                <Col>
-                  <Form.Label className="nav-input-label h6">
-                    LAST DATE OF EXPOSURE
-                    <InfoTooltip tooltipTextKey="lastDateOfExposure" location="right"></InfoTooltip>
-                  </Form.Label>
-                </Col>
-              </Row>
-              <Row>
-                <Col>
-                  <DateInput
-                    id="last_date_of_exposure"
-                    date={this.state.last_date_of_exposure}
-                    minDate={'2020-01-01'}
-                    maxDate={moment()
-                      .add(30, 'days')
-                      .format('YYYY-MM-DD')}
-                    onChange={this.openLastDateOfExposureModal}
-                    placement="top"
-                    customClass="form-control-lg"
-                    ariaLabel="Last Date of Exposure Input"
-                    isClearable
-                  />
-                </Col>
-              </Row>
-              <Row className="pt-2">
-                <Col>
-                  <OverlayTrigger
-                    key="tooltip-ot-ce"
-                    placement="left"
-                    overlay={
-                      <Tooltip id="tooltip-ce" style={this.props.patient.monitoring ? { display: 'none' } : {}}>
-                        Continuous Exposure cannot be turned on or off for records on the Closed line list. If this monitoree requires monitoring due to a
-                        Continuous Exposure, you may update this field after changing Monitoring Status to &quot;Actively Monitoring&quot;
-                      </Tooltip>
-                    }>
-                    <span className="d-inline-block">
-                      <Form.Check
-                        size="lg"
-                        label="CONTINUOUS EXPOSURE"
-                        id="continuous_exposure"
-                        disabled={!this.props.patient.monitoring}
-                        checked={this.state.continuous_exposure}
-                        onChange={() => this.openContinuousExposureModal()}
-                      />
-                    </span>
-                  </OverlayTrigger>
-                  <InfoTooltip tooltipTextKey="continuousExposure" location="right"></InfoTooltip>
-                </Col>
-              </Row>
-            </Form.Group>
-          )}
-          {this.props.patient.isolation ? (
-            <ExtendedIsolation authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
+          {!this.props.patient.isolation ? (
+            <>
+              <Form.Group as={Col} controlId="last_date_of_exposure">
+                <Row className="reports-actions-title">
+                  <Col>
+                    <Form.Label className="nav-input-label h6">
+                      LAST DATE OF EXPOSURE
+                      <InfoTooltip tooltipTextKey="lastDateOfExposure" location="right"></InfoTooltip>
+                    </Form.Label>
+                  </Col>
+                </Row>
+                <Row>
+                  <Col>
+                    <DateInput
+                      id="last_date_of_exposure"
+                      date={this.state.last_date_of_exposure}
+                      minDate={'2020-01-01'}
+                      maxDate={moment()
+                        .add(30, 'days')
+                        .format('YYYY-MM-DD')}
+                      onChange={this.openLastDateOfExposureModal}
+                      placement="top"
+                      customClass="form-control-lg"
+                      ariaLabel="Last Date of Exposure Input"
+                      isClearable
+                    />
+                  </Col>
+                </Row>
+                <Row className="pt-2">
+                  <Col>
+                    <OverlayTrigger
+                      key="tooltip-ot-ce"
+                      placement="left"
+                      overlay={
+                        <Tooltip id="tooltip-ce" style={this.props.patient.monitoring ? { display: 'none' } : {}}>
+                          Continuous Exposure cannot be turned on or off for records on the Closed line list. If this monitoree requires monitoring due to a
+                          Continuous Exposure, you may update this field after changing Monitoring Status to &quot;Actively Monitoring&quot;
+                        </Tooltip>
+                      }>
+                      <span className="d-inline-block">
+                        <Form.Check
+                          size="lg"
+                          label="CONTINUOUS EXPOSURE"
+                          id="continuous_exposure"
+                          disabled={!this.props.patient.monitoring}
+                          checked={this.state.continuous_exposure}
+                          onChange={() => this.openContinuousExposureModal()}
+                        />
+                      </span>
+                    </OverlayTrigger>
+                    <InfoTooltip tooltipTextKey="continuousExposure" location="right"></InfoTooltip>
+                  </Col>
+                </Row>
+              </Form.Group>
+              <Col>
+                <Row className="reports-actions-title">
+                  <Col>
+                    <span className="nav-input-label">END OF MONITORING</span>
+                    <InfoTooltip getCustomText={this.endOfMonitoringTooltipText} location="right"></InfoTooltip>
+                  </Col>
+                </Row>
+                <Row>
+                  <Col>{this.formatEndOfMonitoringDate()}</Col>
+                </Row>
+                <Row>
+                  <Col></Col>
+                </Row>
+              </Col>
+            </>
           ) : (
-            <Col>
-              <Row className="reports-actions-title">
-                <Col>
-                  <span className="nav-input-label">END OF MONITORING</span>
-                  <InfoTooltip getCustomText={this.endOfMonitoringTooltipText} location="right"></InfoTooltip>
-                </Col>
-              </Row>
-              <Row>
-                <Col>{this.formatEndOfMonitoringDate()}</Col>
-              </Row>
-              <Row>
-                <Col></Col>
-              </Row>
-            </Col>
+            <ExtendedIsolation authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
           )}
         </Row>
       </React.Fragment>

--- a/app/javascript/components/patient/assessment/actions/LastDateExposure.js
+++ b/app/javascript/components/patient/assessment/actions/LastDateExposure.js
@@ -222,31 +222,27 @@ class LastDateExposure extends React.Component {
                   ariaLabel="Last Date of Exposure Input"
                   isClearable
                 />
-                {/* <Row className="pt-2">
-                  <Col> */}
-                    <OverlayTrigger
-                      key="tooltip-ot-ce"
-                      placement="left"
-                      overlay={
-                        <Tooltip id="tooltip-ce" style={this.props.patient.monitoring ? { display: 'none' } : {}}>
-                          Continuous Exposure cannot be turned on or off for records on the Closed line list. If this monitoree requires monitoring due to a
-                          Continuous Exposure, you may update this field after changing Monitoring Status to &quot;Actively Monitoring&quot;
-                        </Tooltip>
-                      }>
-                      <span className="d-inline-block">
-                        <Form.Check
-                          size="lg"
-                          label="CONTINUOUS EXPOSURE"
-                          id="continuous_exposure"
-                          disabled={!this.props.patient.monitoring}
-                          checked={this.state.continuous_exposure}
-                          onChange={() => this.openContinuousExposureModal()}
-                        />
-                      </span>
-                    </OverlayTrigger>
-                    <InfoTooltip tooltipTextKey="continuousExposure" location="right"></InfoTooltip>
-                  {/* </Col>
-                </Row> */}
+                <OverlayTrigger
+                  key="tooltip-ot-ce"
+                  placement="left"
+                  overlay={
+                    <Tooltip id="tooltip-ce" style={this.props.patient.monitoring ? { display: 'none' } : {}}>
+                      Continuous Exposure cannot be turned on or off for records on the Closed line list. If this monitoree requires monitoring due to a
+                      Continuous Exposure, you may update this field after changing Monitoring Status to &quot;Actively Monitoring&quot;
+                    </Tooltip>
+                  }>
+                  <span className="d-inline-block">
+                    <Form.Check
+                      size="lg"
+                      label="CONTINUOUS EXPOSURE"
+                      id="continuous_exposure"
+                      disabled={!this.props.patient.monitoring}
+                      checked={this.state.continuous_exposure}
+                      onChange={() => this.openContinuousExposureModal()}
+                    />
+                  </span>
+                </OverlayTrigger>
+                <InfoTooltip tooltipTextKey="continuousExposure" location="right"></InfoTooltip>
               </Form.Group>
               <Col md={8}>
                 <span className="nav-input-label">END OF MONITORING</span>

--- a/app/javascript/components/patient/assessment/actions/LastDateExposure.js
+++ b/app/javascript/components/patient/assessment/actions/LastDateExposure.js
@@ -202,58 +202,60 @@ class LastDateExposure extends React.Component {
           )}
         <Row>
           <SymptomOnset authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
-          <Form.Group as={Col} controlId="last_date_of_exposure">
-            <Row className="reports-actions-title">
-              <Col>
-                <Form.Label className="nav-input-label h6">
-                  LAST DATE OF EXPOSURE
-                  <InfoTooltip tooltipTextKey="lastDateOfExposure" location="right"></InfoTooltip>
-                </Form.Label>
-              </Col>
-            </Row>
-            <Row>
-              <Col>
-                <DateInput
-                  id="last_date_of_exposure"
-                  date={this.state.last_date_of_exposure}
-                  minDate={'2020-01-01'}
-                  maxDate={moment()
-                    .add(30, 'days')
-                    .format('YYYY-MM-DD')}
-                  onChange={this.openLastDateOfExposureModal}
-                  placement="top"
-                  customClass="form-control-lg"
-                  ariaLabel="Last Date of Exposure Input"
-                  isClearable
-                />
-              </Col>
-            </Row>
-            <Row className="pt-2">
-              <Col>
-                <OverlayTrigger
-                  key="tooltip-ot-ce"
-                  placement="left"
-                  overlay={
-                    <Tooltip id="tooltip-ce" style={this.props.patient.monitoring ? { display: 'none' } : {}}>
-                      Continuous Exposure cannot be turned on or off for records on the Closed line list. If this monitoree requires monitoring due to a
-                      Continuous Exposure, you may update this field after changing Monitoring Status to &quot;Actively Monitoring&quot;
-                    </Tooltip>
-                  }>
-                  <span className="d-inline-block">
-                    <Form.Check
-                      size="lg"
-                      label="CONTINUOUS EXPOSURE"
-                      id="continuous_exposure"
-                      disabled={!this.props.patient.monitoring}
-                      checked={this.state.continuous_exposure}
-                      onChange={() => this.openContinuousExposureModal()}
-                    />
-                  </span>
-                </OverlayTrigger>
-                <InfoTooltip tooltipTextKey="continuousExposure" location="right"></InfoTooltip>
-              </Col>
-            </Row>
-          </Form.Group>
+          {!this.props.patient.isolation && (
+            <Form.Group as={Col} controlId="last_date_of_exposure">
+              <Row className="reports-actions-title">
+                <Col>
+                  <Form.Label className="nav-input-label h6">
+                    LAST DATE OF EXPOSURE
+                    <InfoTooltip tooltipTextKey="lastDateOfExposure" location="right"></InfoTooltip>
+                  </Form.Label>
+                </Col>
+              </Row>
+              <Row>
+                <Col>
+                  <DateInput
+                    id="last_date_of_exposure"
+                    date={this.state.last_date_of_exposure}
+                    minDate={'2020-01-01'}
+                    maxDate={moment()
+                      .add(30, 'days')
+                      .format('YYYY-MM-DD')}
+                    onChange={this.openLastDateOfExposureModal}
+                    placement="top"
+                    customClass="form-control-lg"
+                    ariaLabel="Last Date of Exposure Input"
+                    isClearable
+                  />
+                </Col>
+              </Row>
+              <Row className="pt-2">
+                <Col>
+                  <OverlayTrigger
+                    key="tooltip-ot-ce"
+                    placement="left"
+                    overlay={
+                      <Tooltip id="tooltip-ce" style={this.props.patient.monitoring ? { display: 'none' } : {}}>
+                        Continuous Exposure cannot be turned on or off for records on the Closed line list. If this monitoree requires monitoring due to a
+                        Continuous Exposure, you may update this field after changing Monitoring Status to &quot;Actively Monitoring&quot;
+                      </Tooltip>
+                    }>
+                    <span className="d-inline-block">
+                      <Form.Check
+                        size="lg"
+                        label="CONTINUOUS EXPOSURE"
+                        id="continuous_exposure"
+                        disabled={!this.props.patient.monitoring}
+                        checked={this.state.continuous_exposure}
+                        onChange={() => this.openContinuousExposureModal()}
+                      />
+                    </span>
+                  </OverlayTrigger>
+                  <InfoTooltip tooltipTextKey="continuousExposure" location="right"></InfoTooltip>
+                </Col>
+              </Row>
+            </Form.Group>
+          )}
           {this.props.patient.isolation ? (
             <ExtendedIsolation authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
           ) : (

--- a/app/javascript/components/patient/assessment/actions/SymptomOnset.js
+++ b/app/javascript/components/patient/assessment/actions/SymptomOnset.js
@@ -64,50 +64,39 @@ class SymptomOnset extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Form.Group as={Col} controlId="symptom_onset">
-          <Row className="reports-actions-title">
-            <Col>
-              <Form.Label className="nav-input-label">
-                SYMPTOM ONSET
-                <InfoTooltip tooltipTextKey={this.props.patient.isolation ? 'isolationSymptomOnset' : 'exposureSymptomOnset'} location="right"></InfoTooltip>
-                <div style={{ display: 'inline' }}>
-                  <span data-for="user_defined_symptom_onset_tooltip" data-tip="" className="ml-2">
-                    {this.props.patient.user_defined_symptom_onset ? <i className="fas fa-user"></i> : <i className="fas fa-desktop"></i>}
+        <Form.Group as={Col} md={this.props.patient.isolation ? 12 : 8} xl={8} controlId="symptom_onset">
+          <Form.Label className="nav-input-label">
+            SYMPTOM ONSET
+            <InfoTooltip tooltipTextKey={this.props.patient.isolation ? 'isolationSymptomOnset' : 'exposureSymptomOnset'} location="right"></InfoTooltip>
+            <div style={{ display: 'inline' }}>
+              <span data-for="user_defined_symptom_onset_tooltip" data-tip="" className="ml-2">
+                {this.props.patient.user_defined_symptom_onset ? <i className="fas fa-user"></i> : <i className="fas fa-desktop"></i>}
+              </span>
+              <ReactTooltip id="user_defined_symptom_onset_tooltip" multiline={true} place="right" type="dark" effect="solid" className="tooltip-container">
+                {this.props.patient.user_defined_symptom_onset ? (
+                  <span>This date was set by a user</span>
+                ) : (
+                  <span>
+                    This date is auto-populated by the system as the date of the earliest report flagged as symptomatic (red highlight) in the reports
+                    table. Field is blank when there are no symptomatic reports.
                   </span>
-                  <ReactTooltip id="user_defined_symptom_onset_tooltip" multiline={true} place="right" type="dark" effect="solid" className="tooltip-container">
-                    {this.props.patient.user_defined_symptom_onset ? (
-                      <span>This date was set by a user</span>
-                    ) : (
-                      <span>
-                        This date is auto-populated by the system as the date of the earliest report flagged as symptomatic (red highlight) in the reports
-                        table. Field is blank when there are no symptomatic reports.
-                      </span>
-                    )}
-                  </ReactTooltip>
-                </div>
-              </Form.Label>
-            </Col>
-          </Row>
-          <Row>
-            <Col>
-              <DateInput
-                id="symptom_onset"
-                date={this.state.symptom_onset}
-                minDate={'2020-01-01'}
-                maxDate={moment()
-                  .add(30, 'days')
-                  .format('YYYY-MM-DD')}
-                onChange={this.handleDateChange}
-                placement="bottom"
-                isClearable={this.props.patient.user_defined_symptom_onset}
-                customClass="form-control-lg"
-                ariaLabel="Symptom Onset Date Input"
-              />
-            </Col>
-          </Row>
-          <Row>
-            <Col></Col>
-          </Row>
+                )}
+              </ReactTooltip>
+            </div>
+          </Form.Label>
+          <DateInput
+            id="symptom_onset"
+            date={this.state.symptom_onset}
+            minDate={'2020-01-01'}
+            maxDate={moment()
+              .add(30, 'days')
+              .format('YYYY-MM-DD')}
+            onChange={this.handleDateChange}
+            placement="bottom"
+            isClearable={this.props.patient.user_defined_symptom_onset}
+            customClass="form-control-lg"
+            ariaLabel="Symptom Onset Date Input"
+          />
         </Form.Group>
       </React.Fragment>
     );

--- a/app/javascript/components/patient/assessment/actions/SymptomOnset.js
+++ b/app/javascript/components/patient/assessment/actions/SymptomOnset.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
-import { Col, Form, Row } from 'react-bootstrap';
+import { Col, Form } from 'react-bootstrap';
 import ReactTooltip from 'react-tooltip';
 import axios from 'axios';
 import moment from 'moment';

--- a/app/javascript/packs/stylesheets/bootstrap.scss
+++ b/app/javascript/packs/stylesheets/bootstrap.scss
@@ -273,10 +273,6 @@ select.form-control {
   max-width: 900px !important;
 }
 
-.reports-actions-title {
-  height: 30px !important;
-}
-
 .dropdown-menu {
   border-radius: 0 !important;
 }

--- a/app/javascript/packs/stylesheets/custom_table.scss
+++ b/app/javascript/packs/stylesheets/custom_table.scss
@@ -37,24 +37,13 @@
   width: 100%;
 }
 
-.left-container {
-  display: inline-block;
-  width: 430px !important;
-}
-
 .left-box-1 {
-  width: 40%;
+  width: 200px !important;
   display: inline-block;
 }
 
 .left-box-2 {
-  width: 60%;
   display: inline-block;
-}
-
-.right-container {
-  display: inline;
-  float: right;
 }
 
 // the medium bootstrap breakpoint


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-[1053](https://tracker.codev.mitre.org/browse/SARAALERT-1053)

Remove last date of exposure and continuous exposure from a monitoree's profile while in the isolation workflow.

## (Feature) Demo/Screenshots
Exposure
![image](https://user-images.githubusercontent.com/7842704/118537512-08870b00-b71b-11eb-9e18-b0d90610a4b5.png)

Isolation
![image](https://user-images.githubusercontent.com/7842704/118537482-fefda300-b71a-11eb-951c-51e15dc07734.png)

## (Bugfix) How to Replicate
Look at a monitoree in both the isolation and exposure workflow. On 1.30 they both have last date of exposure and continuous exposure.

## (Bugfix) Solution
Look at a monitoree in both the isolation and exposure workflow. On this branch they have last date of exposure and continuous exposure in the exposure workflow and neither in the isolation workflow.


## Important Changes
Added a check if the patient was in isolation before displaying those fields.


# Checklists

**Submitter:**
- [ ] This PR describes why these changes were made.
- [ ] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA ticket reference.
- [ ] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@tstrass :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@sgober  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@DPC15038  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
