### PR TITLE
Updated benchmarking thresholds

### DIFF
--- a/performance/benchmarks/send_assessments_job_benchmark.rb
+++ b/performance/benchmarks/send_assessments_job_benchmark.rb
@@ -6,7 +6,7 @@ require_relative '../benchmark'
 # Time Threshold: 200 seconds
 benchmark(
   name: 'SendAssessmentsJob',
-  time_threshold: 200,
+  time_threshold: 310,
   setup: proc { Timecop.travel(Time.now.utc.change(hour: 18)) },
   teardown: proc { Timecop.return }
 ) { SendAssessmentsJob.perform_now }

--- a/performance/benchmarks/send_assessments_job_benchmark.rb
+++ b/performance/benchmarks/send_assessments_job_benchmark.rb
@@ -7,6 +7,6 @@ require_relative '../benchmark'
 benchmark(
   name: 'SendAssessmentsJob',
   time_threshold: 200,
-  setup: proc { Timecop.travel(Time.now.utc.change(hour: 21)) },
+  setup: proc { Timecop.travel(Time.now.utc.change(hour: 18)) },
   teardown: proc { Timecop.return }
 ) { SendAssessmentsJob.perform_now }


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-NONE

The only threshold that needed to be changed was the send assessments job benchmark.

## Important Changes

`performance/benchmarks/send_assessments_job_benchmark.rb`
- The Timecop time should have been set to 1800 UTC like the scope's micro benchmark (I thought I changed this previously but it must have gotten lost somwhere)
- The failure threshold is now set to 310 seconds to accommodate the new (somewhat larger) performance DB

![Screen Shot 2021-05-19 at 10 01 10 AM](https://user-images.githubusercontent.com/24628687/118845598-25415100-b889-11eb-8ac0-8b942dff4775.png)

# Checklists

**Submitter:**
- [ ] This PR describes why these changes were made.
- [ ] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA ticket reference.
- [ ] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@holmesie  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@Bialogs :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
