### PR TITLE
SARAALERT-1355 lab validation

### DIFF
--- a/app/javascript/components/patient/laboratory/LaboratoryModal.js
+++ b/app/javascript/components/patient/laboratory/LaboratoryModal.js
@@ -173,7 +173,7 @@ class LaboratoryModal extends React.Component {
           {/* This does not impact component functionality at all. */}
           {!isValid && (
             <ReactTooltip id="submit-tooltip" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container text-left">
-              Please enter at minimum a report date or specimen date and a result
+              Please enter at minimum a result and either a report date or specimen date
             </ReactTooltip>
           )}
         </Modal.Footer>

--- a/app/javascript/components/patient/laboratory/LaboratoryModal.js
+++ b/app/javascript/components/patient/laboratory/LaboratoryModal.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Alert, Button, Col, Form, Modal, Row } from 'react-bootstrap';
 import moment from 'moment';
+import ReactTooltip from 'react-tooltip';
 
 import DateInput from '../../util/DateInput';
 
@@ -51,6 +52,8 @@ class LaboratoryModal extends React.Component {
   };
 
   render() {
+    // Data is valid and can be saved if there is either a report or specimen collection date AND a result
+    const isValid = (this.state.report || this.state.specimen_collection) && this.state.result;
     return (
       <Modal size="lg" className="laboratory-modal-container" show centered onHide={this.props.cancel}>
         <h1 className="sr-only">{this.props.editMode ? 'Edit' : 'Add New'} Lab Result</h1>
@@ -160,12 +163,19 @@ class LaboratoryModal extends React.Component {
           <Button variant="secondary btn-square" onClick={this.props.cancel}>
             Cancel
           </Button>
-          <Button
-            variant="primary btn-square"
-            disabled={this.props.loading || this.state.reportInvalid || (this.props.specimenCollectionRequired && !this.state.specimen_collection)}
-            onClick={this.submit}>
-            {this.props.editMode ? 'Update' : 'Create'}
-          </Button>
+          <span data-for="submit-tooltip" data-tip="" className="ml-1">
+            <Button variant="primary btn-square" disabled={this.props.loading || this.state.reportInvalid || !isValid} onClick={this.submit}>
+              {this.props.editMode ? 'Update' : 'Create'}
+            </Button>
+          </span>
+          {/* Typically we pair the ReactTooltip up directly next to the mount point. However, due to the disabled attribute on the button */}
+          {/* above, this Tooltip should be placed outside the parent component (to prevent unwanted parent opacity settings from being inherited) */}
+          {/* This does not impact component functionality at all. */}
+          {!isValid && (
+            <ReactTooltip id="submit-tooltip" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container text-left">
+              Please enter at minimum a report date or specimen date and a result
+            </ReactTooltip>
+          )}
         </Modal.Footer>
       </Modal>
     );

--- a/app/models/concerns/laboratory_date_validator.rb
+++ b/app/models/concerns/laboratory_date_validator.rb
@@ -8,5 +8,8 @@ class LaboratoryDateValidator < ActiveModel::Validator
     year_start = Date.new(2020, 1, 1)
     validate_between_dates(record, :report, year_start, Time.now.to_date) if record.report_changed?
     validate_between_dates(record, :specimen_collection, year_start, Time.now.to_date) if record.specimen_collection_changed?
+    return unless record.report && record.specimen_collection && (record.specimen_collection > record.report)
+
+    record.errors.add(:specimen_collection, 'Report Date cannot be before Specimen Collection Date.')
   end
 end

--- a/app/models/concerns/laboratory_date_validator.rb
+++ b/app/models/concerns/laboratory_date_validator.rb
@@ -10,6 +10,6 @@ class LaboratoryDateValidator < ActiveModel::Validator
     validate_between_dates(record, :specimen_collection, year_start, Time.now.to_date) if record.specimen_collection_changed?
     return unless record.report && record.specimen_collection && (record.specimen_collection > record.report)
 
-    record.errors.add(:specimen_collection, 'Report Date cannot be before Specimen Collection Date.')
+    record.errors.add(:report, 'cannot be before Specimen Collection Date.')
   end
 end

--- a/app/models/laboratory.rb
+++ b/app/models/laboratory.rb
@@ -42,8 +42,7 @@ class Laboratory < ApplicationRecord
     validates date_field, on: %i[api import], date: true
   end
 
-  # NOTE: Commented out until additional testing
-  # validates_with LaboratoryDateValidator
+  validates_with LaboratoryDateValidator
 
   after_save :update_patient_linelist_after_save
   before_destroy :update_patient_linelist_before_destroy

--- a/app/models/laboratory.rb
+++ b/app/models/laboratory.rb
@@ -42,7 +42,7 @@ class Laboratory < ApplicationRecord
     validates date_field, on: %i[api import], date: true
   end
 
-  validates_with LaboratoryDateValidator
+  validates_with LaboratoryDateValidator, on: %i[api import]
 
   after_save :update_patient_linelist_after_save
   before_destroy :update_patient_linelist_before_destroy

--- a/test/models/laboratory_test.rb
+++ b/test/models/laboratory_test.rb
@@ -15,39 +15,48 @@ class LaboratoryTest < ActiveSupport::TestCase
     end
   end
 
-  # test 'validates report date constraints' do
-  #   laboratory = build(:laboratory, report: 30.days.ago)
-  #   assert laboratory.valid?
+  test 'validates report date constraints' do
+    laboratory = build(:laboratory, report: 30.days.ago)
+    assert laboratory.valid?
 
-  #   laboratory = build(:laboratory, report: nil)
-  #   assert laboratory.valid?
+    laboratory = build(:laboratory, report: nil)
+    assert laboratory.valid?
 
-  #   laboratory = build(:laboratory, report: Time.now)
-  #   assert laboratory.valid?
+    laboratory = build(:laboratory, report: Time.now)
+    assert laboratory.valid?
 
-  #   laboratory = build(:laboratory, report: 1.day.from_now)
-  #   assert_not laboratory.valid?
+    # Date cannot be in the future
+    laboratory = build(:laboratory, report: 1.day.from_now)
+    assert_not laboratory.valid?
 
-  #   laboratory = build(:laboratory, report: Date.new(1900, 1, 1))
-  #   assert_not laboratory.valid?
-  # end
+    # Date cannot be before start year
+    laboratory = build(:laboratory, report: Date.new(1900, 1, 1))
+    assert_not laboratory.valid?
+  end
 
-  # test 'validates specimen collection date constraints' do
-  #   laboratory = build(:laboratory, specimen_collection: 30.days.ago)
-  #   assert laboratory.valid?
+  test 'validates specimen collection date constraints' do
+    laboratory = build(:laboratory, specimen_collection: 30.days.ago)
+    assert laboratory.valid?
 
-  #   laboratory = build(:laboratory, specimen_collection: nil)
-  #   assert laboratory.valid?
+    laboratory = build(:laboratory, specimen_collection: nil)
+    assert laboratory.valid?
 
-  #   laboratory = build(:laboratory, specimen_collection: Time.now)
-  #   assert laboratory.valid?
+    laboratory = build(:laboratory, specimen_collection: Time.now)
+    assert laboratory.valid?
 
-  #   laboratory = build(:laboratory, specimen_collection: 1.day.from_now)
-  #   assert_not laboratory.valid?
+    laboratory = build(:laboratory, specimen_collection: 1.day.from_now)
+    assert_not laboratory.valid?
 
-  #   laboratory = build(:laboratory, specimen_collection: Date.new(1900, 1, 1))
-  #   assert_not laboratory.valid?
-  # end
+    laboratory = build(:laboratory, specimen_collection: Date.new(1900, 1, 1))
+    assert_not laboratory.valid?
+
+    # Ensure specimen collection date is before report date
+    laboratory = build(:laboratory, specimen_collection: 1.days.ago, report: 2.days.ago)
+    assert_not laboratory.valid?
+
+    laboratory = build(:laboratory, specimen_collection: 2.days.ago, report: 1.days.ago)
+    assert laboratory.valid?
+  end
 
   test 'update patient updated_at upon laboratory create, update, and delete' do
     patient = create(:patient)

--- a/test/models/laboratory_test.rb
+++ b/test/models/laboratory_test.rb
@@ -17,45 +17,57 @@ class LaboratoryTest < ActiveSupport::TestCase
 
   test 'validates report date constraints' do
     laboratory = build(:laboratory, report: 30.days.ago)
-    assert laboratory.valid?
+    assert laboratory.valid?(:api)
+    assert laboratory.valid?(:import)
 
     laboratory = build(:laboratory, report: nil)
-    assert laboratory.valid?
+    assert laboratory.valid?(:api)
+    assert laboratory.valid?(:import)
 
     laboratory = build(:laboratory, report: Time.now)
-    assert laboratory.valid?
+    assert laboratory.valid?(:api)
+    assert laboratory.valid?(:import)
 
     # Date cannot be in the future
     laboratory = build(:laboratory, report: 1.day.from_now)
-    assert_not laboratory.valid?
+    assert_not laboratory.valid?(:api)
+    assert_not laboratory.valid?(:import)
 
     # Date cannot be before start year
     laboratory = build(:laboratory, report: Date.new(1900, 1, 1))
-    assert_not laboratory.valid?
+    assert_not laboratory.valid?(:api)
+    assert_not laboratory.valid?(:import)
   end
 
   test 'validates specimen collection date constraints' do
     laboratory = build(:laboratory, specimen_collection: 30.days.ago)
-    assert laboratory.valid?
+    assert laboratory.valid?(:api)
+    assert laboratory.valid?(:import)
 
     laboratory = build(:laboratory, specimen_collection: nil)
-    assert laboratory.valid?
+    assert laboratory.valid?(:api)
+    assert laboratory.valid?(:import)
 
     laboratory = build(:laboratory, specimen_collection: Time.now)
-    assert laboratory.valid?
+    assert laboratory.valid?(:api)
+    assert laboratory.valid?(:import)
 
     laboratory = build(:laboratory, specimen_collection: 1.day.from_now)
-    assert_not laboratory.valid?
+    assert_not laboratory.valid?(:api)
+    assert_not laboratory.valid?(:import)
 
     laboratory = build(:laboratory, specimen_collection: Date.new(1900, 1, 1))
-    assert_not laboratory.valid?
+    assert_not laboratory.valid?(:api)
+    assert_not laboratory.valid?(:import)
 
     # Ensure specimen collection date is before report date
     laboratory = build(:laboratory, specimen_collection: 1.days.ago, report: 2.days.ago)
-    assert_not laboratory.valid?
+    assert_not laboratory.valid?(:api)
+    assert_not laboratory.valid?(:import)
 
     laboratory = build(:laboratory, specimen_collection: 2.days.ago, report: 1.days.ago)
-    assert laboratory.valid?
+    assert laboratory.valid?(:api)
+    assert laboratory.valid?(:import)
   end
 
   test 'update patient updated_at upon laboratory create, update, and delete' do

--- a/test/models/laboratory_test.rb
+++ b/test/models/laboratory_test.rb
@@ -214,6 +214,32 @@ class LaboratoryTest < ActiveSupport::TestCase
     assert_not lab.valid?(:api)
     assert_not lab.valid?(:import)
     assert lab.valid?
+
+    lab.specimen_collection = '2021-02-02 2021-01-01'
+    assert_not lab.valid?(:import)
+
+    lab.specimen_collection = 'typo2021-01-01'
+    assert_not lab.valid?(:api)
+    assert_not lab.valid?(:import)
+
+    lab.specimen_collection = '2021-01-01typo'
+    assert_not lab.valid?(:api)
+    assert_not lab.valid?(:import)
+
+    lab.specimen_collection = 20_210_101
+    assert_not lab.valid?(:import)
+    assert_not lab.valid?(:api)
+    assert_equal 'is not a valid date, please use the \'YYYY-MM-DD\' format', lab.errors[:specimen_collection][0]
+
+    lab.specimen_collection = 20_210_001
+    assert_not lab.valid?(:import)
+    assert_not lab.valid?(:api)
+    assert_equal 'is not a valid date, please use the \'YYYY-MM-DD\' format', lab.errors[:specimen_collection][0]
+
+    lab.specimen_collection = 20_210_101.001
+    assert_not lab.valid?(:import)
+    assert_not lab.valid?(:api)
+    assert_equal 'is not a valid date, please use the \'YYYY-MM-DD\' format', lab.errors[:specimen_collection][0]
   end
 
   test 'validates report is a valid date' do
@@ -240,5 +266,31 @@ class LaboratoryTest < ActiveSupport::TestCase
     assert_not lab.valid?(:api)
     assert_not lab.valid?(:import)
     assert lab.valid?
+
+    lab.report = '2021-02-02 2021-01-01'
+    assert_not lab.valid?(:import)
+
+    lab.report = 'typo2021-01-01'
+    assert_not lab.valid?(:api)
+    assert_not lab.valid?(:import)
+
+    lab.report = '2021-01-01typo'
+    assert_not lab.valid?(:api)
+    assert_not lab.valid?(:import)
+
+    lab.report = 20_210_101
+    assert_not lab.valid?(:import)
+    assert_not lab.valid?(:api)
+    assert_equal 'is not a valid date, please use the \'YYYY-MM-DD\' format', lab.errors[:report][0]
+
+    lab.report = 20_210_001
+    assert_not lab.valid?(:import)
+    assert_not lab.valid?(:api)
+    assert_equal 'is not a valid date, please use the \'YYYY-MM-DD\' format', lab.errors[:report][0]
+
+    lab.report = 20_210_101.001
+    assert_not lab.valid?(:import)
+    assert_not lab.valid?(:api)
+    assert_equal 'is not a valid date, please use the \'YYYY-MM-DD\' format', lab.errors[:report][0]
   end
 end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -2436,52 +2436,52 @@ class PatientTest < ActiveSupport::TestCase
 
   test 'seven_day_quarantine_candidates scope asserts lab results specimen_collection within correct range around LDE' do
     # LDE + 4 days: too early
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
-    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: 1.day.ago.utc)
-    create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: 3.days.ago.utc.to_date)
-    scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
+    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: 4.day.ago.utc)
+    create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: 6.days.ago.utc.to_date)
+    scoped_patients = Patient.seven_day_quarantine_candidates(3.days.ago.utc.to_date)
     assert_not scoped_patients.where(id: patient.id).present?
 
     # LDE + 5 days: in range
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
-    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc)
-    create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: 2.days.ago)
-    scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
+    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: 3.days.ago.utc)
+    create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: 5.days.ago.utc.to_date)
+    scoped_patients = Patient.seven_day_quarantine_candidates(3.days.ago.utc.to_date)
     assert scoped_patients.where(id: patient.id).present?
 
     # # LDE + 6 days: in range
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
-    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 1.day)
-    create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: 1.day.ago)
-    scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
+    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: 2.days.ago.utc.to_date)
+    create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: 4.days.ago.utc.to_date)
+    scoped_patients = Patient.seven_day_quarantine_candidates(3.days.ago.utc.to_date)
     assert scoped_patients.where(id: patient.id).present?
 
     # # LDE + 7 days: in range
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
-    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 2.day)
-    create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
-    scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
+    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: 1.day.ago.utc.to_date)
+    create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: 3.days.ago.utc.to_date)
+    scoped_patients = Patient.seven_day_quarantine_candidates(3.days.ago.utc.to_date)
     assert scoped_patients.where(id: patient.id).present?
 
     # # LDE + 8 days: in range
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
-    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 3.day)
-    create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date + 1.day)
-    scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
+    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc)
+    create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: 1.day.ago.utc.to_date)
+    scoped_patients = Patient.seven_day_quarantine_candidates(3.days.ago.utc.to_date)
     assert_not scoped_patients.where(id: patient.id).present?
 
     # LDE + 9 days: in range
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
-    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 3.day)
-    create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date + 2.days)
-    scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
+    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc)
+    create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: 2.days.ago.utc.to_date)
+    scoped_patients = Patient.seven_day_quarantine_candidates(3.days.ago.utc.to_date)
     assert_not scoped_patients.where(id: patient.id).present?
 
     # LDE + 10 days: too late
-    patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
-    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 3.day)
-    create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date + 3.days)
-    scoped_patients = Patient.seven_day_quarantine_candidates(DateTime.now.utc)
+    patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
+    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc)
+    create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc)
+    scoped_patients = Patient.seven_day_quarantine_candidates(3.days.ago.utc.to_date)
     assert_not scoped_patients.where(id: patient.id).present?
   end
 


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1355](https://tracker.codev.mitre.org/browse/SARAALERT-1355)

Write out a concise summary of this pull request and what it addresses.

This PR adds validation for lab results to the frontend making it so that a user cannot create a lab result if it does not have at least a specimen_date or report date AND a result. This also expands upon some of the existing backend validations.


## (Feature) Demo/Screenshots
Insert demo video or photos for a new or updated feature or capability.

## (Bugfix) How to Replicate
Add lab results with no fields populated.

## (Bugfix) Solution
Try to add lab results without the required fields, see that creation is blocked.


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary NA


@Bialogs  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
