### PR TITLE
SARAALERT-1517: Cleaned up UI for blocked sms

### DIFF
--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -275,9 +275,7 @@ class Contact extends React.Component {
                   </Form.Control.Feedback>
                 </Form.Group>
                 <Form.Group as={Col} className="mb-0" sm={{ span: 24, order: 3 }} lg={{ span: 12, order: 2 }} controlId="secondary_telephone">
-                  <Form.Label className="input-label">
-                    SECONDARY TELEPHONE NUMBER{schema?.fields?.secondary_telephone?._exclusive?.required && ' *'}
-                  </Form.Label>
+                  <Form.Label className="input-label">SECONDARY TELEPHONE NUMBER{schema?.fields?.secondary_telephone?._exclusive?.required && ' *'}</Form.Label>
                   <PhoneInput
                     id="secondary_telephone"
                     value={this.state.current.patient.secondary_telephone}
@@ -317,9 +315,7 @@ class Contact extends React.Component {
                   </Form.Control.Feedback>
                 </Form.Group>
                 <Form.Group as={Col} className="mb-0" sm={{ span: 24, order: 3 }} lg={{ span: 12, order: 2 }} controlId="secondary_telephone_type">
-                  <Form.Label className="input-label">
-                    SECONDARY PHONE TYPE{schema?.fields?.secondary_telephone_type?._exclusive?.required && ' *'}
-                  </Form.Label>
+                  <Form.Label className="input-label">SECONDARY PHONE TYPE{schema?.fields?.secondary_telephone_type?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control
                     isInvalid={this.state.errors['secondary_telephone_type']}
                     as="select"
@@ -336,32 +332,32 @@ class Contact extends React.Component {
                     {this.state.errors['secondary_telephone_type']}
                   </Form.Control.Feedback>
                 </Form.Group>
-                  {this.state.current.patient.preferred_contact_method === 'SMS Texted Weblink' &&
-                    this.state.current.patient.primary_telephone_type == 'Plain Cell' && (
-                      <Form.Group as={Col} className="mt-1 mb-3 mb-lg-0" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
-                        <Alert variant="danger" className="mb-0">
-                          <b>Warning:</b> Plain cell phones cannot receive web-links. Please make sure the monitoree has a compatible device to receive this
-                          type of message.
-                        </Alert>
-                      </Form.Group>
+                {this.state.current.patient.preferred_contact_method === 'SMS Texted Weblink' &&
+                  this.state.current.patient.primary_telephone_type == 'Plain Cell' && (
+                    <Form.Group as={Col} className="mt-1 mb-3 mb-lg-0" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
+                      <Alert variant="danger" className="mb-0">
+                        <b>Warning:</b> Plain cell phones cannot receive web-links. Please make sure the monitoree has a compatible device to receive this type
+                        of message.
+                      </Alert>
+                    </Form.Group>
                   )}
-                  {this.state.current.patient.preferred_contact_method === 'SMS Texted Weblink' &&
-                    this.state.current.patient.primary_telephone_type == 'Landline' && (
-                      <Form.Group as={Col} className="mt-1 mb-3 mb-lg-0" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
-                        <Alert variant="danger" className="mb-0">
-                          <b>Warning:</b> Landline phones cannot receive web-links. Please make sure the monitoree has a compatible device to receive this
-                          type of message.
-                          </Alert>
-                      </Form.Group>
+                {this.state.current.patient.preferred_contact_method === 'SMS Texted Weblink' &&
+                  this.state.current.patient.primary_telephone_type == 'Landline' && (
+                    <Form.Group as={Col} className="mt-1 mb-3 mb-lg-0" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
+                      <Alert variant="danger" className="mb-0">
+                        <b>Warning:</b> Landline phones cannot receive web-links. Please make sure the monitoree has a compatible device to receive this type of
+                        message.
+                      </Alert>
+                    </Form.Group>
                   )}
-                  {this.state.current.patient.preferred_contact_method === 'SMS Text-message' &&
-                    this.state.current.patient.primary_telephone_type === 'Landline' && (
-                      <Form.Group as={Col} className="mt-1 mb-3 mb-lg-0" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
-                        <Alert variant="danger" className="mb-0">
-                          <b>Warning:</b> Landline phones cannot receive text messages. Please make sure the monitoree has a compatible device to receive this
-                          type of message.
-                        </Alert>
-                      </Form.Group>
+                {this.state.current.patient.preferred_contact_method === 'SMS Text-message' &&
+                  this.state.current.patient.primary_telephone_type === 'Landline' && (
+                    <Form.Group as={Col} className="mt-1 mb-3 mb-lg-0" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
+                      <Alert variant="danger" className="mb-0">
+                        <b>Warning:</b> Landline phones cannot receive text messages. Please make sure the monitoree has a compatible device to receive this
+                        type of message.
+                      </Alert>
+                    </Form.Group>
                   )}
               </Form.Row>
               <Form.Row>

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -194,7 +194,7 @@ class Contact extends React.Component {
           {showTooltip && <InfoTooltip tooltipTextKey="blockedSMSContactMethod" location="right" />}
         </Alert>
       </Form.Group>
-    )
+    );
   }
 
   render() {

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -240,11 +240,14 @@ class Contact extends React.Component {
                       <option>Evening</option>
                     </Form.Control>
                     <div className="mt-3">
-                      Morning: <span className="font-weight-light">Between 8:00 and 12:00 in monitoree&apos;s timezone</span>
+                      <span className="font-weight-bold">Morning: </span>
+                      <span className="font-weight-light">Between 8:00 and 12:00 in monitoree&apos;s timezone</span>
                       <br />
-                      Afternoon: <span className="font-weight-light">Between 12:00 and 16:00 in monitoree&apos;s timezone</span>
+                      <span className="font-weight-bold">Afternoon: </span>
+                      <span className="font-weight-light">Between 12:00 and 16:00 in monitoree&apos;s timezone</span>
                       <br />
-                      Evening: <span className="font-weight-light">Between 16:00 and 20:00 in monitoree&apos;s timezone</span>
+                      <span className="font-weight-bold">Evening: </span>
+                      <span className="font-weight-light">Between 16:00 and 20:00 in monitoree&apos;s timezone</span>
                     </div>
                     <Form.Control.Feedback className="d-block" type="invalid">
                       {this.state.errors['preferred_contact_time']}
@@ -364,11 +367,14 @@ class Contact extends React.Component {
               <Form.Row>
                 <Form.Group as={Col}>
                   <div>
-                    Smartphone: <span className="font-weight-light">Phone capable of accessing web-based reporting tool</span>
+                    <span className="font-weight-bold">Smartphone: </span>
+                    <span className="font-weight-light">Phone capable of accessing web-based reporting tool</span>
                     <br />
-                    Plain Cell: <span className="font-weight-light">Phone capable of SMS messaging</span>
+                    <span className="font-weight-bold">Plain Cell: </span>
+                    <span className="font-weight-light">Phone capable of SMS messaging</span>
                     <br />
-                    Landline: <span className="font-weight-light">Has telephone but cannot use SMS or web-based reporting tool</span>
+                    <span className="font-weight-bold">Landline: </span>
+                    <span className="font-weight-light">Has telephone but cannot use SMS or web-based reporting tool</span>
                   </div>
                 </Form.Group>
               </Form.Row>

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -194,7 +194,7 @@ class Contact extends React.Component {
           <Card.Header className="h5">Monitoree Contact Information</Card.Header>
           <Card.Body>
             <Form>
-              <Form.Row className="mb-2">
+              <Form.Row>
                 <Form.Group as={Col} lg="12" xl="10" controlId="preferred_contact_method">
                   <Form.Label className="input-label">
                     PREFERRED REPORTING METHOD{schema?.fields?.preferred_contact_method?._exclusive?.required && ' *'}
@@ -239,7 +239,7 @@ class Contact extends React.Component {
                       <option>Afternoon</option>
                       <option>Evening</option>
                     </Form.Control>
-                    <div className="my-1">
+                    <div className="mt-3">
                       Morning: <span className="font-weight-light">Between 8:00 and 12:00 in monitoree&apos;s timezone</span>
                       <br />
                       Afternoon: <span className="font-weight-light">Between 12:00 and 16:00 in monitoree&apos;s timezone</span>
@@ -253,7 +253,7 @@ class Contact extends React.Component {
                 )}
               </Form.Row>
               <Form.Row>
-                <Form.Group as={Col} lg="12" xl="10" controlId="primary_telephone">
+                <Form.Group as={Col} className="mb-0" sm={{ span: 24, order: 1 }} lg={{ span: 12, order: 1 }} xl={{ span: 10, order: 1 }} controlId="primary_telephone">
                   <Form.Label className="input-label">PRIMARY TELEPHONE NUMBER{schema?.fields?.primary_telephone?._exclusive?.required && ' *'}</Form.Label>
                   {this.state.current.blocked_sms && (
                     <span className="float-right font-weight-bold">
@@ -267,19 +267,11 @@ class Contact extends React.Component {
                     onChange={this.handleChange}
                     isInvalid={!!this.state.errors['primary_telephone']}
                   />
-                  {this.state.current.patient?.preferred_contact_method?.includes('SMS') && this.state.current.blocked_sms && (
-                    <div className="pt-1">
-                      <i>
-                        <b>* Warning:</b> SMS-based reporting selected and this phone number has blocked SMS communications with Sara Alert.
-                      </i>
-                      <InfoTooltip tooltipTextKey="blockedSMSContactMethod" location="right" />
-                    </div>
-                  )}
                   <Form.Control.Feedback className="d-block" type="invalid">
                     {this.state.errors['primary_telephone']}
                   </Form.Control.Feedback>
                 </Form.Group>
-                <Form.Group as={Col} lg="12" xl="10" controlId="secondary_telephone">
+                <Form.Group as={Col} className="mb-3 mb-lg-0" sm={{ span: 24, order: 3 }} lg={{ span: 12, order: 2 }} xl={{ span: 10, order: 2 }}  controlId="secondary_telephone">
                   <Form.Label className="input-label">
                     SECONDARY TELEPHONE NUMBER{schema?.fields?.secondary_telephone?._exclusive?.required && ' *'}
                   </Form.Label>
@@ -293,9 +285,17 @@ class Contact extends React.Component {
                     {this.state.errors['secondary_telephone']}
                   </Form.Control.Feedback>
                 </Form.Group>
+                {this.state.current.patient?.preferred_contact_method?.includes('SMS') && this.state.current.blocked_sms && (
+                  <Form.Group as={Col} className="mt-1" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
+                    <i>
+                      <b>* Warning:</b> SMS-based reporting selected and this phone number has blocked SMS communications with Sara Alert
+                    </i>
+                    <InfoTooltip tooltipTextKey="blockedSMSContactMethod" location="right" />
+                  </Form.Group>
+                )}
               </Form.Row>
               <Form.Row>
-                <Form.Group as={Col} lg="12" xl="10" controlId="primary_telephone_type" className="mb-0">
+                <Form.Group as={Col} className="mb-0" sm={{ span: 24, order: 1 }} lg={{ span: 12, order: 1 }} xl={{ span: 10, order: 1 }} controlId="primary_telephone_type">
                   <Form.Label className="input-label">PRIMARY PHONE TYPE{schema?.fields?.primary_telephone_type?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control
                     isInvalid={this.state.errors['primary_telephone_type']}
@@ -313,7 +313,7 @@ class Contact extends React.Component {
                     {this.state.errors['primary_telephone_type']}
                   </Form.Control.Feedback>
                 </Form.Group>
-                <Form.Group as={Col} lg="12" xl="10" controlId="secondary_telephone_type" className="mb-0">
+                <Form.Group as={Col} className="mb-3 mb-lg-0" sm={{ span: 24, order: 3 }} lg={{ span: 12, order: 2 }} xl={{ span: 10, order: 2 }} controlId="secondary_telephone_type">
                   <Form.Label className="input-label">
                     SECONDARY PHONE TYPE{schema?.fields?.secondary_telephone_type?._exclusive?.required && ' *'}
                   </Form.Label>
@@ -333,31 +333,33 @@ class Contact extends React.Component {
                     {this.state.errors['secondary_telephone_type']}
                   </Form.Control.Feedback>
                 </Form.Group>
-                <Form.Group as={Col} controlId="primary_phone_type_warning_message">
-                  <Form.Row>
-                    {this.state.current.patient.preferred_contact_method === 'SMS Texted Weblink' &&
-                      this.state.current.patient.primary_telephone_type == 'Plain Cell' && (
+                  {this.state.current.patient.preferred_contact_method === 'SMS Texted Weblink' &&
+                    this.state.current.patient.primary_telephone_type == 'Plain Cell' && (
+                      <Form.Group as={Col} className="mt-1" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
                         <i>
                           <b>* Warning:</b> Plain cell phones cannot receive web-links. Please make sure the monitoree has a compatible device to receive this
                           type of message.
                         </i>
-                      )}
-                    {this.state.current.patient.preferred_contact_method === 'SMS Texted Weblink' &&
-                      this.state.current.patient.primary_telephone_type == 'Landline' && (
+                      </Form.Group>
+                  )}
+                  {this.state.current.patient.preferred_contact_method === 'SMS Texted Weblink' &&
+                    this.state.current.patient.primary_telephone_type == 'Landline' && (
+                      <Form.Group as={Col} className="mt-1" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
                         <i>
                           <b>* Warning:</b> Landline phones cannot receive web-links. Please make sure the monitoree has a compatible device to receive this
                           type of message.
                         </i>
-                      )}
-                    {this.state.current.patient.preferred_contact_method === 'SMS Text-message' &&
-                      this.state.current.patient.primary_telephone_type === 'Landline' && (
+                      </Form.Group>
+                  )}
+                  {this.state.current.patient.preferred_contact_method === 'SMS Text-message' &&
+                    this.state.current.patient.primary_telephone_type === 'Landline' && (
+                      <Form.Group as={Col} className="mt-1" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
                         <i>
                           <b>* Warning:</b> Landline phones cannot receive text messages. Please make sure the monitoree has a compatible device to receive this
                           type of message.
                         </i>
-                      )}
-                  </Form.Row>
-                </Form.Group>
+                      </Form.Group>
+                  )}
               </Form.Row>
               <Form.Row>
                 <Form.Group as={Col}>

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -83,8 +83,8 @@ class Contact extends React.Component {
     let modified = this.state.modified;
     this.setState(
       {
-        current: { ...current, blocked_sms: blocked_sms, patient: { ...current.patient, [event.target.id]: value } },
-        modified: { ...modified, blocked_sms: blocked_sms, patient: { ...modified.patient, [event.target.id]: value } },
+        current: { ...current, blocked_sms, patient: { ...current.patient, [event.target.id]: value } },
+        modified: { ...modified, blocked_sms, patient: { ...modified.patient, [event.target.id]: value } },
       },
       () => {
         this.props.setEnrollmentState({ ...this.state.modified });
@@ -194,8 +194,8 @@ class Contact extends React.Component {
           <Card.Header className="h5">Monitoree Contact Information</Card.Header>
           <Card.Body>
             <Form>
-              <Form.Row className="pb-3">
-                <Form.Group as={Col} md="8" controlId="preferred_contact_method">
+              <Form.Row className="mb-2">
+                <Form.Group as={Col} lg="12" xl="10" controlId="preferred_contact_method">
                   <Form.Label className="input-label">
                     PREFERRED REPORTING METHOD{schema?.fields?.preferred_contact_method?._exclusive?.required && ' *'}
                   </Form.Label>
@@ -222,7 +222,7 @@ class Contact extends React.Component {
                   this.state.current.patient.preferred_contact_method === 'Telephone call' ||
                   this.state.current.patient.preferred_contact_method === 'SMS Text-message' ||
                   this.state.current.patient.preferred_contact_method === 'E-mailed Web Link') && (
-                  <Form.Group as={Col} md="8" controlId="preferred_contact_time">
+                  <Form.Group as={Col} lg="12" xl="10" controlId="preferred_contact_time">
                     <Form.Label className="input-label">
                       PREFERRED CONTACT TIME{schema?.fields?.preferred_contact_time?._exclusive?.required && ' *'}
                       <InfoTooltip tooltipTextKey="preferredContactTime" location="right"></InfoTooltip>
@@ -239,22 +239,13 @@ class Contact extends React.Component {
                       <option>Afternoon</option>
                       <option>Evening</option>
                     </Form.Control>
-                    <Form.Row>
-                      <Form.Group as={Col} md="auto">
-                        Morning:
-                        <br />
-                        Afternoon:
-                        <br />
-                        Evening:
-                      </Form.Group>
-                      <Form.Group as={Col} md="auto">
-                        <span className="font-weight-light">Between 8:00 and 12:00 in monitoree&apos;s timezone</span>
-                        <br />
-                        <span className="font-weight-light">Between 12:00 and 16:00 in monitoree&apos;s timezone</span>
-                        <br />
-                        <span className="font-weight-light">Between 16:00 and 20:00 in monitoree&apos;s timezone</span>
-                      </Form.Group>
-                    </Form.Row>
+                    <div className="my-1">
+                      Morning: <span className="font-weight-light">Between 8:00 and 12:00 in monitoree&apos;s timezone</span>
+                      <br />
+                      Afternoon: <span className="font-weight-light">Between 12:00 and 16:00 in monitoree&apos;s timezone</span>
+                      <br />
+                      Evening: <span className="font-weight-light">Between 16:00 and 20:00 in monitoree&apos;s timezone</span>
+                    </div>
                     <Form.Control.Feedback className="d-block" type="invalid">
                       {this.state.errors['preferred_contact_time']}
                     </Form.Control.Feedback>
@@ -262,44 +253,36 @@ class Contact extends React.Component {
                 )}
               </Form.Row>
               <Form.Row>
-                <Form.Group as={Col} md="11">
-                  <Form.Row>
-                    <Form.Group as={Col}>
-                      <Form.Label htmlFor="primary_telephone" className="input-label">
-                        PRIMARY TELEPHONE NUMBER{schema?.fields?.primary_telephone?._exclusive?.required && ' *'}
-                      </Form.Label>
-                      <PhoneInput
-                        id="primary_telephone"
-                        value={this.state.current.patient.primary_telephone}
-                        onChange={this.handleChange}
-                        isInvalid={!!this.state.errors['primary_telephone']}
-                      />
-                    </Form.Group>
-                    <Form.Group as={Col}>
-                      {this.state.current.blocked_sms && (
-                        <Form.Label className="tooltip-whitespace input-label font-weight-bold py-2">
-                          SMS Blocked <InfoTooltip tooltipTextKey="blockedSMS" location="top"></InfoTooltip>
-                        </Form.Label>
-                      )}
-                    </Form.Group>
-                  </Form.Row>
-                  {this.state.current.patient?.preferred_contact_method?.includes('SMS') && this.state.current.blocked_sms === true && (
-                    <Form.Label className="tooltip-whitespace">
+                <Form.Group as={Col} lg="12" xl="10" controlId="primary_telephone">
+                  <Form.Label className="input-label">PRIMARY TELEPHONE NUMBER{schema?.fields?.primary_telephone?._exclusive?.required && ' *'}</Form.Label>
+                  {this.state.current.blocked_sms && (
+                    <span className="float-right font-weight-bold">
+                      SMS Blocked
+                      <InfoTooltip tooltipTextKey="blockedSMS" location="right" />
+                    </span>
+                  )}
+                  <PhoneInput
+                    id="primary_telephone"
+                    value={this.state.current.patient.primary_telephone}
+                    onChange={this.handleChange}
+                    isInvalid={!!this.state.errors['primary_telephone']}
+                  />
+                  {this.state.current.patient?.preferred_contact_method?.includes('SMS') && this.state.current.blocked_sms && (
+                    <div className="pt-1">
                       <i>
                         <b>* Warning:</b> SMS-based reporting selected and this phone number has blocked SMS communications with Sara Alert.
                       </i>
-                      <b>
-                        <InfoTooltip tooltipTextKey="blockedSMSContactMethod" location="top"></InfoTooltip>
-                      </b>
-                    </Form.Label>
+                      <InfoTooltip tooltipTextKey="blockedSMSContactMethod" location="right" />
+                    </div>
                   )}
                   <Form.Control.Feedback className="d-block" type="invalid">
                     {this.state.errors['primary_telephone']}
                   </Form.Control.Feedback>
                 </Form.Group>
-                <Form.Group as={Col} md="2"></Form.Group>
-                <Form.Group as={Col} md="11" controlId="secondary_telephone">
-                  <Form.Label className="input-label">SECONDARY TELEPHONE NUMBER{schema?.fields?.secondary_telephone?._exclusive?.required && ' *'}</Form.Label>
+                <Form.Group as={Col} lg="12" xl="10" controlId="secondary_telephone">
+                  <Form.Label className="input-label">
+                    SECONDARY TELEPHONE NUMBER{schema?.fields?.secondary_telephone?._exclusive?.required && ' *'}
+                  </Form.Label>
                   <PhoneInput
                     id="secondary_telephone"
                     value={this.state.current.patient.secondary_telephone}
@@ -312,7 +295,7 @@ class Contact extends React.Component {
                 </Form.Group>
               </Form.Row>
               <Form.Row>
-                <Form.Group as={Col} md="11" controlId="primary_telephone_type">
+                <Form.Group as={Col} lg="12" xl="10" controlId="primary_telephone_type" className="mb-0">
                   <Form.Label className="input-label">PRIMARY PHONE TYPE{schema?.fields?.primary_telephone_type?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control
                     isInvalid={this.state.errors['primary_telephone_type']}
@@ -330,9 +313,10 @@ class Contact extends React.Component {
                     {this.state.errors['primary_telephone_type']}
                   </Form.Control.Feedback>
                 </Form.Group>
-                <Form.Group as={Col} md="2"></Form.Group>
-                <Form.Group as={Col} md="11" controlId="secondary_telephone_type">
-                  <Form.Label className="input-label">SECONDARY PHONE TYPE{schema?.fields?.secondary_telephone_type?._exclusive?.required && ' *'}</Form.Label>
+                <Form.Group as={Col} lg="12" xl="10" controlId="secondary_telephone_type" className="mb-0">
+                  <Form.Label className="input-label">
+                    SECONDARY PHONE TYPE{schema?.fields?.secondary_telephone_type?._exclusive?.required && ' *'}
+                  </Form.Label>
                   <Form.Control
                     isInvalid={this.state.errors['secondary_telephone_type']}
                     as="select"
@@ -376,23 +360,18 @@ class Contact extends React.Component {
                 </Form.Group>
               </Form.Row>
               <Form.Row>
-                <Form.Group as={Col} md="auto">
-                  Smartphone:
-                  <br />
-                  Plain Cell:
-                  <br />
-                  Landline:
-                </Form.Group>
-                <Form.Group as={Col} md="auto">
-                  <span className="font-weight-light">Phone capable of accessing web-based reporting tool</span>
-                  <br />
-                  <span className="font-weight-light">Phone capable of SMS messaging</span>
-                  <br />
-                  <span className="font-weight-light">Has telephone but cannot use SMS or web-based reporting tool</span>
+                <Form.Group as={Col}>
+                  <div>
+                    Smartphone: <span className="font-weight-light">Phone capable of accessing web-based reporting tool</span>
+                    <br />
+                    Plain Cell: <span className="font-weight-light">Phone capable of SMS messaging</span>
+                    <br />
+                    Landline: <span className="font-weight-light">Has telephone but cannot use SMS or web-based reporting tool</span>
+                  </div>
                 </Form.Group>
               </Form.Row>
-              <Form.Row className="pt-3 pb-2">
-                <Form.Group as={Col} md="8" controlId="email">
+              <Form.Row className="mt-2">
+                <Form.Group as={Col} lg="12" xl="10" controlId="email">
                   <Form.Label className="input-label">E-MAIL ADDRESS{schema?.fields?.email?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control
                     isInvalid={this.state.errors['email']}
@@ -405,7 +384,7 @@ class Contact extends React.Component {
                     {this.state.errors['email']}
                   </Form.Control.Feedback>
                 </Form.Group>
-                <Form.Group as={Col} md="8" controlId="confirm_email">
+                <Form.Group as={Col} lg="12" xl="10" controlId="confirm_email">
                   <Form.Label className="input-label">CONFIRM E-MAIL ADDRESS{schema?.fields?.confirm_email?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control
                     isInvalid={this.state.errors['confirm_email']}

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -186,6 +186,17 @@ class Contact extends React.Component {
       });
   };
 
+  renderWarningBanner = (message, showTooltip)  => {
+    return(
+      <Form.Group as={Col} className="mt-1 mb-3 mb-lg-0" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
+        <Alert variant="danger" className="mb-0">
+          <b>Warning:</b> {message}
+          {showTooltip && <InfoTooltip tooltipTextKey="blockedSMSContactMethod" location="right" />}
+        </Alert>
+      </Form.Group>
+    )
+  }
+
   render() {
     return (
       <React.Fragment>
@@ -287,12 +298,7 @@ class Contact extends React.Component {
                   </Form.Control.Feedback>
                 </Form.Group>
                 {this.state.current.patient?.preferred_contact_method?.includes('SMS') && this.state.current.blocked_sms && (
-                  <Form.Group as={Col} className="mt-1 mb-3 mb-lg-0" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
-                    <Alert variant="danger" className="mb-0">
-                      <b>Warning:</b> SMS-based reporting selected and this phone number has blocked SMS communications with Sara Alert
-                      <InfoTooltip tooltipTextKey="blockedSMSContactMethod" location="right" />
-                    </Alert>
-                  </Form.Group>
+                  this.renderWarningBanner('SMS-based reporting selected and this phone number has blocked SMS communications with Sara Alert)', true)
                 )}
               </Form.Row>
               <Form.Row className="mb-3">
@@ -334,30 +340,15 @@ class Contact extends React.Component {
                 </Form.Group>
                 {this.state.current.patient.preferred_contact_method === 'SMS Texted Weblink' &&
                   this.state.current.patient.primary_telephone_type == 'Plain Cell' && (
-                    <Form.Group as={Col} className="mt-1 mb-3 mb-lg-0" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
-                      <Alert variant="danger" className="mb-0">
-                        <b>Warning:</b> Plain cell phones cannot receive web-links. Please make sure the monitoree has a compatible device to receive this type
-                        of message.
-                      </Alert>
-                    </Form.Group>
+                    this.renderWarningBanner('Plain cell phones cannot receive web-links. Please make sure the monitoree has a compatible device to receive this type of message.')
                   )}
                 {this.state.current.patient.preferred_contact_method === 'SMS Texted Weblink' &&
                   this.state.current.patient.primary_telephone_type == 'Landline' && (
-                    <Form.Group as={Col} className="mt-1 mb-3 mb-lg-0" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
-                      <Alert variant="danger" className="mb-0">
-                        <b>Warning:</b> Landline phones cannot receive web-links. Please make sure the monitoree has a compatible device to receive this type of
-                        message.
-                      </Alert>
-                    </Form.Group>
+                    this.renderWarningBanner('Landline phones cannot receive web-links. Please make sure the monitoree has a compatible device to receive this type of message.')
                   )}
                 {this.state.current.patient.preferred_contact_method === 'SMS Text-message' &&
                   this.state.current.patient.primary_telephone_type === 'Landline' && (
-                    <Form.Group as={Col} className="mt-1 mb-3 mb-lg-0" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
-                      <Alert variant="danger" className="mb-0">
-                        <b>Warning:</b> Landline phones cannot receive text messages. Please make sure the monitoree has a compatible device to receive this
-                        type of message.
-                      </Alert>
-                    </Form.Group>
+                    this.renderWarningBanner('Landline phones cannot receive text messages. Please make sure the monitoree has a compatible device to receive this type of message.')
                   )}
               </Form.Row>
               <Form.Row>

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
-import { Card, Button, Form, Col } from 'react-bootstrap';
+import { Alert, Card, Button, Form, Col } from 'react-bootstrap';
 import * as yup from 'yup';
 import axios from 'axios';
 import libphonenumber from 'google-libphonenumber';
@@ -195,7 +195,7 @@ class Contact extends React.Component {
           <Card.Body>
             <Form>
               <Form.Row>
-                <Form.Group as={Col} lg="12" xl="10" controlId="preferred_contact_method">
+                <Form.Group as={Col} lg="12" controlId="preferred_contact_method">
                   <Form.Label className="input-label">
                     PREFERRED REPORTING METHOD{schema?.fields?.preferred_contact_method?._exclusive?.required && ' *'}
                   </Form.Label>
@@ -222,7 +222,7 @@ class Contact extends React.Component {
                   this.state.current.patient.preferred_contact_method === 'Telephone call' ||
                   this.state.current.patient.preferred_contact_method === 'SMS Text-message' ||
                   this.state.current.patient.preferred_contact_method === 'E-mailed Web Link') && (
-                  <Form.Group as={Col} lg="12" xl="10" controlId="preferred_contact_time">
+                  <Form.Group as={Col} lg="12" controlId="preferred_contact_time">
                     <Form.Label className="input-label">
                       PREFERRED CONTACT TIME{schema?.fields?.preferred_contact_time?._exclusive?.required && ' *'}
                       <InfoTooltip tooltipTextKey="preferredContactTime" location="right"></InfoTooltip>
@@ -252,8 +252,8 @@ class Contact extends React.Component {
                   </Form.Group>
                 )}
               </Form.Row>
-              <Form.Row>
-                <Form.Group as={Col} className="mb-0" sm={{ span: 24, order: 1 }} lg={{ span: 12, order: 1 }} xl={{ span: 10, order: 1 }} controlId="primary_telephone">
+              <Form.Row className="mb-4">
+                <Form.Group as={Col} className="mb-0" sm={{ span: 24, order: 1 }} lg={{ span: 12, order: 1 }} controlId="primary_telephone">
                   <Form.Label className="input-label">PRIMARY TELEPHONE NUMBER{schema?.fields?.primary_telephone?._exclusive?.required && ' *'}</Form.Label>
                   {this.state.current.blocked_sms && (
                     <span className="float-right font-weight-bold">
@@ -271,7 +271,7 @@ class Contact extends React.Component {
                     {this.state.errors['primary_telephone']}
                   </Form.Control.Feedback>
                 </Form.Group>
-                <Form.Group as={Col} className="mb-3 mb-lg-0" sm={{ span: 24, order: 3 }} lg={{ span: 12, order: 2 }} xl={{ span: 10, order: 2 }}  controlId="secondary_telephone">
+                <Form.Group as={Col} className="mb-0" sm={{ span: 24, order: 3 }} lg={{ span: 12, order: 2 }} controlId="secondary_telephone">
                   <Form.Label className="input-label">
                     SECONDARY TELEPHONE NUMBER{schema?.fields?.secondary_telephone?._exclusive?.required && ' *'}
                   </Form.Label>
@@ -286,16 +286,16 @@ class Contact extends React.Component {
                   </Form.Control.Feedback>
                 </Form.Group>
                 {this.state.current.patient?.preferred_contact_method?.includes('SMS') && this.state.current.blocked_sms && (
-                  <Form.Group as={Col} className="mt-1" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
-                    <i>
-                      <b>* Warning:</b> SMS-based reporting selected and this phone number has blocked SMS communications with Sara Alert
-                    </i>
-                    <InfoTooltip tooltipTextKey="blockedSMSContactMethod" location="right" />
+                  <Form.Group as={Col} className="mt-1 mb-3 mb-lg-0" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
+                    <Alert variant="danger" className="mb-0">
+                      <b>Warning:</b> SMS-based reporting selected and this phone number has blocked SMS communications with Sara Alert
+                      <InfoTooltip tooltipTextKey="blockedSMSContactMethod" location="right" />
+                    </Alert>
                   </Form.Group>
                 )}
               </Form.Row>
-              <Form.Row>
-                <Form.Group as={Col} className="mb-0" sm={{ span: 24, order: 1 }} lg={{ span: 12, order: 1 }} xl={{ span: 10, order: 1 }} controlId="primary_telephone_type">
+              <Form.Row className="mb-3">
+                <Form.Group as={Col} className="mb-0" sm={{ span: 24, order: 1 }} lg={{ span: 12, order: 1 }} controlId="primary_telephone_type">
                   <Form.Label className="input-label">PRIMARY PHONE TYPE{schema?.fields?.primary_telephone_type?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control
                     isInvalid={this.state.errors['primary_telephone_type']}
@@ -313,7 +313,7 @@ class Contact extends React.Component {
                     {this.state.errors['primary_telephone_type']}
                   </Form.Control.Feedback>
                 </Form.Group>
-                <Form.Group as={Col} className="mb-3 mb-lg-0" sm={{ span: 24, order: 3 }} lg={{ span: 12, order: 2 }} xl={{ span: 10, order: 2 }} controlId="secondary_telephone_type">
+                <Form.Group as={Col} className="mb-0" sm={{ span: 24, order: 3 }} lg={{ span: 12, order: 2 }} controlId="secondary_telephone_type">
                   <Form.Label className="input-label">
                     SECONDARY PHONE TYPE{schema?.fields?.secondary_telephone_type?._exclusive?.required && ' *'}
                   </Form.Label>
@@ -335,29 +335,29 @@ class Contact extends React.Component {
                 </Form.Group>
                   {this.state.current.patient.preferred_contact_method === 'SMS Texted Weblink' &&
                     this.state.current.patient.primary_telephone_type == 'Plain Cell' && (
-                      <Form.Group as={Col} className="mt-1" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
-                        <i>
-                          <b>* Warning:</b> Plain cell phones cannot receive web-links. Please make sure the monitoree has a compatible device to receive this
+                      <Form.Group as={Col} className="mt-1 mb-3 mb-lg-0" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
+                        <Alert variant="danger" className="mb-0">
+                          <b>Warning:</b> Plain cell phones cannot receive web-links. Please make sure the monitoree has a compatible device to receive this
                           type of message.
-                        </i>
+                        </Alert>
                       </Form.Group>
                   )}
                   {this.state.current.patient.preferred_contact_method === 'SMS Texted Weblink' &&
                     this.state.current.patient.primary_telephone_type == 'Landline' && (
-                      <Form.Group as={Col} className="mt-1" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
-                        <i>
-                          <b>* Warning:</b> Landline phones cannot receive web-links. Please make sure the monitoree has a compatible device to receive this
+                      <Form.Group as={Col} className="mt-1 mb-3 mb-lg-0" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
+                        <Alert variant="danger" className="mb-0">
+                          <b>Warning:</b> Landline phones cannot receive web-links. Please make sure the monitoree has a compatible device to receive this
                           type of message.
-                        </i>
+                          </Alert>
                       </Form.Group>
                   )}
                   {this.state.current.patient.preferred_contact_method === 'SMS Text-message' &&
                     this.state.current.patient.primary_telephone_type === 'Landline' && (
-                      <Form.Group as={Col} className="mt-1" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
-                        <i>
-                          <b>* Warning:</b> Landline phones cannot receive text messages. Please make sure the monitoree has a compatible device to receive this
+                      <Form.Group as={Col} className="mt-1 mb-3 mb-lg-0" sm={{ span: 24, order: 2 }} lg={{ span: 24, order: 3 }}>
+                        <Alert variant="danger" className="mb-0">
+                          <b>Warning:</b> Landline phones cannot receive text messages. Please make sure the monitoree has a compatible device to receive this
                           type of message.
-                        </i>
+                        </Alert>
                       </Form.Group>
                   )}
               </Form.Row>
@@ -373,7 +373,7 @@ class Contact extends React.Component {
                 </Form.Group>
               </Form.Row>
               <Form.Row className="mt-2">
-                <Form.Group as={Col} lg="12" xl="10" controlId="email">
+                <Form.Group as={Col} lg="12" controlId="email">
                   <Form.Label className="input-label">E-MAIL ADDRESS{schema?.fields?.email?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control
                     isInvalid={this.state.errors['email']}
@@ -386,7 +386,7 @@ class Contact extends React.Component {
                     {this.state.errors['email']}
                   </Form.Control.Feedback>
                 </Form.Group>
-                <Form.Group as={Col} lg="12" xl="10" controlId="confirm_email">
+                <Form.Group as={Col} lg="12" controlId="confirm_email">
                   <Form.Label className="input-label">CONFIRM E-MAIL ADDRESS{schema?.fields?.confirm_email?._exclusive?.required && ' *'}</Form.Label>
                   <Form.Control
                     isInvalid={this.state.errors['confirm_email']}

--- a/app/javascript/components/enrollment/steps/Identification.js
+++ b/app/javascript/components/enrollment/steps/Identification.js
@@ -213,6 +213,16 @@ class Identification extends React.Component {
       });
   };
 
+  renderWarningBanner = message => {
+    return (
+      <Alert variant="warning" className="mt-2 mb-0 px-3 py-2">
+        <i>
+          <b>Warning:</b> {message}
+        </i>
+      </Alert>
+    );
+  };
+
   renderPrimaryLanguageSupportMessage = () => {
     let selectedLanguage = this.state.primaryLanguageData;
     if (!_.isEmpty(selectedLanguage)) {
@@ -244,13 +254,7 @@ class Identification extends React.Component {
           message +=
             ' is supported for email and SMS text reporting methods only. If telephone call is selected as the preferred reporting method, the call will be in English.';
         }
-        return (
-          <Alert variant="warning" className="mt-2 mb-0 px-3 py-2">
-            <i>
-              <b>Warning:</b> {message}
-            </i>
-          </Alert>
-        );
+        return this.renderWarningBanner(message);
       }
     }
   };
@@ -521,13 +525,8 @@ class Identification extends React.Component {
                     <InfoTooltip tooltipTextKey="secondaryLanguage" location="right"></InfoTooltip>
                   </Form.Label>
                   {this.renderLanguageSelect(false)}
-                  {this.state.current.patient.secondary_language && (
-                    <Alert variant="warning" className="mt-2 mb-0 px-3 py-2">
-                      <i>
-                        <b>Warning:</b> Not used to determine which language the system sends messages to the monitoree in.
-                      </i>
-                    </Alert>
-                  )}
+                  {this.state.current.patient.secondary_language &&
+                    this.renderWarningBanner('Not used to determine which language the system sends messages to the monitoree in.')}
                 </Form.Group>
               </Form.Row>
               <Form.Row className="pt-1">

--- a/app/javascript/components/enrollment/steps/Identification.js
+++ b/app/javascript/components/enrollment/steps/Identification.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
-import { Button, Card, Col, Form } from 'react-bootstrap';
+import { Alert, Button, Card, Col, Form } from 'react-bootstrap';
 import Select from 'react-select';
 import { cursorPointerStyle } from '../../../packs/stylesheets/ReactSelectStyling';
 
@@ -245,9 +245,11 @@ class Identification extends React.Component {
             ' is supported for email and SMS text reporting methods only. If telephone call is selected as the preferred reporting method, the call will be in English.';
         }
         return (
-          <i>
-            <b>* Warning:</b> {message}
-          </i>
+          <Alert variant="warning" className="mt-2 mb-0 px-3 py-2">
+            <i>
+              <b>Warning:</b> {message}
+            </i>
+          </Alert>
         );
       }
     }
@@ -505,30 +507,26 @@ class Identification extends React.Component {
               </Form.Row>
               <Form.Row className="pb-3 ml-0">Languages that are not fully supported are indicated by a (*) in the below list.</Form.Row>
               <Form.Row>
-                <Form.Group as={Col} sm={24} md={12} id="primary_language_wrapper" className="pr-md-4 mb-2">
+                <Form.Group as={Col} sm={24} md={12} id="primary_language_wrapper" className="pr-md-1 mb-3">
                   <Form.Label htmlFor="primary-language-select" className="input-label">
                     PRIMARY LANGUAGE{schema?.fields?.primary_language?._exclusive?.required && ' *'}
                     <InfoTooltip tooltipTextKey="primaryLanguage" location="right"></InfoTooltip>
                   </Form.Label>
                   {this.renderLanguageSelect(true)}
+                  {this.renderPrimaryLanguageSupportMessage()}
                 </Form.Group>
-                <Form.Group as={Col} sm={24} md={12} id="secondary_language_wrapper" className="pl-md-4 mb-2">
+                <Form.Group as={Col} sm={24} md={12} id="secondary_language_wrapper" className="pl-md-1 mb-3">
                   <Form.Label htmlFor="secondary-language-select" className="input-label">
                     SECONDARY LANGUAGE{schema?.fields?.secondary_language?._exclusive?.required && ' *'}
                     <InfoTooltip tooltipTextKey="secondaryLanguage" location="right"></InfoTooltip>
                   </Form.Label>
                   {this.renderLanguageSelect(false)}
-                </Form.Group>
-              </Form.Row>
-              <Form.Row>
-                <Form.Group as={Col} sm={24} md={12} controlId="primary_language_support_message" className="pr-md-4 mb-0">
-                  {this.renderPrimaryLanguageSupportMessage()}
-                </Form.Group>
-                <Form.Group as={Col} sm={24} md={12} controlId="secondary_language_support_message" className="pl-md-4 mb-0">
                   {this.state.current.patient.secondary_language && (
-                    <i>
-                      <b>* Warning:</b> Not used to determine which language the system sends messages to the monitoree in.
-                    </i>
+                    <Alert variant="warning" className="mt-2 mb-0 px-3 py-2">
+                      <i>
+                        <b>Warning:</b> Not used to determine which language the system sends messages to the monitoree in.
+                      </i>
+                    </Alert>
                   )}
                 </Form.Group>
               </Form.Row>

--- a/app/javascript/components/patient/Patient.js
+++ b/app/javascript/components/patient/Patient.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
-import { Button, Col, Collapse, Form, Row } from 'react-bootstrap';
+import { Button, Col, Collapse, Row } from 'react-bootstrap';
 import moment from 'moment';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
@@ -241,9 +241,10 @@ class Patient extends React.Component {
               <div>
                 <b>Phone:</b> <span>{this.props.details.primary_telephone ? `${formatPhoneNumber(this.props.details.primary_telephone)}` : '--'}</span>
                 {this.props.details.blocked_sms && (
-                  <Form.Label className="tooltip-whitespace input-label font-weight-bold">
-                    &nbsp;SMS Blocked <InfoTooltip tooltipTextKey="blockedSMS" location="top"></InfoTooltip>
-                  </Form.Label>
+                  <span className="font-weight-bold pl-2">
+                    SMS Blocked
+                    <InfoTooltip tooltipTextKey="blockedSMS" location="top" />
+                  </span>
                 )}
               </div>
               <div>
@@ -262,10 +263,8 @@ class Patient extends React.Component {
                 )}
                 {this.props.details.blocked_sms && this.props.details.preferred_contact_method?.includes('SMS') && (
                   <span className="font-weight-bold text-danger">
-                    {this.props.details.preferred_contact_method || '--'}
-                    <Form.Label className="tooltip-whitespace">
-                      <InfoTooltip tooltipTextKey="blockedSMSContactMethod" location="top"></InfoTooltip>
-                    </Form.Label>
+                    {this.props.details.preferred_contact_method}
+                    <InfoTooltip tooltipTextKey="blockedSMSContactMethod" location="top" />
                   </span>
                 )}
               </div>

--- a/app/javascript/packs/stylesheets/layout.scss
+++ b/app/javascript/packs/stylesheets/layout.scss
@@ -8,10 +8,6 @@
   max-width: 300px;
 }
 
-.tooltip-whitespace {
-  white-space: normal !important;
-}
-
 .character-limit-text {
   width: 100%;
   font-size: 12px;

--- a/app/javascript/tests/patient/Patient.test.js
+++ b/app/javascript/tests/patient/Patient.test.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import Patient from '../../components/patient/Patient';
 import FollowUpFlagPanel from '../../components/patient/follow_up_flag/FollowUpFlagPanel';
 import BadgeHoH from '../../components/patient/household/utils/BadgeHoH';
+import InfoTooltip from '../../components/util/InfoTooltip';
 import { mockUser1 } from '../mocks/mockUsers';
 import { mockPatient1, mockPatient2, mockPatient3, mockPatient4, mockPatient5, blankMockPatient } from '../mocks/mockPatients';
 import { mockJurisdictionPaths } from '../mocks/mockJurisdiction';
@@ -90,6 +91,22 @@ describe('Patient', () => {
     contactFields.forEach((field, index) => {
       expect(section.find('b').at(index).text()).toEqual(field + ':');
     });
+  });
+
+  it('Properly renders contact information section if SMS is blocked', () => {
+    const wrapper = shallow(<Patient details={{ ...mockPatient2, blocked_sms: true }} collapse={true} edit_mode={false} jurisdiction_paths={mockJurisdictionPaths} />);
+    const section = wrapper.find('#contact-information');
+    const phone = section.find('.item-group').find('div').at(1);
+    const preferredContactMethod = section.find('.item-group').find('div').at(5);
+    expect(phone.find('b').text()).toEqual('Phone:');
+    expect(phone.find('span').at(0).text()).toEqual(mockPatient2.primary_telephone);
+    expect(phone.find('span').at(1).text().includes('SMS Blocked')).toBeTruthy();
+    expect(phone.find(InfoTooltip).exists()).toBeTruthy();
+    expect(phone.find(InfoTooltip).prop('tooltipTextKey')).toEqual('blockedSMS');
+    expect(preferredContactMethod.find('b').text()).toEqual('Preferred Reporting Method:');
+    expect(preferredContactMethod.find('span').text().includes('SMS Texted Weblink')).toBeTruthy();
+    expect(preferredContactMethod.find(InfoTooltip).exists()).toBeTruthy();
+    expect(preferredContactMethod.find(InfoTooltip).prop('tooltipTextKey')).toEqual('blockedSMSContactMethod');
   });
 
   it('Properly renders show/hide divider when props.collapse is true', () => {


### PR DESCRIPTION
# Description
JIRA: [SARAALERT-1517](https://tracker.codev.mitre.org/browse/SARAALERT-1517)

Noticed a while back that the blocked sms tag made the enrollment contact window pretty screwy.  This just fixes the styling related to the blocked SMS badge.

Be sure to test with and without a blocked number in the enrollment window, and use all different screen sizes.

To block a number, run `BlockedNumber.create(phone_number: '+15555550153')` in the rails console with the relevant number

## (Feature) Demo/Screenshots
**Enrollment with no blocked number:**

Before:
![Screen Shot 2021-06-16 at 1 33 58 PM](https://user-images.githubusercontent.com/35042815/122266394-c252d200-cea7-11eb-8690-cfbcc9e5f12e.png)

After:
![Screen Shot 2021-06-16 at 1 34 52 PM](https://user-images.githubusercontent.com/35042815/122266418-c5e65900-cea7-11eb-8890-6065a830a1d5.png)

**Enrollment with blocked number:**

Before:
![Screen Shot 2021-06-16 at 1 28 22 PM](https://user-images.githubusercontent.com/35042815/122266624-fb8b4200-cea7-11eb-84fe-7e9479cc53e3.png)

After:
![Screen Shot 2021-06-16 at 1 20 58 PM](https://user-images.githubusercontent.com/35042815/122266655-0514aa00-cea8-11eb-9856-bfe81c5699da.png)

**Monitoree details contact info (not much different):**

Before:
![Screen Shot 2021-06-16 at 1 28 45 PM](https://user-images.githubusercontent.com/35042815/122266104-71db7480-cea7-11eb-8924-68f0420fe85e.png)

After:
![Screen Shot 2021-06-16 at 1 20 36 PM](https://user-images.githubusercontent.com/35042815/122266094-6ee08400-cea7-11eb-84e8-b5742dfb4629.png)


## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`Contact.js`
- Redid the column sizing so the contact part of the enrollment wizard is resizable
- Restyled blocked sms to not screw with the columns and provide a cleaner look

`Patient.js`
- Restyled blocked SMS tag to not be a label (508 issue)
- This also removed the additional space below the phone number if there was a blocked number

`Patient.test.js`
- Added test for blocked sms badge

`layout.scss`
- Removed unused class


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@DPC15038 :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@timwongj :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
