### PR TITLE
SARAALERT-NONE: 1.30.0 API Documentation Updates

### DIFF
--- a/docs/api/api-coming-soon.md
+++ b/docs/api/api-coming-soon.md
@@ -7,10 +7,11 @@ nav_order: 2
 
 **Below you will find a list of ongoing work that affects the Sara Alert™ API. This page will be updated regularly. If you have any questions on the information here, please email them to our API Help Desk, saraalert-interop@mitre.org. For past release notes, please see [API Release Notes](api-release-notes).**
 
-## Planned for 1.30\*:
+## Planned for 1.31\*:
 
 - Support for writing Lab Results via a FHIR Observation.
 - Support for writing Monitorees and Lab Results in bulk via a FHIR transaction Bundle. This will allow for Monitorees to be enrolled alongside their Lab Results, which will enable support for asymptomatic enrollment of Monitorees in the Isolation workflow.
+- Support for reading History via a FHIR Provenance.
 
 ---
 


### PR DESCRIPTION
# Description
Jira Ticket: N/A

Updates the docs for 1.30.0. Since the two major features that could have went to 1.30.0 are pushed to 1.31.0, this only required updating the "Coming Soon".

## Important Changes
`api-coming-soon.md`
- Changed to 1.31.0


# Checklists
N/A
