### PR TITLE
Close job refactor

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -716,6 +716,12 @@ class Patient < ApplicationRecord
                  .submitted_assessment_today
                  .end_of_monitoring_period
 
+    # If a patient record has been inactive for 30 days or more
+    # in the exposure workflow and is non-reporting
+    no_recent_activity = where(isolation: false)
+                         .non_reporting
+                         .where('updated_at <= ?', 30.days.ago)
+
     case reason
     when nil
       base_scope.or(no_recent_activity)
@@ -730,14 +736,6 @@ class Patient < ApplicationRecord
     else
       throw Exception.new('Invalid reason provided to close_eligible scope!')
     end
-  }
-
-  # If a patient record has been inactive for 30 days or more,
-  # then it should be automatically closed as part of the close patients job.
-  scope :no_recent_activity, lambda {
-    where(isolation: false)
-      .non_reporting
-      .where('updated_at <= ?', 30.days.ago)
   }
 
   # Patients are enrolled past the monitoring period OF:

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -3154,35 +3154,92 @@ class PatientTest < ActiveSupport::TestCase
     ADMIN_OPTIONS['reporting_period_minutes'] = original_reporting_period
   end
 
-  test 'no_recent_activity scope in exposure' do
+  test 'no_recent_activity reason in close_eligible scope' do
     patient = create(:patient, isolation: false, monitoring: true, created_at: 100.days.ago)
 
-    assert_nil Patient.no_recent_activity.find_by(id: patient.id)
+    assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
     patient.update(updated_at: 1.day.ago)
-    assert_nil Patient.no_recent_activity.find_by(id: patient.id)
+    assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
     patient.update(updated_at: 5.days.ago)
-    assert_nil Patient.no_recent_activity.find_by(id: patient.id)
+    assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
     patient.update(updated_at: 10.days.ago)
-    assert_nil Patient.no_recent_activity.find_by(id: patient.id)
+    assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
     patient.update(updated_at: 20.days.ago)
-    assert_nil Patient.no_recent_activity.find_by(id: patient.id)
+    assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
     patient.update(updated_at: 29.days.ago)
-    assert_nil Patient.no_recent_activity.find_by(id: patient.id)
+    assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
     # 30 day border is sensitive to when DST starts
     patient.update(updated_at: correct_dst_edge(patient, 30.days.ago))
-    # assert_not_nil Patient.no_recent_activity.find_by(id: patient.id)
+    # assert_not_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
     patient.update(updated_at: 31.days.ago)
-    assert_not_nil Patient.no_recent_activity.find_by(id: patient.id)
+    assert_not_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
     patient.update(updated_at: 300.days.ago)
