### PR TITLE
SARAALERT-1427: Fixes tooltip width bug in safari

### DIFF
--- a/app/javascript/packs/stylesheets/layout.scss
+++ b/app/javascript/packs/stylesheets/layout.scss
@@ -12,6 +12,12 @@
   width: 300px;
 }
 
+.__react_component_tooltip {
+  // Specifying a max-width here prevents Safari
+  // From drawing any parent containers larger than 300px
+  max-width: 300px;
+}
+
 .tooltip-whitespace {
   white-space: normal !important;
 }


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1427

There is a bug in Safari, where it will render the width of certain dropdowns in the Enrollment at an incorrect width. It looks like the tooltip div is defaulting to the content width during initial rendering, which causes these dropdowns to be wider than the content of the selects. DOM repaint forced by the menu div shown when you open the Workflow dropdown causes it to recompute the width of the tooltip divs.

## (Feature) Demo/Screenshots
The Old, Incorrect, Behavior:
![image](https://user-images.githubusercontent.com/17532163/118851124-752b1280-b89f-11eb-9a8f-8bb5b512ab76.png)

The New, Correct Behavior:
![image](https://user-images.githubusercontent.com/17532163/118851156-7eb47a80-b89f-11eb-9bf3-4f53bc0a02ba.png)

## Important Changes

`/stylesheets/layout.scss`
- Fixes safari-tooltip width issue


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@timwongj  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@sgober   :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@jkufro  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
