### PR TITLE
SARAALERT-NONE Benchmark artifacts (REDO)

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           name: close-patients-job-benchmark
           path: performance/benchmarks/output/
-          retention-days: 2
+          retention-days: 14
 
   send-assessments-job-benchmark:
     runs-on: ubuntu-18.04
@@ -137,7 +137,7 @@ jobs:
         with:
           name: send-assessments-job-benchmark
           path: performance/benchmarks/output/
-          retention-days: 2
+          retention-days: 14
 
   micro-benchmarks:
     runs-on: ubuntu-18.04
@@ -204,7 +204,7 @@ jobs:
         with:
           name: micro-benchmarks
           path: performance/benchmarks/output/
-          retention-days: 2
+          retention-days: 14
 
   jmeter-benchmark:
     runs-on: ubuntu-18.04
@@ -287,4 +287,4 @@ jobs:
         with:
           name: send-assessments-job-benchmark
           path: performance/benchmarks/output/
-          retention-days: 2
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,8 @@ sara_database_*
 *.jtl
 *.hprof
 jmeter.log
+
+# Other performance testing files
+performance/benchmarks/output/
+performance/github_artifacts/
+

--- a/Gemfile
+++ b/Gemfile
@@ -116,6 +116,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'ffi-hunspell'
   gem 'memory_profiler'
+  gem 'octokit', '~> 4.0'
   gem 'rubocop'
   gem 'ruby-jmeter'
   gem 'stackprof'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,6 +268,9 @@ GEM
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     numerizer (0.2.0)
+    octokit (4.21.0)
+      faraday (>= 0.9)
+      sawyer (~> 0.8.0, >= 0.5.3)
     order_as_specified (1.7)
       activerecord (>= 5.0.0)
     orm_adapter (0.5.0)
@@ -379,6 +382,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -494,6 +500,7 @@ DEPENDENCIES
   mocha
   mysql2 (>= 0.4.4)
   newrelic_rpm
+  octokit (~> 4.0)
   order_as_specified
   ox
   phonelib

--- a/performance/aggregate_benchmark_results.rb
+++ b/performance/aggregate_benchmark_results.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'caxlsx'
+require 'fast_excel'
+require 'byebug'
+
+# Common variables
+path_prefix = 'performance/github_artifacts'
+json_folder = "#{path_prefix}/json"
+xlsx_folder = "#{path_prefix}/xlsx"
+
+# Ensure folders exist
+`mkdir -p #{json_folder}`
+`mkdir -p #{xlsx_folder}`
+
+# Find all JSON files
+json_files = `ls #{json_folder}`.split("\n").map { |p| "#{json_folder}/#{p}" }
+
+# Parse all JSON contents
+all_json_contents = json_files.map { |json_path| JSON.parse(File.read(json_path)) }
+
+# Group all JSON by the test name
+grouped_benchmarks = all_json_contents.group_by { |json| json['name'] }
+
+# The columns that we expect in every result JSON
+data_columns = %w[
+  name
+  branch
+  duration
+  threshold
+  passed
+  stackprof_enabled
+  memprof_enabled
+  created_at
+]
+
+# https://github.com/caxlsx/caxlsx/blob/master/docs/style_reference.md
+data_column_widths = [
+  35, # name
+  35, # branch
+  18, # duration
+  10, # threshold
+  10, # passed
+  18, # stackprof_enabled
+  18, # memprof_enabled
+  30 # created_at
+]
+
+# Write all data to an excel file
+# caxlsx was writing invalid workbooks for an unknown reason when writing data.
+xlsx_file = "#{xlsx_folder}/GitHub_Actions_Performance_Data_#{Time.now.to_i}.xlsx"
+workbook = FastExcel.open(xlsx_file, constant_memory: true)
+workbook.default_format.set(
+  font_size: 12,
+  font_family: 'Courier',
+  align: { h: :align_center, v: :align_vertical_center }
+)
+
+grouped_benchmarks.each do |group_name, group|
+  worksheet = workbook.add_worksheet(group_name)
+  worksheet.append_row data_columns
+  data_column_widths.each_with_index { |width, col| worksheet.set_column_width(col, width) }
+  group.each do |json|
+    row = [
+      json['name'],
+      json['branch'],
+      json['duration'].truncate(7),
+      json['threshold'],
+      json['passed'],
+      json['stackprof_enabled'],
+      json['memprof_enabled'],
+      json['created_at']
+    ]
+    worksheet.append_row row
+  end
+end
+workbook.close
+
+puts "All data written to #{xlsx_file}"

