### PR TITLE
SARAALERT-1407: Update History Logic

### DIFF
--- a/app/javascript/components/public_health/actions/UpdateCaseStatus.js
+++ b/app/javascript/components/public_health/actions/UpdateCaseStatus.js
@@ -130,7 +130,13 @@ class UpdateCaseStatus extends React.Component {
 
     this.setState({ loading: true }, () => {
       // Per feedback, include the monitoring_reason in the reasoning text, as the user might not inlude any text
-      let reasoning = this.state.isolation ? '' : [this.state.monitoring_reason, this.state.reasoning].filter(x => x).join(', ');
+      let reasoning;
+      // We want to include the monitoring_reason in the reasoning text ONLY if case_status was also updated
+      if (diffState.includes('monitoring_reason') && !diffState.includes('case_status')) {
+        reasoning = this.state.isolation ? '' : this.state.reasoning;
+      } else {
+        reasoning = this.state.isolation ? '' : [this.state.monitoring_reason, this.state.reasoning].filter(x => x).join(', ');
+      }
       // Add a period at the end of the Reasoning (if it's not already included)
       if (reasoning && !['.', '!', '?'].includes(_.last(reasoning))) {
         reasoning += '.';


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-1407 

For Monitorees in the Closed Line List, through the Bulk Action Case Status Modal, it is possible to update their `Reason for Closure` without also updating their Case Status. This is the only situation where it is possible to update `RoC` without also updating `Case Status`. When a monitoree is closed a History Item is created. It is in the format:

`User updated Monitoring Status from X to Y. Reason: REASON_FOR_CLOSURE, FREE_TEXT_NOTES_HERE.`
and no history item for Reason for Closure is created.

However, when updating Monitorees from the Closed Line list, if you only updated the Reason for Closure, you would get a history item that looks like:

`User changed Reason for Closure from "Meets criteria to shorten quarantine" to "Does not meet criteria for monitoring". Reason: Does not meet criteria for monitoring, FREE_TEXT_NOTES_HERE.`

This is obviously an unintended duplication of the Reason for Closure in the History Item. 
**This is the behavior that this PR fixes.**

The new behavior changes the history item in this case to:

`User changed Reason for Closure from "Meets criteria to shorten quarantine" to "Does not meet criteria for monitoring". Reason: FREE_TEXT_NOTES_HERE.`

The PR adds the following logic:
1. If only Reason for Closure changed (and not `case_status` as well)
2. Don't include Reason for Closure in the `reason` part of the History item

Again, this behavior is only possible when updating Closed Monitorees via the Bulk Action Case Status Modal.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/javascript/components/public_health/actions/UpdateCaseStatus.js`
- Only includes `reason_for_closure` in the Reason section of the History Item, if `case_status` is also updated.


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@holmesie 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@sgober 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
