### PR TITLE
Alter symptom_names_and_labels queries to avoid MySQL has gone away errors

### DIFF
--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -157,7 +157,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
                                        .where('symptoms.label IS NOT NULL')
                                        .where('symptoms.name IS NOT NULL')
                                        .distinct
-                                       .order('symptom.label')
+                                       .order('symptoms.label')
                                        .pluck('symptoms.name', 'symptoms.label')
                                        .transpose
 

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -157,8 +157,8 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
                                        .where('symptoms.label IS NOT NULL')
                                        .where('symptoms.name IS NOT NULL')
                                        .distinct
-                                       .order(:label)
-                                       .pluck(:name, :label)
+                                       .order('symptom.label')
+                                       .pluck('symptoms.name', 'symptoms.label')
                                        .transpose
 
     # Empty symptoms check

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -153,16 +153,13 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
     data[:assessments][:checked].delete(:symptoms)
     data[:assessments][:headers].delete('Symptoms Reported')
 
-    # For large queries (e.g. 100k patients) of the `Symptom.where(...) query below
-    # we saw MySQL give up on queries and throw an exception.
-    # The workaround for this is to collect the symptom ids in a set and find them
-    # using batches of patients.
-    symptom_ids = Set.new
-    patients.pluck(:id).in_groups_of(10_000, false) do |batch|
-      symptom_ids << Symptom.where(condition_id: ReportedCondition.where(assessment_id: Assessment.where(patient_id: batch).pluck(:id)).pluck(:id)).pluck(:id)
-    end
-    symptom_names_and_labels = Symptom.where(id: symptom_ids.to_a.flatten).where.not(label: nil).where.not(name: nil)
-                                      .distinct.order(:label).pluck(:name, :label).transpose
+    symptom_names_and_labels = patients.joins(assessments: { reported_condition: :symptoms })
+                                       .where('symptoms.label IS NOT NULL')
+                                       .where('symptoms.name IS NOT NULL')
+                                       .distinct
+                                       .order(:label)
+                                       .pluck(:name, :label)
+                                       .transpose
 
     # Empty symptoms check
     return [] unless symptom_names_and_labels.present?


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-###](https://tracker.codev.mitre.org/browse/SARAALERT-###)

The goal of this PR is to address the failures due to "MySQL server has gone away" errors on L165 of import_export.

## (Bugfix) How to Replicate
L165 of import export was causing failures due to "MySQL server has gone away" errors. This can be replicated by attempting to export a large number of patients at once (I'm testing with the 500k database).

## (Bugfix) Solution
I tested this solution on the 500k database and the change appears to be functionally the same as what we had before but does not encounter the MySQL server has gone away error.

I was able to successfully export all 500k patients from the 500k performance datbase (took about 2300 seconds / 40 minutes). The excel file is 500MB and takes a few minutes to actually open (I'm not sure of the limits of how big we really should allow ourselves to make excel files)

The new query generates SQL that looks like this 
```sql
SELECT DISTINCT `name`, `label`
FROM `patients` 
    INNER JOIN `assessments` ON `assessments`.`patient_id` = `patients`.`id` 
    INNER JOIN `conditions` ON `conditions`.`assessment_id` = `assessments`.`id` AND `conditions`.`type` = 'ReportedCondition' 
    INNER JOIN `symptoms` ON `symptoms`.`condition_id` = `conditions`.`id` 
ORDER BY `label` ASC
```

```ruby
r1 = Patient.all.joins(assessments: { reported_condition: :symptoms }).distinct.order(:label).pluck(:name, :label).transpose
# => [["chills", "Chills"], ["congestion-or-runny-nose", "Congestion or Runny Nose"], ["cough", "Cough"], ["diarrhea", "Diarrhea"], ["difficulty-breathing", "Difficulty Breathing"], ["fatigue", "Fatigue"], ["fever", "Fever"], ["headache", "Headache"], ["muscle-pain", "Muscle Pain"], ["nausea-or-vomiting", "Nausea or Vomiting"], ["new-loss-of-smell", "New Loss of Smell"], ["new-loss-of-taste", "New Loss of Taste"], ["pulse-ox", "Pulse Ox"], ["repeated-shaking-with-chills", "Repeated Shaking with Chills"], ["shortness-of-breath", "Shortness of Breath"], ["sore-throat", "Sore Throat"], ["used-a-fever-reducer", "Used A Fever Reducer"]]

# ---------------------------- #

# This isn't exactly what was in import_export but still mimics the logic of it 
symptoms = Set.new
Patient.all.pluck(:id).in_groups_of(10_000, false) do |batch|
  Symptom.where(
    condition_id: ReportedCondition.where(assessment_id: Assessment.where(patient_id: batch).pluck(:id)).pluck(:id)
  ).pluck(:name, :label).each { |symptom| symptoms.add(symptom) }
end
r2 = symptoms.to_a.sort { |a, b| a[1] <=> b[1] }.transpose
# => [["chills", "Chills"], ["congestion-or-runny-nose", "Congestion or Runny Nose"], ["cough", "Cough"], ["diarrhea", "Diarrhea"], ["difficulty-breathing", "Difficulty Breathing"], ["fatigue", "Fatigue"], ["fever", "Fever"], ["headache", "Headache"], ["muscle-pain", "Muscle Pain"], ["nausea-or-vomiting", "Nausea or Vomiting"], ["new-loss-of-smell", "New Loss of Smell"], ["new-loss-of-taste", "New Loss of Taste"], ["pulse-ox", "Pulse Ox"], ["repeated-shaking-with-chills", "Repeated Shaking with Chills"], ["shortness-of-breath", "Shortness of Breath"], ["sore-throat", "Sore Throat"], ["used-a-fever-reducer", "Used A Fever Reducer"]]

# ---------------------------- #

r1 == r2
```

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`import_export.js`
- refactor queries into a single query with joins


# Checklists

**Submitter:**
- [ ] This PR describes why these changes were made.
- [ ] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA ticket reference.
- [ ] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
