### PR TITLE
fixes cc contact_attempt method

### DIFF
--- a/app/javascript/components/patient/close_contact/CloseContact.js
+++ b/app/javascript/components/patient/close_contact/CloseContact.js
@@ -75,7 +75,7 @@ class CloseContact extends React.Component {
   contactAttempt = async () => {
     if (await confirmDialog('Are you sure you want to log an additional contact attempt?', { title: 'New Contact Attempt' })) {
       this.setState({ contact_attempts: this.state.contact_attempts + 1 }, () => {
-        this.submit();
+        this.handleCloseContactSubmit();
       });
     }
   };


### PR DESCRIPTION
Renames an incorrect method to prevent the Close Contact Modal from error-ing out.