### PR TITLE
SARAALERT-448: Global Dashboard

### DIFF
--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -9,7 +9,7 @@ class ExportController < ApplicationController
 
   def csv_linelist
     # Verify params
-    redirect_to(root_url) && return unless %w[exposure isolation].include?(params[:workflow])
+    redirect_to(root_url) && return unless %w[global exposure isolation].include?(params[:workflow])
 
     export_type = "csv_linelist_#{params[:workflow]}".to_sym
     return if exported_recently?(export_type)
@@ -23,7 +23,7 @@ class ExportController < ApplicationController
       user_id: current_user.id,
       export_type: export_type,
       format: 'csv',
-      filename: "Sara-Alert-Linelist-#{params[:workflow] == 'isolation' ? 'Isolation' : 'Exposure'}",
+      filename: "Sara-Alert-Linelist-#{params[:workflow].capitalize}",
       filename_data_type: false,
       data: {
         patients: {
@@ -43,7 +43,7 @@ class ExportController < ApplicationController
 
   def sara_alert_format
     # Verify params
-    redirect_to(root_url) && return unless %w[exposure isolation].include?(params[:workflow])
+    redirect_to(root_url) && return unless %w[global exposure isolation].include?(params[:workflow])
 
     export_type = "sara_alert_format_#{params[:workflow]}".to_sym
     return if exported_recently?(export_type)
@@ -57,7 +57,7 @@ class ExportController < ApplicationController
       user_id: current_user.id,
       export_type: export_type,
       format: 'xlsx',
-      filename: "Sara-Alert-Format-##{params[:workflow] == 'isolation' ? 'Isolation' : 'Exposure'}",
+      filename: "Sara-Alert-Format-##{params[:workflow].capitalize}",
       filename_data_type: false,
       data: {
         patients: {

--- a/app/helpers/patient_helper.rb
+++ b/app/helpers/patient_helper.rb
@@ -43,6 +43,10 @@ module PatientHelper
     patient.assessments.where(symptomatic: true).minimum(:created_at)&.to_date
   end
 
+  def dashboard_crumb_title(dashboard)
+    dashboard.nil? ? 'Return To Dashboard' : "Return to #{dashboard.titleize} Dashboard"
+  end
+
   def self.monitoring_fields
     %i[
       monitoring

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -35,17 +35,18 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
                                      filter: [:value, :numberOption, :dateOption, :relativeOption, :additionalFilterOption, { filterOption: {}, value: {} }])
 
     # Validate workflow
-    workflow = query[:workflow]&.to_sym || :all
-    raise InvalidQueryError.new(:workflow, workflow) unless %i[exposure isolation all].include?(workflow)
+    workflow = query[:workflow]&.to_sym || :global
+    raise InvalidQueryError.new(:workflow, workflow) unless %i[global exposure isolation].include?(workflow)
 
     # Validate tab (linelist)
     tab = query[:tab]&.to_sym || :all
-    if workflow == :exposure
+    case workflow
+    when :global
+      raise InvalidQueryError.new(:tab, tab) unless %i[all active priority_review non_reporting closed transferred_in transferred_out].include?(tab)
+    when :exposure
       raise InvalidQueryError.new(:tab, tab) unless %i[all symptomatic non_reporting asymptomatic pui closed transferred_in transferred_out].include?(tab)
-    elsif workflow == :isolation
+    when :isolation
       raise InvalidQueryError.new(:tab, tab) unless %i[all requiring_review non_reporting reporting closed transferred_in transferred_out].include?(tab)
-    else
-      raise InvalidQueryError.new(:tab, tab) unless %i[all closed transferred_in transferred_out].include?(tab)
     end
 
     # Validate jurisdiction
@@ -149,6 +150,9 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
 
       current_user.patients&.where(isolation: true, purged: false)
     else
+      return current_user.patients&.monitoring_active(true) if tab == :active
+      return current_user.patients&.exposure_symptomatic&.merge(current_user.patients&.isolation_requiring_review) if tab == :priority_review
+      return current_user.patients&.exposure_non_reporting&.merge(current_user.patients&.isolation_non_reporting) if tab == :non_reporting
       return current_user.patients&.monitoring_closed_without_purged if tab == :closed
       return jurisdiction.transferred_in_patients if tab == :transferred_in
       return jurisdiction.transferred_out_patients if tab == :transferred_out
@@ -679,6 +683,8 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
       details[:status] = patient.status.to_s.gsub('_', ' ').sub('exposure ', '')&.sub('isolation ', '') if fields.include?(:status)
       details[:report_eligibility] = patient.report_eligibility if fields.include?(:report_eligibility)
       details[:is_hoh] = patient.head_of_household?
+      details[:workflow] = patient[:isolation] ? 'Isolation' : 'Exposure' if fields.include?(:workflow)
+      details[:reporter] = patient[:responder_id] if fields.include?(:reporter)
 
       linelist << details
     end
@@ -687,30 +693,45 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
   end
 
   def linelist_specific_fields(workflow, tab)
-    return %i[flagged_for_follow_up jurisdiction assigned_user expected_purge_date reason_for_closure closed_at] if tab == :closed
-
-    if workflow == :isolation
-      if tab == :all
-        return %i[flagged_for_follow_up jurisdiction assigned_user extended_isolation first_positive_lab_at symptom_onset monitoring_plan
-                  latest_report status report_eligibility]
+    case workflow
+    when :global
+      case tab
+      when :closed
+        %i[flagged_for_follow_up jurisdiction assigned_user expected_purge_date reason_for_closure closed_at workflow]
+      else
+        %i[flagged_for_follow_up jurisdiction assigned_user end_of_monitoring monitoring_plan reporter latest_report workflow status report_eligibility]
       end
-      return %i[flagged_for_follow_up transferred_from monitoring_plan transferred_at] if tab == :transferred_in
-      return %i[transferred_to monitoring_plan transferred_at] if tab == :transferred_out
-
-      return %i[flagged_for_follow_up jurisdiction assigned_user extended_isolation first_positive_lab_at symptom_onset monitoring_plan
-                latest_report report_eligibility]
+    when :exposure
+      case tab
+      when :all
+        %i[flagged_for_follow_up jurisdiction assigned_user end_of_monitoring risk_level monitoring_plan latest_report status report_eligibility]
+      when :pui
+        %i[flagged_for_follow_up jurisdiction assigned_user end_of_monitoring risk_level public_health_action latest_report report_eligibility]
+      when :transferred_in
+        %i[flagged_for_follow_up transferred_from end_of_monitoring risk_level monitoring_plan transferred_at]
+      when :transferred_out
+        %i[transferred_to end_of_monitoring risk_level monitoring_plan transferred_at]
+      when :closed
+        %i[flagged_for_follow_up jurisdiction assigned_user expected_purge_date reason_for_closure closed_at]
+      else
+        %i[flagged_for_follow_up jurisdiction assigned_user end_of_monitoring risk_level monitoring_plan latest_report report_eligibility]
+      end
+    when :isolation
+      case tab
+      when :all
+        %i[flagged_for_follow_up jurisdiction assigned_user extended_isolation first_positive_lab_at symptom_onset monitoring_plan latest_report status
+           report_eligibility]
+      when :transferred_in
+        %i[flagged_for_follow_up transferred_from monitoring_plan transferred_at]
+      when :transferred_out
+        %i[transferred_to monitoring_plan transferred_at]
+      when :closed
+        %i[flagged_for_follow_up jurisdiction assigned_user expected_purge_date reason_for_closure closed_at]
+      else
+        %i[flagged_for_follow_up jurisdiction assigned_user extended_isolation first_positive_lab_at symptom_onset monitoring_plan latest_report
+           report_eligibility]
+      end
     end
-
-    case tab
-    when :all
-      return %i[flagged_for_follow_up jurisdiction assigned_user end_of_monitoring risk_level monitoring_plan latest_report status report_eligibility]
-    when :pui
-      return %i[flagged_for_follow_up jurisdiction assigned_user end_of_monitoring risk_level public_health_action latest_report report_eligibility]
-    end
-    return %i[flagged_for_follow_up transferred_from end_of_monitoring risk_level monitoring_plan transferred_at] if tab == :transferred_in
-    return %i[transferred_to end_of_monitoring risk_level monitoring_plan transferred_at] if tab == :transferred_out
-
-    %i[flagged_for_follow_up jurisdiction assigned_user end_of_monitoring risk_level monitoring_plan latest_report report_eligibility]
   end
 end
 

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -151,8 +151,8 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
       current_user.patients&.where(isolation: true, purged: false)
     else
       return current_user.patients&.monitoring_active(true) if tab == :active
-      return current_user.patients&.exposure_symptomatic&.merge(current_user.patients&.isolation_requiring_review) if tab == :priority_review
-      return current_user.patients&.exposure_non_reporting&.merge(current_user.patients&.isolation_non_reporting) if tab == :non_reporting
+      return current_user.patients&.global_priority_review if tab == :priority_review
+      return current_user.patients&.global_non_reporting if tab == :non_reporting
       return current_user.patients&.monitoring_closed_without_purged if tab == :closed
       return jurisdiction.transferred_in_patients if tab == :transferred_in
       return jurisdiction.transferred_out_patients if tab == :transferred_out

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -150,7 +150,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
 
       current_user.patients&.where(isolation: true, purged: false)
     else
-      return current_user.patients&.monitoring_active(true) if tab == :active
+      return current_user.patients&.monitoring_open if tab == :active
       return current_user.patients&.global_priority_review if tab == :priority_review
       return current_user.patients&.global_non_reporting if tab == :non_reporting
       return current_user.patients&.monitoring_closed_without_purged if tab == :closed

--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -17,6 +17,7 @@ import Exposure from './steps/Exposure';
 import Review from './steps/Review';
 import confirmDialog from '../util/ConfirmDialog';
 import reportError from '../util/ReportError';
+import { navQueryParam } from '../../utils/Navigation';
 
 const PNF = libphonenumber.PhoneNumberFormat;
 const phoneUtil = libphonenumber.PhoneNumberUtil.getInstance();
@@ -69,7 +70,9 @@ class Enrollment extends React.Component {
           toast.success(message, {
             onClose: () =>
               (location.href =
-                window.BASE_PATH + (groupMember ? '/patients/' + response['data']['responder_id'] + '/group' : '/patients/' + response['data']['id'])),
+                window.BASE_PATH +
+                (groupMember ? '/patients/' + response['data']['responder_id'] + '/group' : '/patients/' + response['data']['id']) +
+                navQueryParam(this.props.workflow, true)),
           });
         })
         .catch(err => {
@@ -161,7 +164,9 @@ class Enrollment extends React.Component {
           toast.success(message, {
             onClose: () =>
               (location.href =
-                window.BASE_PATH + (groupMember ? '/patients/' + response['data']['responder_id'] + '/group' : '/patients/' + response['data']['id'])),
+                window.BASE_PATH +
+                (groupMember ? '/patients/' + response['data']['responder_id'] + '/group' : '/patients/' + response['data']['id']) +
+                navQueryParam(this.props.workflow, true)),
           });
         }
       })
@@ -276,6 +281,7 @@ class Enrollment extends React.Component {
               canAddGroup={this.props.can_add_group}
               jurisdiction_paths={this.props.jurisdiction_paths}
               authenticity_token={this.props.authenticity_token}
+              workflow={this.props.workflow}
             />
           </Carousel.Item>
         </Carousel>
@@ -302,6 +308,7 @@ Enrollment.propTypes = {
   blocked_sms: PropTypes.bool,
   first_positive_lab: PropTypes.object,
   symptomatic_assessments_exist: PropTypes.bool,
+  workflow: PropTypes.string,
 };
 
 export default Enrollment;

--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -70,8 +70,8 @@ class Enrollment extends React.Component {
           toast.success(message, {
             onClose: () =>
               (location.href =
-                window.BASE_PATH +
-                (groupMember ? '/patients/' + response['data']['responder_id'] + '/group' : '/patients/' + response['data']['id']) +
+                `${window.BASE_PATH}/patients/` +
+                (groupMember ? `${response['data']['responder_id']}/group` : response['data']['id']) +
                 navQueryParam(this.props.workflow, true)),
           });
         })
@@ -164,8 +164,8 @@ class Enrollment extends React.Component {
           toast.success(message, {
             onClose: () =>
               (location.href =
-                window.BASE_PATH +
-                (groupMember ? '/patients/' + response['data']['responder_id'] + '/group' : '/patients/' + response['data']['id']) +
+                `${window.BASE_PATH}/patients/` +
+                (groupMember ? `${response['data']['responder_id']}/group` : response['data']['id']) +
                 navQueryParam(this.props.workflow, true)),
           });
         }

--- a/app/javascript/components/enrollment/steps/Review.js
+++ b/app/javascript/components/enrollment/steps/Review.js
@@ -70,6 +70,7 @@ class Review extends React.Component {
               jurisdiction_paths={this.props.jurisdiction_paths}
               details={{ ...this.props.currentState.patient, blocked_sms: this.props.currentState.blocked_sms } || {}}
               authenticity_token={this.props.authenticity_token}
+              workflow={this.props.workflow}
             />
             <div className="pb-4"></div>
             {this.props.previous && (
@@ -120,6 +121,7 @@ Review.propTypes = {
   canAddGroup: PropTypes.bool,
   jurisdiction_paths: PropTypes.object,
   authenticity_token: PropTypes.string,
+  workflow: PropTypes.string,
 };
 
 export default Review;

--- a/app/javascript/components/layout/Breadcrumb.js
+++ b/app/javascript/components/layout/Breadcrumb.js
@@ -33,8 +33,6 @@ class Breadcrumb extends React.Component {
 Breadcrumb.propTypes = {
   crumbs: PropTypes.array,
   jurisdiction: PropTypes.string,
-  isolation: PropTypes.bool,
-  enroller: PropTypes.bool,
 };
 
 export default Breadcrumb;

--- a/app/javascript/components/layout/Breadcrumb.js
+++ b/app/javascript/components/layout/Breadcrumb.js
@@ -9,7 +9,7 @@ class Breadcrumb extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <div className="mx-2 my-4">
+        <div className="mx-2 mt-4 mb-3">
           <nav aria-label="breadcrumb">
             <ol className="breadcrumb">
               {this.props.crumbs?.map((crumb, index) => {

--- a/app/javascript/components/layout/Breadcrumb.js
+++ b/app/javascript/components/layout/Breadcrumb.js
@@ -6,43 +6,6 @@ class Breadcrumb extends React.Component {
     super(props);
   }
 
-  goBack(index) {
-    // check for if the browser is safari and bump up the index due to a safari off by one history.go bug
-    // remove once this bug is fixed in safari
-    var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-    if (isSafari) index++;
-
-    window.history.go(0 - index);
-  }
-
-  renderWorkflowName = name => {
-    if (this.props.enroller && name?.includes('Dashboard')) {
-      return 'Return To Dashboard';
-    }
-    if (this.props.isolation) {
-      return name.replace('Exposure', 'Isolation');
-    }
-    if (window?.WORKFLOW === 'exposure') {
-      return name;
-    }
-    if (window?.location?.pathname?.endsWith('/public_health')) {
-      return name;
-    }
-    if (window?.WORKFLOW === 'isolation') {
-      return name.replace('Exposure', 'Isolation');
-    }
-    if (window?.location?.href?.includes('isolation')) {
-      return name.replace('Exposure', 'Isolation');
-    }
-    if (document?.referrer?.includes('exposure')) {
-      return name;
-    }
-    if (document?.referrer?.includes('isolation')) {
-      return name.replace('Exposure', 'Isolation');
-    }
-    return name;
-  };
-
   render() {
     return (
       <React.Fragment>
@@ -50,29 +13,11 @@ class Breadcrumb extends React.Component {
           <nav aria-label="breadcrumb">
             <ol className="breadcrumb">
               {this.props.crumbs?.map((crumb, index) => {
+                var text = crumb['value'];
                 return (
                   <li key={'bc' + index} className={'breadcrumb-item lead ' + (crumb['href'] && 'active')}>
-                    {crumb['href'] && (
-                      <a
-                        href="#"
-                        onClick={() => {
-                          if (this.renderWorkflowName(crumb['value']).includes('Isolation')) {
-                            // Public Health "Return to Isolation Dashboard"
-                            location.assign(`${window.BASE_PATH}/public_health/isolation`);
-                          } else if (this.renderWorkflowName(crumb['value']).includes('Exposure')) {
-                            // Public Health "Return to Exposure Dashboard"
-                            location.assign(`${window.BASE_PATH}/public_health`);
-                          } else if (this.renderWorkflowName(crumb['value']).includes('Dashboard')) {
-                            // Enroller "Return to Dashboard"
-                            location.assign(`${window.BASE_PATH}/patients`);
-                          } else {
-                            this.goBack(this.props.crumbs.length - (index + 1));
-                          }
-                        }}>
-                        {this.renderWorkflowName(crumb['value'])}
-                      </a>
-                    )}
-                    {!crumb['href'] && crumb['value']}
+                    {crumb['href'] && <a href={`${window.BASE_PATH}${crumb['href']}`}>{text}</a>}
+                    {!crumb['href'] && text}
                   </li>
                 );
               })}

--- a/app/javascript/components/patient/Patient.js
+++ b/app/javascript/components/patient/Patient.js
@@ -11,6 +11,7 @@ import { convertLanguageCodesToNames } from '../../utils/Languages';
 import { formatName, formatPhoneNumber, formatRace } from '../../utils/Patient';
 import FollowUpFlagPanel from './follow_up_flag/FollowUpFlagPanel';
 import FollowUpFlagModal from './follow_up_flag/FollowUpFlagModal';
+import { navQueryParam } from '../../utils/Navigation';
 
 class Patient extends React.Component {
   constructor(props) {
@@ -67,7 +68,10 @@ class Patient extends React.Component {
     } else {
       return (
         <div className="edit-link">
-          <a href={`${window.BASE_PATH}/patients/${this.props.details.id}/edit?step=${enrollmentStep}`} id={sectionId} aria-label={`Edit ${section}`}>
+          <a
+            href={`${window.BASE_PATH}/patients/${this.props.details.id}/edit?step=${enrollmentStep}${navQueryParam(this.props.workflow, false)}`}
+            id={sectionId}
+            aria-label={`Edit ${section}`}>
             Edit
           </a>
         </div>
@@ -712,6 +716,7 @@ Patient.propTypes = {
   other_household_members: PropTypes.array,
   can_modify_subject_status: PropTypes.bool,
   authenticity_token: PropTypes.string,
+  workflow: PropTypes.string,
 };
 
 export default Patient;

--- a/app/javascript/components/patient/PatientPage.js
+++ b/app/javascript/components/patient/PatientPage.js
@@ -23,6 +23,7 @@ class PatientPage extends React.Component {
             other_household_members={this.props.other_household_members}
             can_modify_subject_status={this.props.can_modify_subject_status}
             authenticity_token={this.props.authenticity_token}
+            workflow={this.props.workflow}
           />
           <div className="household-info">
             {!this.props.patient.head_of_household && this.props?.other_household_members?.length > 0 && (
@@ -32,6 +33,7 @@ class PatientPage extends React.Component {
                 current_user={this.props.current_user}
                 jurisdiction_paths={this.props.jurisdiction_paths}
                 authenticity_token={this.props.authenticity_token}
+                workflow={this.props.workflow}
               />
             )}
             {this.props.patient.head_of_household && (
@@ -42,10 +44,16 @@ class PatientPage extends React.Component {
                 current_user={this.props.current_user}
                 jurisdiction_paths={this.props.jurisdiction_paths}
                 authenticity_token={this.props.authenticity_token}
+                workflow={this.props.workflow}
               />
             )}
             {!this.props.patient.head_of_household && this.props?.other_household_members?.length === 0 && (
-              <Individual patient={this.props.patient} can_add_group={this.props.can_add_group} authenticity_token={this.props.authenticity_token} />
+              <Individual
+                patient={this.props.patient}
+                can_add_group={this.props.can_add_group}
+                authenticity_token={this.props.authenticity_token}
+                workflow={this.props.workflow}
+              />
             )}
           </div>
         </Card.Body>
@@ -63,6 +71,7 @@ PatientPage.propTypes = {
   authenticity_token: PropTypes.string,
   jurisdiction_paths: PropTypes.object,
   blocked_sms: PropTypes.bool,
+  workflow: PropTypes.string,
 };
 
 export default PatientPage;

--- a/app/javascript/components/patient/assessment/AssessmentTable.js
+++ b/app/javascript/components/patient/assessment/AssessmentTable.js
@@ -368,6 +368,7 @@ class AssessmentTable extends React.Component {
               jurisdiction_paths={this.props.jurisdiction_paths}
               household_members={this.props.household_members}
               monitoring_period_days={this.props.monitoring_period_days}
+              workflow={this.props.workflow}
             />
           </Card.Body>
         </Card>
@@ -423,6 +424,7 @@ AssessmentTable.propTypes = {
   translations: PropTypes.object,
   authenticity_token: PropTypes.string,
   jurisdiction_paths: PropTypes.object,
+  workflow: PropTypes.string,
 };
 
 export default AssessmentTable;

--- a/app/javascript/components/patient/assessment/actions/LastDateExposure.js
+++ b/app/javascript/components/patient/assessment/actions/LastDateExposure.js
@@ -129,6 +129,7 @@ class LastDateExposure extends React.Component {
               jurisdiction_paths={this.props.jurisdiction_paths}
               handleApplyHouseholdChange={this.handleApplyHouseholdChange}
               handleApplyHouseholdIdsChange={this.handleApplyHouseholdIdsChange}
+              workflow={this.props.workflow}
             />
           )}
           {!!this.props.patient.continuous_exposure && !this.state.continuous_exposure && (
@@ -281,6 +282,7 @@ LastDateExposure.propTypes = {
   patient: PropTypes.object,
   current_user: PropTypes.object,
   jurisdiction_paths: PropTypes.object,
+  workflow: PropTypes.string,
 };
 
 export default LastDateExposure;

--- a/app/javascript/components/patient/household/Dependent.js
+++ b/app/javascript/components/patient/household/Dependent.js
@@ -17,6 +17,7 @@ class Dependent extends React.Component {
             current_user={this.props.current_user}
             jurisdiction_paths={this.props.jurisdiction_paths}
             isSelectable={false}
+            workflow={this.props.workflow}
           />
         </Row>
         <Row>
@@ -33,6 +34,7 @@ Dependent.propTypes = {
   current_user: PropTypes.object,
   jurisdiction_paths: PropTypes.object,
   authenticity_token: PropTypes.string,
+  workflow: PropTypes.string,
 };
 
 export default Dependent;

--- a/app/javascript/components/patient/household/HeadOfHousehold.js
+++ b/app/javascript/components/patient/household/HeadOfHousehold.js
@@ -16,11 +16,12 @@ class HeadOfHousehold extends React.Component {
             current_user={this.props.current_user}
             jurisdiction_paths={this.props.jurisdiction_paths}
             isSelectable={false}
+            workflow={this.props.workflow}
           />
         </Row>
         <Row>
           <ChangeHoH patient={this.props.patient} dependents={this.props.other_household_members} authenticity_token={this.props.authenticity_token} />
-          {this.props.can_add_group && <EnrollHouseholdMember responderId={this.props.patient.id} isHoh={true} />}
+          {this.props.can_add_group && <EnrollHouseholdMember responderId={this.props.patient.id} isHoh={true} workflow={this.props.workflow} />}
         </Row>
       </div>
     );
@@ -34,6 +35,7 @@ HeadOfHousehold.propTypes = {
   current_user: PropTypes.object,
   jurisdiction_paths: PropTypes.object,
   authenticity_token: PropTypes.string,
+  workflow: PropTypes.string,
 };
 
 export default HeadOfHousehold;

--- a/app/javascript/components/patient/household/Individual.js
+++ b/app/javascript/components/patient/household/Individual.js
@@ -10,7 +10,7 @@ class Individual extends React.Component {
       <div id="no-household">
         <Row>This monitoree is not a member of a household.</Row>
         <Row>
-          <MoveToHousehold patient={this.props.patient} authenticity_token={this.props.authenticity_token} />
+          <MoveToHousehold patient={this.props.patient} authenticity_token={this.props.authenticity_token} workflow={this.props.workflow} />
           {this.props.can_add_group && <EnrollHouseholdMember responderId={this.props.patient.id} isHoh={false} workflow={this.props.workflow} />}
         </Row>
       </div>

--- a/app/javascript/components/patient/household/Individual.js
+++ b/app/javascript/components/patient/household/Individual.js
@@ -11,7 +11,7 @@ class Individual extends React.Component {
         <Row>This monitoree is not a member of a household.</Row>
         <Row>
           <MoveToHousehold patient={this.props.patient} authenticity_token={this.props.authenticity_token} />
-          {this.props.can_add_group && <EnrollHouseholdMember responderId={this.props.patient.id} isHoh={false} />}
+          {this.props.can_add_group && <EnrollHouseholdMember responderId={this.props.patient.id} isHoh={false} workflow={this.props.workflow} />}
         </Row>
       </div>
     );
@@ -22,6 +22,7 @@ Individual.propTypes = {
   can_add_group: PropTypes.bool,
   patient: PropTypes.object,
   authenticity_token: PropTypes.string,
+  workflow: PropTypes.string,
 };
 
 export default Individual;

--- a/app/javascript/components/patient/household/actions/ApplyToHousehold.js
+++ b/app/javascript/components/patient/household/actions/ApplyToHousehold.js
@@ -52,6 +52,7 @@ class ApplyToHousehold extends React.Component {
             isSelectable={true}
             handleApplyHouseholdChange={this.props.handleApplyHouseholdChange}
             handleApplyHouseholdIdsChange={this.props.handleApplyHouseholdIdsChange}
+            workflow={this.props.workflow}
           />
         )}
       </React.Fragment>
@@ -65,6 +66,7 @@ ApplyToHousehold.propTypes = {
   jurisdiction_paths: PropTypes.object,
   handleApplyHouseholdChange: PropTypes.func,
   handleApplyHouseholdIdsChange: PropTypes.func,
+  workflow: PropTypes.string,
 };
 
 export default ApplyToHousehold;

--- a/app/javascript/components/patient/household/actions/EnrollHouseholdMember.js
+++ b/app/javascript/components/patient/household/actions/EnrollHouseholdMember.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Button, Modal } from 'react-bootstrap';
+import { navQueryParam } from '../../../../utils/Navigation';
 
 class EnrollHouseholdMember extends React.Component {
   constructor(props) {
@@ -43,7 +44,7 @@ class EnrollHouseholdMember extends React.Component {
           </Button>
           <Button
             variant="primary btn-square"
-            href={`${window.BASE_PATH}/patients/${this.props.responderId}/group`}
+            href={`${window.BASE_PATH}/patients/${this.props.responderId}/group${navQueryParam(this.props.workflow, true)}`}
             onClick={() => {
               this.setState({ loading: true });
             }}
@@ -75,6 +76,7 @@ class EnrollHouseholdMember extends React.Component {
 EnrollHouseholdMember.propTypes = {
   responderId: PropTypes.number,
   isHoh: PropTypes.bool,
+  workflow: PropTypes.string,
 };
 
 export default EnrollHouseholdMember;

--- a/app/javascript/components/patient/household/actions/MoveToHousehold.js
+++ b/app/javascript/components/patient/household/actions/MoveToHousehold.js
@@ -29,7 +29,7 @@ class MoveToHousehold extends React.Component {
         page: 0,
         search: '',
         entries: 5,
-        workflow: 'all',
+        workflow: 'global',
         tab: 'all',
         scope: 'all',
         tz_offset: new Date().getTimezoneOffset(),

--- a/app/javascript/components/patient/household/actions/MoveToHousehold.js
+++ b/app/javascript/components/patient/household/actions/MoveToHousehold.js
@@ -9,6 +9,7 @@ import { formatNameAlt } from '../../../../utils/Patient';
 import BadgeHoH from '../utils/BadgeHoH';
 import CustomTable from '../../../layout/CustomTable';
 import reportError from '../../../util/ReportError';
+import { patientHref } from '../../../../utils/Navigation';
 
 class MoveToHousehold extends React.Component {
   constructor(props) {
@@ -66,11 +67,11 @@ class MoveToHousehold extends React.Component {
       return (
         <div>
           <BadgeHoH patientId={rowData.id.toString()} customClass={'float-right ml-1'} location={'right'} />
-          <a href={`${window.BASE_PATH}/patients/${rowData.id}`}>{name}</a>
+          <a href={patientHref(rowData.id, this.props.workflow)}>{name}</a>
         </div>
       );
     }
-    return <a href={`${window.BASE_PATH}/patients/${rowData.id}`}>{name}</a>;
+    return <a href={patientHref(rowData.id, this.props.workflow)}>{name}</a>;
   };
 
   /**
@@ -353,6 +354,7 @@ class MoveToHousehold extends React.Component {
 MoveToHousehold.propTypes = {
   patient: PropTypes.object,
   authenticity_token: PropTypes.string,
+  workflow: PropTypes.string,
 };
 
 export default MoveToHousehold;

--- a/app/javascript/components/patient/household/utils/HouseholdMemberTable.js
+++ b/app/javascript/components/patient/household/utils/HouseholdMemberTable.js
@@ -7,7 +7,7 @@ import { formatNameAlt } from '../../../../utils/Patient';
 
 import BadgeHoH from '../utils/BadgeHoH';
 import CustomTable from '../../../layout/CustomTable';
-import { navQueryParam } from '../../../../utils/Navigation';
+import { patientHref } from '../../../../utils/Navigation';
 
 class HouseholdMemberTable extends React.Component {
   constructor(props) {
@@ -263,7 +263,7 @@ class HouseholdMemberTable extends React.Component {
         {rowData.head_of_household && <BadgeHoH patientId={rowData.id.toString()} customClass={'float-right ml-1'} location={'right'} />}
         <a
           id={rowData.head_of_household ? 'dependent-hoh-link' : null}
-          href={`${window.BASE_PATH}/patients/${rowData.id}${navQueryParam(this.props.workflow, true)}`}
+          href={patientHref(rowData.id, this.props.workflow)}
           target={this.props.isSelectable ? '_blank' : '_self'}
           rel="noreferrer">
           {monitoreeName}

--- a/app/javascript/components/patient/household/utils/HouseholdMemberTable.js
+++ b/app/javascript/components/patient/household/utils/HouseholdMemberTable.js
@@ -7,6 +7,7 @@ import { formatNameAlt } from '../../../../utils/Patient';
 
 import BadgeHoH from '../utils/BadgeHoH';
 import CustomTable from '../../../layout/CustomTable';
+import { navQueryParam } from '../../../../utils/Navigation';
 
 class HouseholdMemberTable extends React.Component {
   constructor(props) {
@@ -262,7 +263,7 @@ class HouseholdMemberTable extends React.Component {
         {rowData.head_of_household && <BadgeHoH patientId={rowData.id.toString()} customClass={'float-right ml-1'} location={'right'} />}
         <a
           id={rowData.head_of_household ? 'dependent-hoh-link' : null}
-          href={`${window.BASE_PATH}/patients/${rowData.id}`}
+          href={`${window.BASE_PATH}/patients/${rowData.id}${navQueryParam(this.props.workflow, true)}`}
           target={this.props.isSelectable ? '_blank' : '_self'}
           rel="noreferrer">
           {monitoreeName}
@@ -308,6 +309,7 @@ HouseholdMemberTable.propTypes = {
   isSelectable: PropTypes.bool,
   handleApplyHouseholdChange: PropTypes.func,
   handleApplyHouseholdIdsChange: PropTypes.func,
+  workflow: PropTypes.string,
 };
 
 export default HouseholdMemberTable;

--- a/app/javascript/components/patient/monitoring_actions/AssignedUser.js
+++ b/app/javascript/components/patient/monitoring_actions/AssignedUser.js
@@ -107,6 +107,7 @@ class AssignedUser extends React.Component {
               jurisdiction_paths={this.props.jurisdiction_paths}
               handleApplyHouseholdChange={this.handleApplyHouseholdChange}
               handleApplyHouseholdIdsChange={this.handleApplyHouseholdIdsChange}
+              workflow={this.props.workflow}
             />
           )}
           <Form.Group>
@@ -187,6 +188,7 @@ AssignedUser.propTypes = {
   assigned_users: PropTypes.array,
   current_user: PropTypes.object,
   jurisdiction_paths: PropTypes.object,
+  workflow: PropTypes.string,
 };
 
 export default AssignedUser;

--- a/app/javascript/components/patient/monitoring_actions/CaseStatus.js
+++ b/app/javascript/components/patient/monitoring_actions/CaseStatus.js
@@ -245,6 +245,7 @@ class CaseStatus extends React.Component {
               jurisdiction_paths={this.props.jurisdiction_paths}
               handleApplyHouseholdChange={this.handleApplyHouseholdChange}
               handleApplyHouseholdIdsChange={this.handleApplyHouseholdIdsChange}
+              workflow={this.props.workflow}
             />
           )}
         </Modal.Body>
@@ -308,6 +309,7 @@ CaseStatus.propTypes = {
   current_user: PropTypes.object,
   jurisdiction_paths: PropTypes.object,
   monitoring_reasons: PropTypes.array,
+  workflow: PropTypes.string,
 };
 
 export default CaseStatus;

--- a/app/javascript/components/patient/monitoring_actions/ExposureRiskAssessment.js
+++ b/app/javascript/components/patient/monitoring_actions/ExposureRiskAssessment.js
@@ -98,6 +98,7 @@ class ExposureRiskAssessment extends React.Component {
               handleApplyHouseholdIdsChange={this.handleApplyHouseholdIdsChange}
               current_user={this.props.current_user}
               jurisdiction_paths={this.props.jurisdiction_paths}
+              workflow={this.props.workflow}
             />
           )}
           <Form.Group>
@@ -162,6 +163,7 @@ ExposureRiskAssessment.propTypes = {
   household_members: PropTypes.array,
   current_user: PropTypes.object,
   jurisdiction_paths: PropTypes.object,
+  workflow: PropTypes.string,
 };
 
 export default ExposureRiskAssessment;

--- a/app/javascript/components/patient/monitoring_actions/Jurisdiction.js
+++ b/app/javascript/components/patient/monitoring_actions/Jurisdiction.js
@@ -94,7 +94,7 @@ class Jurisdiction extends React.Component {
           // check if current_user has access to the changed jurisdiction
           // if so, reload the page, if not, redirect to exposure or isolation dashboard
           if (!this.state.jurisdiction_path.startsWith(currentUserJurisdictionString)) {
-            location.assign(`${window.BASE_PATH}/public_health${this.state.isolation ? '/isolation' : ''}`);
+            location.assign(`${window.BASE_PATH}/public_health${this.state.isolation ? '/isolation' : '/exposure'}`);
           } else {
             location.reload();
           }
@@ -124,6 +124,7 @@ class Jurisdiction extends React.Component {
               jurisdiction_paths={this.props.jurisdiction_paths}
               handleApplyHouseholdChange={this.handleApplyHouseholdChange}
               handleApplyHouseholdIdsChange={this.handleApplyHouseholdIdsChange}
+              workflow={this.props.workflow}
             />
           )}
           <Form.Group>
@@ -206,6 +207,7 @@ Jurisdiction.propTypes = {
   jurisdiction_paths: PropTypes.object,
   current_user: PropTypes.object,
   user_can_transfer: PropTypes.bool,
+  workflow: PropTypes.string,
 };
 
 export default Jurisdiction;

--- a/app/javascript/components/patient/monitoring_actions/MonitoringActions.js
+++ b/app/javascript/components/patient/monitoring_actions/MonitoringActions.js
@@ -28,6 +28,7 @@ class MonitoringActions extends React.Component {
                 monitoring_reasons={this.props.monitoring_reasons}
                 current_user={this.props.current_user}
                 jurisdiction_paths={this.props.jurisdiction_paths}
+                workflow={this.props.workflow}
               />
             </Form.Group>
             <Form.Group as={Col} md="12" lg="8" className="pt-2">
@@ -37,6 +38,7 @@ class MonitoringActions extends React.Component {
                 household_members={this.props.household_members}
                 current_user={this.props.current_user}
                 jurisdiction_paths={this.props.jurisdiction_paths}
+                workflow={this.props.workflow}
               />
             </Form.Group>
             <Form.Group as={Col} md="12" lg="8" className="pt-2">
@@ -46,6 +48,7 @@ class MonitoringActions extends React.Component {
                 household_members={this.props.household_members}
                 current_user={this.props.current_user}
                 jurisdiction_paths={this.props.jurisdiction_paths}
+                workflow={this.props.workflow}
               />
             </Form.Group>
             <Form.Group as={Col} md="12" lg="8" className="pt-2">
@@ -56,6 +59,7 @@ class MonitoringActions extends React.Component {
                 monitoring_reasons={this.props.monitoring_reasons}
                 current_user={this.props.current_user}
                 jurisdiction_paths={this.props.jurisdiction_paths}
+                workflow={this.props.workflow}
               />
             </Form.Group>
             <Form.Group as={Col} md="12" lg="8" className="pt-2">
@@ -65,6 +69,7 @@ class MonitoringActions extends React.Component {
                 household_members={this.props.household_members}
                 current_user={this.props.current_user}
                 jurisdiction_paths={this.props.jurisdiction_paths}
+                workflow={this.props.workflow}
               />
             </Form.Group>
             <Form.Group as={Col} md="12" lg="8" className="pt-2">
@@ -75,6 +80,7 @@ class MonitoringActions extends React.Component {
                 assigned_users={this.props.assigned_users}
                 current_user={this.props.current_user}
                 jurisdiction_paths={this.props.jurisdiction_paths}
+                workflow={this.props.workflow}
               />
             </Form.Group>
             <Form.Group as={Col} lg="24" className="pt-2">
@@ -84,6 +90,7 @@ class MonitoringActions extends React.Component {
                 household_members={this.props.household_members}
                 jurisdiction_paths={this.props.jurisdiction_paths}
                 current_user={this.props.current_user}
+                workflow={this.props.workflow}
               />
             </Form.Group>
           </Form.Row>
@@ -102,6 +109,7 @@ MonitoringActions.propTypes = {
   assigned_users: PropTypes.array,
   household_members: PropTypes.array,
   monitoring_reasons: PropTypes.array,
+  workflow: PropTypes.string,
 };
 
 export default MonitoringActions;

--- a/app/javascript/components/patient/monitoring_actions/MonitoringPlan.js
+++ b/app/javascript/components/patient/monitoring_actions/MonitoringPlan.js
@@ -95,6 +95,7 @@ class MonitoringPlan extends React.Component {
               jurisdiction_paths={this.props.jurisdiction_paths}
               handleApplyHouseholdChange={this.handleApplyHouseholdChange}
               handleApplyHouseholdIdsChange={this.handleApplyHouseholdIdsChange}
+              workflow={this.props.workflow}
             />
           )}
           <Form.Group>
@@ -160,6 +161,7 @@ MonitoringPlan.propTypes = {
   household_members: PropTypes.array,
   current_user: PropTypes.object,
   jurisdiction_paths: PropTypes.object,
+  workflow: PropTypes.string,
 };
 
 export default MonitoringPlan;

--- a/app/javascript/components/patient/monitoring_actions/MonitoringStatus.js
+++ b/app/javascript/components/patient/monitoring_actions/MonitoringStatus.js
@@ -122,6 +122,7 @@ class MonitoringStatus extends React.Component {
               jurisdiction_paths={this.props.jurisdiction_paths}
               handleApplyHouseholdChange={this.handleApplyHouseholdChange}
               handleApplyHouseholdIdsChange={this.handleApplyHouseholdIdsChange}
+              workflow={this.props.workflow}
             />
           )}
           {!this.state.monitoring && (
@@ -246,6 +247,7 @@ MonitoringStatus.propTypes = {
   monitoring_reasons: PropTypes.array,
   current_user: PropTypes.object,
   jurisdiction_paths: PropTypes.object,
+  workflow: PropTypes.string,
 };
 
 export default MonitoringStatus;

--- a/app/javascript/components/patient/monitoring_actions/PublicHealthAction.js
+++ b/app/javascript/components/patient/monitoring_actions/PublicHealthAction.js
@@ -112,6 +112,7 @@ class PublicHealthAction extends React.Component {
                 jurisdiction_paths={this.props.jurisdiction_paths}
                 handleApplyHouseholdChange={this.handleApplyHouseholdChange}
                 handleApplyHouseholdIdsChange={this.handleApplyHouseholdIdsChange}
+                workflow={this.props.workflow}
               />
               {this.state.apply_to_household && this.props.patient.monitoring && (
                 <Form.Group>
@@ -187,6 +188,7 @@ PublicHealthAction.propTypes = {
   household_members: PropTypes.array,
   current_user: PropTypes.object,
   jurisdiction_paths: PropTypes.object,
+  workflow: PropTypes.string,
 };
 
 export default PublicHealthAction;

--- a/app/javascript/components/public_health/CustomExport.js
+++ b/app/javascript/components/public_health/CustomExport.js
@@ -28,7 +28,15 @@ class CustomExport extends React.Component {
       selected_records: props.preset?.id ? 'custom' : 'current',
       custom_patient_query: props.preset?.config?.data?.patients?.query
         ? _.clone(props.preset.config.data.patients.query)
-        : { workflow: 'all', tab: 'all', jurisdiction: props.jurisdiction.id, scope: 'all', user: null, search: '', tz_offset: new Date().getTimezoneOffset() },
+        : {
+            workflow: 'global',
+            tab: 'all',
+            jurisdiction: props.jurisdiction.id,
+            scope: 'all',
+            user: null,
+            search: '',
+            tz_offset: new Date().getTimezoneOffset(),
+          },
       filtered_monitorees_count: props.all_monitorees_count,
       show_confirm_export_modal: false,
       cancel_token: axios.CancelToken.source(),
@@ -146,7 +154,7 @@ class CustomExport extends React.Component {
         this.handlePresetChange('config.data.patients.query', this.state.custom_patient_query);
       } else if (selected_records === 'all') {
         this.handlePresetChange('config.data.patients.query', {
-          workflow: 'all',
+          workflow: 'global',
           tab: 'all',
           jurisdiction: this.props.jurisdiction.id,
           scope: 'all',
@@ -208,7 +216,12 @@ class CustomExport extends React.Component {
                   {this.state.selected_records === 'current' && (
                     <div className="px-1 pb-1">
                       <Badge variant="secondary" className="mr-1">
-                        {this.props.patient_query.workflow === 'isolation' ? 'Isolation' : 'Exposure'} - {this.props.tabs[this.props.patient_query.tab]?.label}
+                        {this.props.patient_query.workflow === 'isolation'
+                          ? 'Isolation '
+                          : this.props.patient_query.workflow === 'exposure'
+                          ? 'Exposure '
+                          : 'Global '}
+                        - {this.props.tabs[this.props.patient_query.tab]?.label}
                       </Badge>
                       {this.props.patient_query.jurisdiction !== this.props.jurisdiction.id && (
                         <Badge variant="secondary" className="mr-1">

--- a/app/javascript/components/public_health/CustomExport.js
+++ b/app/javascript/components/public_health/CustomExport.js
@@ -175,10 +175,6 @@ class CustomExport extends React.Component {
     }, cb);
   };
 
-  firstLetterToUpper = str => {
-    return str.charAt(0).toUpperCase() + str.slice(1);
-  };
-
   render() {
     const non_zero_elements_selected =
       this.state.preset?.config?.data?.patients?.checked?.length > 0 ||
@@ -220,7 +216,7 @@ class CustomExport extends React.Component {
                   {this.state.selected_records === 'current' && (
                     <div className="px-1 pb-1">
                       <Badge variant="secondary" className="mr-1">
-                        {`${this.firstLetterToUpper(this.props.patient_query.workflow)} - ${this.props.tabs[this.props.patient_query.tab]?.label}`}
+                        {`${_.capitalize(this.props.patient_query.workflow)} - ${this.props.tabs[this.props.patient_query.tab]?.label}`}
                       </Badge>
                       {this.props.patient_query.jurisdiction !== this.props.jurisdiction.id && (
                         <Badge variant="secondary" className="mr-1">

--- a/app/javascript/components/public_health/CustomExport.js
+++ b/app/javascript/components/public_health/CustomExport.js
@@ -175,6 +175,10 @@ class CustomExport extends React.Component {
     }, cb);
   };
 
+  firstLetterToUpper = str => {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  };
+
   render() {
     const non_zero_elements_selected =
       this.state.preset?.config?.data?.patients?.checked?.length > 0 ||
@@ -216,12 +220,7 @@ class CustomExport extends React.Component {
                   {this.state.selected_records === 'current' && (
                     <div className="px-1 pb-1">
                       <Badge variant="secondary" className="mr-1">
-                        {this.props.patient_query.workflow === 'isolation'
-                          ? 'Isolation '
-                          : this.props.patient_query.workflow === 'exposure'
-                          ? 'Exposure '
-                          : 'Global '}
-                        - {this.props.tabs[this.props.patient_query.tab]?.label}
+                        {`${this.firstLetterToUpper(this.props.patient_query.workflow)} - ${this.props.tabs[this.props.patient_query.tab]?.label}`}
                       </Badge>
                       {this.props.patient_query.jurisdiction !== this.props.jurisdiction.id && (
                         <Badge variant="secondary" className="mr-1">

--- a/app/javascript/components/public_health/Import.js
+++ b/app/javascript/components/public_health/Import.js
@@ -120,7 +120,7 @@ class Import extends React.Component {
       };
       if (await confirmDialog(confirmText, options)) {
         this.setState({ isPaused: false });
-        location.href = `${window.BASE_PATH}/public_health/${this.props.workflow === 'exposure' ? '' : 'isolation'}`;
+        location.href = `${window.BASE_PATH}/public_health/${this.props.workflow === 'isolation' ? 'isolation' : 'exposure'}`;
       } else {
         this.setState({ isPaused: false });
         if (this.state.acceptedAllStarted) {

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -616,7 +616,8 @@ class PatientsTable extends React.Component {
               <Row>
                 <Col md="18">
                   <div id="tab-description" className="lead mt-1 mb-3">
-                    {this.props.tabs[this.state.query.tab].description} You are currently in the <u>{this.props.workflow}</u> workflow.
+                    {this.props.tabs[this.state.query.tab].description} You are currently in the <u>{this.props.workflow}</u>{' '}
+                    {this.props.workflow === 'global' ? 'dashboard' : 'workflow'}.
                     {this.props.tabs[this.state.query.tab].tooltip && (
                       <InfoTooltip tooltipTextKey={this.props.tabs[this.state.query.tab].tooltip} location="right"></InfoTooltip>
                     )}

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -37,7 +37,7 @@ import JurisdictionFilter from './query/JurisdictionFilter';
 import AssignedUserFilter from './query/AssignedUserFilter';
 import EligibilityTooltip from '../util/EligibilityTooltip';
 import confirmDialog from '../util/ConfirmDialog';
-import { navQueryParam } from '../../utils/Navigation';
+import { patientHref } from '../../utils/Navigation';
 
 class PatientsTable extends React.Component {
   constructor(props) {
@@ -59,7 +59,7 @@ class PatientsTable extends React.Component {
           { field: 'symptom_onset', label: 'Symptom Onset', isSortable: true, tooltip: null, filter: this.formatSymptomOnset },
           { field: 'risk_level', label: 'Risk Level', isSortable: true, tooltip: null },
           { field: 'monitoring_plan', label: 'Monitoring Plan', isSortable: true, tooltip: null },
-          { field: 'reporter', label: 'Reporter ID', isSortable: true, tooltip: null },
+          { field: 'reporter', label: 'Reporter ID', isSortable: true, tooltip: null, filter: this.linkReporter },
           { field: 'public_health_action', label: 'Latest Public Health Action', isSortable: true, tooltip: null },
           { field: 'expected_purge_date', label: 'Eligible for Purge After', isSortable: true, tooltip: 'purgeDate', filter: formatTimestamp },
           { field: 'reason_for_closure', label: 'Reason for Closure', isSortable: true, tooltip: null },
@@ -473,11 +473,19 @@ class PatientsTable extends React.Component {
       return (
         <div>
           <BadgeHoH patientId={rowData.id.toString()} customClass={'float-right ml-1'} location={'right'} />
-          <a href={`${window.BASE_PATH}/patients/${rowData.id}${navQueryParam(this.props.workflow, true)}`}>{name}</a>
+          {this.createPatientLink(rowData.id, name)}
         </div>
       );
     }
-    return <a href={`${window.BASE_PATH}/patients/${rowData.id}${navQueryParam(this.props.workflow, true)}`}>{name}</a>;
+    return this.createPatientLink(rowData.id, name);
+  };
+
+  linkReporter = data => {
+    return this.createPatientLink(data.value, data.value);
+  };
+
+  createPatientLink = (id, text) => {
+    return <a href={patientHref(id, this.props.workflow)}>{text}</a>;
   };
 
   formatEndOfMonitoring = data => {

--- a/app/javascript/components/public_health/PublicHealthHeader.js
+++ b/app/javascript/components/public_health/PublicHealthHeader.js
@@ -6,6 +6,7 @@ import axios from 'axios';
 import Export from './Export';
 import Import from './Import';
 import confirmDialog from '../util/ConfirmDialog';
+import { navQueryParam } from '../../utils/Navigation';
 
 class PublicHealthHeader extends React.Component {
   constructor(props) {
@@ -71,7 +72,7 @@ class PublicHealthHeader extends React.Component {
               additionalNote: 'Records imported prior to clicking "X" will not be deleted from the system.',
             };
             if (await confirmDialog(confirmText, options)) {
-              location.href = `${window.BASE_PATH}/public_health/${this.props.workflow === 'exposure' ? '' : 'isolation'}`;
+              location.href = `${window.BASE_PATH}/public_health/${this.props.workflow}`;
             }
           } else {
             const confirmText = 'You are about to cancel the import process. Are you sure you want to do this?';
@@ -153,8 +154,11 @@ class PublicHealthHeader extends React.Component {
                 <Button
                   variant="primary"
                   className="mb-2"
-                  href={`${window.BASE_PATH}/patients/new${this.props.workflow === 'exposure' ? '' : '?isolation=true'}`}>
-                  {this.props.workflow === 'exposure' && (
+                  href={`${window.BASE_PATH}/patients/new?${this.props.workflow === 'isolation' ? 'isolation=true' : ''}${navQueryParam(
+                    this.props.workflow,
+                    false
+                  )}`}>
+                  {(this.props.workflow === 'exposure' || this.props.workflow === 'global') && (
                     <span>
                       <i className="fas fa-user-plus"></i> Enroll New Monitoree
                     </span>
@@ -197,7 +201,11 @@ class PublicHealthHeader extends React.Component {
               )}
             </ButtonGroup>
             <ButtonGroup className="float-right mb-2">
-              <Button variant={this.props.workflow === 'exposure' ? 'primary' : 'outline-primary'} href={`${window.BASE_PATH}/public_health`}>
+              <Button variant={this.props.workflow === 'global' ? 'primary' : 'outline-primary'} href={`${window.BASE_PATH}/public_health/global`}>
+                <i className="fas fa-globe"></i> Global Dashboard{' '}
+                {this.state.counts.exposure !== undefined && <span id="globalCount">({this.state.counts.global})</span>}
+              </Button>
+              <Button variant={this.props.workflow === 'exposure' ? 'primary' : 'outline-primary'} href={`${window.BASE_PATH}/public_health/exposure`}>
                 <i className="fas fa-people-arrows"></i> Exposure Monitoring{' '}
                 {this.state.counts.exposure !== undefined && <span id="exposureCount">({this.state.counts.exposure})</span>}
               </Button>
@@ -218,7 +226,7 @@ class PublicHealthHeader extends React.Component {
 PublicHealthHeader.propTypes = {
   authenticity_token: PropTypes.string,
   jurisdiction_paths: PropTypes.object,
-  workflow: PropTypes.oneOf(['exposure', 'isolation']),
+  workflow: PropTypes.oneOf(['global', 'exposure', 'isolation']),
   jurisdiction: PropTypes.object,
   tabs: PropTypes.object,
   abilities: PropTypes.exact({

--- a/app/javascript/components/public_health/PublicHealthHeader.js
+++ b/app/javascript/components/public_health/PublicHealthHeader.js
@@ -201,10 +201,6 @@ class PublicHealthHeader extends React.Component {
               )}
             </ButtonGroup>
             <ButtonGroup className="float-right mb-2">
-              <Button variant={this.props.workflow === 'global' ? 'primary' : 'outline-primary'} href={`${window.BASE_PATH}/public_health/global`}>
-                <i className="fas fa-globe"></i> Global<span className="d-none d-xl-inline"> Dashboard</span>{' '}
-                {this.state.counts.exposure !== undefined && <span id="globalCount">({this.state.counts.global})</span>}
-              </Button>
               <Button variant={this.props.workflow === 'exposure' ? 'primary' : 'outline-primary'} href={`${window.BASE_PATH}/public_health/exposure`}>
                 <i className="fas fa-people-arrows"></i> Exposure <span className="d-none d-xl-inline"> Monitoring</span>{' '}
                 {this.state.counts.exposure !== undefined && <span id="exposureCount">({this.state.counts.exposure})</span>}
@@ -212,6 +208,10 @@ class PublicHealthHeader extends React.Component {
               <Button variant={this.props.workflow === 'isolation' ? 'primary' : 'outline-primary'} href={`${window.BASE_PATH}/public_health/isolation`}>
                 <i className="fas fa-street-view"></i> Isolation <span className="d-none d-xl-inline"> Monitoring</span>{' '}
                 {this.state.counts.isolation !== undefined && <span id="isolationCount">({this.state.counts.isolation})</span>}
+              </Button>
+              <Button variant={this.props.workflow === 'global' ? 'primary' : 'outline-primary'} href={`${window.BASE_PATH}/public_health/global`}>
+                <i className="fas fa-globe"></i> Global<span className="d-none d-xl-inline"> Dashboard</span>{' '}
+                {this.state.counts.exposure !== undefined && <span id="globalCount">({this.state.counts.global})</span>}
               </Button>
             </ButtonGroup>
           </Col>

--- a/app/javascript/components/public_health/PublicHealthHeader.js
+++ b/app/javascript/components/public_health/PublicHealthHeader.js
@@ -202,15 +202,15 @@ class PublicHealthHeader extends React.Component {
             </ButtonGroup>
             <ButtonGroup className="float-right mb-2">
               <Button variant={this.props.workflow === 'global' ? 'primary' : 'outline-primary'} href={`${window.BASE_PATH}/public_health/global`}>
-                <i className="fas fa-globe"></i> Global Dashboard{' '}
+                <i className="fas fa-globe"></i> Global<span className="d-none d-xl-inline"> Dashboard</span>{' '}
                 {this.state.counts.exposure !== undefined && <span id="globalCount">({this.state.counts.global})</span>}
               </Button>
               <Button variant={this.props.workflow === 'exposure' ? 'primary' : 'outline-primary'} href={`${window.BASE_PATH}/public_health/exposure`}>
-                <i className="fas fa-people-arrows"></i> Exposure Monitoring{' '}
+                <i className="fas fa-people-arrows"></i> Exposure <span className="d-none d-xl-inline"> Monitoring</span>{' '}
                 {this.state.counts.exposure !== undefined && <span id="exposureCount">({this.state.counts.exposure})</span>}
               </Button>
               <Button variant={this.props.workflow === 'isolation' ? 'primary' : 'outline-primary'} href={`${window.BASE_PATH}/public_health/isolation`}>
-                <i className="fas fa-street-view"></i> Isolation Monitoring{' '}
+                <i className="fas fa-street-view"></i> Isolation <span className="d-none d-xl-inline"> Monitoring</span>{' '}
                 {this.state.counts.isolation !== undefined && <span id="isolationCount">({this.state.counts.isolation})</span>}
               </Button>
             </ButtonGroup>

--- a/app/javascript/components/public_health/PublicHealthHeader.js
+++ b/app/javascript/components/public_health/PublicHealthHeader.js
@@ -147,7 +147,7 @@ class PublicHealthHeader extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Row className="mx-2 my-3">
+        <Row className="mx-2 my-2">
           <Col className="p-0">
             <ButtonGroup>
               {this.props.abilities.enrollment && (

--- a/app/javascript/components/public_health/Workflow.js
+++ b/app/javascript/components/public_health/Workflow.js
@@ -42,6 +42,7 @@ class Workflow extends React.Component {
           workflow={this.props.workflow}
           jurisdiction={this.props.jurisdiction}
           tabs={this.props.tabs}
+          default_tab={this.props.default_tab}
           monitoring_reasons={this.props.monitoring_reasons}
           setQuery={query => this.setState({ query })}
           setFilteredMonitoreesCount={current_monitorees_count => this.setState({ current_monitorees_count })}
@@ -57,6 +58,7 @@ Workflow.propTypes = {
   jurisdiction: PropTypes.object,
   workflow: PropTypes.string,
   tabs: PropTypes.object,
+  default_tab: PropTypes.string,
   custom_export_options: PropTypes.object,
   monitoring_reasons: PropTypes.array,
 };

--- a/app/javascript/components/public_health/custom_export/PatientsFilters.js
+++ b/app/javascript/components/public_health/custom_export/PatientsFilters.js
@@ -61,7 +61,7 @@ class PatientsFilters extends React.Component {
                   this.props.onQueryChange('tab', 'all');
                 }}
                 value={this.props.query?.workflow}>
-                <option value="all">All</option>
+                <option value="global">Global</option>
                 <option value="exposure">Exposure</option>
                 <option value="isolation">Isolation</option>
               </Form.Control>
@@ -98,6 +98,13 @@ class PatientsFilters extends React.Component {
                     <option value="requiring_review">Records Requiring Review</option>
                     <option value="non_reporting">Non-Reporting</option>
                     <option value="reporting">Reporting</option>
+                  </React.Fragment>
+                )}
+                {this.props.query?.workflow === 'global' && (
+                  <React.Fragment>
+                    <option value="active">Active</option>
+                    <option value="priority_review">Priority Review</option>
+                    <option value="non_reporting">Non-Reporting</option>
                   </React.Fragment>
                 )}
                 <option value="closed">Closed</option>
@@ -161,7 +168,6 @@ class PatientsFilters extends React.Component {
                   )
                 }
                 authenticity_token={this.props.authenticity_token}
-                workflow={this.props.query?.workflow}
                 updateStickySettings={false}
               />
             </InputGroup>

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -1299,9 +1299,7 @@ class AdvancedFilter extends React.Component {
           </Row>
         </Modal.Body>
         <Modal.Footer className="justify-unset">
-          <p className="lead mr-auto">
-            Filter will be applied to the line lists in the <u>{this.props.workflow}</u> workflow until reset.
-          </p>
+          <p className="lead mr-auto">Filter will be applied to all line lists in the current Dashboard until reset.</p>
           <Button id="advanced-filter-cancel" variant="secondary btn-square" onClick={this.cancel}>
             Cancel
           </Button>
@@ -1376,7 +1374,7 @@ class AdvancedFilter extends React.Component {
       <React.Fragment>
         {this.state.showAdvancedFilterModal && this.renderAdvancedFilterModal()}
         {this.state.showFilterNameModal && this.renderFilterNameModal()}
-        <OverlayTrigger overlay={<Tooltip>Find monitorees that meet specified parameters within current workflow</Tooltip>}>
+        <OverlayTrigger overlay={<Tooltip>Find monitorees that meet specified parameters</Tooltip>}>
           <Button
             size="sm"
             className="ml-2"
@@ -1424,7 +1422,6 @@ class AdvancedFilter extends React.Component {
 AdvancedFilter.propTypes = {
   authenticity_token: PropTypes.string,
   advancedFilterUpdate: PropTypes.func,
-  workflow: PropTypes.string,
   updateStickySettings: PropTypes.bool,
 };
 

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -1299,7 +1299,7 @@ class AdvancedFilter extends React.Component {
           </Row>
         </Modal.Body>
         <Modal.Footer className="justify-unset">
-          <p className="lead mr-auto">Filter will be applied to all line lists in the current Dashboard until reset.</p>
+          <p className="lead mr-auto">Filter will be applied to all line lists in the current dashboard until reset.</p>
           <Button id="advanced-filter-cancel" variant="secondary btn-square" onClick={this.cancel}>
             Cancel
           </Button>

--- a/app/javascript/packs/stylesheets/dashboard.scss
+++ b/app/javascript/packs/stylesheets/dashboard.scss
@@ -14,6 +14,35 @@
   }
 }
 
+/* styling for global dashboard navbar on smaller screens only */
+@media only screen and (max-width : 1082px) {
+  .global-dashboard {
+    .nav-tabs {     
+      .nav-link {
+        width: 230px;
+        border: 1px #dee2e6 solid;
+        margin-bottom: -.05px;
+
+        &:hover {
+          border-color:#606060;
+        }
+
+        &.active {
+          border: 1px #606060 solid !important;
+        }
+
+        .badge {
+          float: right !important
+        }
+      }
+    }
+
+    .nav-item:last-child {
+      margin-left: 0px;
+    }
+  }
+}
+
 /* styling for exposure dashboard navbar on smaller screens only */
 @media only screen and (max-width : 1310px) {
   .exposure-dashboard {

--- a/app/javascript/tests/layout/Breadcrumb.test.js
+++ b/app/javascript/tests/layout/Breadcrumb.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Breadcrumb from '../../components/layout/Breadcrumb';
+import { mockBreadcrumbs1 } from '../mocks/mockBreadcrumbs';
+import { mockJurisdiction1 } from '../mocks/mockJurisdiction';
+
+describe('Breadcrumb', () => {
+  it('Properly renders breadcrumb text and links and jurisdiction', () => {
+    const wrapper = shallow(<Breadcrumb crumbs={mockBreadcrumbs1} jurisdiction={mockJurisdiction1.path} />);
+    mockBreadcrumbs1.forEach((crumb, index) => {
+      if (crumb.href === null) {
+        expect(wrapper.find('li').at(index).text()).toEqual(crumb.value);
+      } else {
+        expect(wrapper.find('li').at(index).find('a').text()).toEqual(crumb.value);
+        expect(wrapper.find('li').at(index).find('a').prop('href')).toEqual(`${window.BASE_PATH}${crumb.href}`);
+      }
+    });
+
+    expect(wrapper.find('li').last().text()).toEqual(`Your Jurisdiction: ${mockJurisdiction1.path}`);
+  });
+});

--- a/app/javascript/tests/layout/Breadcrumb.test.js
+++ b/app/javascript/tests/layout/Breadcrumb.test.js
@@ -10,6 +10,7 @@ describe('Breadcrumb', () => {
     mockBreadcrumbs1.forEach((crumb, index) => {
       if (crumb.href === null) {
         expect(wrapper.find('li').at(index).text()).toEqual(crumb.value);
+        expect(wrapper.find('li').at(index).find('a').exists()).toEqual(false);
       } else {
         expect(wrapper.find('li').at(index).find('a').text()).toEqual(crumb.value);
         expect(wrapper.find('li').at(index).find('a').prop('href')).toEqual(`${window.BASE_PATH}${crumb.href}`);

--- a/app/javascript/tests/mocks/mockBreadcrumbs.js
+++ b/app/javascript/tests/mocks/mockBreadcrumbs.js
@@ -1,0 +1,16 @@
+const mockBreadcrumbs1 = [
+  {
+    value: 'This is the Mock Dashboard',
+    href: '/public_health/mock',
+  },
+  {
+    value: 'Mock Details',
+    href: '/mocks/5',
+  },
+  {
+    value: 'Edit Mock',
+    href: null,
+  },
+];
+
+export { mockBreadcrumbs1 };

--- a/app/javascript/tests/mocks/mockTabs.js
+++ b/app/javascript/tests/mocks/mockTabs.js
@@ -95,7 +95,7 @@ const mockGlobalTabs = {
     variant: 'primary',
   },
   closed: {
-    description: 'Monitorees not currently being monitored across both the exposure and isolation workflows.',
+    description: 'Monitorees not currently being actively monitored across both the exposure and isolation workflows.',
     label: 'Closed',
     variant: 'secondary',
   },

--- a/app/javascript/tests/mocks/mockTabs.js
+++ b/app/javascript/tests/mocks/mockTabs.js
@@ -88,4 +88,43 @@ const mockIsolationTabs = {
   },
 };
 
-export { mockExposureTabs, mockIsolationTabs };
+const mockGlobalTabs = {
+  all: {
+    description: 'All Monitorees in this jurisdiction across both the exposure and isolation workflows.',
+    label: 'All Monitorees',
+    variant: 'primary',
+  },
+  closed: {
+    description: 'Monitorees not currently being monitored across both the exposure and isolation workflows.',
+    label: 'Closed',
+    variant: 'secondary',
+  },
+  non_reporting: {
+    description: 'All monitorees who have failed to report in the last day across both the exposure and isolation workflows.',
+    label: 'Non-Reporting',
+    variant: 'warning',
+  },
+  priority_review: {
+    description:
+      'Monitorees who meet the criteria to appear on either the Symptomatic line list (exposure) or Records Requiring Review line list (isolation) which need to be reviewed.',
+    label: 'Priority Review',
+    variant: 'danger',
+  },
+  active: {
+    description: 'Monitorees currently being monitored across both the exposure and isolation workflows.',
+    label: 'Active',
+    variant: 'success',
+  },
+  transferred_in: {
+    description: 'Cases that have been transferred into this jurisdiction during the last 24 hours.',
+    label: 'Transferred In',
+    variant: 'info',
+  },
+  transferred_out: {
+    description: 'Cases that have been transferred out of this jurisdiction.',
+    label: 'Transferred Out',
+    variant: 'info',
+  },
+};
+
+export { mockExposureTabs, mockIsolationTabs, mockGlobalTabs };

--- a/app/javascript/tests/patient/Patient.test.js
+++ b/app/javascript/tests/patient/Patient.test.js
@@ -29,7 +29,7 @@ const riskFactors = [
 
 describe('Patient', () => {
   it('Properly renders all main components when not in edit mode', () => {
-    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     expect(wrapper.find('#monitoree-details-header').exists()).toBeTruthy();
     expect(wrapper.find('#monitoree-details-header').find('h3').find('span').text()).toEqual(nameFormatter(mockPatient1));
     expect(wrapper.find('#monitoree-details-header').find(BadgeHoH).exists()).toBeTruthy();
@@ -50,7 +50,7 @@ describe('Patient', () => {
   });
 
   it('Properly renders all main components when in edit mode', () => {
-    const wrapper = shallow(<Patient details={mockPatient4} goto={goToMock} collapse={true} edit_mode={true} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient4} goto={goToMock} collapse={true} edit_mode={true} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     expect(wrapper.find('#monitoree-details-header').exists()).toBeTruthy();
     expect(wrapper.find('#monitoree-details-header').find('h3').find('span').text()).toEqual(nameFormatter(mockPatient4));
     expect(wrapper.find('#monitoree-details-header').find(BadgeHoH).exists()).toBeFalsy();
@@ -71,27 +71,29 @@ describe('Patient', () => {
   });
 
   it('Properly renders identification section', () => {
-    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     const section = wrapper.find('#identification');
     expect(section.find('h4').text()).toEqual('Identification');
     expect(section.find('.edit-link').exists()).toBeTruthy();
+    expect(section.find('a').prop('href')).toEqual(window.BASE_PATH + '/patients/' + mockPatient1.id + '/edit?step=0&nav=global');
     identificationFields.forEach((field, index) => {
       expect(section.find('b').at(index).text()).toEqual(field + ':');
     });
   });
 
   it('Properly renders contact information section', () => {
-    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     const section = wrapper.find('#contact-information');
     expect(section.find('h4').text()).toEqual('Contact Information');
     expect(section.find('.edit-link').exists()).toBeTruthy();
+    expect(section.find('a').prop('href')).toEqual(window.BASE_PATH + '/patients/' + mockPatient1.id + '/edit?step=2&nav=global');
     contactFields.forEach((field, index) => {
       expect(section.find('b').at(index).text()).toEqual(field + ':');
     });
   });
 
   it('Properly renders show/hide divider when props.collapse is true', () => {
-    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     expect(wrapper.find('.details-expander').exists()).toBeTruthy();
     expect(wrapper.find('#details-expander-link').exists()).toBeTruthy();
     expect(wrapper.find('.details-expander').find(FontAwesomeIcon).exists()).toBeTruthy();
@@ -101,7 +103,7 @@ describe('Patient', () => {
   });
 
   it('Properly renders show/hide divider when props.collapse is false', () => {
-    const wrapper = shallow(<Patient details={mockPatient1} collapse={false} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient1} collapse={false} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     expect(wrapper.find('.details-expander').exists()).toBeTruthy();
     expect(wrapper.find('#details-expander-link').exists()).toBeTruthy();
     expect(wrapper.find('.details-expander').find(FontAwesomeIcon).exists()).toBeTruthy();
@@ -111,7 +113,7 @@ describe('Patient', () => {
   });
 
   it('Clicking show/hide divider updates label and expands or collapses details', () => {
-    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     expect(wrapper.find(Collapse).prop('in')).toBeFalsy();
     expect(wrapper.state('expanded')).toBeFalsy();
     wrapper.find('#details-expander-link').simulate('click');
@@ -123,10 +125,11 @@ describe('Patient', () => {
   });
 
   it('Properly renders address section for domestic address with no monitoring address', () => {
-    const wrapper = shallow(<Patient details={mockPatient2} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient2} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     const section = wrapper.find('#address');
     expect(section.find('h4').text()).toEqual('Address');
     expect(section.find('.edit-link').exists()).toBeTruthy();
+    expect(section.find('a').prop('href')).toEqual(window.BASE_PATH + '/patients/' + mockPatient2.id + '/edit?step=1&nav=global');
     expect(section.find(Row).find(Col).length).toEqual(1);
     const domesticAddressColumn = section.find(Row).find(Col);
     expect(domesticAddressColumn.prop('sm')).toEqual(24);
@@ -137,10 +140,11 @@ describe('Patient', () => {
   });
 
   it('Properly renders address section for domestic address and monitoring address', () => {
-    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     const section = wrapper.find('#address');
     expect(section.find('h4').text()).toEqual('Address');
     expect(section.find('.edit-link').exists()).toBeTruthy();
+    expect(section.find('a').prop('href')).toEqual(window.BASE_PATH + '/patients/' + mockPatient1.id + '/edit?step=1&nav=global');
     expect(section.find(Row).find(Col).length).toEqual(2);
     const domesticAddressColumn = section.find(Row).find(Col).at(0);
     const monitoringAddressColumn = section.find(Row).find(Col).at(1);
@@ -157,10 +161,11 @@ describe('Patient', () => {
   });
 
   it('Properly renders address section for foreign address with no monitoring address', () => {
-    const wrapper = shallow(<Patient details={mockPatient5} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient5} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     const section = wrapper.find('#address');
     expect(section.find('h4').text()).toEqual('Address');
     expect(section.find('.edit-link').exists()).toBeTruthy();
+    expect(section.find('a').prop('href')).toEqual(window.BASE_PATH + '/patients/' + mockPatient5.id + '/edit?step=1&nav=global');
     expect(section.find(Row).find(Col).length).toEqual(1);
     const foreignAddressColumn = section.find(Row).find(Col);
     expect(foreignAddressColumn.prop('sm')).toEqual(24);
@@ -171,10 +176,11 @@ describe('Patient', () => {
   });
 
   it('Properly renders address section for foreign address and monitoring address', () => {
-    const wrapper = shallow(<Patient details={mockPatient4} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient4} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     const section = wrapper.find('#address');
     expect(section.find('h4').text()).toEqual('Address');
     expect(section.find('.edit-link').exists()).toBeTruthy();
+    expect(section.find('a').prop('href')).toEqual(window.BASE_PATH + '/patients/' + mockPatient4.id + '/edit?step=1&nav=global');
     expect(section.find(Row).find(Col).length).toEqual(2);
     const foreignAddressColumn = section.find(Row).find(Col).at(0);
     const monitoringAddressColumn = section.find(Row).find(Col).at(1);
@@ -191,10 +197,11 @@ describe('Patient', () => {
   });
 
   it('Properly renders arrival information section', () => {
-    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     const section = wrapper.find('#arrival-information');
     expect(section.find('h4').text()).toEqual('Arrival Information');
     expect(section.find('.edit-link').exists()).toBeTruthy();
+    expect(section.find('a').prop('href')).toEqual(window.BASE_PATH + '/patients/' + mockPatient1.id + '/edit?step=3&nav=global');
     expect(section.find('.none-text').exists()).toBeFalsy();
     const departedColumn = section.find(Row).find(Col).at(0);
     const arrivalColumn = section.find(Row).find(Col).at(1);
@@ -220,7 +227,7 @@ describe('Patient', () => {
   });
 
   it('Collapses/expands travel related notes if longer than 400 characters', () => {
-    const wrapper = shallow(<Patient details={mockPatient3} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient3} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     expect(wrapper.find('#arrival-information').find('.notes-section').find(Button).exists()).toBeTruthy();
     expect(wrapper.state('expandArrivalNotes')).toBeFalsy();
     expect(wrapper.find('#arrival-information').find('.notes-section').find(Button).text()).toEqual('(View all)');
@@ -236,7 +243,7 @@ describe('Patient', () => {
   });
 
   it('Displays "None" if arrival information has no information', () => {
-    const wrapper = shallow(<Patient details={blankMockPatient} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={blankMockPatient} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     const section = wrapper.find('#arrival-information');
     expect(section.exists()).toBeTruthy();
     expect(section.find('.none-text').exists()).toBeTruthy();
@@ -244,10 +251,11 @@ describe('Patient', () => {
   });
 
   it('Properly renders planned travel section', () => {
-    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     const section = wrapper.find('#planned-travel');
     expect(section.find('h4').text()).toEqual('Additional Planned Travel');
     expect(section.find('.edit-link').exists()).toBeTruthy();
+    expect(section.find('a').prop('href')).toEqual(window.BASE_PATH + '/patients/' + mockPatient1.id + '/edit?step=4&nav=global');
     expect(section.find('.none-text').exists()).toBeFalsy();
     additionalTravelFields.forEach((field, index) => {
       expect(section.find('b').at(index).text()).toEqual(field + ':');
@@ -259,7 +267,7 @@ describe('Patient', () => {
   });
 
   it('Collapses/expands additional planned travel notes if longer than 400 characters', () => {
-    const wrapper = shallow(<Patient details={mockPatient3} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient3} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     expect(wrapper.find('#planned-travel').find('.notes-section').find(Button).exists()).toBeTruthy();
     expect(wrapper.state('expandPlannedTravelNotes')).toBeFalsy();
     expect(wrapper.find('#planned-travel').find('.notes-section').find(Button).text()).toEqual('(View all)');
@@ -275,7 +283,7 @@ describe('Patient', () => {
   });
 
   it('Displays "None" if planned travel has no information', () => {
-    const wrapper = shallow(<Patient details={blankMockPatient} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={blankMockPatient} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     const section = wrapper.find('#planned-travel');
     expect(section.exists()).toBeTruthy();
     expect(section.find('.none-text').exists()).toBeTruthy();
@@ -283,10 +291,11 @@ describe('Patient', () => {
   });
 
   it('Properly renders potential exposure information section', () => {
-    const wrapper = shallow(<Patient details={mockPatient2} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient2} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     const section = wrapper.find('#potential-exposure-information');
     expect(section.find('h4').text()).toEqual('Potential Exposure Information');
     expect(section.find('.edit-link').exists()).toBeTruthy();
+    expect(section.find('a').prop('href')).toEqual(window.BASE_PATH + '/patients/' + mockPatient2.id + '/edit?step=5&nav=global');
     expect(section.find('.item-group').exists()).toBeTruthy();
     expect(section.find('.item-group').find('b').at(0).text()).toEqual('Last Date of Exposure:');
     expect(section.find('.item-group').find('span').at(0).text()).toEqual(formatDate(mockPatient2.last_date_of_exposure));
@@ -309,7 +318,7 @@ describe('Patient', () => {
   it('Properly renders notes in potential exposure information section if the rest of the section is empty', () => {
     let newMockPatient5 = _.cloneDeep(mockPatient5);
     newMockPatient5.exposure_notes = 'new exposure note';
-    const wrapper = shallow(<Patient details={newMockPatient5} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={newMockPatient5} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     const section = wrapper.find('#potential-exposure-information');
     expect(section.find('.item-group').exists()).toBeFalsy();
     expect(section.find('.risk-factors').exists()).toBeFalsy();
@@ -320,7 +329,7 @@ describe('Patient', () => {
   });
 
   it('Collapses/expands exposure notes in potential exposure information section if longer than 400 characters', () => {
-    const wrapper = shallow(<Patient details={mockPatient5} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient5} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     expect(wrapper.find('#potential-exposure-information').find(Button).exists()).toBeTruthy();
     expect(wrapper.find('#potential-exposure-information').find(Button).text()).toEqual('(View all)');
     expect(wrapper.find('#potential-exposure-information').find('.notes-text').text()).toEqual(mockPatient5.exposure_notes.slice(0, 400) + ' ...');
@@ -333,7 +342,7 @@ describe('Patient', () => {
   });
 
   it('Displays "None" if potential exposure information has no information', () => {
-    const wrapper = shallow(<Patient details={blankMockPatient} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={blankMockPatient} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     const section = wrapper.find('#potential-exposure-information');
     expect(section.exists()).toBeTruthy();
     expect(section.find('.none-text').exists()).toBeTruthy();
@@ -344,10 +353,11 @@ describe('Patient', () => {
   });
 
   it('Properly renders case information section', () => {
-    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     const section = wrapper.find('#case-information');
     expect(section.find('h4').text()).toEqual('Case Information');
     expect(section.find('.edit-link').exists()).toBeTruthy();
+    expect(section.find('a').prop('href')).toEqual(window.BASE_PATH + '/patients/' + mockPatient1.id + '/edit?step=5&nav=global');
     expect(section.find('b').at(0).text()).toEqual('Case Status: ');
     expect(section.find('span').at(0).text()).toEqual(mockPatient1.case_status);
     expect(section.find('b').at(1).text()).toEqual('First Positive Lab Collected: ');
@@ -357,12 +367,12 @@ describe('Patient', () => {
   });
 
   it('Hides case information section when monitoree is in the exposure workflow', () => {
-    const wrapper = shallow(<Patient details={mockPatient2} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient2} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     expect(wrapper.find('#case-information').exists()).toBeFalsy();
   });
 
   it('Properly renders notes section', () => {
-    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     const section = wrapper.find('#exposure-notes');
     expect(section.find('h4').text()).toEqual('Notes');
     expect(section.find('.none-text').exists()).toBeFalsy();
@@ -372,7 +382,7 @@ describe('Patient', () => {
   });
 
   it('Collapses/expands exposure notes if longer than 400 characters', () => {
-    const wrapper = shallow(<Patient details={mockPatient3} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient3} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     expect(wrapper.find('#exposure-notes').find(Button).exists()).toBeTruthy();
     expect(wrapper.find('#exposure-notes').find(Button).text()).toEqual('(View all)');
     expect(wrapper.find('#exposure-notes').find('.notes-text').text()).toEqual(mockPatient3.exposure_notes.slice(0, 400) + ' ...');
@@ -385,7 +395,7 @@ describe('Patient', () => {
   });
 
   it('Displays "None" if exposure notes is null', () => {
-    const wrapper = shallow(<Patient details={mockPatient4} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient4} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     const section = wrapper.find('#exposure-notes');
     expect(section.exists()).toBeTruthy();
     expect(section.find('.none-text').exists()).toBeTruthy();
@@ -395,12 +405,12 @@ describe('Patient', () => {
   });
 
   it('Properly renders no details message', () => {
-    const blankWrapper = shallow(<Patient details={null} />);
+    const blankWrapper = shallow(<Patient details={null} workflow="global" />);
     expect(blankWrapper.text()).toEqual('No monitoree details to show.');
   });
 
   it('Renders edit buttons if props.goto is defined', () => {
-    const wrapper = shallow(<Patient details={mockPatient1} goto={goToMock} collapse={true} edit_mode={true} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient1} goto={goToMock} collapse={true} edit_mode={true} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     expect(wrapper.find('.edit-link').find(Button).length).toEqual(7);
     expect(wrapper.find('.edit-link').find('a').exists()).toBeFalsy();
     wrapper
@@ -413,7 +423,7 @@ describe('Patient', () => {
 
   it('Renders edit hrefs if props.goto is not defined', () => {
     const stepIds = [0, 2, 1, 3, 4, 5, 5];
-    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={true} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient1} collapse={true} edit_mode={true} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     expect(wrapper.find('.edit-link').find(Button).exists()).toBeFalsy();
     expect(wrapper.find('.edit-link').find('a').length).toEqual(7);
     wrapper
@@ -421,12 +431,12 @@ describe('Patient', () => {
       .find('a')
       .forEach((link, index) => {
         expect(link.text()).toEqual('Edit');
-        expect(link.prop('href')).toEqual(`${window.BASE_PATH}/patients/${mockPatient1.id}/edit?step=${stepIds[Number(index)]}`);
+        expect(link.prop('href')).toEqual(`${window.BASE_PATH}/patients/${mockPatient1.id}/edit?step=${stepIds[Number(index)]}&nav=global`);
       });
   });
 
   it('Calls props goto method when the edit buttons are clicked', () => {
-    const wrapper = shallow(<Patient details={mockPatient1} goto={goToMock} collapse={true} edit_mode={true} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient1} goto={goToMock} collapse={true} edit_mode={true} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     expect(goToMock).toHaveBeenCalledTimes(0);
     wrapper
       .find('.edit-link')
@@ -438,7 +448,7 @@ describe('Patient', () => {
   });
 
   it('Displays the Follow up Flag panel when a monitoree has a follow up flag set', () => {
-    const wrapper = shallow(<Patient details={mockPatient3} goto={goToMock} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} />);
+    const wrapper = shallow(<Patient details={mockPatient3} goto={goToMock} collapse={true} edit_mode={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} other_household_members={[]} can_modify_subject_status={true} workflow="global" />);
     expect(wrapper.find(FollowUpFlagPanel).exists()).toBeTruthy();
     expect(wrapper.find('#set-follow-up-flag-link').exists()).toBeFalsy();
   });

--- a/app/javascript/tests/patient/PatientPage.test.js
+++ b/app/javascript/tests/patient/PatientPage.test.js
@@ -12,7 +12,7 @@ import { mockJurisdictionPaths } from '../mocks/mockJurisdiction';
 const mockToken = 'testMockTokenString12345';
 
 function getWrapper(patient, householdMembers) {
-  return shallow(<PatientPage patient={patient} other_household_members={householdMembers} blocked_sms={false} current_user={mockUser1} can_add_group={true} can_modify_subject_status={true} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} />);
+  return shallow(<PatientPage patient={patient} other_household_members={householdMembers} blocked_sms={false} current_user={mockUser1} can_add_group={true} can_modify_subject_status={true} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} workflow={'global'} />);
 }
 
 describe('PatientPage', () => {

--- a/app/javascript/tests/patient/household/HeadOfHousehold.test.js
+++ b/app/javascript/tests/patient/household/HeadOfHousehold.test.js
@@ -13,8 +13,8 @@ const mockToken = 'testMockTokenString12345';
 
 describe('HeadOfHousehold', () => {
   it('Properly renders all main components', () => {
-    const wrapper1 = shallow(<HeadOfHousehold patient={mockPatient1} other_household_members={[mockPatient2]} can_add_group={true} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} />);
-    const wrapper2 = shallow(<HeadOfHousehold patient={mockPatient1} other_household_members={[mockPatient2]} can_add_group={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} />);
+    const wrapper1 = shallow(<HeadOfHousehold patient={mockPatient1} other_household_members={[mockPatient2]} can_add_group={true} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} workflow={'global'} />);
+    const wrapper2 = shallow(<HeadOfHousehold patient={mockPatient1} other_household_members={[mockPatient2]} can_add_group={false} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} workflow={'global'} />);
 
     // if user can add group
     expect(wrapper1.find(Row).length).toEqual(2);

--- a/app/javascript/tests/patient/household/Individual.test.js
+++ b/app/javascript/tests/patient/household/Individual.test.js
@@ -11,8 +11,8 @@ const mockToken = 'testMockTokenString12345';
 
 describe('Individual', () => {
   it('Properly renders all main components', () => {
-    const wrapper1 = shallow(<Individual patient={mockPatient3} can_add_group={true} authenticity_token={mockToken} />);
-    const wrapper2 = shallow(<Individual patient={mockPatient3} can_add_group={false} authenticity_token={mockToken} />);
+    const wrapper1 = shallow(<Individual patient={mockPatient3} can_add_group={true} authenticity_token={mockToken} workflow={'global'} />);
+    const wrapper2 = shallow(<Individual patient={mockPatient3} can_add_group={false} authenticity_token={mockToken} workflow={'global'} />);
 
     // if user can add group
     expect(wrapper1.find(Row).length).toEqual(2);

--- a/app/javascript/tests/patient/household/actions/ApplyToHousehold.test.js
+++ b/app/javascript/tests/patient/household/actions/ApplyToHousehold.test.js
@@ -12,7 +12,7 @@ const handleApplyHouseholdChangeMock = jest.fn();
 const handleApplyHouseholdIdsChangeMock = jest.fn();
 
 function getWrapper() {
-  return shallow(<ApplyToHousehold household_members={householdMembers} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} handleApplyHouseholdChange={handleApplyHouseholdChangeMock} handleApplyHouseholdIdsChange={handleApplyHouseholdIdsChangeMock} />);
+  return shallow(<ApplyToHousehold household_members={householdMembers} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} handleApplyHouseholdChange={handleApplyHouseholdChangeMock} handleApplyHouseholdIdsChange={handleApplyHouseholdIdsChangeMock} workflow={'global'} />);
 }
 
 afterEach(() => {

--- a/app/javascript/tests/patient/household/actions/EnrollHouseholdMember.test.js
+++ b/app/javascript/tests/patient/household/actions/EnrollHouseholdMember.test.js
@@ -4,7 +4,7 @@ import { Button, Modal } from 'react-bootstrap';
 import EnrollHouseholdMember from '../../../../components/patient/household/actions/EnrollHouseholdMember';
 
 function getWrapper(isHoh) {
-  return shallow(<EnrollHouseholdMember responderId={123} isHoh={isHoh} />);
+  return shallow(<EnrollHouseholdMember responderId={123} isHoh={isHoh} workflow={'global'} />);
 }
 
 describe('EnrollHouseholdMember', () => {
@@ -33,7 +33,7 @@ describe('EnrollHouseholdMember', () => {
     expect(wrapper.find(Modal.Footer).find(Button).length).toEqual(2);
     expect(wrapper.find(Modal.Footer).find(Button).at(0).text()).toEqual('Cancel');
     expect(wrapper.find(Modal.Footer).find(Button).at(1).text()).toEqual('Continue');
-    expect(wrapper.find(Modal.Footer).find(Button).at(1).prop('href').includes('/patients/123/group')).toBeTruthy();
+    expect(wrapper.find(Modal.Footer).find(Button).at(1).prop('href').includes('/patients/123/group?nav=global')).toBeTruthy();
   });
 
   it('Properly renders modal for single household member (no depenedents)', () => {
@@ -44,7 +44,7 @@ describe('EnrollHouseholdMember', () => {
     expect(wrapper.find(Modal.Footer).find(Button).length).toEqual(2);
     expect(wrapper.find(Modal.Footer).find(Button).at(0).text()).toEqual('Cancel');
     expect(wrapper.find(Modal.Footer).find(Button).at(1).text()).toEqual('Continue');
-    expect(wrapper.find(Modal.Footer).find(Button).at(1).prop('href').includes('/patients/123/group')).toBeTruthy();
+    expect(wrapper.find(Modal.Footer).find(Button).at(1).prop('href').includes('/patients/123/group?nav=global')).toBeTruthy();
   });
 
   it('Clicking Cancel button closes modal and resets state', () => {

--- a/app/javascript/tests/patient/household/actions/MoveToHousehold.test.js
+++ b/app/javascript/tests/patient/household/actions/MoveToHousehold.test.js
@@ -11,7 +11,7 @@ import _ from 'lodash';
 const mockToken = 'testMockTokenString12345';
 
 function getWrapper() {
-  return shallow(<MoveToHousehold patient={mockPatient1} authenticity_token={mockToken} />);
+  return shallow(<MoveToHousehold patient={mockPatient1} authenticity_token={mockToken} workflow={'global'} />);
 }
 
 describe('MoveToHousehold', () => {

--- a/app/javascript/tests/patient/household/utils/HouseholdMemberTable.test.js
+++ b/app/javascript/tests/patient/household/utils/HouseholdMemberTable.test.js
@@ -13,11 +13,11 @@ const handleApplyHouseholdChangeMock = jest.fn();
 const handleApplyHouseholdIdsChangeMock = jest.fn();
 
 function getWrapper(isSelectable) {
-  return shallow(<HouseholdMemberTable household_members={householdMembers} isSelectable={isSelectable} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} handleApplyHouseholdChange={handleApplyHouseholdChangeMock} handleApplyHouseholdIdsChange={handleApplyHouseholdIdsChangeMock} />);
+  return shallow(<HouseholdMemberTable household_members={householdMembers} isSelectable={isSelectable} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} handleApplyHouseholdChange={handleApplyHouseholdChangeMock} handleApplyHouseholdIdsChange={handleApplyHouseholdIdsChangeMock} workflow={'global'} />);
 }
 
 function getMountedWrapper(isSelectable) {
-  return mount(<HouseholdMemberTable household_members={householdMembers} isSelectable={isSelectable} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} handleApplyHouseholdChange={handleApplyHouseholdChangeMock} handleApplyHouseholdIdsChange={handleApplyHouseholdIdsChangeMock} />);
+  return mount(<HouseholdMemberTable household_members={householdMembers} isSelectable={isSelectable} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} handleApplyHouseholdChange={handleApplyHouseholdChangeMock} handleApplyHouseholdIdsChange={handleApplyHouseholdIdsChangeMock} workflow={'global'} />);
 }
 
 afterEach(() => {
@@ -34,20 +34,8 @@ describe('HouseholdMemberTable', () => {
     const wrapper = getMountedWrapper(true);
     expect(wrapper.find('thead').exists()).toBeTruthy();
     expect(wrapper.find('th').length).toEqual(wrapper.state('table').colData.length + 1);
-    expect(
-      wrapper
-        .find('th')
-        .at(0)
-        .find('input')
-        .exists()
-    ).toBeTruthy();
-    expect(
-      wrapper
-        .find('th')
-        .at(0)
-        .find('input')
-        .prop('checked')
-    ).toBeFalsy();
+    expect(wrapper.find('th').at(0).find('input').exists()).toBeTruthy();
+    expect(wrapper.find('th').at(0).find('input').prop('checked')).toBeFalsy();
     wrapper.state('table').colData.forEach((colData, index) => {
       expect(
         wrapper
@@ -81,86 +69,21 @@ describe('HouseholdMemberTable', () => {
     expect(wrapper.find('tbody').exists()).toBeTruthy();
     expect(wrapper.find('tbody').find('tr').length).toEqual(wrapper.state('table').rowData.length);
     wrapper.state('table').rowData.forEach((rowData, index) => {
-      const row = wrapper
-        .find('tbody')
-        .find('tr')
-        .at(index);
-      expect(
-        row
-          .find('td')
-          .at(0)
-          .find('input')
-          .exists()
-      ).toBeTruthy();
-      expect(
-        row
-          .find('td')
-          .at(0)
-          .find('input')
-          .prop('checked')
-      ).toBeFalsy();
-      expect(
-        row
-          .find('td')
-          .at(1)
-          .find('a')
-          .exists()
-      ).toBeTruthy();
-      expect(
-        row
-          .find('td')
-          .at(1)
-          .find('a')
-          .prop('href')
-      ).toEqual(`${window.BASE_PATH}/patients/${rowData.id}`);
-      expect(
-        row
-          .find('td')
-          .at(1)
-          .find('a')
-          .text()
-      ).toEqual(nameFormatterAlt(rowData));
+      const row = wrapper.find('tbody').find('tr').at(index);
+      expect(row.find('td').at(0).find('input').exists()).toBeTruthy();
+      expect(row.find('td').at(0).find('input').prop('checked')).toBeFalsy();
+      expect(row.find('td').at(1).find('a').exists()).toBeTruthy();
+      expect(row.find('td').at(1).find('a').prop('href')).toEqual(`${window.BASE_PATH}/patients/${rowData.id}?nav=global`);
+      expect(row.find('td').at(1).find('a').text()).toEqual(nameFormatterAlt(rowData));
       if (rowData.head_of_household) {
-        expect(
-          row
-            .find('td')
-            .at(1)
-            .find(BadgeHoH)
-            .exists()
-        ).toBeTruthy();
+        expect(row.find('td').at(1).find(BadgeHoH).exists()).toBeTruthy();
       } else {
-        expect(
-          row
-            .find('td')
-            .at(1)
-            .find(BadgeHoH)
-            .exists()
-        ).toBeFalsy();
+        expect(row.find('td').at(1).find(BadgeHoH).exists()).toBeFalsy();
       }
-      expect(
-        row
-          .find('td')
-          .at(2)
-          .text()
-      ).toEqual(formatDate(rowData[wrapper.state('table').colData[1].field]));
-      expect(
-        row
-          .find('td')
-          .at(3)
-          .text()
-      ).toEqual(rowData[wrapper.state('table').colData[2].field] ? 'Isolation' : 'Exposure');
-      expect(
-        row
-          .find('td')
-          .at(4)
-          .text()
-      ).toEqual(rowData[wrapper.state('table').colData[3].field] ? 'Actively Monitoring' : 'Not Monitoring');
-      expect(
-        row
-          .find('td')
-          .at(5)
-          .text()
-      ).toEqual(rowData[wrapper.state('table').colData[4].field] ? 'Yes' : 'No');
+      expect(row.find('td').at(2).text()).toEqual(formatDate(rowData[wrapper.state('table').colData[1].field]));
+      expect(row.find('td').at(3).text()).toEqual(rowData[wrapper.state('table').colData[2].field] ? 'Isolation' : 'Exposure');
+      expect(row.find('td').at(4).text()).toEqual(rowData[wrapper.state('table').colData[3].field] ? 'Actively Monitoring' : 'Not Monitoring');
+      expect(row.find('td').at(5).text()).toEqual(rowData[wrapper.state('table').colData[4].field] ? 'Yes' : 'No');
     });
   });
 
@@ -177,20 +100,14 @@ describe('HouseholdMemberTable', () => {
     wrapper.find('tr').forEach(row => {
       expect(row.find('input').prop('checked')).toBeFalsy();
     });
-    wrapper
-      .find('th')
-      .find('input')
-      .simulate('change');
+    wrapper.find('th').find('input').simulate('change');
     expect(wrapper.state('table').selectAll).toBeTruthy();
     expect(wrapper.state('table').selectedRows).toEqual([0, 1, 2, 3]);
     expect(wrapper.state('selectedIds')).toEqual([mockPatient1.id, mockPatient2.id, mockPatient3.id, mockPatient4.id]);
     wrapper.find('tr').forEach(row => {
       expect(row.find('input').prop('checked')).toBeTruthy();
     });
-    wrapper
-      .find('th')
-      .find('input')
-      .simulate('change');
+    wrapper.find('th').find('input').simulate('change');
     expect(wrapper.state('table').selectAll).toBeFalsy();
     expect(wrapper.state('table').selectedRows).toEqual([]);
     expect(wrapper.state('selectedIds')).toEqual([]);
@@ -264,71 +181,41 @@ describe('HouseholdMemberTable', () => {
 
   it('Properly sorts table by name', () => {
     const wrapper = getMountedWrapper(true);
-    wrapper
-      .find('th')
-      .at(1)
-      .simulate('click');
+    wrapper.find('th').at(1).simulate('click');
     expect(wrapper.state('table').rowData).toEqual(sortByNameAscending(householdMembers));
-    wrapper
-      .find('th')
-      .at(1)
-      .simulate('click');
+    wrapper.find('th').at(1).simulate('click');
     expect(wrapper.state('table').rowData).toEqual(sortByNameDescending(householdMembers));
   });
 
   it('Properly sorts table by DOB', () => {
     const wrapper = getMountedWrapper(true);
-    wrapper
-      .find('th')
-      .at(2)
-      .simulate('click');
+    wrapper.find('th').at(2).simulate('click');
     expect(wrapper.state('table').rowData).toEqual(sortByDateAscending(householdMembers, 'date_of_birth'));
-    wrapper
-      .find('th')
-      .at(2)
-      .simulate('click');
+    wrapper.find('th').at(2).simulate('click');
     expect(wrapper.state('table').rowData).toEqual(sortByDateDescending(householdMembers, 'date_of_birth'));
   });
 
   it('Properly sorts table by workflow', () => {
     const wrapper = getMountedWrapper(true);
-    wrapper
-      .find('th')
-      .at(3)
-      .simulate('click');
+    wrapper.find('th').at(3).simulate('click');
     expect(wrapper.state('table').rowData).toEqual(sortByAscending(householdMembers, 'isolation'));
-    wrapper
-      .find('th')
-      .at(3)
-      .simulate('click');
+    wrapper.find('th').at(3).simulate('click');
     expect(wrapper.state('table').rowData).toEqual(sortByDescending(householdMembers, 'isolation'));
   });
 
   it('Properly sorts table by monitoring status', () => {
     const wrapper = getMountedWrapper(true);
-    wrapper
-      .find('th')
-      .at(4)
-      .simulate('click');
+    wrapper.find('th').at(4).simulate('click');
     expect(wrapper.state('table').rowData).toEqual(sortByDescending(householdMembers, 'monitoring'));
-    wrapper
-      .find('th')
-      .at(4)
-      .simulate('click');
+    wrapper.find('th').at(4).simulate('click');
     expect(wrapper.state('table').rowData).toEqual(sortByAscending(householdMembers, 'monitoring'));
   });
 
   it('Properly sorts table by continuous exposure', () => {
     const wrapper = getMountedWrapper(true);
-    wrapper
-      .find('th')
-      .at(5)
-      .simulate('click');
+    wrapper.find('th').at(5).simulate('click');
     expect(wrapper.state('table').rowData).toEqual(sortByAscending(householdMembers, 'continuous_exposure'));
-    wrapper
-      .find('th')
-      .at(5)
-      .simulate('click');
+    wrapper.find('th').at(5).simulate('click');
     expect(wrapper.state('table').rowData).toEqual(sortByDescending(householdMembers, 'continuous_exposure'));
   });
 
@@ -336,7 +223,7 @@ describe('HouseholdMemberTable', () => {
     householdMembers.push(mockPatient5);
     let selectedRows = [0, 2];
     let selectedIds = [householdMembers[0].id, householdMembers[2].id];
-    const wrapper = mount(<HouseholdMemberTable household_members={householdMembers} isSelectable={true} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} handleApplyHouseholdChange={handleApplyHouseholdChangeMock} handleApplyHouseholdIdsChange={handleApplyHouseholdIdsChangeMock} />);
+    const wrapper = mount(<HouseholdMemberTable household_members={householdMembers} isSelectable={true} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} handleApplyHouseholdChange={handleApplyHouseholdChangeMock} handleApplyHouseholdIdsChange={handleApplyHouseholdIdsChangeMock} workflow={'global'} />);
 
     // initial load
     selectedRows.forEach(rowId => {
@@ -351,157 +238,74 @@ describe('HouseholdMemberTable', () => {
     expect(wrapper.state('table').selectAll).toBeFalsy();
     expect(wrapper.state('table').selectedRows).toEqual(selectedRows);
     expect(wrapper.state('selectedIds')).toEqual(selectedIds);
-    expect(
-      wrapper
-        .find('thead')
-        .find('input')
-        .prop('checked')
-    ).toBeFalsy();
-    expect(
-      wrapper
-        .find('thead')
-        .find('input')
-        .prop('disabled')
-    ).toBeFalsy();
+    expect(wrapper.find('thead').find('input').prop('checked')).toBeFalsy();
+    expect(wrapper.find('thead').find('input').prop('disabled')).toBeFalsy();
     wrapper
       .find('tbody')
       .find('tr')
       .forEach((row, index) => {
         expect(row.find('input').prop('checked')).toEqual(selectedRows.includes(index));
-        expect(
-          row
-            .find('td')
-            .at(1)
-            .find('a')
-            .text()
-        ).toEqual(nameFormatterAlt(householdMembers[Number(index)]));
+        expect(row.find('td').at(1).find('a').text()).toEqual(nameFormatterAlt(householdMembers[Number(index)]));
       });
 
     // sort by name, asc
     let sortedHouseholdMembers = sortByNameAscending(householdMembers);
     selectedRows = [2, 4];
-    wrapper
-      .find('th')
-      .at(1)
-      .simulate('click');
+    wrapper.find('th').at(1).simulate('click');
     expect(wrapper.state('table').rowData).toEqual(sortedHouseholdMembers);
     expect(wrapper.state('table').selectAll).toBeFalsy();
     expect(wrapper.state('table').selectedRows).toEqual(selectedRows);
     expect(wrapper.state('selectedIds')).toEqual(selectedIds);
-    expect(
-      wrapper
-        .find('thead')
-        .find('input')
-        .prop('checked')
-    ).toBeFalsy();
-    expect(
-      wrapper
-        .find('thead')
-        .find('input')
-        .prop('disabled')
-    ).toBeFalsy();
+    expect(wrapper.find('thead').find('input').prop('checked')).toBeFalsy();
+    expect(wrapper.find('thead').find('input').prop('disabled')).toBeFalsy();
     wrapper
       .find('tbody')
       .find('tr')
       .forEach((row, index) => {
         expect(row.find('input').prop('checked')).toEqual(selectedRows.includes(index));
-        expect(
-          row
-            .find('td')
-            .at(1)
-            .find('a')
-            .text()
-        ).toEqual(nameFormatterAlt(sortedHouseholdMembers[Number(index)]));
+        expect(row.find('td').at(1).find('a').text()).toEqual(nameFormatterAlt(sortedHouseholdMembers[Number(index)]));
       });
 
     // sort by DOB, desc
     sortedHouseholdMembers = sortByDateDescending(sortedHouseholdMembers, 'date_of_birth');
     selectedRows = [1, 2];
-    wrapper
-      .find('th')
-      .at(2)
-      .simulate('click');
+    wrapper.find('th').at(2).simulate('click');
     expect(wrapper.state('table').rowData).toEqual(sortedHouseholdMembers);
     expect(wrapper.state('table').selectAll).toBeFalsy();
     expect(wrapper.state('table').selectedRows).toEqual(selectedRows);
     expect(wrapper.state('selectedIds')).toEqual(selectedIds);
-    expect(
-      wrapper
-        .find('thead')
-        .find('input')
-        .prop('checked')
-    ).toBeFalsy();
-    expect(
-      wrapper
-        .find('thead')
-        .find('input')
-        .prop('disabled')
-    ).toBeFalsy();
+    expect(wrapper.find('thead').find('input').prop('checked')).toBeFalsy();
+    expect(wrapper.find('thead').find('input').prop('disabled')).toBeFalsy();
     wrapper
       .find('tbody')
       .find('tr')
       .forEach((row, index) => {
         expect(row.find('input').prop('checked')).toEqual(selectedRows.includes(index));
-        expect(
-          row
-            .find('td')
-            .at(1)
-            .find('a')
-            .text()
-        ).toEqual(nameFormatterAlt(sortedHouseholdMembers[Number(index)]));
+        expect(row.find('td').at(1).find('a').text()).toEqual(nameFormatterAlt(sortedHouseholdMembers[Number(index)]));
       });
 
     // sort by workflow, asc
     sortedHouseholdMembers = sortByAscending(sortedHouseholdMembers, 'isolation');
     selectedRows = [0, 4];
-    wrapper
-      .find('th')
-      .at(3)
-      .simulate('click');
+    wrapper.find('th').at(3).simulate('click');
     expect(wrapper.state('table').rowData).toEqual(sortedHouseholdMembers);
     expect(wrapper.state('table').selectAll).toBeFalsy();
     expect(wrapper.state('table').selectedRows).toEqual(selectedRows);
     expect(wrapper.state('selectedIds')).toEqual(selectedIds);
-    expect(
-      wrapper
-        .find('thead')
-        .find('input')
-        .prop('checked')
-    ).toBeFalsy();
-    expect(
-      wrapper
-        .find('thead')
-        .find('input')
-        .prop('disabled')
-    ).toBeFalsy();
+    expect(wrapper.find('thead').find('input').prop('checked')).toBeFalsy();
+    expect(wrapper.find('thead').find('input').prop('disabled')).toBeFalsy();
     wrapper
       .find('tbody')
       .find('tr')
       .forEach((row, index) => {
         expect(row.find('input').prop('checked')).toEqual(selectedRows.includes(index));
-        expect(
-          row
-            .find('td')
-            .at(1)
-            .find('a')
-            .text()
-        ).toEqual(nameFormatterAlt(sortedHouseholdMembers[Number(index)]));
+        expect(row.find('td').at(1).find('a').text()).toEqual(nameFormatterAlt(sortedHouseholdMembers[Number(index)]));
       });
   });
 
   it('Hides checkboxes when props.isSelectable is false', () => {
     const wrapper = getMountedWrapper(false);
-    expect(
-      wrapper
-        .find('thead')
-        .find('input')
-        .exists()
-    ).toBeFalsy();
-    expect(
-      wrapper
-        .find('tbody')
-        .find('input')
-        .exists()
-    ).toBeFalsy();
+    expect(wrapper.find('thead').find('input').exists()).toBeFalsy();
+    expect(wrapper.find('tbody').find('input').exists()).toBeFalsy();
   });
 });

--- a/app/javascript/tests/patient/monitoring_actions/AssignedUser.test.js
+++ b/app/javascript/tests/patient/monitoring_actions/AssignedUser.test.js
@@ -13,7 +13,7 @@ const mockToken = 'testMockTokenString12345';
 const assigned_users = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 21];
 
 function getWrapper() {
-  return shallow(<AssignedUser patient={mockPatient1} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} assigned_users={assigned_users} household_members={[]} authenticity_token={mockToken} />);
+  return shallow(<AssignedUser patient={mockPatient1} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} assigned_users={assigned_users} household_members={[]} authenticity_token={mockToken} workflow={'global'} />);
 }
 
 describe('AssignedUser', () => {
@@ -73,7 +73,7 @@ describe('AssignedUser', () => {
   });
 
   it('Toggling HoH radio buttons hides/shows household members table and updates state', () => {
-    const wrapper = mount(<AssignedUser patient={mockPatient1} assigned_users={assigned_users} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} household_members={[mockPatient2, mockPatient3, mockPatient4]} />);
+    const wrapper = mount(<AssignedUser patient={mockPatient1} assigned_users={assigned_users} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} household_members={[mockPatient2, mockPatient3, mockPatient4]} workflow={'global'} />);
     wrapper
       .find('#assigned_user')
       .at(1)

--- a/app/javascript/tests/patient/monitoring_actions/CaseStatus.test.js
+++ b/app/javascript/tests/patient/monitoring_actions/CaseStatus.test.js
@@ -15,7 +15,7 @@ const caseStatusValues = ['', 'Confirmed', 'Probable', 'Suspect', 'Unknown', 'No
 const monitoringOptionValues = ['', 'End Monitoring', 'Continue Monitoring in Isolation Workflow'];
 
 function getWrapper(patient) {
-  return shallow(<CaseStatus patient={patient} current_user={mockUser1} household_members={[]} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} monitoring_reasons={mockMonitoringReasons} />);
+  return shallow(<CaseStatus patient={patient} current_user={mockUser1} household_members={[]} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} monitoring_reasons={mockMonitoringReasons} workflow={'global'} />);
 }
 
 describe('CaseStatus', () => {
@@ -202,7 +202,7 @@ describe('CaseStatus', () => {
   });
 
   it('Toggling HoH radio buttons hides/shows household members table and updates state', () => {
-    const wrapper = mount(<CaseStatus patient={mockPatient1} current_user={mockUser1} household_members={[mockPatient2, mockPatient3, mockPatient4]} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} />);
+    const wrapper = mount(<CaseStatus patient={mockPatient1} current_user={mockUser1} household_members={[mockPatient2, mockPatient3, mockPatient4]} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} workflow={'global'} />);
     wrapper
       .find('#case_status')
       .at(1)

--- a/app/javascript/tests/patient/monitoring_actions/ExposureRiskAssessment.test.js
+++ b/app/javascript/tests/patient/monitoring_actions/ExposureRiskAssessment.test.js
@@ -13,7 +13,7 @@ const mockToken = 'testMockTokenString12345';
 const exposureRiskAssessmentOptions = ['', 'High', 'Medium', 'Low', 'No Identified Risk'];
 
 function getWrapper() {
-  return shallow(<ExposureRiskAssessment patient={mockPatient1} household_members={[]} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} />);
+  return shallow(<ExposureRiskAssessment patient={mockPatient1} household_members={[]} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} workflow={'global'} />);
 }
 
 describe('ExposureRiskAssessment', () => {
@@ -60,7 +60,7 @@ describe('ExposureRiskAssessment', () => {
   });
 
   it('Toggling HoH radio buttons hides/shows household members table and updates state', () => {
-    const wrapper = mount(<ExposureRiskAssessment patient={mockPatient1} household_members={[mockPatient2, mockPatient3, mockPatient4]} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} />);
+    const wrapper = mount(<ExposureRiskAssessment patient={mockPatient1} household_members={[mockPatient2, mockPatient3, mockPatient4]} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} workflow={'global'} />);
     wrapper
       .find('#exposure_risk_assessment')
       .at(1)

--- a/app/javascript/tests/patient/monitoring_actions/Jurisdiction.test.js
+++ b/app/javascript/tests/patient/monitoring_actions/Jurisdiction.test.js
@@ -12,7 +12,7 @@ import { mockPatient1, mockPatient2, mockPatient3, mockPatient4 } from '../../mo
 const mockToken = 'testMockTokenString12345';
 
 function getWrapper() {
-  return shallow(<Jurisdiction patient={mockPatient1} current_user={mockUser1} household_members={[]} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} user_can_transfer={true} />);
+  return shallow(<Jurisdiction patient={mockPatient1} current_user={mockUser1} household_members={[]} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} user_can_transfer={true} workflow={'global'} />);
 }
 
 describe('Jurisdiction', () => {
@@ -90,7 +90,7 @@ describe('Jurisdiction', () => {
   });
 
   it('Toggling HoH radio buttons hides/shows household members table and updates state', () => {
-    const wrapper = mount(<Jurisdiction patient={mockPatient1} current_user={mockUser1} household_members={[mockPatient2, mockPatient3, mockPatient4]} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} user_can_transfer={true} />);
+    const wrapper = mount(<Jurisdiction patient={mockPatient1} current_user={mockUser1} household_members={[mockPatient2, mockPatient3, mockPatient4]} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} user_can_transfer={true} workflow={'global'} />);
     wrapper
       .find('#jurisdiction_id')
       .at(1)

--- a/app/javascript/tests/patient/monitoring_actions/MonitoringActions.test.js
+++ b/app/javascript/tests/patient/monitoring_actions/MonitoringActions.test.js
@@ -19,7 +19,7 @@ const assigned_users = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
 
 describe('MonitoringActions', () => {
   it('Properly renders all main components', () => {
-    const wrapper = shallow(<MonitoringActions patient={mockPatient1} household_members={[]} isolation={false} authenticity_token={mockToken} jurisdiction_paths={mockJurisdictionPaths} current_user={mockUser1} assigned_users={assigned_users} user_can_transfer={false} monitoring_reasons={mockMonitoringReasons} />);
+    const wrapper = shallow(<MonitoringActions patient={mockPatient1} household_members={[]} isolation={false} authenticity_token={mockToken} jurisdiction_paths={mockJurisdictionPaths} current_user={mockUser1} assigned_users={assigned_users} user_can_transfer={false} monitoring_reasons={mockMonitoringReasons} workflow={'global'} />);
 
     expect(wrapper.find(Form).exists()).toBeTruthy();
     expect(wrapper.find(Form.Group).length).toEqual(7);

--- a/app/javascript/tests/patient/monitoring_actions/MonitoringPlan.test.js
+++ b/app/javascript/tests/patient/monitoring_actions/MonitoringPlan.test.js
@@ -13,7 +13,7 @@ const mockToken = 'testMockTokenString12345';
 const monitoringPlanOptions = ['', 'None', 'Daily active monitoring', 'Self-monitoring with public health supervision', 'Self-monitoring with delegated supervision', 'Self-observation'];
 
 function getWrapper() {
-  return shallow(<MonitoringPlan patient={mockPatient1} household_members={[]} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} />);
+  return shallow(<MonitoringPlan patient={mockPatient1} household_members={[]} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} workflow={'global'} />);
 }
 
 describe('MonitoringPlan', () => {
@@ -60,7 +60,7 @@ describe('MonitoringPlan', () => {
   });
 
   it('Toggling HoH radio buttons hides/shows household members table and updates state', () => {
-    const wrapper = mount(<MonitoringPlan patient={mockPatient1} household_members={[mockPatient2, mockPatient3, mockPatient4]} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} />);
+    const wrapper = mount(<MonitoringPlan patient={mockPatient1} household_members={[mockPatient2, mockPatient3, mockPatient4]} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} workflow={'global'} />);
     wrapper
       .find('#monitoring_plan')
       .at(1)

--- a/app/javascript/tests/patient/monitoring_actions/MonitoringStatus.test.js
+++ b/app/javascript/tests/patient/monitoring_actions/MonitoringStatus.test.js
@@ -18,11 +18,11 @@ const mockToken = 'testMockTokenString12345';
 const monitoringStatusValues = ['Actively Monitoring', 'Not Monitoring'];
 
 function getWrapper(patient, householdMembers) {
-  return shallow(<MonitoringStatus patient={patient} household_members={householdMembers || []} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} monitoring_reasons={mockMonitoringReasons} />);
+  return shallow(<MonitoringStatus patient={patient} household_members={householdMembers || []} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} monitoring_reasons={mockMonitoringReasons} workflow={'global'} />);
 }
 
 function getMountedWrapper() {
-  return mount(<MonitoringStatus patient={mockPatient1} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} household_members={[mockPatient2, mockPatient3, mockPatient4]} authenticity_token={mockToken} monitoring_reasons={mockMonitoringReasons} />);
+  return mount(<MonitoringStatus patient={mockPatient1} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} household_members={[mockPatient2, mockPatient3, mockPatient4]} authenticity_token={mockToken} monitoring_reasons={mockMonitoringReasons} workflow={'global'} />);
 }
 
 describe('MonitoringStatus', () => {

--- a/app/javascript/tests/patient/monitoring_actions/PublicHealthAction.test.js
+++ b/app/javascript/tests/patient/monitoring_actions/PublicHealthAction.test.js
@@ -13,11 +13,11 @@ const mockToken = 'testMockTokenString12345';
 const publicHealthActionOptions = ['None', 'Recommended medical evaluation of symptoms', 'Document results of medical evaluation', 'Recommended laboratory testing'];
 
 function getWrapper(patient) {
-  return shallow(<PublicHealthAction patient={patient} household_members={[]} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} />);
+  return shallow(<PublicHealthAction patient={patient} household_members={[]} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} workflow={'global'} />);
 }
 
 function getMountedWrapper(patient) {
-  return mount(<PublicHealthAction patient={patient} household_members={[mockPatient3, mockPatient4]} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} />);
+  return mount(<PublicHealthAction patient={patient} household_members={[mockPatient3, mockPatient4]} current_user={mockUser1} jurisdiction_paths={mockJurisdictionPaths} authenticity_token={mockToken} workflow={'global'} />);
 }
 
 describe('PublicHealthAction', () => {

--- a/app/javascript/tests/public_health/PatientsTable.test.js
+++ b/app/javascript/tests/public_health/PatientsTable.test.js
@@ -79,7 +79,7 @@ describe('PatientsTable', () => {
     expect(wrapper.containsMatchingElement(AdvancedFilter)).toBeTruthy();
     expect(wrapper.containsMatchingElement(CustomTable)).toBeTruthy();
     expect(wrapper.containsMatchingElement(DropdownButton)).toBeTruthy();
-    expect(wrapper.find(Dropdown.Item).length).toEqual(2);
+    expect(wrapper.find(Dropdown.Item).length).toEqual(3);
 
     const defaultTab = Object.keys(mockIsolationTabs)[0];
     expect(wrapper.find('#tab-description').text()).toEqual(mockGlobalTabs[`${defaultTab}`]['description'] + ' You are currently in the global dashboard.');

--- a/app/javascript/tests/public_health/PatientsTable.test.js
+++ b/app/javascript/tests/public_health/PatientsTable.test.js
@@ -12,7 +12,7 @@ import FollowUpFlag from '../../components/patient/follow_up_flag/FollowUpFlag';
 import UpdateCaseStatus from '../../components/public_health/actions/UpdateCaseStatus';
 import UpdateAssignedUser from '../../components/public_health/actions/UpdateAssignedUser';
 import { mockJurisdiction1, mockJurisdictionPaths } from '../mocks/mockJurisdiction';
-import { mockExposureTabs, mockIsolationTabs } from '../mocks/mockTabs';
+import { mockExposureTabs, mockIsolationTabs, mockGlobalTabs } from '../mocks/mockTabs';
 import { mockMonitoringReasons } from '../mocks/mockMonitoringReasons';
 
 const mockToken = 'testMockTokenString12345';
@@ -26,6 +26,10 @@ function getExposureWrapper() {
 
 function getIsolationWrapper() {
   return shallow(<PatientsTable authenticity_token={mockToken} jurisdiction_paths={mockJurisdictionPaths} workflow={'isolation'} jurisdiction={mockJurisdiction1} tabs={mockIsolationTabs} monitoring_reasons={mockMonitoringReasons} setQuery={setQueryMock} setFilteredMonitoreesCount={setMonitoreeCountMock} />);
+}
+
+function getGlobalWrapper() {
+  return shallow(<PatientsTable authenticity_token={mockToken} jurisdiction_paths={mockJurisdictionPaths} workflow={'global'} jurisdiction={mockJurisdiction1} tabs={mockGlobalTabs} default_tab={'all'} monitoring_reasons={mockMonitoringReasons} setQuery={setQueryMock} setFilteredMonitoreesCount={setMonitoreeCountMock} />);
 }
 
 afterEach(() => {
@@ -63,6 +67,22 @@ describe('PatientsTable', () => {
 
     const defaultTab = Object.keys(mockIsolationTabs)[0];
     expect(wrapper.find('#tab-description').text()).toEqual(mockIsolationTabs[`${defaultTab}`]['description'] + ' You are currently in the isolation workflow.');
+  });
+
+  it('Properly renders all main components for the global workflow', () => {
+    const wrapper = getGlobalWrapper();
+    expect(wrapper.find('#search').exists()).toBeTruthy();
+    expect(wrapper.find('#tab-description').exists()).toBeTruthy();
+    expect(wrapper.find('#clear-all-filters').exists()).toBeTruthy();
+    expect(wrapper.containsMatchingElement(JurisdictionFilter)).toBeTruthy();
+    expect(wrapper.containsMatchingElement(AssignedUserFilter)).toBeTruthy();
+    expect(wrapper.containsMatchingElement(AdvancedFilter)).toBeTruthy();
+    expect(wrapper.containsMatchingElement(CustomTable)).toBeTruthy();
+    expect(wrapper.containsMatchingElement(DropdownButton)).toBeTruthy();
+    expect(wrapper.find(Dropdown.Item).length).toEqual(2);
+
+    const defaultTab = Object.keys(mockIsolationTabs)[0];
+    expect(wrapper.find('#tab-description').text()).toEqual(mockGlobalTabs[`${defaultTab}`]['description'] + ' You are currently in the global workflow.');
   });
 
   it('Sets intial state after mount correctly', () => {
@@ -163,6 +183,14 @@ describe('PatientsTable', () => {
     for (var key of Object.keys(mockIsolationTabs)) {
       expect(wrapper.find('#' + key + '_tab').exists()).toBeTruthy();
       expect(wrapper.find('#' + key + '_tab').text()).toEqual(mockIsolationTabs[`${key}`]['label']);
+    }
+  });
+
+  it('Properly renders all tabs on global dashboard', () => {
+    const wrapper = getGlobalWrapper();
+    for (var key of Object.keys(mockGlobalTabs)) {
+      expect(wrapper.find('#' + key + '_tab').exists()).toBeTruthy();
+      expect(wrapper.find('#' + key + '_tab').text()).toEqual(mockGlobalTabs[`${key}`]['label']);
     }
   });
 });

--- a/app/javascript/tests/public_health/PatientsTable.test.js
+++ b/app/javascript/tests/public_health/PatientsTable.test.js
@@ -82,7 +82,7 @@ describe('PatientsTable', () => {
     expect(wrapper.find(Dropdown.Item).length).toEqual(2);
 
     const defaultTab = Object.keys(mockIsolationTabs)[0];
-    expect(wrapper.find('#tab-description').text()).toEqual(mockGlobalTabs[`${defaultTab}`]['description'] + ' You are currently in the global workflow.');
+    expect(wrapper.find('#tab-description').text()).toEqual(mockGlobalTabs[`${defaultTab}`]['description'] + ' You are currently in the global dashboard.');
   });
 
   it('Sets intial state after mount correctly', () => {

--- a/app/javascript/tests/public_health/query/AdvancedFilter.test.js
+++ b/app/javascript/tests/public_health/query/AdvancedFilter.test.js
@@ -133,7 +133,7 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find(Modal.Body).find('.remove-filter-row').exists()).toBeTruthy();
     expect(wrapper.find(Modal.Body).find('#add-filter-row').exists()).toBeTruthy();
     expect(wrapper.find(Modal.Footer).exists()).toBeTruthy();
-    expect(wrapper.find(Modal.Footer).find('p').text()).toEqual('Filter will be applied to all line lists in the current Dashboard until reset.');
+    expect(wrapper.find(Modal.Footer).find('p').text()).toEqual('Filter will be applied to all line lists in the current dashboard until reset.');
     expect(wrapper.find(Modal.Footer).find(Button).length).toEqual(2);
     expect(wrapper.find(Modal.Footer).find('#advanced-filter-cancel').exists()).toBeTruthy();
     expect(wrapper.find(Modal.Footer).find('#advanced-filter-cancel').text()).toEqual('Cancel');
@@ -181,7 +181,7 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find(Modal.Body).find('.remove-filter-row').exists()).toBeTruthy();
     expect(wrapper.find(Modal.Body).find('#add-filter-row').exists()).toBeTruthy();
     expect(wrapper.find(Modal.Footer).exists()).toBeTruthy();
-    expect(wrapper.find(Modal.Footer).find('p').text()).toEqual('Filter will be applied to all line lists in the current Dashboard until reset.');
+    expect(wrapper.find(Modal.Footer).find('p').text()).toEqual('Filter will be applied to all line lists in the current dashboard until reset.');
     expect(wrapper.find(Modal.Footer).find(Button).length).toEqual(2);
     expect(wrapper.find(Modal.Footer).find('#advanced-filter-cancel').exists()).toBeTruthy();
     expect(wrapper.find(Modal.Footer).find('#advanced-filter-cancel').text()).toEqual('Cancel');

--- a/app/javascript/tests/public_health/query/AdvancedFilter.test.js
+++ b/app/javascript/tests/public_health/query/AdvancedFilter.test.js
@@ -133,8 +133,7 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find(Modal.Body).find('.remove-filter-row').exists()).toBeTruthy();
     expect(wrapper.find(Modal.Body).find('#add-filter-row').exists()).toBeTruthy();
     expect(wrapper.find(Modal.Footer).exists()).toBeTruthy();
-    expect(wrapper.find(Modal.Footer).find('p').text()).toEqual('Filter will be applied to the line lists in the exposure workflow until reset.');
-    expect(wrapper.find(Modal.Footer).find('u').text()).toEqual('exposure');
+    expect(wrapper.find(Modal.Footer).find('p').text()).toEqual('Filter will be applied to all line lists in the current Dashboard until reset.');
     expect(wrapper.find(Modal.Footer).find(Button).length).toEqual(2);
     expect(wrapper.find(Modal.Footer).find('#advanced-filter-cancel').exists()).toBeTruthy();
     expect(wrapper.find(Modal.Footer).find('#advanced-filter-cancel').text()).toEqual('Cancel');
@@ -182,8 +181,7 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find(Modal.Body).find('.remove-filter-row').exists()).toBeTruthy();
     expect(wrapper.find(Modal.Body).find('#add-filter-row').exists()).toBeTruthy();
     expect(wrapper.find(Modal.Footer).exists()).toBeTruthy();
-    expect(wrapper.find(Modal.Footer).find('p').text()).toEqual('Filter will be applied to the line lists in the exposure workflow until reset.');
-    expect(wrapper.find(Modal.Footer).find('u').text()).toEqual('exposure');
+    expect(wrapper.find(Modal.Footer).find('p').text()).toEqual('Filter will be applied to all line lists in the current Dashboard until reset.');
     expect(wrapper.find(Modal.Footer).find(Button).length).toEqual(2);
     expect(wrapper.find(Modal.Footer).find('#advanced-filter-cancel').exists()).toBeTruthy();
     expect(wrapper.find(Modal.Footer).find('#advanced-filter-cancel').text()).toEqual('Cancel');

--- a/app/javascript/utils/Navigation.js
+++ b/app/javascript/utils/Navigation.js
@@ -6,4 +6,12 @@ function navQueryParam(workflow, firstParam) {
   return workflow ? `${firstParam ? '?' : '&'}nav=${workflow}` : "";
 }
 
-export { navQueryParam };
+/**
+ * @param {String} id - the ID of the patient to link to 
+ * @param {String} workflow  - the workflow for the nav query param
+ */
+function patientHref(id, workflow) {
+  return `${window.BASE_PATH}/patients/${id}${navQueryParam(workflow, true)}`;
+}
+
+export { navQueryParam, patientHref };

--- a/app/javascript/utils/Navigation.js
+++ b/app/javascript/utils/Navigation.js
@@ -1,0 +1,9 @@
+/**
+ * @param {String} workflow - the value of the navigation quary param
+ * @param {Boolean} firstParam - whether the nav param is the first query param in the URL
+ */
+function navQueryParam(workflow, firstParam) {
+  return workflow ? `${firstParam ? '?' : '&'}nav=${workflow}` : "";
+}
+
+export { navQueryParam };

--- a/app/lib/import_export_constants.rb
+++ b/app/lib/import_export_constants.rb
@@ -5,8 +5,10 @@ module ImportExportConstants # rubocop:todo Metrics/ModuleLength
   EXPORT_TYPES = {
     csv_linelist_exposure: { label: 'Line list CSV (exposure)', filename: 'Sara-Alert-Linelist-Exposure' },
     csv_linelist_isolation: { label: 'Line list CSV (isolation)', filename: 'Sara-Alert-Linelist-Isolation' },
+    csv_linelist_global: { label: 'Line list CSV (global)', filename: 'Sara-Alert-Linelist-Global' },
     sara_alert_format_exposure: { label: 'Sara Alert Format (exposure)', filename: 'Sara-Alert-Format-Exposure' },
     sara_alert_format_isolation: { label: 'Sara Alert Format (isolation)', filename: 'Sara-Alert-Format-Isolation' },
+    sara_alert_format_global: { label: 'Sara Alert Format (global)', filename: 'Sara-Alert-Format-Global' },
     full_history_patients_all: { label: 'Excel Export For All Monitorees', filename: 'Sara-Alert-Full-Export' },
     full_history_patients_purgeable: { label: 'Excel Export For Purge-Eligible Monitorees', filename: 'Sara-Alert-Purge-Eligible-Export' },
     custom: { label: 'Custom Export', filename: 'Sara-Alert-Custom-Export' }

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -542,6 +542,16 @@ class Patient < ApplicationRecord
          )
   }
 
+  # Individuals either in exposure who are considered symptomatic or in isolation who require review
+  scope :global_priority_review, lambda {
+    exposure_symptomatic.or(isolation_requiring_review)
+  }
+
+  # Individuals not meeting review and are not reporting (exposure or isolation)
+  scope :global_non_reporting, lambda {
+    exposure_non_reporting.or(isolation_non_reporting)
+  }
+
   # Monitorees who have reported in the last hour that are considered symptomatic
   scope :recently_symptomatic, lambda {
     where(monitoring: true)

--- a/app/views/layouts/_breadcrumb.html.erb
+++ b/app/views/layouts/_breadcrumb.html.erb
@@ -1,1 +1,1 @@
-<%= react_component('layout/Breadcrumb', { crumbs: crumbs, jurisdiction: jurisdiction_path.join(', '), isolation: (defined?(isolation) && isolation) || false, enroller: current_user.role?(Roles::ENROLLER) }) %>
+<%= react_component('layout/Breadcrumb', { crumbs: crumbs || [], jurisdiction: jurisdiction_path.join(', '), enroller: current_user.role?(Roles::ENROLLER) }) %>

--- a/app/views/patients/edit.html.erb
+++ b/app/views/patients/edit.html.erb
@@ -1,4 +1,11 @@
-<%= render partial: 'layouts/breadcrumb', locals: { jurisdiction_path: current_user.jurisdiction_path, crumbs: [{ value: 'Return to Exposure Dashboard', href: '/' }, { value: 'Return to Monitoree Details', href: '/' }, { value: 'Edit Monitoree', href: nil }], isolation: @patient&.isolation || false } %>
+<%= render partial: 'layouts/breadcrumb', locals: {
+      jurisdiction_path: current_user.jurisdiction_path,
+      crumbs: [
+        { value: dashboard_crumb_title(@dashboard), href: @dashboard_path },
+        { value: 'Return to Monitoree Details', href: patient_path(@patient.id) + (@dashboard ? "?nav=#{@dashboard}" : '') },
+        { value: 'Edit Monitoree', href: nil }
+      ]
+    } %>
 
 <%= react_component('enrollment/Enrollment', {
                       current_user: current_user,
@@ -14,5 +21,6 @@
                       race_options: ValidationHelper::RACE_OPTIONS,
                       blocked_sms: @patient.blocked_sms,
                       first_positive_lab: @patient.laboratories.where(result: 'positive').order(:specimen_collection).first,
-                      symptomatic_assessments_exist: @patient.assessments.where(symptomatic: true).any?
+                      symptomatic_assessments_exist: @patient.assessments.where(symptomatic: true).any?,
+                      workflow: @dashboard
                     }) %>

--- a/app/views/patients/new.html.erb
+++ b/app/views/patients/new.html.erb
@@ -1,4 +1,7 @@
-<%= render partial: 'layouts/breadcrumb', locals: { jurisdiction_path: current_user.jurisdiction_path, crumbs: [{ value: 'Return to Exposure Dashboard', href: '/' }, { value: 'Enroll New Monitoree', href: nil }] } %>
+<%= render partial: 'layouts/breadcrumb', locals: {
+      jurisdiction_path: current_user.jurisdiction_path,
+      crumbs: [{ value: dashboard_crumb_title(@dashboard), href: @dashboard_path }, { value: 'Enroll New Monitoree', href: nil }]
+    } %>
 
 <%= react_component('enrollment/Enrollment', {
                       current_user: current_user,
@@ -13,7 +16,8 @@
                       race_options: ValidationHelper::RACE_OPTIONS,
                       cc_id: @close_contact&.id,
                       first_positive_lab: nil,
-                      symptomatic_assessments_exist: false
+                      symptomatic_assessments_exist: false,
+                      workflow: @dashboard
                     }) %>
 
 <div class="pb-4"></div>

--- a/app/views/patients/new_group_member.html.erb
+++ b/app/views/patients/new_group_member.html.erb
@@ -1,4 +1,7 @@
-<%= render partial: 'layouts/breadcrumb', locals: { jurisdiction_path: current_user.jurisdiction_path, crumbs: [{ value: 'Return to Exposure Dashboard', href: '/' }, { value: 'Enroll New Monitoree', href: nil }] } %>
+<%= render partial: 'layouts/breadcrumb', locals: {
+      jurisdiction_path: current_user.jurisdiction_path,
+      crumbs: [{ value: dashboard_crumb_title(@dashboard), href: @dashboard_path }, { value: 'Enroll New Monitoree', href: nil }]
+    } %>
 
 <%= react_component('enrollment/Enrollment', {
                       current_user: current_user,
@@ -13,7 +16,8 @@
                       assigned_users: @patient.jurisdiction.assigned_users,
                       race_options: ValidationHelper::RACE_OPTIONS,
                       first_positive_lab: nil,
-                      symptomatic_assessments_exist: false
+                      symptomatic_assessments_exist: false,
+                      workflow: @dashboard
                     }) %>
 
 <div class="pb-4"></div>

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -5,8 +5,7 @@
 <%= render partial: 'layouts/breadcrumb',
            locals: {
              jurisdiction_path: current_user.jurisdiction_path,
-             crumbs: [{ value: 'Return to Exposure Dashboard', href: '/' }, { value: 'Monitoree Details', href: nil }],
-             isolation: @patient&.isolation || false
+             crumbs: [{ value: dashboard_crumb_title(@dashboard), href: @dashboard_path }, { value: 'Monitoree Details', href: nil }]
            } %>
 
 <% if current_user.can_download_monitoree_data? %>
@@ -21,7 +20,8 @@
                       other_household_members: @household_members_exclude_self,
                       authenticity_token: form_authenticity_token,
                       jurisdiction_paths: @possible_jurisdiction_paths,
-                      blocked_sms: @patient.blocked_sms
+                      blocked_sms: @patient.blocked_sms,
+                      workflow: @dashboard
                     }) %>
 
 <% if current_user.can_modify_subject_status? %>
@@ -35,7 +35,8 @@
                         patient: @patient,
                         jurisdiction_paths: @possible_jurisdiction_paths,
                         assigned_users: @possible_assigned_users,
-                        monitoring_reasons: ValidationHelper::USER_SELECTABLE_MONITORING_REASONS
+                        monitoring_reasons: ValidationHelper::USER_SELECTABLE_MONITORING_REASONS,
+                        workflow: @dashboard
                       }) %>
 </div>
 <% end %>
@@ -55,7 +56,8 @@
                         current_user: current_user,
                         translations: Assessment.new.translations,
                         authenticity_token: form_authenticity_token,
-                        jurisdiction_paths: @possible_jurisdiction_paths
+                        jurisdiction_paths: @possible_jurisdiction_paths,
+                        workflow: @dashboard
                       }) %>
 <% end %>
 

--- a/app/views/public_health/exposure.html.erb
+++ b/app/views/public_health/exposure.html.erb
@@ -64,6 +64,7 @@
                           description: 'All Monitorees in this jurisdiction, in the Exposure workflow.'
                         }
                       },
+                      default_tab: 'symptomatic',
                       custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS,
                       monitoring_reasons: ValidationHelper::USER_SELECTABLE_MONITORING_REASONS
                     }) %>

--- a/app/views/public_health/global.html.erb
+++ b/app/views/public_health/global.html.erb
@@ -21,7 +21,7 @@
                         active: {
                           label: 'Active',
                           variant: 'success',
-                          description: 'Monitorees currently being monitored across both the exposure and isolation workflows.'
+                          description: 'Monitorees currently being actively monitored across both the exposure and isolation workflows.'
                         },
                         priority_review: {
                           label: 'Priority Review',

--- a/app/views/public_health/global.html.erb
+++ b/app/views/public_health/global.html.erb
@@ -1,0 +1,50 @@
+<% content_for :assets do %>
+  <%= javascript_packs_with_chunks_tag 'moment' %>
+<% end %>
+
+<%= render partial: 'layouts/breadcrumb', locals: { jurisdiction_path: current_user.jurisdiction_path, crumbs: [{ value: 'Global Dashboard', href: nil }] } %>
+
+<%= react_component('public_health/Workflow', {
+                      authenticity_token: form_authenticity_token,
+                      abilities: {
+                        analytics: current_user.can_view_analytics?,
+                        enrollment: current_user.can_create_patient?,
+                        export: current_user.can_export?,
+                        import: false
+                      },
+                      jurisdiction: {
+                        id: current_user.jurisdiction_id,
+                        path: current_user.jurisdiction[:path]
+                      },
+                      workflow: 'global',
+                      tabs: {
+                        active: {
+                          label: 'Active',
+                          variant: 'success',
+                          description: 'Monitorees currently being monitored across both the exposure and isolation workflows.'
+                        },
+                        priority_review: {
+                          label: 'Priority Review',
+                          variant: 'danger',
+                          description: 'Monitorees who meet the criteria to appear on either the Symptomatic line list (exposure) or Records Requiring Review line list (isolation) which need to be reviewed.'
+                        },
+                        non_reporting: {
+                          label: 'Non-Reporting',
+                          variant: 'warning',
+                          description: 'All monitorees who have failed to report in the last day across both the exposure and isolation workflows.'
+                        },
+                        closed: {
+                          label: 'Closed',
+                          variant: 'secondary',
+                          description: 'Monitorees not currently being monitored across both the exposure and isolation workflows.'
+                        },
+                        all: {
+                          label: 'All Monitorees',
+                          variant: 'primary',
+                          description: 'All Monitorees in this jurisdiction across both the exposure and isolation workflows.'
+                        }
+                      },
+                      default_tab: 'all',
+                      custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS,
+                      monitoring_reasons: ValidationHelper::USER_SELECTABLE_MONITORING_REASONS
+                    }) %>

--- a/app/views/public_health/isolation.html.erb
+++ b/app/views/public_health/isolation.html.erb
@@ -58,6 +58,7 @@
                           description: 'All cases in this jurisdiction, in the Isolation workflow.'
                         }
                       },
+                      default_tab: 'requiring_review',
                       custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS,
                       monitoring_reasons: ValidationHelper::USER_SELECTABLE_MONITORING_REASONS
                     }) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,7 +136,9 @@ Rails.application.routes.draw do
 
   post '/patients/:patient_submission_token/assessments/:id', to: 'assessments#update'
 
-  get '/public_health', to: 'public_health#exposure', as: :public_health
+  get '/public_health', to: redirect('/public_health/exposure')
+  get '/public_health/global', to: 'public_health#global', as: :public_health_global
+  get '/public_health/exposure', to: 'public_health#exposure', as: :public_health_exposure
   get '/public_health/isolation', to: 'public_health#isolation', as: :public_health_isolation
   post '/public_health/patients', to: 'public_health#patients', as: :public_health_patients
   post '/public_health/patients/count', to: 'public_health#patients_count', as: :public_health_patients_count

--- a/db/migrate/20210614190551_change_export_presets_workflow_all_to_global.rb
+++ b/db/migrate/20210614190551_change_export_presets_workflow_all_to_global.rb
@@ -1,0 +1,29 @@
+class ChangeExportPresetsWorkflowAllToGlobal < ActiveRecord::Migration[6.1]
+  # Rename the 'all' workflow to 'global' in export presets
+  def up
+    # Parse and modify the data in memory, because the JSON to modify is stored as a string in the database
+    UserExportPreset.all.in_batches do |batch|
+      batch.each do |uep|
+        config = JSON.parse(uep.config)
+        if config.dig('data', 'patients', 'query', 'workflow') == 'all'
+          config['data']['patients']['query']['workflow'] = 'global'
+          uep.update(config: config.to_json)
+        end
+      end
+    end
+  end
+
+  # Revert the 'global' workflow back to 'all' in export presets
+  def down
+    # Parse and modify the data in memory, because the JSON to modify is stored as a string in the database
+    UserExportPreset.all.in_batches do |batch|
+      batch.each do |uep|
+        config = JSON.parse(uep.config)
+        if config.dig('data', 'patients', 'query', 'workflow') == 'global'
+          config['data']['patients']['query']['workflow'] = 'all'
+          uep.update(config: config.to_json)
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20210614190551_change_export_presets_workflow_all_to_global.rb
+++ b/db/migrate/20210614190551_change_export_presets_workflow_all_to_global.rb
@@ -1,29 +1,37 @@
 class ChangeExportPresetsWorkflowAllToGlobal < ActiveRecord::Migration[6.1]
   # Rename the 'all' workflow to 'global' in export presets
   def up
+    ActiveRecord::Base.record_timestamps = false
+
     # Parse and modify the data in memory, because the JSON to modify is stored as a string in the database
     UserExportPreset.all.in_batches do |batch|
       batch.each do |uep|
         config = JSON.parse(uep.config)
         if config.dig('data', 'patients', 'query', 'workflow') == 'all'
           config['data']['patients']['query']['workflow'] = 'global'
-          uep.update(config: config.to_json)
+          uep.update!(config: config.to_json)
         end
       end
     end
+
+    ActiveRecord::Base.record_timestamps = true
   end
 
   # Revert the 'global' workflow back to 'all' in export presets
   def down
+    ActiveRecord::Base.record_timestamps = false
+
     # Parse and modify the data in memory, because the JSON to modify is stored as a string in the database
     UserExportPreset.all.in_batches do |batch|
       batch.each do |uep|
         config = JSON.parse(uep.config)
         if config.dig('data', 'patients', 'query', 'workflow') == 'global'
           config['data']['patients']['query']['workflow'] = 'all'
-          uep.update(config: config.to_json)
+          uep.update!(config: config.to_json)
         end
       end
     end
+
+    ActiveRecord::Base.record_timestamps = true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_14_112417) do
+ActiveRecord::Schema.define(version: 2021_06_14_190551) do
 
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -182,6 +182,7 @@ ActiveRecord::Schema.define(version: 2021_05_14_112417) do
     t.string "webpage"
     t.string "message"
     t.boolean "send_digest", default: false
+    t.boolean "send_close", default: false
     t.index ["ancestry"], name: "index_jurisdictions_on_ancestry"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -182,7 +182,6 @@ ActiveRecord::Schema.define(version: 2021_06_14_190551) do
     t.string "webpage"
     t.string "message"
     t.boolean "send_digest", default: false
-    t.boolean "send_close", default: false
     t.index ["ancestry"], name: "index_jurisdictions_on_ancestry"
   end
 

--- a/test/controllers/jurisdictions_controller_test.rb
+++ b/test/controllers/jurisdictions_controller_test.rb
@@ -170,15 +170,15 @@ class JurisdictionsControllerTest < ActionController::TestCase
                            end
           assert_equal assigned_users, JSON.parse(response.body)['assigned_users']
 
-          post :assigned_users_for_viewable_patients, params: { query: { jurisdiction: jur.id, scope: scope, workflow: 'all', tab: 'all' } },
+          post :assigned_users_for_viewable_patients, params: { query: { jurisdiction: jur.id, scope: scope, workflow: 'global', tab: 'all' } },
                                                       as: :json
           assert_equal patients.where(purged: false).distinct.pluck(:assigned_user).sort, JSON.parse(response.body)['assigned_users']
 
-          post :assigned_users_for_viewable_patients, params: { query: { jurisdiction: jur.id, scope: scope, workflow: 'all', tab: 'closed' } },
+          post :assigned_users_for_viewable_patients, params: { query: { jurisdiction: jur.id, scope: scope, workflow: 'global', tab: 'closed' } },
                                                       as: :json
           assert_equal patients.where(monitoring: false, purged: false).distinct.pluck(:assigned_user).sort, JSON.parse(response.body)['assigned_users']
 
-          post :assigned_users_for_viewable_patients, params: { query: { jurisdiction: jur.id, scope: scope, workflow: 'all', tab: 'transferred_in' } },
+          post :assigned_users_for_viewable_patients, params: { query: { jurisdiction: jur.id, scope: scope, workflow: 'global', tab: 'transferred_in' } },
                                                       as: :json
           assigned_users = if scope == 'exact'
                              jur.transferred_in_patients.where(jurisdiction: jur.id).where.not(assigned_user: nil).distinct.pluck(:assigned_user).sort

--- a/test/controllers/public_health_controller_test.rb
+++ b/test/controllers/public_health_controller_test.rb
@@ -492,13 +492,13 @@ class PublicHealthControllerTest < ActionController::TestCase
         assert_equal user.viewable_patients.where(isolation: true, purged: false).size, JSON.parse(response.body)['total']
 
         get :tab_counts, params: { workflow: 'global', tab: 'active' }
-        assert_equal user.viewable_patients.monitoring_active(true).size, JSON.parse(response.body)['total']
+        assert_equal user.viewable_patients.monitoring_open.size, JSON.parse(response.body)['total']
 
         get :tab_counts, params: { workflow: 'global', tab: 'priority_review' }
-        assert_equal user.viewable_patients.exposure_symptomatic.merge(user.patients.isolation_requiring_review).size, JSON.parse(response.body)['total']
+        assert_equal user.viewable_patients.global_priority_review.size, JSON.parse(response.body)['total']
 
         get :tab_counts, params: { workflow: 'global', tab: 'non_reporting' }
-        assert_equal user.viewable_patients.exposure_non_reporting.merge(user.patients.isolation_non_reporting).size, JSON.parse(response.body)['total']
+        assert_equal user.viewable_patients.global_non_reporting.size, JSON.parse(response.body)['total']
 
         get :tab_counts, params: { workflow: 'global', tab: 'closed' }
         assert_equal user.viewable_patients.monitoring_closed_without_purged.size, JSON.parse(response.body)['total']

--- a/test/controllers/public_health_controller_test.rb
+++ b/test/controllers/public_health_controller_test.rb
@@ -243,13 +243,13 @@ class PublicHealthControllerTest < ActionController::TestCase
 
       post :patients, params: { query: { workflow: 'global', tab: 'priority_review' } }, as: :json
       json_response = JSON.parse(response.body)
-      patients = user.viewable_patients.exposure_symptomatic.merge(user.viewable_patients.isolation_requiring_review)
+      patients = user.viewable_patients.global_priority_review
       assert_equal patients.order(:id).pluck(:id), json_response['linelist'].map { |patient| patient['id'] }.sort
       assert_equal patients.size, json_response['total']
 
       post :patients, params: { query: { workflow: 'global', tab: 'non_reporting' } }, as: :json
       json_response = JSON.parse(response.body)
-      patients = user.viewable_patients.exposure_non_reporting.merge(user.patients.isolation_non_reporting)
+      patients = user.patients.global_non_reporting
       assert_equal patients.order(:id).pluck(:id), json_response['linelist'].map { |patient| patient['id'] }.sort
       assert_equal patients.size, json_response['total']
 

--- a/test/system/roles/public_health/dashboard/dashboard.rb
+++ b/test/system/roles/public_health/dashboard/dashboard.rb
@@ -212,6 +212,7 @@ class PublicHealthDashboard < ApplicationSystemTestCase
 
   def select_monitorees_for_bulk_edit(workflow, tab, patient_labels)
     click_on WORKFLOW_CLICK_MAP[workflow] if workflow.present?
+    sleep(1)
     @@system_test_utils.go_to_tab(tab)
     sleep(2)
     patient_labels.each { |patient| check_patient(patient) }

--- a/test/system/roles/public_health/dashboard/dashboard.rb
+++ b/test/system/roles/public_health/dashboard/dashboard.rb
@@ -13,6 +13,11 @@ class PublicHealthDashboard < ApplicationSystemTestCase
 
   PATIENTS = SystemTestUtils::PATIENTS
   MONITOREES = SystemTestUtils::MONITOREES
+  WORKFLOW_CLICK_MAP = {
+    exposure: 'Exposure Monitoring',
+    isolation: 'Isolation Monitoring',
+    global: 'Global Dashboard'
+  }.freeze
 
   def search_for_and_view_patient(tab, patient_label)
     @@system_test_utils.go_to_tab(tab)
@@ -47,7 +52,7 @@ class PublicHealthDashboard < ApplicationSystemTestCase
   end
 
   def start_export(workflow, export_type, action)
-    click_on 'Isolation Monitoring' if workflow == :isolation
+    click_on WORKFLOW_CLICK_MAP[workflow] if workflow.present?
     click_on 'Export'
     click_on export_type
     click_on action == :export ? 'Start Export' : 'Cancel'
@@ -60,7 +65,7 @@ class PublicHealthDashboard < ApplicationSystemTestCase
   end
 
   def export_custom(user_label, settings)
-    click_on (settings[:workflow] == :exposure ? 'Exposure Monitoring' : 'Isolation Monitoring').to_s if settings[:workflow].present?
+    click_on WORKFLOW_CLICK_MAP[settings[:workflow]] if settings[:workflow].present?
     @@system_test_utils.go_to_tab(settings[:tab]) if settings[:tab].present?
 
     click_on 'Export'
@@ -106,7 +111,7 @@ class PublicHealthDashboard < ApplicationSystemTestCase
   end
 
   def import_epi_x(jurisdiction, workflow, file_name, validity, rejects, accept_duplicates)
-    click_on 'Isolation Monitoring' if workflow == :isolation
+    click_on WORKFLOW_CLICK_MAP[workflow] if workflow.present?
     click_on 'Import'
     find('a', text: "Epi-X (#{workflow})").click
     page.attach_file(file_fixture(file_name))
@@ -125,7 +130,7 @@ class PublicHealthDashboard < ApplicationSystemTestCase
   end
 
   def import_sara_alert_format(jurisdiction, workflow, file_name, validity, rejects, accept_duplicates)
-    click_on 'Isolation Monitoring' if workflow == :isolation
+    click_on WORKFLOW_CLICK_MAP[workflow] if workflow.present?
     click_on 'Import'
     find('a', text: "Sara Alert Format (#{workflow})").click
     page.attach_file(file_fixture(file_name))
@@ -144,7 +149,7 @@ class PublicHealthDashboard < ApplicationSystemTestCase
   end
 
   def import_and_cancel(workflow, file_name, file_type)
-    click_on 'Isolation Monitoring' if workflow == :isolation
+    click_on WORKFLOW_CLICK_MAP[workflow] if workflow.present?
     click_on 'Import'
     find('a', text: "#{file_type} (#{workflow})").click
     page.attach_file(file_fixture(file_name))
@@ -178,7 +183,7 @@ class PublicHealthDashboard < ApplicationSystemTestCase
   end
 
   def download_sara_alert_format_guidance(workflow)
-    click_on 'Isolation Monitoring' if workflow == :isolation
+    click_on WORKFLOW_CLICK_MAP[workflow] if workflow.present?
     click_on 'Import'
     find('a', text: "Sara Alert Format (#{workflow})").click
     click_on 'Download formatting guidance'
@@ -206,7 +211,7 @@ class PublicHealthDashboard < ApplicationSystemTestCase
   end
 
   def select_monitorees_for_bulk_edit(workflow, tab, patient_labels)
-    click_on 'Isolation Monitoring' if workflow == :isolation
+    click_on WORKFLOW_CLICK_MAP[workflow] if workflow.present?
     @@system_test_utils.go_to_tab(tab)
     sleep(2)
     patient_labels.each { |patient| check_patient(patient) }
@@ -244,8 +249,8 @@ class PublicHealthDashboard < ApplicationSystemTestCase
   end
 
   def go_to_other_workflow(workflow)
-    click_on 'Isolation Monitoring' if workflow == :exposure
+    click_on WORKFLOW_CLICK_MAP[:isolation] if workflow == :exposure
 
-    click_on 'Exposure Monitoring' if workflow == :isolation
+    click_on WORKFLOW_CLICK_MAP[:exposure] if workflow == :isolation
   end
 end

--- a/test/system/roles/public_health/dashboard/dashboard.rb
+++ b/test/system/roles/public_health/dashboard/dashboard.rb
@@ -212,7 +212,7 @@ class PublicHealthDashboard < ApplicationSystemTestCase
 
   def select_monitorees_for_bulk_edit(workflow, tab, patient_labels)
     click_on WORKFLOW_CLICK_MAP[workflow] if workflow.present?
-    sleep(1)
+    sleep(2)
     @@system_test_utils.go_to_tab(tab)
     sleep(2)
     patient_labels.each { |patient| check_patient(patient) }

--- a/test/system/roles/public_health/dashboard/export_verifier.rb
+++ b/test/system/roles/public_health/dashboard/export_verifier.rb
@@ -17,7 +17,8 @@ class PublicHealthMonitoringExportVerifier < ApplicationSystemTestCase
     user = @@system_test_utils.get_user(user_label)
     export_type = "csv_linelist_#{workflow}".to_sym
     download_export_files(user, export_type)
-    patients = user.jurisdiction.all_patients_excluding_purged.where(isolation: workflow == :isolation).reorder('')
+    patients = user.jurisdiction.all_patients_excluding_purged
+    patients = patients.where(isolation: workflow == :isolation).reorder('') unless workflow == :global
 
     csv = get_csv("Sara-Alert-Linelist-#{workflow.to_s.humanize}-????-??-??T??-??-?????-??.csv")
     verify_csv_linelist_export(csv, patients.order(:id))
@@ -27,7 +28,8 @@ class PublicHealthMonitoringExportVerifier < ApplicationSystemTestCase
     user = @@system_test_utils.get_user(user_label)
     export_type = "sara_alert_format_#{workflow}".to_sym
     download_export_files(user, export_type)
-    patients = user.jurisdiction.all_patients_excluding_purged.where(isolation: workflow == :isolation).reorder('')
+    patients = user.jurisdiction.all_patients_excluding_purged
+    patients = patients.where(isolation: workflow == :isolation).reorder('') unless workflow == :global
     xlsx = get_xlsx("Sara-Alert-Format-#{workflow.to_s.humanize}-????-??-??T??-??-?????-??.xlsx")
     verify_sara_alert_format_export(xlsx, patients.order(:id))
   end

--- a/test/system/roles/public_health/patient_page/patient_page.rb
+++ b/test/system/roles/public_health/patient_page/patient_page.rb
@@ -64,6 +64,6 @@ class PublicHealthPatientPage < ApplicationSystemTestCase
     assert page.has_button?('Select', count: 1)
     click_on 'Select'
 
-    assert page.find('#household-member-not-hoh').has_link?(href: "/patients/#{new_responder_id}")
+    assert page.find('#household-member-not-hoh').has_link?(href: "/patients/#{new_responder_id}?nav=exposure")
   end
 end

--- a/test/system/roles/public_health/public_health_bulk_edit_test.rb
+++ b/test/system/roles/public_health/public_health_bulk_edit_test.rb
@@ -45,12 +45,20 @@ class PublicHealthBulkEditTest < ApplicationSystemTestCase
     @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_45 patient_47], :isolation, 'all', 'Completed Monitoring', 'reasoning')
   end
 
+  test 'bulk edit close records from global workflow' do
+    @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_1 patient_45], :global, 'all', 'Completed Monitoring', 'reasoning')
+  end
+
   test 'bulk edit close records from exposure workflow with household' do
     @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_52], :exposure, 'all', 'Duplicate', '', apply_to_household: true)
   end
 
   test 'bulk edit close records from isolation workflow with household' do
     @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_54], :isolation, 'all', nil, 'details', apply_to_household: true)
+  end
+
+  test 'bulk edit close records from global workflow with household' do
+    @@public_health_test_helper.bulk_edit_close_records('state1_epi', %w[patient_52 patient_54], :global, 'all', nil, 'details', apply_to_household: true)
   end
 
   test 'bulk edit assigned user from exposure workflow' do
@@ -61,11 +69,19 @@ class PublicHealthBulkEditTest < ApplicationSystemTestCase
     @@public_health_test_helper.bulk_edit_update_assigned_user('state1_epi', %w[patient_58 patient_59], :isolation, 'all', 32)
   end
 
+  test 'bulk edit assigned user from global workflow' do
+    @@public_health_test_helper.bulk_edit_update_assigned_user('state1_epi', %w[patient_56 patient_58], :global, 'all', 32)
+  end
+
   test 'bulk edit assigned user from exposure workflow with household' do
     @@public_health_test_helper.bulk_edit_update_assigned_user('state1_epi', %w[patient_60], :exposure, 'all', 32, apply_to_household: true)
   end
 
   test 'bulk edit assigned user from isolation workflow with household' do
     @@public_health_test_helper.bulk_edit_update_assigned_user('state1_epi', %w[patient_63], :isolation, 'all', 32, apply_to_household: true)
+  end
+
+  test 'bulk edit assigned user from global workflow with household' do
+    @@public_health_test_helper.bulk_edit_update_assigned_user('state1_epi', %w[patient_60 patient_63], :global, 'all', 32, apply_to_household: true)
   end
 end

--- a/test/system/roles/public_health/public_health_custom_export_test.rb
+++ b/test/system/roles/public_health/public_health_custom_export_test.rb
@@ -159,7 +159,7 @@ class PublicHealthCustomExportTest < ApplicationSystemTestCase
           selected: ['Monitoree Details'],
           checked: all_custom_export_patient_fields,
           query: {
-            workflow: 'all',
+            workflow: 'global',
             tab: 'all',
             jurisdiction: 1,
             scope: 'all',
@@ -312,7 +312,7 @@ class PublicHealthCustomExportTest < ApplicationSystemTestCase
           selected: ['Monitoree Details'],
           checked: all_custom_export_patient_fields,
           query: {
-            workflow: 'all',
+            workflow: 'global',
             tab: 'all',
             jurisdiction: 1,
             scope: 'all',
@@ -360,7 +360,7 @@ class PublicHealthCustomExportTest < ApplicationSystemTestCase
           selected: ['Monitoree Details'],
           checked: all_custom_export_patient_fields,
           query: {
-            workflow: 'all',
+            workflow: 'global',
             tab: 'all',
             jurisdiction: 1,
             scope: 'all',

--- a/test/system/roles/public_health/public_health_export_test.rb
+++ b/test/system/roles/public_health/public_health_export_test.rb
@@ -35,6 +35,11 @@ class PublicHealthImportExportTest < ApplicationSystemTestCase
     @@public_health_test_helper.export_csv_linelist('state1_epi_enroller', :isolation, :export)
   end
 
+  test 'export line list csv (global)' do
+    @@public_health_test_helper.export_csv_linelist('locals2c4_epi', :global, :cancel)
+    @@public_health_test_helper.export_csv_linelist('state1_epi_enroller', :global, :export)
+  end
+
   test 'export sara alert format (exposure)' do
     @@public_health_test_helper.export_sara_alert_format('locals1c1_epi', :exposure, :cancel)
     @@public_health_test_helper.export_sara_alert_format('state1_epi_enroller', :exposure, :export)
@@ -45,14 +50,21 @@ class PublicHealthImportExportTest < ApplicationSystemTestCase
     @@public_health_test_helper.export_sara_alert_format('state1_epi', :isolation, :export)
   end
 
+  test 'export sara alert format (global)' do
+    @@public_health_test_helper.export_sara_alert_format('locals2c3_epi', :global, :cancel)
+    @@public_health_test_helper.export_sara_alert_format('state1_epi', :global, :export)
+  end
+
   test 'export full history purge-eligible monitorees' do
     @@public_health_test_helper.export_full_history_patients('state1_epi_enroller', :isolation, :cancel, :purgeable)
     @@public_health_test_helper.export_full_history_patients('state1_epi', :exposure, :export, :purgeable)
+    @@public_health_test_helper.export_full_history_patients('state1_epi', :global, :export, :purgeable)
   end
 
   test 'export full history all monitorees' do
     @@public_health_test_helper.export_full_history_patients('locals1c1_epi', :exposure, :cancel, :all)
     @@public_health_test_helper.export_full_history_patients('state1_epi', :isolation, :export, :all)
+    @@public_health_test_helper.export_full_history_patients('state1_epi', :global, :export, :all)
   end
 
   test 'export full history single monitoree' do
@@ -77,6 +89,14 @@ class PublicHealthImportExportTest < ApplicationSystemTestCase
     @@public_health_test_helper.export_csv_linelist('state1_epi_enroller', :isolation, :export)
   end
 
+  test 'export line list csv (global) with batching' do
+    ENV['EXPORT_INNER_BATCH_SIZE'] = '2'
+    load 'app/jobs/export_job.rb'
+
+    @@public_health_test_helper.export_csv_linelist('locals2c4_epi', :global, :cancel)
+    @@public_health_test_helper.export_csv_linelist('state1_epi_enroller', :global, :export)
+  end
+
   test 'export sara alert format (exposure) with batching' do
     ENV['EXPORT_INNER_BATCH_SIZE'] = '2'
     load 'app/jobs/export_job.rb'
@@ -91,6 +111,14 @@ class PublicHealthImportExportTest < ApplicationSystemTestCase
 
     @@public_health_test_helper.export_sara_alert_format('locals2c3_epi', :isolation, :cancel)
     @@public_health_test_helper.export_sara_alert_format('state1_epi', :isolation, :export)
+  end
+
+  test 'export sara alert format (global) with batching' do
+    ENV['EXPORT_INNER_BATCH_SIZE'] = '2'
+    load 'app/jobs/export_job.rb'
+
+    @@public_health_test_helper.export_sara_alert_format('locals2c3_epi', :global, :cancel)
+    @@public_health_test_helper.export_sara_alert_format('state1_epi', :global, :export)
   end
 
   test 'export full history purge-eligible monitorees with batching' do


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-448](https://tracker.codev.mitre.org/browse/SARAALERT-448)

- Adds a third dashboard on top of the existing exposure and isolation dashboards, which includes all monitorees from both workflows
  - The new dashboard includes new linelists: active and priority review
  - Includes the ability to perform all the same export types as exposure and isolation dashboards
  - Custom export includes transferred in and transferred out line lists in addition to the line lists shown in the dashboard
  - Does not include import
  - Excludes "Update Case Status" from bulk actions
- Includes a refactor of breadcrumbs. Previously we were rendering crumbs (e.g. "Return to X Dashboard") based on whether a monitoree is in isolation or exposure. But if a user clicks on a monitoree in the global dashboard, we want to keep that context in the crumbs. The new way of doing crumbs is based on using a new query param called nav. This param is propagated through all the relevant views in order to maintain the context throughout, including in all monitoree enrolling, viewing, and editing.

This depends on #931. The new Global Dashboard button crowds the space more, so we need improved responsiveness on the line list tabs.

**NOTE: I know there are a LOT of files changed, but I promise it's not as bad as it looks. I did my best to walk you through everything in the Important Changes section below to make reviewing more tractable, so I recommend starting there.**

## Screenshots
Global Dashboard:
![image](https://user-images.githubusercontent.com/8235974/121819874-888e8b00-cc5d-11eb-8ddf-13c188036757.png)

Global custom export:
![image](https://user-images.githubusercontent.com/8235974/121819641-3d27ad00-cc5c-11eb-99ac-fe90e4ca2611.png)

Breadcrumbs, URL query param:
![image](https://user-images.githubusercontent.com/8235974/121819906-b83d9300-cc5d-11eb-9c96-51e99046edf7.png)

## Important Changes

### The Dashboard
`routes.rb`
- New `/public_health/global` route.
- Changed exposure route from `/public_health` to `/public_health/exposure`.
- Added a redirect from `/public_health` to new exposure URL.
  - Makes it so this is the only place you need to make a change in order to change the default dashboard (previously would've had to make changes in multiple views).

`global.html.erb`, `PublicHealthHeader.js`, `PatientsTable.js`
- The new global dashboard view, including the tabs, the button, excluding the import button, excluding case status bulk action.
- Includes a new prop `default_tab` for `PatientsTable`, since UAT feedback determined the "all" tab should be default.

### Export
`CustomExport.js`, `PatientsFilters.js`, `export_controller.rb`, `import_export_constants.rb`
- Allow for exports of new global line lists.

`patient_query_helper.rb`, `public_health_controller.rb`
- Validation and logic for the global line lists, used in custom export and the patient table tabs.

`20210614190551_change_export_presets_workflow_all_to_global.rb`
- Export presets migration for the renaming of workflow 'all' to 'global' in custom exports.

### Breadcrumbs
`patients_controller.rb`
- New method to set instance variables for breadcrumb rendering.

`show.html.erb`, `new.html.erb`, `edit.html.erb`, `new_group_member.html.erb` (patient views), `patient_helper.rb`
- Use new instance variables and new helper method for breadcrumbs.
- Pass new workflow argument into the react components.

`Breadcrumb.js`, `_breadcrumb.html.erb`
- Simplification of breadcrumb view, removed application logic. Logic for breadcrumbs now lives in back end.

`patients_controller.rb`, **EVERY OTHER REACT COMPONENT**
- New URL optional query param called `nav` (can be `global`, `exposure`, or `isolation`) to facilitate contextual breadcrumbs.
- Components now use this everywhere we render a link to a page that requires contextual breadcrumbs.
- I know there are a LOT of components modified, but they're mostly either just passing along the `workflow` prop or using the `workflow` prop to render a link with the proper `nav`.

`Navigation.js`
- Helper method for creating the nav query param in URLs

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@holmesie:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@sgober:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@timwongj:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
