### PR TITLE
Replace monitoring active scope with monitoring open scope

### DIFF
--- a/app/jobs/cache_analytics_job.rb
+++ b/app/jobs/cache_analytics_job.rb
@@ -94,7 +94,7 @@ class CacheAnalyticsJob < ApplicationJob
         WHEN TIMESTAMPDIFF(YEAR, date_of_birth, CURDATE()) >= 110 THEN 'FAKE_BIRTHDATE'
       END
     SQL
-    monitorees.monitoring_active(true)
+    monitorees.monitoring_open
               .group(age_groups, :isolation)
               .order(Arel.sql(age_groups), :isolation)
               .size
@@ -126,7 +126,7 @@ class CacheAnalyticsJob < ApplicationJob
   # Monitoree counts by sex
   def self.monitoree_counts_by_sex(analytic_id, monitorees)
     counts = []
-    monitorees.monitoring_active(true)
+    monitorees.monitoring_open
               .group(:sex, :isolation)
               .order(:sex, :isolation)
               .size
@@ -139,7 +139,7 @@ class CacheAnalyticsJob < ApplicationJob
   # Monitoree counts by sexual orientation
   def self.monitoree_counts_by_sexual_orientation(analytic_id, monitorees)
     counts = []
-    monitorees.monitoring_active(true)
+    monitorees.monitoring_open
               .group(:sexual_orientation, :isolation)
               .order(:sexual_orientation, :isolation)
               .size
@@ -176,7 +176,7 @@ class CacheAnalyticsJob < ApplicationJob
         ELSE "Unknown"
       END)
     SQL
-    monitorees.monitoring_active(true)
+    monitorees.monitoring_open
               .group(racial_groups, :isolation)
               .order(Arel.sql(racial_groups), :isolation)
               .size
@@ -196,7 +196,7 @@ class CacheAnalyticsJob < ApplicationJob
   # Monitoree counts by ethnicity
   def self.monitoree_counts_by_ethnicity(analytic_id, monitorees)
     counts = []
-    monitorees.monitoring_active(true)
+    monitorees.monitoring_open
               .group(:ethnicity, :isolation)
               .order(:ethnicity, :isolation)
               .size
@@ -241,7 +241,7 @@ class CacheAnalyticsJob < ApplicationJob
   def self.monitoree_counts_by_risk_factor(analytic_id, monitorees)
     counts = []
     RISK_FACTORS.each do |risk_factor, label|
-      monitorees.monitoring_active(true)
+      monitorees.monitoring_open
                 .where(risk_factor => true)
                 .group(risk_factor, :isolation)
                 .size
@@ -255,7 +255,7 @@ class CacheAnalyticsJob < ApplicationJob
   # Monitoree counts by exposure country
   def self.monitoree_counts_by_exposure_country(analytic_id, monitorees)
     counts = []
-    exposure_countries = monitorees.monitoring_active(true)
+    exposure_countries = monitorees.monitoring_open
                                    .where.not(potential_exposure_country: [nil, ''])
                                    .group(:potential_exposure_country)
                                    .order(count_potential_exposure_country: :desc)
@@ -263,7 +263,7 @@ class CacheAnalyticsJob < ApplicationJob
                                    .limit(NUM_EXPOSURE_COUNTRIES)
                                    .count(:potential_exposure_country)
                                    .map { |c| c[0] }
-    monitorees.monitoring_active(true)
+    monitorees.monitoring_open
               .where(potential_exposure_country: exposure_countries)
               .group(:potential_exposure_country, :isolation)
               .order(:potential_exposure_country, :isolation)
@@ -279,7 +279,7 @@ class CacheAnalyticsJob < ApplicationJob
     counts = []
 
     monitorees.where(isolation: false)
-              .monitoring_active(true)
+              .monitoring_open
               .exposed_in_time_frame(NUM_PAST_DAYS.days.ago.to_date.to_datetime)
               .group(:last_date_of_exposure)
               .order(:last_date_of_exposure)
@@ -289,7 +289,7 @@ class CacheAnalyticsJob < ApplicationJob
               end
 
     monitorees.where(isolation: true)