--- a/performance/aggregate_benchmark_results.rb
+++ b/performance/aggregate_benchmark_results.rb
@@ -11,11 +11,11 @@ json_folder = "#{path_prefix}/json"
 xlsx_folder = "#{path_prefix}/xlsx"
 
 # Ensure folders exist
-`mkdir -p #{json_folder}`
-`mkdir -p #{xlsx_folder}`
+FileUtils.mkdir_p(json_folder)
+FileUtils.mkdir_p(xlsx_folder)
 
 # Find all JSON files
-json_files = `ls #{json_folder}`.split("\n").map { |p| "#{json_folder}/#{p}" }
+json_files = Dir.glob("#{json_folder}/*.json")
 
 # Parse all JSON contents
 all_json_contents = json_files.map { |json_path| JSON.parse(File.read(json_path)) }

--- a/performance/benchmark.rb
+++ b/performance/benchmark.rb
@@ -44,7 +44,7 @@ def benchmark(name: nil, time_threshold: 3600, setup: nil, teardown: nil, no_exi
   ActionMailer::Base.perform_deliveries = false
 
   timestamp = Time.now.utc.iso8601
-  `mkdir -p performance/benchmarks/output` # Create the folder if it doesn't exist already
+  FileUtils.mkdir_p('performance/benchmarks/output') # Create the folder if it doesn't exist already
   stackprof_file = "performance/benchmarks/output/#{name}_#{timestamp}_CPU.dump".gsub(':', '-')
   flamegraph_file = "performance/benchmarks/output/#{name}_#{timestamp}_FLM".gsub(':', '-')
   memprof_file = "performance/benchmarks/output/#{name}_#{timestamp}_MEM.log".gsub(':', '-')

--- a/performance/benchmarks/output/.gitignore
+++ b/performance/benchmarks/output/.gitignore
@@ -1,3 +1,0 @@
-*.log
-*.dump
-*_FLM

--- a/performance/collect_benchmark_results.rb
+++ b/performance/collect_benchmark_results.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'json'
+
+if ENV['PERSONAL_TOKEN'].nil?
+  puts '$PERSONAL_TOKEN must be set and token must have "workflow" permissions!'
+  exit 1
+end
+
+##
+# Get artifact information so that ones we are interested in can be downloaded.
+#
+# https://docs.github.com/en/rest/reference/actions
+#
+def get_artifact_info(page)
+  print "\rFetching artifacts page: #{page}         "
+  artifacts = `curl -s \
+    -H "Authorization: token $PERSONAL_TOKEN" \
+    -H "Accept: application/vnd.github.v3+json" \
+    https://api.github.com/repos/SaraAlert/SaraAlert/actions/artifacts?page=#{page}`
+  JSON.parse(artifacts)
+end
+
+##
+# Download an artifact zip to a specific path.
+#
+# https://docs.github.com/en/rest/reference/actions
+#
+def fetch_artifact_zip(download_path, url)
+  `curl \
+    -sLJo #{download_path} \
+    -H "Authorization: token $PERSONAL_TOKEN" \
+    -H "Accept: application/vnd.github.v3+json" \
+    -H 'Accept: application/octet-stream' \
+    #{url}`
+end
+
+path_prefix = 'performance/github_artifacts'
+
+# Downloaded artifact zips are stored here.
+`mkdir -p #{path_prefix}/zip`
+# The extracted results JSON are extracted here.
+`mkdir -p #{path_prefix}/json`
+
+# These are the job names that artifact zips will be downloaded for.
+interested_names = Set.new(%w[
+                             send-assessments-job-benchmark
+                             close-patients-job-benchmark
+                             micro-benchmarks
+                           ])
+
+# Stores artifact metadata from `get_artifact_info()` for artifacts that
+# we are interested in downloading.
+interested_artifact_info = []
+
+# Will stop the script from collecting more artifact metadata if the size of
+# `interested_artifact_info` becomes larger than this threshold.
+max_artifacts_to_download = 100
+
+# Tracks the page we want to fetch from `get_artifact_info`.
+page = 1
+
+# Tracks how many artifacts that GitHub says are available.
+total_artifact_count = nil
+
+# Tracks how many artifacts we have seen info about.
+total_artifact_seen = 0
+
+# Collection of all of the artifacts that should be downloaded.
+interested_artifact_info += []
+
+# Keep fetching artifact info until we gather enough.
+# `total_artifact_count` initializes as nil and is set once
+# after the first iteration.
+while total_artifact_count.nil? || total_artifact_seen < total_artifact_count
+  break if interested_artifact_info.size >= max_artifacts_to_download
+
+  artifacts = get_artifact_info(page)
+  total_artifact_count ||= artifacts['total_count']
+  total_artifact_seen += artifacts['artifacts'].size
+  interested_artifact_info += artifacts['artifacts'].filter { |artifact| interested_names.include? artifact['name'] }
+
+  # Increment the page number
+  page += 1
+end
+
+puts 'Got all artifact info!'
+
+# Download each interested artifact zip only if we do not have it yet.
+interested_artifact_info.each_with_index do |artifact, index|
+  if File.file?("#{path_prefix}/zip/#{artifact['id']}.zip")
+    print "\r(#{index + 1}/#{interested_artifact_info.size}) Already have artifacts for job: #{artifact['id']}         "
+    next
+  end
+
+  print "\r(#{index + 1}/#{interested_artifact_info.size}) Fetching artifact zip for job: #{artifact['id']}            "
+  fetch_artifact_zip(
+    "#{path_prefix}/zip/#{artifact['id']}.zip",
+    artifact['archive_download_url']
+  )
+end
+
+puts 'Got all artifact zips!'
+
+# Extract the artifact zips into the json folder,
+# but hide all of the zip command's output.
+print 'Extracting all zips'
+`unzip -qq -o #{path_prefix}/zip/\\*.zip -d #{path_prefix}/json &> /dev/null`
+`rm -f #{path_prefix}/json/.gitignore` # some artifacts may have a gitignore file present in them
+puts 'Extracted all zips!'


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-###](https://tracker.codev.mitre.org/browse/SARAALERT-###)

**Something strange seems to have happened where this [original PR was merged](https://github.com/SaraAlert/SaraAlert/pull/889), but none of the changes actually are present in 1.32.0. I have just rebased the branch against the latest 1.32.0 and made this PR.**

For performance benchmarks this PR will make it so that we now generate JSON describing test results and save them to artifacts. This PR also includes two scripts: one that pulls down and unpacks all relevant artifacts, and another that aggregates all of the data into an excel workbook.

To test the scripts, you will need to create a GitHub access token that has "workflow" permissions and set `export PERSONAL_TOKEN='<token value>'`.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`.github/workflows/performance.yml`
- hold artifacts for 14 days

`.gitignore`
- added gitignores for performance stuffs

`performance/collect_benchmark_results.rb`
- Collects all ZIP files for relevant artifacts and then unpacks them

`performance/aggregate_benchmark_results.rb`
- Aggregates all artifact JSON data into an excel workbook

`performance/benchmark.rb`
- ensures output directory exists before running benchmark
- writes benchmark JSON result to output folder


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@Bialogs  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions