### PR TITLE
Bug fix for SARAALERT-928: Clear Flag radio button tooltip

### DIFF
--- a/app/javascript/components/patient/follow_up_flag/FollowUpFlag.js
+++ b/app/javascript/components/patient/follow_up_flag/FollowUpFlag.js
@@ -154,17 +154,17 @@ class FollowUpFlag extends React.Component {
                 onChange={this.handleChange}
                 checked={!this.state.clear_flag}
               />
-              <Form.Check
-                type="radio"
-                name="flag_for_follow_up_option"
-                id="clear_flag_for_follow_up"
-                data-for="clear_flag_disable_reason"
-                data-tip=""
-                label="Clear Follow-up Flag"
-                disabled={this.state.clear_flag_disabled}
-                onChange={this.handleChange}
-                checked={this.state.clear_flag}
-              />
+              <span data-for="clear_flag_disable_reason" data-tip="">
+                <Form.Check
+                  type="radio"
+                  name="flag_for_follow_up_option"
+                  id="clear_flag_for_follow_up"
+                  label="Clear Follow-up Flag"
+                  disabled={this.state.clear_flag_disabled}
+                  onChange={this.handleChange}
+                  checked={this.state.clear_flag}
+                />
+              </span>
               {this.state.clear_flag_disabled && (
                 <ReactTooltip id="clear_flag_disable_reason" multiline={true} place="bottom" type="dark" effect="solid" className="tooltip-container">
                   <div>None of the selected monitorees have a flag set</div>


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-928](https://tracker.codev.mitre.org/browse/SARAALERT-928)

The tooltip that is suppose to appear when a user hovers their mouse over the disabled "Clear Follow-up Flag" button was not working across all broswers. This PR addresses this issue so this tooltip now appears across all browsers.

![image](https://user-images.githubusercontent.com/42656458/122405132-c89b8980-cf4d-11eb-8477-62dd81b1d9f6.png)

## Bugfix - How to Replicate

1. While in Chrome or Safari ...
2. In the Dashboard view, select a monitoree who is not flagged for a bulk action.
3. In the Bulk Actions drop down select "Flag for Follow-up"
4. In the modal, notice that the "Clear Follow-up Flag" radio button is disabled. Hover your mouse over it and notice there is no tooltip that appears.

## Bugfix - Solution
Wrapping the radio button in a `<span>` and associating the tooltip with the `<span>` instead of the `<Form.Check>` addressed the issue. 

## Important Changes

`app/javascript/components/patient/follow_up_flag/FollowUpFlag.js`
- Wrapped the clear flag radio button in a `<span>` and associated the clear flag tooltip with it. 

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] **N/A** If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] **N/A** Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] **N/A** Test fixtures updated and documented as necessary


@sgober :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@timwongj :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
