### PR TITLE
Remove transferred in/out from global export

### DIFF
--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -42,7 +42,7 @@ class PublicHealthController < ApplicationController
     tab = params.require(:tab).to_sym
     case workflow
     when :global
-      return head :bad_request unless %i[all active priority_review non_reporting closed transferred_in transferred_out].include?(tab)
+      return head :bad_request unless %i[all active priority_review non_reporting closed].include?(tab)
     when :exposure
       return head :bad_request unless %i[all symptomatic non_reporting asymptomatic pui closed transferred_in transferred_out].include?(tab)
     when :isolation

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -42,7 +42,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     tab = query[:tab]&.to_sym || :all
     case workflow
     when :global
-      raise InvalidQueryError.new(:tab, tab) unless %i[all active priority_review non_reporting closed transferred_in transferred_out].include?(tab)
+      raise InvalidQueryError.new(:tab, tab) unless %i[all active priority_review non_reporting closed].include?(tab)
     when :exposure
       raise InvalidQueryError.new(:tab, tab) unless %i[all symptomatic non_reporting asymptomatic pui closed transferred_in transferred_out].include?(tab)
     when :isolation
@@ -154,8 +154,6 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
       return current_user.patients&.global_priority_review if tab == :priority_review
       return current_user.patients&.global_non_reporting if tab == :non_reporting
       return current_user.patients&.monitoring_closed_without_purged if tab == :closed
-      return jurisdiction.transferred_in_patients if tab == :transferred_in
-      return jurisdiction.transferred_out_patients if tab == :transferred_out
 
       current_user.patients&.where(purged: false)
     end

