### PR TITLE
Hotfix-SA-1407 Disabled Reasons in Isolation Workflow

### DIFF
--- a/app/javascript/components/patient/monitoring_actions/CaseStatus.js
+++ b/app/javascript/components/patient/monitoring_actions/CaseStatus.js
@@ -45,15 +45,9 @@ class CaseStatus extends React.Component {
       // changing case status of monitoree in the closed line list (either workflow)
       if (!this.props.patient.monitoring) {
         this.setState({
-          modal_text: `Are you sure you want to change case status from ${this.props.patient.case_status} to ${
+          modal_text: `Are you sure you want to change case status from ${this.props.patient.case_status || 'blank'} to ${
             value || 'blank'
           }? Since this record is on the Closed line list, updating this value will not move this record to another line list. If this individual should be actively monitored, please update the record’s Monitoring Status.`,
-        });
-
-        // changing case status to blank from any other case status and either workflow
-      } else if (value === '') {
-        this.setState({
-          modal_text: `Are you sure you want to change case status from ${this.props.patient.case_status} to blank? The monitoree will remain in the same workflow.`,
         });
 
         // changing case status to Unknown, Suspect or Not a Case from Confirmed or Probable in the isolation workflow
@@ -75,7 +69,9 @@ class CaseStatus extends React.Component {
       ) {
         this.setState({
           isolation: true,
-          modal_text: `Are you sure you want to change the case status from ${this.props.patient.case_status} to ${value}? The record will remain in the isolation workflow.`,
+          modal_text: `Are you sure you want to change the case status from ${this.props.patient.case_status || 'blank'} to ${
+            value || 'blank'
+          }? The record will remain in the isolation workflow.`,
         });
 
         // changing case status to Confirmed or Probable (excluding case directly above)
@@ -86,20 +82,24 @@ class CaseStatus extends React.Component {
       } else if (!confirmedOrProbable && this.state.isolation) {
         this.setState({
           isolation: false,
-          modal_text: `The case status for the selected record will be updated to ${value} and moved to the appropriate line list in the Exposure Workflow.`,
+          modal_text: `The case status for the selected record will be updated to ${
+            value || 'blank'
+          } and moved to the appropriate line list in the Exposure Workflow.`,
         });
 
         // changing case status to Unknown, Suspect or Not a Case while on the PUI line list in the exposure workflow
       } else if (!confirmedOrProbable && !this.state.isolation && this.props.patient.public_health_action != 'None') {
         this.setState({
           isolation: false,
-          modal_text: `Are you sure you want to change case status to "${value}"? The monitoree will be placed in the symptomatic, non-reporting, or asymptomatic line list as appropriate to continue exposure monitoring and the Latest Public Health Action will be set to "None".`,
+          modal_text: `Are you sure you want to change case status to "${
+            value || 'blank'
+          }"? The monitoree will be placed in the symptomatic, non-reporting, or asymptomatic line list as appropriate to continue exposure monitoring and the Latest Public Health Action will be set to "None".`,
         });
         // changing case status to Unknown, Suspect or Not a Case while not on the PUI line list in the exposure workflow
       } else if (!confirmedOrProbable && !this.state.isolation) {
         this.setState({
           isolation: false,
-          modal_text: `The case status for the selected record will be updated to ${value}.`,
+          modal_text: `The case status for the selected record will be updated to ${value || 'blank'}.`,
         });
       }
     });