-              .monitoring_active(true)
+              .monitoring_open
               .symptom_onset_in_time_frame(NUM_PAST_DAYS.days.ago.to_date.to_datetime)
               .group(:symptom_onset)
               .order(:symptom_onset)
@@ -310,7 +310,7 @@ class CacheAnalyticsJob < ApplicationJob
       DATE_ADD(symptom_onset, INTERVAL(1 - DAYOFWEEK(symptom_onset)) DAY)
     SQL
     monitorees.where(isolation: false)
-              .monitoring_active(true)
+              .monitoring_open
               .exposed_in_time_frame(NUM_PAST_WEEKS.weeks.ago.to_date.to_datetime)
               .group(exposure_weeks)
               .order(Arel.sql(exposure_weeks))
@@ -319,7 +319,7 @@ class CacheAnalyticsJob < ApplicationJob
                 counts.append(monitoree_count(analytic_id, true, 'Last Exposure Week', week, total, 'Exposure'))
               end
     monitorees.where(isolation: true)
-              .monitoring_active(true)
+              .monitoring_open
               .symptom_onset_in_time_frame(NUM_PAST_WEEKS.weeks.ago.to_date.to_datetime)
               .group(symptom_onset_weeks)
               .order(Arel.sql(symptom_onset_weeks))
@@ -341,7 +341,7 @@ class CacheAnalyticsJob < ApplicationJob
     SQL
 
     monitorees.where(isolation: false)
-              .monitoring_active(true)
+              .monitoring_open
               .exposed_in_time_frame(NUM_PAST_MONTHS.months.ago.to_date.to_datetime)
               .group(exposure_months)
               .order(Arel.sql(exposure_months))
@@ -350,7 +350,7 @@ class CacheAnalyticsJob < ApplicationJob
                 counts.append(monitoree_count(analytic_id, true, 'Last Exposure Month', month, total, 'Exposure'))
               end
     monitorees.where(isolation: true)
-              .monitoring_active(true)
+              .monitoring_open
               .symptom_onset_in_time_frame(NUM_PAST_MONTHS.months.ago.to_date.to_datetime)
               .group(symptom_onset_months)
               .order(Arel.sql(symptom_onset_months))

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -555,11 +555,6 @@ class Patient < ApplicationRecord
       .where_assoc_exists(:assessments, &:symptomatic_last_hour)
   }
 
-  # All individuals currently being monitored if true, all individuals otherwise
-  scope :monitoring_active, lambda { |active_monitoring|
-    where(monitoring: true) if active_monitoring
-  }
-
   # All individuals with the given monitoring status
   scope :monitoring_status, lambda { |monitoring_status|
     case monitoring_status

--- a/test/controllers/public_health_controller_test.rb
+++ b/test/controllers/public_health_controller_test.rb
@@ -237,7 +237,7 @@ class PublicHealthControllerTest < ActionController::TestCase
 
       post :patients, params: { query: { workflow: 'global', tab: 'active', entries: 100 } }, as: :json
       json_response = JSON.parse(response.body)
-      patients = user.viewable_patients.monitoring_active(true)
+      patients = user.viewable_patients.monitoring_open
       assert_equal patients.order(:id).pluck(:id), json_response['linelist'].map { |patient| patient['id'] }.sort
       assert_equal patients.size, json_response['total']
 


### PR DESCRIPTION
# Description
Jira Ticket: N/A

This PR was created as a follow up on this thread: https://github.com/SaraAlert/SaraAlert/pull/937#discussion_r653070079

The `monitoring_active` scope was created for analytics a long time ago but I just noticed that it doesn't include the `where(purged: false)` condition. Although `patients` should never be in a state where monitoring is `true` and purged is `true`, it's better to include in the queries anyways. Adding that condition to the scope would make it the same as the `monitoring_open` scope so I just replaced the `monitoring_active` scope with the `monitoring_open` scope.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/jobs/cache_analytics_job.rb`
- replace `monitoring_active` with `monitoring_open`

`app/models/patient.rb`
- remove `monitoring_open` scope

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] **N/A** This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] **N/A** If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@DPC15038 :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ashankland :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
