### PR TITLE
SARAALERT-NONE: Fix failing workflow system test

### DIFF
--- a/test/system/roles/enroller/enrollment/form.rb
+++ b/test/system/roles/enroller/enrollment/form.rb
@@ -20,7 +20,12 @@ class EnrollmentForm < ApplicationSystemTestCase
     @@enrollment_form_steps.steps.each_key do |step|
       next unless monitoree[step.to_s]
 
-      click_on "edit-#{step}-btn"
+      begin
+        click_on "edit-#{step}-btn"
+      rescue Capybara::ElementNotFound, Selenium::WebDriver::Error::ElementNotInteractableError
+        find('#details-expander-link').click
+        click_on "edit-#{step}-btn"
+      end
       populate_enrollment_step(step, monitoree[step.to_s])
       @@system_test_utils.wait_for_enrollment_page_transition
     end


### PR DESCRIPTION
# Description
Jira Ticket: N/A

On `master`, there is a system test failing in the workflow tests. See [here](https://github.com/SaraAlert/SaraAlert/runs/2666779009) for a log of the error. This PR should fix that error.

## How to Replicate
I'm unable to replicate the bug locally, and the failure is intermittent on GitHub actions, but happens often enough to be an issue. It seems to be that the test fails when this [line](https://github.com/SaraAlert/SaraAlert/blob/e348b8f2d893774781803d79c0d9f78edf5ad8ed/test/system/roles/enroller/enrollment/form.rb#L23) fails to find the relevant section to expand. This seems to happen because the line above clicks the `details-expander-link` button, but in this case that section is already expanded. So the section is actually collapsed, and the section we want to edit cannot be found.

## Solution
This fixes this by trying to expand the `patient-details-expander` link section if we fail to find the desired section, and then searching for that section again. I want to be up front that this is really just my best guess as to why this test is failing, but so far in 7 runs, the tests have passed every time, where they seem to only pass rarely on master.

## Important Changes
`form.rb`
- Catch and handle errors related to not being able to find the desired section.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] (N/A) This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] (N/A) If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