--- a/app/javascript/components/public_health/custom_export/PatientsFilters.js
+++ b/app/javascript/components/public_health/custom_export/PatientsFilters.js
@@ -91,6 +91,9 @@ class PatientsFilters extends React.Component {
                     <option value="non_reporting">Non-Reporting</option>
                     <option value="asymptomatic">Asymptomatic</option>
                     <option value="pui">PUI</option>
+                    <option value="closed">Closed</option>
+                    <option value="transferred_in">Transferred In</option>
+                    <option value="transferred_out">Transferred Out</option>
                   </React.Fragment>
                 )}
                 {this.props.query?.workflow === 'isolation' && (
@@ -98,6 +101,9 @@ class PatientsFilters extends React.Component {
                     <option value="requiring_review">Records Requiring Review</option>
                     <option value="non_reporting">Non-Reporting</option>
                     <option value="reporting">Reporting</option>
+                    <option value="closed">Closed</option>
+                    <option value="transferred_in">Transferred In</option>
+                    <option value="transferred_out">Transferred Out</option>
                   </React.Fragment>
                 )}
                 {this.props.query?.workflow === 'global' && (
@@ -105,11 +111,9 @@ class PatientsFilters extends React.Component {
                     <option value="active">Active</option>
                     <option value="priority_review">Priority Review</option>
                     <option value="non_reporting">Non-Reporting</option>
+                    <option value="closed">Closed</option>
                   </React.Fragment>
                 )}
-                <option value="closed">Closed</option>
-                <option value="transferred_in">Transferred In</option>
-                <option value="transferred_out">Transferred Out</option>
               </Form.Control>
             </InputGroup>
           </Col>

--- a/app/javascript/tests/mocks/mockTabs.js
+++ b/app/javascript/tests/mocks/mockTabs.js
@@ -115,16 +115,6 @@ const mockGlobalTabs = {
     label: 'Active',
     variant: 'success',
   },
-  transferred_in: {
-    description: 'Cases that have been transferred into this jurisdiction during the last 24 hours.',
-    label: 'Transferred In',
-    variant: 'info',
-  },
-  transferred_out: {
-    description: 'Cases that have been transferred out of this jurisdiction.',
-    label: 'Transferred Out',
-    variant: 'info',
-  },
 };
 
 export { mockExposureTabs, mockIsolationTabs, mockGlobalTabs };

--- a/test/controllers/jurisdictions_controller_test.rb
+++ b/test/controllers/jurisdictions_controller_test.rb
@@ -178,12 +178,20 @@ class JurisdictionsControllerTest < ActionController::TestCase
                                                       as: :json
           assert_equal patients.where(monitoring: false, purged: false).distinct.pluck(:assigned_user).sort, JSON.parse(response.body)['assigned_users']
 
-          post :assigned_users_for_viewable_patients, params: { query: { jurisdiction: jur.id, scope: scope, workflow: 'global', tab: 'transferred_in' } },
+          post :assigned_users_for_viewable_patients, params: { query: { jurisdiction: jur.id, scope: scope, workflow: 'global', tab: 'non_reporting' } },
+                                                      as: :json
+          assert_equal patients.global_non_reporting.distinct.pluck(:assigned_user).sort, JSON.parse(response.body)['assigned_users']
+
+          post :assigned_users_for_viewable_patients, params: { query: { jurisdiction: jur.id, scope: scope, workflow: 'global', tab: 'priority_review' } },
+                                                      as: :json
+          assert_equal patients.global_priority_review.distinct.pluck(:assigned_user).sort, JSON.parse(response.body)['assigned_users']
+
+          post :assigned_users_for_viewable_patients, params: { query: { jurisdiction: jur.id, scope: scope, workflow: 'global', tab: 'active' } },
                                                       as: :json
           assigned_users = if scope == 'exact'
-                             jur.transferred_in_patients.where(jurisdiction: jur.id).where.not(assigned_user: nil).distinct.pluck(:assigned_user).sort
+                             patients.monitoring_open.where(jurisdiction: jur.id).where.not(assigned_user: nil).distinct.pluck(:assigned_user).sort
                            else
-                             jur.transferred_in_patients.where.not(assigned_user: nil).distinct.pluck(:assigned_user).sort
+                             patients.monitoring_open.where.not(assigned_user: nil).distinct.pluck(:assigned_user).sort
                            end
           assert_equal assigned_users, JSON.parse(response.body)['assigned_users']
         end

--- a/test/controllers/public_health_controller_test.rb
+++ b/test/controllers/public_health_controller_test.rb
@@ -253,18 +253,6 @@ class PublicHealthControllerTest < ActionController::TestCase
       assert_equal patients.order(:id).pluck(:id), json_response['linelist'].map { |patient| patient['id'] }.sort
       assert_equal patients.size, json_response['total']
 
-      post :patients, params: { query: { workflow: 'global', tab: 'transferred_in' } }, as: :json
-      json_response = JSON.parse(response.body)
-      patients = user_jur.transferred_in_patients
-      assert_equal patients.order(:id).pluck(:id), json_response['linelist'].map { |patient| patient['id'] }.sort
-      assert_equal patients.size, json_response['total']
-
-      post :patients, params: { query: { workflow: 'global', tab: 'transferred_out' } }, as: :json
-      json_response = JSON.parse(response.body)
-      patients = user_jur.transferred_out_patients
-      assert_equal patients.order(:id).pluck(:id), json_response['linelist'].map { |patient| patient['id'] }.sort
-      assert_equal patients.size, json_response['total']
-
       post :patients, params: { query: { workflow: 'global', tab: 'all', entries: 100 } }, as: :json
       json_response = JSON.parse(response.body)
       patients = user.viewable_patients.where(purged: false)
@@ -502,12 +490,6 @@ class PublicHealthControllerTest < ActionController::TestCase
 
         get :tab_counts, params: { workflow: 'global', tab: 'closed' }
         assert_equal user.viewable_patients.monitoring_closed_without_purged.size, JSON.parse(response.body)['total']
-
-        get :tab_counts, params: { workflow: 'global', tab: 'transferred_in' }
-        assert_equal user.jurisdiction.transferred_in_patients.size, JSON.parse(response.body)['total']
-
-        get :tab_counts, params: { workflow: 'global', tab: 'transferred_out' }
-        assert_equal user.jurisdiction.transferred_out_patients.size, JSON.parse(response.body)['total']
 
         sign_out user
       end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-448](https://tracker.codev.mitre.org/browse/SARAALERT-448)

[Slack context](https://mitrecorp.slack.com/archives/C01A6P94R9B/p1623953377090400?thread_ts=1623772268.020300&cid=C01A6P94R9B)

This is a follow on to #937. It was requested that the Transferred In and Transferred Out line lists should be removed from global custom export, since they are not included as tabs in the dashboard.

## Screenshots
![image](https://user-images.githubusercontent.com/8235974/122456349-71aca900-cf7b-11eb-885e-6840b37ed451.png)

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@holmesie:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@sgober:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@timwongj:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
