### PR TITLE
SARAALERT-1519 Bulk clear assigned user

### DIFF
--- a/app/javascript/components/public_health/actions/UpdateAssignedUser.js
+++ b/app/javascript/components/public_health/actions/UpdateAssignedUser.js
@@ -48,7 +48,7 @@ class UpdateAssignedUser extends React.Component {
 
   submit = () => {
     let idArray = this.props.patients.map(x => x['id']);
-    let diffState = Object.keys(this.state).filter(k => _.get(this.state, k) !== _.get(this.origState, k));
+    let diffState = Object.keys(this.state).filter(k => _.get(this.state, k) !== _.get(this.origState, k) || _.isEmpty(_.get(this.state, k)));
 
     this.setState({ loading: true }, () => {
       axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1519](https://tracker.codev.mitre.org/browse/SARAALERT-1519)

This PR adds the ability to to clear out the assigned user via the assigned user bulk action simply by making the field empty and submitting.

## (Bugfix) How to Replicate
The reason this was not working before was that `assigned_user` was not making it into the `diff_state`, so the field would not be updated for the selected patients.

## (Bugfix) Solution
The fix is simply to also include `assigned_user` in the `diff_state` if the `assigned_user` field is blank in the bulk action form. I tested submitting blank assigned users multiple times for patients and the changed history item only appears once.

<img width="1448" alt="Screen Shot 2021-06-18 at 2 01 47 PM" src="https://user-images.githubusercontent.com/24628687/122610955-bac53180-d03d-11eb-9c73-1f0f84c0ab21.png">

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`UpdateAssignedUser.js`
- Add the mentioned additional blank logic to the filtering method that creates `diff_state`


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@holmesie:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
