### PR TITLE
Removed deprecated flag in location.reload

### DIFF
--- a/app/javascript/components/patient/assessment/Assessment.js
+++ b/app/javascript/components/patient/assessment/Assessment.js
@@ -38,7 +38,7 @@ class Assessment extends React.Component {
     })
       .then(() => {
         if (this.props.reload) {
-          location.reload(true);
+          location.reload();
         }
       })
       .catch(error => {

--- a/app/javascript/components/patient/assessment/actions/AddAssessmentNote.js
+++ b/app/javascript/components/patient/assessment/actions/AddAssessmentNote.js
@@ -36,7 +36,7 @@ class AddAssessmentNote extends React.Component {
           history_type: 'Report Note',
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(error => {
           reportError(error);

--- a/app/javascript/components/patient/assessment/actions/ClearAssessments.js
+++ b/app/javascript/components/patient/assessment/actions/ClearAssessments.js
@@ -33,7 +33,7 @@ class ClearAssessments extends React.Component {
           reasoning: this.state.reasoning,
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(error => {
           reportError(error);

--- a/app/javascript/components/patient/assessment/actions/ClearSingleAssessment.js
+++ b/app/javascript/components/patient/assessment/actions/ClearSingleAssessment.js
@@ -33,7 +33,7 @@ class ClearSingleAssessment extends React.Component {
           reasoning: this.state.reasoning,
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(error => {
           reportError(error);

--- a/app/javascript/components/patient/assessment/actions/ContactAttempt.js
+++ b/app/javascript/components/patient/assessment/actions/ContactAttempt.js
@@ -37,7 +37,7 @@ class ContactAttempt extends React.Component {
           comment: this.state.attempt + ' contact attempt.' + (this.state.comment ? ' Note: ' + this.state.comment : ''),
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(error => {
           reportError(error);

--- a/app/javascript/components/patient/assessment/actions/ExtendedIsolation.js
+++ b/app/javascript/components/patient/assessment/actions/ExtendedIsolation.js
@@ -29,7 +29,7 @@ class ExtendedIsolation extends React.Component {
           diffState: ['extended_isolation'],
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(error => {
           reportError(error);

--- a/app/javascript/components/patient/assessment/actions/LastDateExposure.js
+++ b/app/javascript/components/patient/assessment/actions/LastDateExposure.js
@@ -44,7 +44,7 @@ class LastDateExposure extends React.Component {
           diffState: diffState,
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(err => {
           reportError(err?.response?.data?.error ? err.response.data.error : err, false);

--- a/app/javascript/components/patient/assessment/actions/PauseNotifications.js
+++ b/app/javascript/components/patient/assessment/actions/PauseNotifications.js
@@ -26,7 +26,7 @@ class PauseNotifications extends React.Component {
           diffState: ['pause_notifications'],
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(error => {
           reportError(error);

--- a/app/javascript/components/patient/assessment/actions/SymptomOnset.js
+++ b/app/javascript/components/patient/assessment/actions/SymptomOnset.js
@@ -53,7 +53,7 @@ class SymptomOnset extends React.Component {
           diffState: ['symptom_onset', 'user_defined_symptom_onset'],
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(error => {
           reportError(error);

--- a/app/javascript/components/patient/close_contact/CloseContact.js
+++ b/app/javascript/components/patient/close_contact/CloseContact.js
@@ -126,7 +126,7 @@ class CloseContact extends React.Component {
               contact_attempts: this.state.contact_attempts || 0,
             })
             .then(() => {
-              location.reload(true);
+              location.reload();
             })
             .catch(error => {
               reportError(error);

--- a/app/javascript/components/patient/history/History.js
+++ b/app/javascript/components/patient/history/History.js
@@ -44,7 +44,7 @@ class History extends React.Component {
           comment: this.state.comment,
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(error => {
           reportError(error);
@@ -74,7 +74,7 @@ class History extends React.Component {
         delete_reason: deleteReason,
       })
       .then(() => {
-        location.reload(true);
+        location.reload();
       })
       .catch(error => {
         reportError(error);

--- a/app/javascript/components/patient/history/HistoryList.js
+++ b/app/javascript/components/patient/history/HistoryList.js
@@ -66,7 +66,7 @@ class HistoryList extends React.Component {
           comment: this.state.comment,
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(error => {
           reportError(error);

--- a/app/javascript/components/patient/laboratory/Laboratory.js
+++ b/app/javascript/components/patient/laboratory/Laboratory.js
@@ -40,7 +40,7 @@ class Laboratory extends React.Component {
           result: lab.result,
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(error => {
           reportError(error);
@@ -71,7 +71,7 @@ class Laboratory extends React.Component {
         },
       })
       .then(() => {
-        location.reload(true);
+        location.reload();
       })
       .catch(error => {
         reportError(error);

--- a/app/javascript/components/patient/monitoring_actions/AssignedUser.js
+++ b/app/javascript/components/patient/monitoring_actions/AssignedUser.js
@@ -82,7 +82,7 @@ class AssignedUser extends React.Component {
           diffState: diffState,
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(err => {
           reportError(err?.response?.data?.error ? err.response.data.error : err, false);

--- a/app/javascript/components/patient/monitoring_actions/CaseStatus.js
+++ b/app/javascript/components/patient/monitoring_actions/CaseStatus.js
@@ -169,7 +169,7 @@ class CaseStatus extends React.Component {
           diffState: diffState,
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(err => {
           reportError(err?.response?.data?.error ? err.response.data.error : err, false);

--- a/app/javascript/components/patient/monitoring_actions/ExposureRiskAssessment.js
+++ b/app/javascript/components/patient/monitoring_actions/ExposureRiskAssessment.js
@@ -72,7 +72,7 @@ class ExposureRiskAssessment extends React.Component {
           diffState: diffState,
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(err => {
           reportError(err?.response?.data?.error ? err.response.data.error : err, false);

--- a/app/javascript/components/patient/monitoring_actions/Jurisdiction.js
+++ b/app/javascript/components/patient/monitoring_actions/Jurisdiction.js
@@ -96,7 +96,7 @@ class Jurisdiction extends React.Component {
           if (!this.state.jurisdiction_path.startsWith(currentUserJurisdictionString)) {
             location.assign(`${window.BASE_PATH}/public_health${this.state.isolation ? '/isolation' : ''}`);
           } else {
-            location.reload(true);
+            location.reload();
           }
         })
         .catch(err => {

--- a/app/javascript/components/patient/monitoring_actions/MonitoringPlan.js
+++ b/app/javascript/components/patient/monitoring_actions/MonitoringPlan.js
@@ -72,7 +72,7 @@ class MonitoringPlan extends React.Component {
           diffState: diffState,
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(err => {
           reportError(err?.response?.data?.error ? err.response.data.error : err, false);

--- a/app/javascript/components/patient/monitoring_actions/MonitoringStatus.js
+++ b/app/javascript/components/patient/monitoring_actions/MonitoringStatus.js
@@ -92,7 +92,7 @@ class MonitoringStatus extends React.Component {
           diffState: diffState,
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(err => {
           reportError(err?.response?.data?.error ? err.response.data.error : err, false);

--- a/app/javascript/components/patient/monitoring_actions/PublicHealthAction.js
+++ b/app/javascript/components/patient/monitoring_actions/PublicHealthAction.js
@@ -72,7 +72,7 @@ class PublicHealthAction extends React.Component {
           diffState: diffState,
         })
         .then(() => {
-          location.reload(true);
+          location.reload();
         })
         .catch(err => {
           reportError(err?.response?.data?.error ? err.response.data.error : err, false);


### PR DESCRIPTION
# Description
`location.reload(true)` is deprecated because the `forceGet` flag is no longer supported.  I replaced all instances of it in the app with `location.reload()`.  See this thread for more info: https://github.com/Microsoft/TypeScript/issues/28898


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@holmesie :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@DPC15038 :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
