### PR TITLE
SARAALERT-1464: Refactor API Controller

### DIFF
--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -262,8 +262,6 @@ class Fhir::R4::ApiController < ApplicationApiController
     status_created(resource.as_fhir) && return
   rescue JSON::ParserError
     status_bad_request(['Invalid JSON in request body'])
-  rescue ClientError
-    nil # If we reach here, we've already rendered a 422 response
   end
 
   # Create a set of resources as an atomic action
@@ -347,8 +345,6 @@ class Fhir::R4::ApiController < ApplicationApiController
     status_ok(patients_to_fhir_bundle(saved_patients)) && return
   rescue JSON::ParserError
     status_bad_request(['Invalid JSON in request body'])
-  rescue ClientError
-    nil # If we reach here, we've already rendered a 422 response
   end
 
   # Return a FHIR Bundle containing results that match the given query.

--- a/test/controllers/fhir/r4/immunization_test.rb
+++ b/test/controllers/fhir/r4/immunization_test.rb
@@ -73,7 +73,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     histories = History.where(patient: created_vac.patient_id)
     assert_equal(1, histories.count)
     assert_equal 'system-test-everything (API)', histories.first.created_by
-    assert_match(/vaccine added.*API/, histories.first.comment)
+    assert_match(/vaccination added.*API/, histories.first.comment)
   end
 
   test 'SYSTEM FLOW: should be unprocessable entity via Immunization create with invalid Patient reference' do

--- a/test/controllers/fhir/r4/observation_test.rb
+++ b/test/controllers/fhir/r4/observation_test.rb
@@ -142,7 +142,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     histories = History.where(patient: @lab_1.patient_id)
     assert_equal(1, histories.count)
     assert_equal 'system-test-everything (API)', histories.first.created_by
-    assert_match(/Lab Result edited.*API/, histories.first.comment)
+    assert_match(/Lab result edited.*API/, histories.first.comment)
   end
 
   test 'should update Observation via patch update' do


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1464](https://tracker.codev.mitre.org/browse/SARAALERT-1464)

This refactors the API controller to be a little neater and use a little less code. As it stands, this PR only removes about 40 lines of code, but I think it makes the `update` and `create` methods much more readable. Additionally, once #870 and #872 are accounted for in this PR, the difference in code will be more significant.

## Important Changes
`api_controller.rb`
- Refactor the `apply_patch` method to also handle error throwing
- Add an `update_model_from_fhir` method which can be used for any non-Patient model to update it, given the original model, the contents of the update (as FHIR), and a method for converting from FHIR
- Add an `update_record` method which wraps the code for updating and saving a model, and creating corresponding history messages and log messages
- Add a `build_model_from_fhir` method which can be used for any non-Patient model to build it, given the FHIR representation and a method for converting from FHIR
- Add a `save_record` method which can be used for any non-Patient model to save a new record, and create the corresponding history and log messages

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] (N/A) If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ashankland 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
