### PR TITLE
SARAALERT-1175: Refactor ConsumeAssessmentsJob to be performed by Sidekiq Async

### DIFF
--- a/Nginx.Dockerfile
+++ b/Nginx.Dockerfile
@@ -1,11 +1,10 @@
 # Base image:
 ARG sara_alert_image
 FROM ${sara_alert_image} as base
-FROM nginx:latest
-
+FROM nginx:alpine
 
 # Install dependencies
-RUN apt-get update -qq && apt-get -y install apache2-utils
+RUN apk --update add --no-cache apache2-utils
 
 # establish where Nginx should look for files
 ENV RAILS_ROOT /var/www/saraalert

--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ bundle exec sidekiq -q default -q mailers -q exports
 
   The following jobs are configured to run continuously:
   * `ConsumeAssessmentsJob`
-      - Should always be running in order to be ready to consume assessments at any time.
-      - Handles consuming assessments from the assessment container into the enrollment container.
+      - Should always be running to be ready to consume assessments at any time
+      - Handles the processing of incomming Patient assessments from the assessment container into the enrollment container.
+      - Utilizes Redis `RPOPLPUSH` pattern.
       - Run with `bin/bundle exec rake reports:receive_and_process_reports`
 
   The following jobs are configured to run periodically:
@@ -218,7 +219,7 @@ This results in a 'split architecture' where multiple instances of the SaraAlert
 A key portion of this is the use of the Nginx reverse proxy container. The configuration (located at `./nginx.conf`) will route traffic from 'untrusted' users submitting assessments to the `dt-net-assessment` application while, at the same time, enrollers and epidemiologists are routed to the enrollment database.
 
 Below is a graphic depicting the services and applications present on each network:
