### PR TITLE
prevents REASON_FOR_CLOSURE from being blanked out when deleting REAS…

### DIFF
--- a/app/javascript/components/public_health/actions/UpdateCaseStatus.js
+++ b/app/javascript/components/public_health/actions/UpdateCaseStatus.js
@@ -89,6 +89,8 @@ class UpdateCaseStatus extends React.Component {
         }
       } else if (event.target.id === 'monitoring_reason') {
         this.setState({ monitoring_reason: event.target.value });
+      } else if (event.target.id === 'reasoning') {
+        this.setState({ reasoning: event.target.value });
       } else if (event.target.value === 'Suspect' || event.target.value === 'Unknown' || event.target.value === 'Not a Case' || event.target.value === '') {
         this.setState({ monitoring: true, isolation: false, monitoring_reason: this.state.initialMonitoringReason || '', reasoning: '' });
       }


### PR DESCRIPTION
This PR is a follow-up to the [1407 PR](https://github.com/SaraAlert/SaraAlert/pull/923) that added the ability to add Monitoring Reason and some free-text when updating a user's case status via the Case Status Bulk Action Modal.

# The Issue:
In the Bulk Action Case Status Modal, if a user wrote some free text, and then cleared it, the empty string (`''`) would be passed to the `handleChange` function. This was interpreted in that function as though the user had selected the empty string for Case Status (due to incorrect logic).

# The Fix:
This PR adds a conditional to the `handleChange` method, checking whether the incoming event is coming from the Reason free text field. This prevents the Monitoring Reason from being cleared out incorrectly.