-    assert_not_nil Patient.no_recent_activity.find_by(id: patient.id)
+    assert_not_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
+
+    patient.update(isolation: true)
+    assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
+
+    patient.update(isolation: false, monitoring: false)
+    assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
+  end
+
+  test 'invalid reason in close_eligible scope' do
+    exception = assert_raises(Exception) { Patient.close_eligible(:fake_reason) }
+    assert_includes(exception.message, 'Invalid reason provided to close_eligible scope!')
+  end
+
+  test 'completed_monitoring reason in close_eligible scope' do
+    patient = create(:patient,
+                     purged: false,
+                     isolation: false,
+                     monitoring: true,
+                     symptom_onset: nil,
+                     public_health_action: 'None',
+                     latest_assessment_at: Time.now,
+                     last_date_of_exposure: 20.days.ago)
+    assert_not_nil Patient.close_eligible(:completed_monitoring).find_by(id: patient.id)
+  end
+
+  test 'enrolled_last_day_monitoring_period reason in close_eligible scope' do
+    patient = create(:patient,
+                     purged: false,
+                     isolation: false,
+                     monitoring: true,
+                     symptom_onset: nil,
+                     public_health_action: 'None',
+                     latest_assessment_at: Time.now,
+                     created_at: 20.days.ago)
+    assert_not_nil Patient.close_eligible(:completed_monitoring).find_by(id: patient.id)
+    assert_nil Patient.close_eligible(:enrolled_last_day_monitoring_period).find_by(id: patient.id)
+    patient.update(last_date_of_exposure: Time.now.getlocal('-05:00') - 34.days)
+    assert_not_nil Patient.close_eligible(:completed_monitoring).find_by(id: patient.id)
+    assert_not_nil Patient.close_eligible(:enrolled_last_day_monitoring_period).find_by(id: patient.id)
+  end
+
+  test 'enrolled_past_monitioring_period reason in close_eligible scope' do
+    patient = create(:patient,
+                     purged: false,
+                     isolation: false,
+                     monitoring: true,
+                     symptom_onset: nil,
+                     public_health_action: 'None',
+                     latest_assessment_at: Time.now,
+                     created_at: 20.days.ago)
+    assert_not_nil Patient.close_eligible(:completed_monitoring).find_by(id: patient.id)
+    assert_nil Patient.close_eligible(:enrolled_past_monitioring_period).find_by(id: patient.id)
+    assert_nil Patient.close_eligible(:enrolled_last_day_monitoring_period).find_by(id: patient.id)
+    patient.update(last_date_of_exposure: Time.now.getlocal('-05:00') - 35.days)
+    assert_not_nil Patient.close_eligible(:completed_monitoring).find_by(id: patient.id)
+    assert_not_nil Patient.close_eligible(:enrolled_past_monitioring_period).find_by(id: patient.id)
+    assert_nil Patient.close_eligible(:enrolled_last_day_monitoring_period).find_by(id: patient.id)
   end
 
   [

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -3155,7 +3155,8 @@ class PatientTest < ActiveSupport::TestCase
   end
 
   test 'no_recent_activity scope in exposure' do
-    patient = create(:patient)
+    patient = create(:patient, isolation: false, monitoring: true, created_at: 100.days.ago)
+
     assert_nil Patient.no_recent_activity.find_by(id: patient.id)
 
     patient.update(updated_at: 1.day.ago)
@@ -3173,9 +3174,9 @@ class PatientTest < ActiveSupport::TestCase
     patient.update(updated_at: 29.days.ago)
     assert_nil Patient.no_recent_activity.find_by(id: patient.id)
 
-    # 30 day border is sensitive to DST changes
+    # 30 day border is sensitive to when DST starts
     patient.update(updated_at: correct_dst_edge(patient, 30.days.ago))
-    assert_nil Patient.close_eligible.find_by(id: patient.id)
+    # assert_not_nil Patient.no_recent_activity.find_by(id: patient.id)
 
     patient.update(updated_at: 31.days.ago)
     assert_not_nil Patient.no_recent_activity.find_by(id: patient.id)

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -3174,9 +3174,8 @@ class PatientTest < ActiveSupport::TestCase
     patient.update(updated_at: 29.days.ago)
     assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
-    # 30 day border is sensitive to when DST starts
-    patient.update(updated_at: correct_dst_edge(patient, 30.days.ago))
-    # assert_not_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
+    patient.update(updated_at: 30.days.ago)
+    assert_not_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
     patient.update(updated_at: 31.days.ago)
     assert_not_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1504](https://tracker.codev.mitre.org/browse/SARAALERT-1504)

This refactors the close patients job so that there isn't any additional logic added to setting monitoring reasons besides the scopes. This will help ensure that the logic in the job does not fall out of line with the logic in the scopes.

## (Bugfix) How to Replicate
```ruby
# If a patient is created and then creates no reports for 
# an extended period of time...
patient = create(:patient,
                 last_date_of_exposure: 200.days.ago,
                 created_at: 150.days.ago)
patient.update(updated_at: 135.days.ago)
# Then they are not close_eligible based on the previous logic of:
Patient.where(id: patient.id).exposure_asymptomatic.submitted_assessment_today.end_of_monitoring_period
# But ARE close_eligible based on the new logic of:
Patient.where(id: patient.id).where(isolation: false).non_reporting.no_recent_activity
# However, when this patient is fetched by the close_patients job using
# the new logic, then they will actually be assigned the reason for
# closure of 'Enrolled more than 14 days after last date of exposure (system)'
# instead of 'No record activity for 30 days (system)'
```

## (Bugfix) Solution
The solution is to remove all monitoring reason logic in the close job so that there is no chance it can fall out of line with the logic in the scope. 

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`patient.rb`
- allow passing specific symbols to the close_eligible scope to fetch patients that are close_eligible for specific reasons

`patient_test.rb`
- added tests for changes to the close eligible scope

`close_patients_job.rb`
- refactor such that eligible patients are closed in batches according to the monitoring reason


# Checklists

**Submitter:**
- [ ] This PR describes why these changes were made.
- [ ] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA ticket reference.
- [ ] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@holmesie  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@Bialogs  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