--- a/app/javascript/components/public_health/actions/UpdateCaseStatus.js
+++ b/app/javascript/components/public_health/actions/UpdateCaseStatus.js
@@ -249,16 +249,14 @@ class UpdateCaseStatus extends React.Component {
             {this.state.initialIsolation ? (
               // In the Isolation workflow, only show certain explanation statements
               <React.Fragment>
-                {['Confirmed', 'Probable'].includes(this.state.case_status) && (
-                  <p>The selected cases will remain in the isolation workflow. {this.renderClosedStatement()}</p>
-                )}
-                {['', 'Suspect', 'Not a Case', 'Unknown'].includes(this.state.case_status) && (
+                {!this.state.allSelectedAreClosed && (
                   <p>
-                    The selected cases will be moved from the isolation workflow to the exposure workflow and placed in the symptomatic, non-reporting, or
-                    asymptomatic line list as appropriate. {this.renderClosedStatement()}
+                    {['Confirmed', 'Probable'].includes(this.state.case_status) && 'The selected cases will remain in the isolation workflow.'}
+                    {['', 'Suspect', 'Not a Case', 'Unknown'].includes(this.state.case_status) &&
+                      'The selected cases will be moved from the isolation workflow to the exposure workflow and placed in the symptomatic, non-reporting, or asymptomatic line list as appropriate.'}
                   </p>
                 )}
-                {this.state.allSelectedAreClosed && this.renderReasonsSection()}
+                {this.renderClosedStatement()}
               </React.Fragment>
             ) : (
               // In the Exposure workflow, show other explanation statements

--- a/app/javascript/tests/patient/monitoring_actions/CaseStatus.test.js
+++ b/app/javascript/tests/patient/monitoring_actions/CaseStatus.test.js
@@ -64,19 +64,6 @@ describe('CaseStatus', () => {
     expect(modalBody.find('p').text()).toEqual(`Are you sure you want to change case status from ${mockPatient3.case_status} to Confirmed? Since this record is on the Closed line list, updating this value will not move this record to another line list. If this individual should be actively monitored, please update the record’s Monitoring Status.`);
   });
 
-  it('Correctly renders modal body and and does not change line list or workflow when changing Case Status to blank', () => {
-    const wrapper = getWrapper(mockPatient1);
-    wrapper.find('#case_status').simulate('change', { target: { id: 'case_status', value: '' }, persist: jest.fn() });
-    const modalBody = wrapper.find(Modal.Body);
-    expect(wrapper.state('showCaseStatusModal')).toBeTruthy();
-    expect(wrapper.state('showMonitoringDropdown')).toBeFalsy();
-    expect(wrapper.state('case_status')).toEqual('');
-    expect(wrapper.state('confirmedOrProbable')).toBeFalsy();
-    expect(wrapper.state('isolation')).toEqual(mockPatient1.isolation);
-    expect(wrapper.state('monitoring')).toBeTruthy();
-    expect(modalBody.find('p').text()).toEqual(`Are you sure you want to change case status from ${mockPatient1.case_status} to blank? The monitoree will remain in the same workflow.`);
-  });
-
   it('Correctly renders modal body and updates to exposure workflow when changing Case Status to Suspect, Unknown or Not a Case from Confirmed or Probable in isolation workflow', () => {
     const wrapper = getWrapper(mockPatient4);
     wrapper.find('#case_status').simulate('change', { target: { id: 'case_status', value: 'Unknown' }, persist: jest.fn() });
@@ -100,6 +87,18 @@ describe('CaseStatus', () => {
     expect(wrapper.state('confirmedOrProbable')).toBeTruthy();
     expect(wrapper.state('isolation')).toBeTruthy();
     expect(modalBody.find('p').text()).toEqual(`Are you sure you want to change the case status from ${mockPatient4.case_status} to Confirmed? The record will remain in the isolation workflow.`);
+  });
+
+  it('Correctly renders modal body and is moved to the exposure workflow when changing Case Status to Blank in the isolation workflow', () => {
+    const wrapper = getWrapper(blankMockPatient);
+    wrapper.find('#case_status').simulate('change', { target: { id: 'case_status', value: '' }, persist: jest.fn() });
+    const modalBody = wrapper.find(Modal.Body);
+    expect(wrapper.state('showCaseStatusModal')).toBeTruthy();
+    expect(wrapper.state('showMonitoringDropdown')).toBeFalsy();
+    expect(wrapper.state('case_status')).toEqual('');
+    expect(wrapper.state('confirmedOrProbable')).toBeFalsy();
+    expect(wrapper.state('isolation')).toBeFalsy();
+    expect(modalBody.find('p').text()).toEqual('The case status for the selected record will be updated to blank and moved to the appropriate line list in the Exposure Workflow.');
   });
 
   it('Correctly renders modal body and is moved to the exposure workflow when changing Case Status to Suspect, Unknown or Not A Case in the isolation workflow', () => {

--- a/app/javascript/tests/public_health/actions/UpdateCaseStatus.test.js
+++ b/app/javascript/tests/public_health/actions/UpdateCaseStatus.test.js
@@ -65,8 +65,8 @@ describe('UpdateCaseStatus', () => {
   });
 
   it('Properly renders all main components for Patients who are in Isolation only', () => {
-    // mockPatien1 and mockPatient4 are both in the Isolation workflow
-    const wrapper = getWrapper([mockPatient1, mockPatient4]);
+    // mockPatient6 is in the Isolation workflow, but is not closed
+    const wrapper = getWrapper([mockPatient6]);
     expect(wrapper.find('ModalBody').find('p').at(0).text()).toContain('Please select the desired case status to be assigned to all selected patients:');
     wrapper
       .find('#case_status')
@@ -148,7 +148,6 @@ describe('UpdateCaseStatus', () => {
         .first()
         .simulate('change', { target: { id: 'case_status', type: 'change', value: case_status_option }, persist: jest.fn() });
       expect(wrapper.state('case_status')).toEqual(case_status_option);
-
       expect(wrapper.find('p').at(1).text()).toContain('The selected cases will remain in the isolation workflow.');
       // there are no dropdowns for "Suspect", "Unknown" and "Not a Case"
       expect(wrapper.find('FormControl').at(1).exists()).toBeFalsy();


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1407] Part 3

This PR removes the ability to update Reason for Closure for Monitorees in the Isolation Workflow via the Case Status Modal. Per User Feedback, it doesnt make sense to update the RoC via that modal in the Isolation workflow.

## Important Changes

`app/javascript/components/public_health/actions/UpdateCaseStatus.js`
- Removes the ability to update RoC via the Case Status Modal for Isolation Monitorees.


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@hackrm 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@jkufro 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