-![SaraAlertDockerNetworks](https://user-images.githubusercontent.com/3009651/90296500-a7fc3200-de59-11ea-873b-f690c52509bc.png)
+![SaraAlertDockerNetworks](https://user-images.githubusercontent.com/3009651/100016590-a66ece00-2da7-11eb-8908-fca7ac66b635.png)
 
 **Environment Variable Setup**
 
@@ -232,6 +233,10 @@ The content for these files can be based off of the `.env-prod-assessment-exampl
 The `SECRET_KEY_BASE` and `MYSQL_PASSWORD` variables should be changed at the very least. These variables should also not be the same between both assessment and enrollment instances of the files.
 
 Sara Alert relies upon several external services that are configured with environment variables:
+
+***Redis Environment Variables***
+
+The `REDIS_URL` environment variable is utilized within `docker-compose.yml` to specify which Redis instance (bridge or enrollment) the container should connect to. This URL can also incorporate authentication information.
 
 ***Export Environment Variables***
 

--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ bundle exec sidekiq -q default -q mailers -q exports -q assessments
   The following jobs are configured to run continuously:
   * `ConsumeAssessmentsJob`
       - Should always be running to be ready to consume assessments at any time
-      - Handles the processing of incomming Patient assessments from the assessment container into the enrollment container.
+      - Handles the processing of incoming Patient assessments from the assessment container into the enrollment container.
       - Utilizes Redis `RPOPLPUSH` pattern.
-      - Run with `bin/bundle exec rake reports:receive_and_process_reports`
+      - Run with `bin/bundle exec rake reports:queue_reports`
 
   The following jobs are configured to run periodically:
   * `ClosePatientsJob`

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ redis-server
 Sidekiq is the queueing system that ActiveJob interfaces with. Sidekiq should be installed when you ran `bundle install` in the application installation instructions. To start Sidekiq, and make it aware that it is responsible for the mailers queue, execute the following:
 
 ```
-bundle exec sidekiq -q default -q mailers -q exports
+bundle exec sidekiq -q default -q mailers -q exports -q assessments
 ```
 
 ##### Jobs

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -98,7 +98,7 @@ class ConsumeAssessmentsJob
       return
     end
 
-    threshold_condition = ThresholdCondition.where(type: 'ThresholdCondition').find_by(threshold_condition_hash: message['threshold_condition_hash'])
+    threshold_condition = ThresholdCondition.find_by(threshold_condition_hash: message['threshold_condition_hash'])
 
     # Invalid threshold_condition_hash
     if threshold_condition.nil?

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -13,7 +13,7 @@ class ConsumeAssessmentsJob
                                      'response_status',
                                      'error_code')
     # Invalid message
-    if message.nil?
+    if message.empty?
       log_and_capture('ConsumeAssessmentsJob: No valid fields found in message. Skipping.')
       return
     end
@@ -102,8 +102,8 @@ class ConsumeAssessmentsJob
     threshold_condition = ThresholdCondition.find_by(threshold_condition_hash: message['threshold_condition_hash'])
     # Invalid threshold_condition_hash
     if threshold_condition.nil?
-      log_and_capture("ConsumeAssessmentsJob: No ThresholdCondition found (patient: #{patient.id}, \
-                      threshold_condition_hash: #{message['threshold_condition_hash']})")
+      log_and_capture("ConsumeAssessmentsJob: No ThresholdCondition found (patient: #{patient.id}, " \
+                      "threshold_condition_hash: #{message['threshold_condition_hash']})")
       return
     end
 
@@ -120,8 +120,6 @@ class ConsumeAssessmentsJob
       rescue ActiveRecord::RecordInvalid => e
         log_and_capture("ConsumeAssessmentsJob: Unable to save assessment. Patient ID: #{patient.id}. Error: #{e}")
       end
-
-      return
     else
       # If message['reported_symptoms_array'] is not populated then this assessment came in through
       # a generic channel ie: SMS where monitorees are asked YES/NO if they are experiencing symptoms
@@ -151,16 +149,12 @@ class ConsumeAssessmentsJob
         rescue ActiveRecord::RecordInvalid => e
           log_and_capture("ConsumeAssessmentsJob: Unable to save assessment. Patient ID: #{patient.id}. Error: #{e}")
         end
-
-        return
       end
     end
   rescue JSON::ParserError
     # Do not reproduce entire message in the log. There may be sensitive data in the message.
     # Sentry will automatically capture.
     Rails.logger.error('ConsumeAssessmentsJob: Skipping invalid message.')
-
-    return
   end
 
   private

--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -97,6 +97,26 @@ class ConsumeAssessmentsJob
       end
 
       return
+    when 'max_retries_sms'
+      # Maximum amount of SMS response retries reached
+      History.contact_attempt(patient: patient, comment: 'The system could not record a response because the monitoree exceeded the maximum number' \
+                              " of daily report SMS response retries via primary telephone number #{patient.primary_telephone}.")
+      if dependents.present?
+        create_contact_attempt_history_for_dependents(dependents, "The system could not record a response because the monitoree's head of household" \
+          " exceeded the maximum number of daily report SMS response retries via primary telephone number #{patient.primary_telephone}.")
+      end
+
+      return
+    when 'max_retries_voice'
+      # Maximum amount of voice response retries reached
+      History.contact_attempt(patient: patient, comment: 'The system could not record a response because the monitoree exceeded the maximum number' \
+        " of report voice response retries via primary telephone number #{patient.primary_telephone}.")
+      if dependents.present?
+        create_contact_attempt_history_for_dependents(dependents, "The system could not record a response because the monitoree's head of household" \
+          " exceeded the maximum number of report voice response retries via primary telephone number #{patient.primary_telephone}.")
+      end
+
+      return
     end
 
     threshold_condition = ThresholdCondition.find_by(threshold_condition_hash: message['threshold_condition_hash'])

--- a/app/jobs/produce_assessment_job.rb
+++ b/app/jobs/produce_assessment_job.rb
@@ -9,14 +9,15 @@ class ProduceAssessmentJob < ApplicationJob
 
   def perform(assessment)
     queue = Redis::Queue.new('q_bridge', 'bp_q_bridge', redis: Rails.application.config.redis)
+    assessment.symbolize_keys!
     report = {
-      response_status: assessment['response_status'],
-      error_code: assessment['error_code'],
-      threshold_condition_hash: assessment['threshold_hash'],
-      reported_symptoms_array: assessment['symptoms'],
-      experiencing_symptoms: assessment['experiencing_symptoms'],
-      patient_submission_token: assessment['patient_submission_token']
+      response_status: assessment[:response_status],
+      error_code: assessment[:error_code],
+      threshold_condition_hash: assessment[:threshold_hash],
+      reported_symptoms_array: assessment[:symptoms],
+      experiencing_symptoms: assessment[:experiencing_symptoms],
+      patient_submission_token: assessment[:patient_submission_token]
     }
-    queue.push report.to_json
+    queue.push(report.to_json)
   end
 end

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,3 +17,5 @@ services:
     image: ${SARA_ALERT_IMAGE}:latest
   sidekiq-bridge-assessment:
     image: ${SARA_ALERT_IMAGE}:latest
+  rake-bridge-queue-reports:
+    image: ${SARA_ALERT_IMAGE}:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,19 @@ services:
       - redis-enrollment
       - sara-alert-enrollment
       - mysql-enrollment
+  rake-bridge-queue-reports:
+    image: "${SARA_ALERT_IMAGE}:development-test"
+    environment:
+      - REDIS_URL=redis://redis-bridge:6379/1
+      - CONSUME_WORKERS=8
+    env_file:
+      - .env-prod-enrollment
+    restart: unless-stopped
+    networks:
+      - dt-net-bridge
+    command: "bin/bundle exec rake reports:queue_reports"
+    depends_on:
+      - redis-bridge
   sidekiq-bridge-enrollment:
     image: "${SARA_ALERT_IMAGE}:development-test"
     environment:
@@ -153,7 +166,7 @@ services:
     networks:
       - dt-net-bridge
       - dt-net-enrollment
-    command: "bin/bundle exec rake reports:receive_and_process_reports"
+    command: "bin/bundle exec sidekiq -q assessments"
     depends_on:
       - redis-bridge
       - sara-alert-enrollment

--- a/lib/reports_helper.rb
+++ b/lib/reports_helper.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+# Processing and error handling for reports:queue_reports
+# Enables easier unit testing of these methods.
+module ReportsHelper
+  def process(queue, worker_number)
+    loop do
+      @msg = queue.pop if @msg.nil?
+      # If perform_async does not return a job_id (String), throw an error.
+      # Error handling will take over retries.
+      raise('Sidekiq did not return successfully from perform_async') unless ConsumeAssessmentsJob.perform_async(@msg).match?(/[a-f0-9]{24}/)
+
+      queue.commit
+      @sleep_seconds = 0
+      @msg = nil
+    end
+  rescue RuntimeError, Redis::ConnectionError, Redis::CannotConnectError => e
+    # If this point is reached with another 30 second sleep: drop the message, log, and process the next (if the error was with ).
+    if @sleep_seconds == 30
+      handle_complete_failure(e, worker_number)
+    else
+      handle_successive_timeout(e, worker_number)
+    end
+    retry
+  end
+
+  def handle_complete_failure(error, worker_number)
+    # In an effort to not log any PHI or PII the message needs to be parsed a little.
+    submission_token = JSON.parse(@msg)&.slice('patient_submission_token')
+    raise JSON::ParserError, 'JSON parsed correctly but no submission_token was found' if submission_token.empty?
+
+    Rails.logger.error("reports:queue_reports process #{worker_number}: Unable to process a report for #{submission_token} because of #{error}. \
+                        The report has been skipped.")
+    # Setting @msg to nil will grab the next entry from the queue on retry
+  rescue JSON::ParserError
+    # Do not print the JSON parser error. If the incomming report is legitimate, there is a good chance the ParserError will contain PHI or PII.
+    Rails.logger.error("reports:queue_reports process #{worker_number}: Unable to process a report because of #{error}. \
+                        No submission token could be parsed; the report failed parsing. The report has been skipped.")
+  ensure
+    @msg = nil
+  end
+
+  def handle_successive_timeout(error, worker_number)
+    @sleep_seconds = exponential_backoff(@sleep_seconds)
+    Rails.logger.info("reports:queue_reports process #{worker_number}: #{error}, retrying in #{@sleep_seconds} seconds.")
+    sleep(@sleep_seconds)
+  end
+
+  def exponential_backoff(seconds)
+    if seconds > 16
+      # Maximum of 30 second backoff
+      30
+    elsif seconds.zero?
+      1 + rand
+    elsif seconds.floor == 1
+      2 + rand
+    else
+      (seconds.floor**2) + rand
+    end
+  end
+end

--- a/lib/reports_helper.rb
+++ b/lib/reports_helper.rb
@@ -30,11 +30,13 @@ module ReportsHelper
 
     raise 'JSON parsed correctly but no submission_token was found' if submission_token.empty?
 
-    Rails.logger.error("reports:queue_reports process #{worker_number}: Unable to process a report for #{submission_token} because of #{error}. The report has been skipped.")
+    Rails.logger.error("reports:queue_reports process #{worker_number}: Unable to process a report for "\
+       "#{submission_token} because of #{error}. The report has been skipped.")
   rescue JSON::ParserError
     # Do not print the JSON parser error. If the incomming report is legitimate, there is a good chance the ParserError will contain PHI or PII.
     # Instead, print the original error from Redis or Sidekiq
-    Rails.logger.error("reports:queue_reports process #{worker_number}: Unable to process a report because of #{error}. No submission token could be parsed; the report failed parsing. The report has been skipped.")
+    Rails.logger.error("reports:queue_reports process #{worker_number}: Unable to process a report because of #{error}. "\
+      'No submission token could be parsed; the report failed parsing. The report has been skipped.')
   rescue RuntimeError => e
     Rails.logger.error("reports:queue_reports process #{worker_number}: #{e}. Original error: #{error}")
   ensure

--- a/lib/reports_helper.rb
+++ b/lib/reports_helper.rb
@@ -3,6 +3,8 @@
 # Processing and error handling for reports:queue_reports
 # Enables easier unit testing of these methods.
 module ReportsHelper
+  @sleep_seconds = 0
+
   def process(queue, worker_number)
     loop do
       @msg = queue.pop if @msg.nil?
@@ -15,7 +17,7 @@ module ReportsHelper
       @msg = nil
     end
   rescue RuntimeError, Redis::ConnectionError, Redis::CannotConnectError => e
-    # If this point is reached with another 30 second sleep: drop the message, log, and process the next (if the error was with ).
+    # If this point is reached with another 30 second sleep: drop the message, log, and process the next.
     if @sleep_seconds == 30
       handle_complete_failure(e, worker_number)
     else

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -3,10 +3,12 @@
 require 'redis'
 require 'redis-queue'
 require 'json'
+require_relative '../reports_helper'
 
 namespace :reports do
   desc 'Recieve reports from the Redis bridge queue, then move them over to the Sidekiq queue for processing'
   task queue_reports: :environment do
+    include ReportsHelper
     trap_interrupt_signal
     number_of_processes = ENV.fetch('CONSUME_WORKERS', 8).to_i
     Rails.logger.info("Starting the reports:queue_reports task with #{number_of_processes} processes.")
@@ -17,71 +19,13 @@ namespace :reports do
         queue = Redis::Queue.new('q_bridge', 'bp_q_bridge', redis: Rails.application.config.redis)
         Rails.logger.info("reports:queue_reports process #{worker_number} listening on queue: #{queue.instance_values}")
         @sleep_seconds = 0
-        process(queue, worker_number)
+        ReportsHelper.process(queue, worker_number)
       end
     end
     Process.waitall
   end
 
   private
-
-  def process(queue, worker_number)
-    loop do
-      @msg = queue.pop if @msg.nil?
-      # If perform_async does not return a job_id (String), throw an error.
-      # Error handling will take over retries.
-      unless ConsumeAssessmentsJob.perform_async(@msg).match?(/[a-f0-9]{24}/)
-        raise(RuntimeError, 'Sidekiq did not return successfully from perform_async')
-      end
-
-      queue.commit
-      @sleep_seconds = 0
-      @msg = nil
-    end
-  rescue RuntimeError, Redis::ConnectionError, Redis::CannotConnectError => e
-    # If this point is reached with another 30 second sleep: drop the message, log, and process the next (if the error was with ).
-    if @sleep_seconds == 30
-      handle_complete_failure(e, worker_number)
-    else
-      handle_successive_timeout(e, worker_number)
-    end
-    retry
-  end
-
-  def handle_complete_failure(error, worker_number)
-    # In an effort to not log any PHI or PII the message needs to be parsed a little.
-    submission_token = JSON.parse(@msg)&.slice('patient_submission_token')
-    raise JSON::ParserError, 'JSON parsed correctly but no submission_token was found' if submission_token.empty?
-
-    Rails.logger.error("reports:queue_reports process #{worker_number}: Unable to process a report for #{submission_token} because of #{error}. \
-                        The report has been skipped.")
-    # Setting @msg to nil will grab the next entry from the queue on retry
-  rescue JSON::ParserError
-    # Do not print the JSON parser error. If the incomming report is legitimate, there is a good chance the ParserError will contain PHI or PII.
-    Rails.logger.error("reports:queue_reports process #{worker_number}: Unable to process a report because of #{error}. \
-                        No submission token could be parsed; the report failed parsing. The report has been skipped.")
-  ensure
-    @msg = nil
-  end
-
-  def handle_successive_timeout(error, worker_number)
-    @sleep_seconds = exponential_backoff(@sleep_seconds)
-    Rails.logger.info("reports:queue_reports process #{worker_number}: #{error}, retrying in #{@sleep_seconds} seconds.")
-    sleep(@sleep_seconds)
-  end
-
-  def exponential_backoff(seconds)
-    if seconds > 16
-      # Maximum of 30 second backoff
-      30
-    elsif seconds.zero?
-      1 + rand
-    elsif seconds.floor == 1
-      2 + rand
-    else
-      (seconds.floor**2) + rand
-    end
-  end
 
   def trap_interrupt_signal
     Signal.trap('INT') do

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -1,14 +1,95 @@
 # frozen_string_literal: true
 
+require 'redis'
+require 'redis-queue'
+require 'json'
+
 namespace :reports do
-  desc "Receive and Process Reports"
-  task receive_and_process_reports: :environment do
-    consume_workers = ENV.fetch("CONSUME_WORKERS") { 8 }
-    consume_workers.times do
-      Process.fork do
-        ConsumeAssessmentsJob.perform_now
+  desc 'Recieve reports from the Redis bridge queue, then move them over to the Sidekiq queue for processing'
+  task queue_reports: :environment do
+    trap_interrupt_signal
+    number_of_processes = ENV.fetch('CONSUME_WORKERS', 8).to_i
+    Rails.logger.info("Starting the reports:queue_reports task with #{number_of_processes} processes.")
+    @processes = []
+    number_of_processes.times do |worker_number|
+      @processes << Process.fork do
+        Rails.logger.info("reports:queue_reports process #{worker_number} starting.")
+        queue = Redis::Queue.new('q_bridge', 'bp_q_bridge', redis: Rails.application.config.redis)
+        Rails.logger.info("reports:queue_reports process #{worker_number} listening on queue: #{queue.instance_values}")
+        @sleep_seconds = 0
+        process(queue, worker_number)
       end
     end
     Process.waitall
+  end
+
+  private
+
+  def process(queue, worker_number)
+    loop do
+      @msg = queue.pop if @msg.nil?
+      # If perform_async does not return a job_id (String), throw an error.
+      # Error handling will take over retries.
+      unless ConsumeAssessmentsJob.perform_async(@msg).match?(/[a-f0-9]{24}/)
+        raise(RuntimeError, 'Sidekiq did not return successfully from perform_async')
+      end
+
+      queue.commit
+      @sleep_seconds = 0
+      @msg = nil
+    end
+  rescue RuntimeError, Redis::ConnectionError, Redis::CannotConnectError => e
+    # If this point is reached with another 30 second sleep: drop the message, log, and process the next (if the error was with ).
+    if @sleep_seconds == 30
+      handle_complete_failure(e, worker_number)
+    else
+      handle_successive_timeout(e, worker_number)
+    end
+    retry
+  end
+
+  def handle_complete_failure(error, worker_number)
+    # In an effort to not log any PHI or PII the message needs to be parsed a little.
+    submission_token = JSON.parse(@msg)&.slice('patient_submission_token')
+    raise JSON::ParserError, 'JSON parsed correctly but no submission_token was found' if submission_token.empty?
+
+    Rails.logger.error("reports:queue_reports process #{worker_number}: Unable to process a report for #{submission_token} because of #{error}. \
+                        The report has been skipped.")
+    # Setting @msg to nil will grab the next entry from the queue on retry
+  rescue JSON::ParserError
+    # Do not print the JSON parser error. If the incomming report is legitimate, there is a good chance the ParserError will contain PHI or PII.
+    Rails.logger.error("reports:queue_reports process #{worker_number}: Unable to process a report because of #{error}. \
+                        No submission token could be parsed; the report failed parsing. The report has been skipped.")
+  ensure
+    @msg = nil
+  end
+
+  def handle_successive_timeout(error, worker_number)
+    @sleep_seconds = exponential_backoff(@sleep_seconds)
+    Rails.logger.info("reports:queue_reports process #{worker_number}: #{error}, retrying in #{@sleep_seconds} seconds.")
+    sleep(@sleep_seconds)
+  end
+
+  def exponential_backoff(seconds)
+    if seconds > 16
+      # Maximum of 30 second backoff
+      30
+    elsif seconds.zero?
+      1 + rand
+    elsif seconds.floor == 1
+      2 + rand
+    else
+      (seconds.floor**2) + rand
+    end
+  end
+
+  def trap_interrupt_signal
+    Signal.trap('INT') do
+      # Interrupted before Processes are created
+      return if @processes.empty?
+
+      # Exit all child processes, avoid zombies
+      Process.kill('TERM', 0)
+    end
   end
 end

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -18,7 +18,6 @@ namespace :reports do
         Rails.logger.info("reports:queue_reports process #{worker_number} starting.")
         queue = Redis::Queue.new('q_bridge', 'bp_q_bridge', redis: Rails.application.config.redis)
         Rails.logger.info("reports:queue_reports process #{worker_number} listening on queue: #{queue.instance_values}")
-        @sleep_seconds = 0
         ReportsHelper.process(queue, worker_number)
       end
     end

--- a/test/jobs/consume_assessments_job_test.rb
+++ b/test/jobs/consume_assessments_job_test.rb
@@ -5,29 +5,29 @@ require_relative '../test_helpers/consume_assessments_job_test_helper'
 
 class ConsumeAssessmentsJobTest < ActiveJob::TestCase
   def setup
-    Sidekiq::Testing.fake!
-    @redis = Rails.application.config.redis
-    @redis_queue = Redis::Queue.new('q_bridge', 'bp_q_bridge', redis: @redis)
     @patient = create(:patient, submission_token: SecureRandom.hex(20), primary_telephone: '(555) 555-0111')
     @assessment_generator = ConsumeAssessmentsJobTestHelper::AssessmentGenerator.new(@patient)
   end
 
-  def teardown
-    Sidekiq::Testing.inline!
-  end
+  def teardown; end
 
   test 'consume assessment bad json' do
-    @redis_queue.push 'not json'
-    # The mocking framework will just return when a 'next' is called
-    assert_nil ConsumeAssessmentsJob.perform_now
+    # There are no other side effects to test except examining the logger.
+    expect_any_instance_of(ActiveSupport::Logger).to(receive(:error).with('ConsumeAssessmentsJob: Skipping invalid message.'))
+    ConsumeAssessmentsJob.perform_async('not json')
+  end
+
+  test 'consume assessment valid json with wrong fields' do
+    # There are no other side effects to test except examining the logger.
+    expect_any_instance_of(ActiveSupport::Logger).to(receive(:info).with('ConsumeAssessmentsJob: No valid fields found in message. Skipping.'))
+    ConsumeAssessmentsJob.perform_async('{"key": 0}')
   end
 
   ConsumeAssessmentsJobTestHelper::AssessmentGenerator.response_statuses.each do |response_status|
     test "response status #{response_status}" do
       @patient.update(last_assessment_reminder_sent: 1.day.ago)
       assert_difference '@patient.histories.count', 1 do
-        @redis_queue.push @assessment_generator.no_answer_assessment(response_status)
-        ConsumeAssessmentsJob.perform_now
+        ConsumeAssessmentsJob.perform_async(@assessment_generator.no_answer_assessment(response_status))
         @patient.reload
         assert_equal 'Contact Attempt', @patient.histories.first.history_type
         assert_includes @patient.histories.first.comment, @patient.primary_telephone
@@ -37,9 +37,8 @@ class ConsumeAssessmentsJobTest < ActiveJob::TestCase
     test "#{response_status} contact attempt history for dependents" do
       dependent = create(:patient)
       dependent.update(responder_id: @patient.id, submission_token: SecureRandom.hex(20))
-      @redis_queue.push @assessment_generator.no_answer_assessment(response_status)
       assert_difference 'dependent.histories.count', 1 do
-        ConsumeAssessmentsJob.perform_now
+        ConsumeAssessmentsJob.perform_async(@assessment_generator.no_answer_assessment(response_status))
         dependent.reload
         assert_equal 'Contact Attempt', dependent.histories.first.history_type
         assert_includes dependent.histories.first.comment.gsub(/\s{2,}/, ' '), 'head of household'
@@ -50,28 +49,41 @@ class ConsumeAssessmentsJobTest < ActiveJob::TestCase
   test 'consume assessment for a patient that has submitted recently' do
     # reporting limit defaults to 15 minutes
     @patient.update(assessments: [create(:assessment, patient: @patient)])
-    @redis_queue.push @assessment_generator.generic_assessment(symptomatic: false)
-    # The mocking framework will just return when a 'next' is called
-    assert_nil ConsumeAssessmentsJob.perform_now
+    latest_assessment = @patient.latest_assessment_at
+    ConsumeAssessmentsJob.perform_async(@assessment_generator.generic_assessment(symptomatic: false))
+    @patient.reload
+    assert_equal latest_assessment, @patient.latest_assessment_at
+  end
+
+  test 'consume assessment patient not found by submission token' do
+    assessment = @assessment_generator.invalid_submission_token
+    parsed_assessment = JSON.parse(assessment)
+    message = "ConsumeAssessmentsJob: No patient found with submission_token: #{parsed_assessment['patient_submission_token']}"
+    # There are no other side effects to test except examining the logger.
+    expect_any_instance_of(ActiveSupport::Logger).to(receive(:info).with(message))
+    ConsumeAssessmentsJob.perform_async(assessment)
   end
 
   test 'consume assessment no threshold condition' do
-    @redis_queue.push @assessment_generator.missing_threshold_condition
-    assert_nil ConsumeAssessmentsJob.perform_now
+    assessment = @assessment_generator.missing_threshold_condition
+    parsed_assessment = JSON.parse(assessment)
+    message = 'ConsumeAssessmentsJob: No ThresholdCondition found' \
+    " (patient: #{@assessment_generator.patient.id}, threshold_condition_hash: #{parsed_assessment['threshold_condition_hash']})"
+    # There are no other side effects to test except examining the logger.
+    expect_any_instance_of(ActiveSupport::Logger).to(receive(:info).with(message))
+    ConsumeAssessmentsJob.perform_async(assessment)
   end
 
   test 'consume assessment with reported symptoms' do
     assert_difference '@patient.assessments.count', 1 do
-      @redis_queue.push @assessment_generator.reported_symptom_assessment
-      ConsumeAssessmentsJob.perform_now
+      ConsumeAssessmentsJob.perform_async(@assessment_generator.reported_symptom_assessment)
     end
   end
 
   test 'consume assessment with experiencing symptoms' do
     assert_difference '@patient.assessments.count', 1 do
       # Force experiencing_symptoms to true
-      @redis_queue.push @assessment_generator.reported_symptom_assessment(symptomatic: true)
-      ConsumeAssessmentsJob.perform_now
+      ConsumeAssessmentsJob.perform_async(@assessment_generator.reported_symptom_assessment(symptomatic: true))
       @patient.reload
       assert @patient.assessments.first.symptomatic
     end
@@ -79,8 +91,7 @@ class ConsumeAssessmentsJobTest < ActiveJob::TestCase
 
   test 'consume generic assessment symptomatic' do
     assert_difference '@patient.assessments.count', 1 do
-      @redis_queue.push @assessment_generator.generic_assessment(symptomatic: true)
-      ConsumeAssessmentsJob.perform_now
+      ConsumeAssessmentsJob.perform_async(@assessment_generator.generic_assessment(symptomatic: true))
       @patient.reload
       assert @patient.assessments.first.symptomatic
       assert_equal 'Monitoree', @patient.assessments.first.who_reported
@@ -90,8 +101,7 @@ class ConsumeAssessmentsJobTest < ActiveJob::TestCase
     @patient.update(assessments: [])
 
     assert_difference '@patient.assessments.count', 1 do
-      @redis_queue.push @assessment_generator.generic_assessment(symptomatic: false)
-      ConsumeAssessmentsJob.perform_now
+      ConsumeAssessmentsJob.perform_async(@assessment_generator.generic_assessment(symptomatic: false))
       @patient.reload
       assert_not @patient.assessments.first.symptomatic
       assert_equal 'Monitoree', @patient.assessments.first.who_reported
@@ -102,8 +112,7 @@ class ConsumeAssessmentsJobTest < ActiveJob::TestCase
     dependent = create(:patient)
     dependent.update(responder_id: @patient.id, submission_token: SecureRandom.hex(20))
     assert_difference 'dependent.assessments.count', 1 do
-      @redis_queue.push @assessment_generator.generic_assessment(symptomatic: true)
-      ConsumeAssessmentsJob.perform_now
+      ConsumeAssessmentsJob.perform_async(@assessment_generator.generic_assessment(symptomatic: true))
       dependent.reload
       assert dependent.assessments.first.symptomatic
       assert_equal 'Proxy', dependent.assessments.first.who_reported
@@ -114,8 +123,7 @@ class ConsumeAssessmentsJobTest < ActiveJob::TestCase
     @patient.update(preferred_contact_method: 'SMS Texted Weblink')
     assert_difference '@patient.assessments.count', 0 do
       assert_difference '@patient.histories.count', 1 do
-        @redis_queue.push @assessment_generator.error_sms_assessment
-        ConsumeAssessmentsJob.perform_now
+        ConsumeAssessmentsJob.perform_async(@assessment_generator.error_sms_assessment)
         @patient.reload
       end
     end
@@ -127,8 +135,7 @@ class ConsumeAssessmentsJobTest < ActiveJob::TestCase
     assert_difference '@patient.assessments.count', 0 do
       assert_difference '@patient.histories.count', 1 do
         assert_changes '@patient.last_assessment_reminder_sent' do
-          @redis_queue.push @assessment_generator.error_sms_assessment(error_code: error_code)
-          ConsumeAssessmentsJob.perform_now
+          ConsumeAssessmentsJob.perform_async(@assessment_generator.error_sms_assessment(error_code: error_code))
           @patient.reload
         end
       end
@@ -139,8 +146,7 @@ class ConsumeAssessmentsJobTest < ActiveJob::TestCase
     @patient.update(preferred_contact_method: 'Telephone Call')
     assert_difference '@patient.assessments.count', 0 do
       assert_difference '@patient.histories.count', 1 do
-        @redis_queue.push @assessment_generator.error_voice_assessment
-        ConsumeAssessmentsJob.perform_now
+        ConsumeAssessmentsJob.perform_async(@assessment_generator.error_voice_assessment)
         @patient.reload
       end
     end
@@ -155,9 +161,8 @@ class ConsumeAssessmentsJobTest < ActiveJob::TestCase
         assert_difference 'dependent.histories.count', 1 do
           # Assert that patient (HoH) gets a history item for themseleves and their dependent
           assert_difference '@patient.histories.count', 2 do
-            @redis_queue.push @assessment_generator.error_sms_assessment
-            @redis_queue.push @assessment_generator.error_sms_assessment(patient: dependent)
-            ConsumeAssessmentsJob.perform_now
+            ConsumeAssessmentsJob.perform_async(@assessment_generator.error_sms_assessment)
+            ConsumeAssessmentsJob.perform_async(@assessment_generator.error_sms_assessment(patient: dependent))
             @patient.reload
             dependent.reload
           end
@@ -174,8 +179,7 @@ class ConsumeAssessmentsJobTest < ActiveJob::TestCase
       assert_difference 'dependent.assessments.count', 0 do
         assert_difference 'dependent.histories.count', 1 do
           assert_difference '@patient.histories.count', 1 do
-            @redis_queue.push @assessment_generator.error_voice_assessment
-            ConsumeAssessmentsJob.perform_now
+            ConsumeAssessmentsJob.perform_async(@assessment_generator.error_voice_assessment)
             @patient.reload
             dependent.reload
           end

--- a/test/rake/reports_helper_test.rb
+++ b/test/rake/reports_helper_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'test_case'
+load 'lib/reports_helper.rb'
+
+class ReportsHelperTest < ActiveSupport::TestCase
+  include ReportsHelper
+
+  test 'process' do
+    class ::Object::Array
+      def commit
+        true
+      end
+    end
+
+    queue = [{status: true}.to_json] # "queue"
+    @sleep_seconds = 1 # to ensure it gets reset
+    # Assert raises because on the second iteration of the loop the queue will pop nil
+    assert_raises(TypeError) do
+      error_message = 'ConsumeAssessmentsJob: No valid fields found in message. Skipping.'
+      expect_any_instance_of(ActiveSupport::Logger).to(receive(:info).with(error_message))
+      process(queue, 0)
+      assert_equal(0, @sleep_seconds)
+      assert_nil(@msg)
+    end
+  end
+
+  test 'expotential backoff' do
+    15.times do |i|
+      # Max 30 seconds
+      assert_operator(exponential_backoff(i), :<=, 30)
+    end
+    # base case
+    assert_operator(exponential_backoff(0), :<, 2)
+    # base +1 case
+    assert_operator(exponential_backoff(1), :<, 3)
+  end
+
+  test 'handle complete failure without patient submission token' do
+    # No token
+    @msg = {}.to_json
+    error_message = 'reports:queue_reports process 0: JSON parsed correctly but no submission_token was found. Original error: error'
+    expect_any_instance_of(ActiveSupport::Logger).to(receive(:error).with(error_message))
+    handle_complete_failure('error', 0)
+    assert_nil(@msg)
+  end
+
+  test 'handle complete failure msg is invalid' do
+    @msg = '{true}' # invalid JSON
+    error_message = "reports:queue_reports process 0: Unable to process a report because of error. No submission token could be parsed; the report failed parsing. The report has been skipped."
+    expect_any_instance_of(ActiveSupport::Logger).to(receive(:error).with(error_message))
+    handle_complete_failure('error', 0)
+    assert_nil(@msg)
+  end
+
+  test 'handle complete failure msg is valid' do
+    @msg = {patient_submission_token: 'submission_token'}.to_json
+    error_message = 'reports:queue_reports process 0: Unable to process a report for {"patient_submission_token"=>"submission_token"} because of error. The report has been skipped.'
+    expect_any_instance_of(ActiveSupport::Logger).to(receive(:error).with(error_message))
+    handle_complete_failure('error', 0)
+    assert_nil(@msg)
+  end
+end

--- a/test/sidekiq/sidekiq_test.rb
+++ b/test/sidekiq/sidekiq_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'test_case'
+
+class SidekiqTest < ActiveSupport::TestCase
+  test 'sidekiq returns a length 24 hex string' do
+    assert ConsumeAssessmentsJob.perform_async("{'key': true}").match?(/[a-f0-9]{24}/)
+  end
+end

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -12,6 +12,7 @@ class ActiveSupport::TestCase
 
   def setup
     Sidekiq::Worker.clear_all
+    super
   end
 
   def assert_histories_contain(patient, history_comment_substring)

--- a/test/test_helpers/consume_assessments_job_test_helper.rb
+++ b/test/test_helpers/consume_assessments_job_test_helper.rb
@@ -15,11 +15,13 @@ module ConsumeAssessmentsJobTestHelper
     end
 
     def invalid_submission_token
-      { response_status: nil,
+      {
+        response_status: nil,
         threshold_condition_hash: @patient.jurisdiction.hierarchical_symptomatic_condition.threshold_condition_hash,
         reported_symptoms_array: nil,
         experiencing_symptoms: false,
-        patient_submission_token: 'invalid token' }.to_json
+        patient_submission_token: 'invalid token'
+      }.to_json
     end
 
     def reported_symptom_assessment(symptomatic: nil)

--- a/test/test_helpers/consume_assessments_job_test_helper.rb
+++ b/test/test_helpers/consume_assessments_job_test_helper.rb
@@ -2,6 +2,8 @@
 
 module ConsumeAssessmentsJobTestHelper
   class AssessmentGenerator
+    attr_reader :patient
+
     @@response_statuses = %w[no_answer_voice no_answer_sms error_voice error_sms]
 
     def initialize(patient)
@@ -10,6 +12,14 @@ module ConsumeAssessmentsJobTestHelper
 
     def self.response_statuses
       @@response_statuses
+    end
+
+    def invalid_submission_token
+      { response_status: nil,
+        threshold_condition_hash: @patient.jurisdiction.hierarchical_symptomatic_condition.threshold_condition_hash,
+        reported_symptoms_array: nil,
+        experiencing_symptoms: false,
+        patient_submission_token: 'invalid token' }.to_json
     end
 
     def reported_symptom_assessment(symptomatic: nil)
@@ -66,7 +76,7 @@ module ConsumeAssessmentsJobTestHelper
     def missing_threshold_condition
       {
         response_status: nil,
-        threshold_condition_hash: nil,
+        threshold_condition_hash: 'invalid thresholdcondition hash',
         reported_symptoms_array: nil,
         experiencing_symptoms: false,
         patient_submission_token: @patient.submission_token


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1175](https://tracker.codev.mitre.org/browse/SARAALERT-1175)

Maybe also [SARAALERT-1377](https://tracker.codev.mitre.org/browse/SARAALERT-1377)

Currently ConsumeAssessmentsJob launches into an infinite loop. This means we cannot see any timings/performance on any of the methods inside this loop - we will only get notified of a final exception because at that point the thread will actually exit.

The main benefit of this reorganization is visibility into the log
and 'errors' during a ConsumeAssessmentJob. Secondary benefit is a
scaling architecture which is homogeneous with the rest of of
background jobs.

## Important Changes

`reports.rake`
* Refactor reports.rake to launch a queue only job ("queue job").
  - Improve error handling within queue job to include publish backoff
  - Improved error messaging and logging within queue job
  - Update threading logic to fix issue where throughput would decline
    when a thread would crash

`docker-compose.yml`
* Update docker-compose.yml with queue job and related changes

`Nginx.Dockerfile`
* Change nginx container from `latest` to `alpine` to eliminate
  vulnerabilities with Debian 10.

`README.md`
* Update README.md with new diagram and updated names/descriptions.

`consume_assessments_job.rb`
* Log information messages within ConsumeAssementsJob to Sentry.

`produce_assessments_job.rb`
* Symbolize assessment keys to assist in debugging
  ConsumeAssessmentsJob, ProduceAssessmentsJob, and reports.rake.


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@holmesie  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@mayerm94  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@timwongj  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
