### PR TITLE
SARAALERT-1451: Scroll to Top of Enrollment

### DIFF
--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -171,6 +171,7 @@ class Enrollment extends React.Component {
   };
 
   next = () => {
+    window.scroll(0, 0);
     let index = this.state.index;
     let lastIndex = this.state.lastIndex;
     if (lastIndex) {
@@ -185,6 +186,7 @@ class Enrollment extends React.Component {
   };
 
   previous = () => {
+    window.scroll(0, 0);
     let index = this.state.index;
     this.setState({ direction: 'prev' }, () => {
       this.setState({ index: index - 1, lastIndex: null });
@@ -192,6 +194,7 @@ class Enrollment extends React.Component {
   };
 
   goto = targetIndex => {
+    window.scroll(0, 0);
     let index = this.state.index;
     if (targetIndex > index) {
       this.setState({ direction: 'next' }, () => {


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1451

This PR scrolls to the top of the page in Enrollment when clicking `next()` or `previous()`

## (Bugfix) How to Replicate
This isnt a bug, but if you scroll to the bottom of the window during enrollment and click next, the next card will render at the bottom. This is a feature of the browser itself. This PR has the browser scroll back to the top when clicking next.


## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/javascript/components/enrollment/Enrollment.js`
- Scrolls to the top when changing cards in the carousel


# Checklists

**Submitter:**
- [ ] This PR describes why these changes were made.
- [ ] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA ticket reference.
- [ ] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@sgober :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@timwongj :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie   :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
