### PR TITLE
BUGFIX: Symptoms not being exported

### DIFF
--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -161,7 +161,8 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
     patients.pluck(:id).in_groups_of(10_000, false) do |batch|
       symptom_ids << Symptom.where(condition_id: ReportedCondition.where(assessment_id: Assessment.where(patient_id: batch).pluck(:id)).pluck(:id)).pluck(:id)
     end
-    symptom_names_and_labels = Symptom.where(id: symptom_ids).where.not(label: nil).where.not(name: nil).distinct.order(:label).pluck(:name, :label).transpose
+    symptom_names_and_labels = Symptom.where(id: symptom_ids.to_a.flatten).where.not(label: nil).where.not(name: nil)
+                                      .distinct.order(:label).pluck(:name, :label).transpose
 
     # Empty symptoms check
     return [] unless symptom_names_and_labels.present?


### PR DESCRIPTION
# Description
Jira Ticket: N/A

Symptoms are not being exported sometimes because the query for `symptom_ids` does not work properly when there is more than one batch

## (Bugfix) How to Replicate
Perform an export with symptoms with over 10k patients

## (Bugfix) Solution
Convert `symptom_ids` to array and flatten before passing to the query

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`example_file.js`
- Example change (ex: refactored import function)


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] **N/A** This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] **N/A** If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
