### PR TITLE
SARAALERT-890: For changes to household, note where change originated in history. 

### DIFF
--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -1096,7 +1096,7 @@ class Fhir::R4::ApiController < ApplicationApiController
       patient_before: patient_before,
       patient: patient,
       updates: updates,
-      household_status: :patient,
+      household_status: patient.id,
       propagation: :none
     }
     patient.monitoring_history_edit(history_data, nil)

--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -1096,7 +1096,7 @@ class Fhir::R4::ApiController < ApplicationApiController
       patient_before: patient_before,
       patient: patient,
       updates: updates,
-      household_status: patient.id,
+      initiator_id: patient.id,
       propagation: :none
     }
     patient.monitoring_history_edit(history_data, nil)

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -487,7 +487,7 @@ class PatientsController < ApplicationController
       patients.each do |patient|
         # We never want to update closed records monitoring status via the bulk_update
         update_params = patient.monitoring ? params : closed_params
-        update_monitoring_fields(patient, update_params, non_dependent_patient_ids.include?(patient[:id]) ? patient.id : nil,
+        update_monitoring_fields(patient, update_params, non_dependent_patient_ids.include?(patient[:id]) ? patient.id : patient.responder_id,
                                  update_params[:apply_to_household] ? :group : :none)
       end
     end

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -594,7 +594,7 @@ class PatientsController < ApplicationController
     history_data = {}
     if clear_flag
       clear_flag_reason = params.permit(:clear_flag_reason)[:clear_flag_reason]
-      clear_follow_up_flag(patient, clear_flag_reason)
+      clear_follow_up_flag(patient, patient.id, clear_flag_reason)
     else
       follow_up_reason = params.permit(:follow_up_reason)[:follow_up_reason]
       follow_up_note = params.permit(:follow_up_note)[:follow_up_note]
@@ -603,6 +603,7 @@ class PatientsController < ApplicationController
       history_data = {
         created_by: current_user.email,
         patient: patient,
+        household_status: patient.id,
         follow_up_reason: follow_up_reason,
         follow_up_note: follow_up_note,
         follow_up_reason_before: patient.follow_up_reason,
@@ -630,7 +631,7 @@ class PatientsController < ApplicationController
         next if member.nil?
 
         clear_flag_reason = params.permit(:clear_flag_reason)[:clear_flag_reason]
-        clear_follow_up_flag(member, clear_flag_reason)
+        clear_follow_up_flag(member, patient.id, clear_flag_reason)
       end
     else
       apply_to_household_ids.each do |id|
@@ -656,11 +657,12 @@ class PatientsController < ApplicationController
   #
   # patient - The Patient to update.
   # clear_flag_reason - The note to include in the history item
-  def clear_follow_up_flag(patient, clear_flag_reason)
+  def clear_follow_up_flag(patient, household_status, clear_flag_reason)
     # Prep data needed to create history items based on this update
     history_data = {
       created_by: current_user.email,
       patient: patient,
+      household_status: household_status,
       clear_flag_reason: clear_flag_reason,
       follow_up_reason_before: patient.follow_up_reason
     }

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -534,9 +534,9 @@ class PatientsController < ApplicationController
   #
   # patient - The Patient to update.
   # params - The request params.
-  # household - Indicates if the Patient was updated directly (household = :patient) or updated because their head of household was (household = :dependent)
+  # initiator_id - Indicates the id of the record that was originally modified to cause the change, for instance if the change was propagated to the patient.
   # propogation - Indicates why the updates are being propogated to the Patient.
-  def update_monitoring_fields(patient, params, household, propagation)
+  def update_monitoring_fields(patient, params, initiator_id, propagation)
     # Figure out what exactly changed, and limit update to only those fields
     diff_state = params[:diffState]&.map(&:to_sym)
     permitted_params = if diff_state.nil?
@@ -567,7 +567,7 @@ class PatientsController < ApplicationController
       patient_before: patient_before,
       patient: patient,
       updates: updates,
-      household_status: household,
+      initiator_id: initiator_id,
       propagation: propagation,
       reason: params[:reasoning]
     }
@@ -603,7 +603,7 @@ class PatientsController < ApplicationController
       history_data = {
         created_by: current_user.email,
         patient: patient,
-        household_status: patient.id,
+        initiator_id: patient.id,
         follow_up_reason: follow_up_reason,
         follow_up_note: follow_up_note,
         follow_up_reason_before: patient.follow_up_reason,
@@ -657,12 +657,12 @@ class PatientsController < ApplicationController
   #
   # patient - The Patient to update.
   # clear_flag_reason - The note to include in the history item
-  def clear_follow_up_flag(patient, household_status, clear_flag_reason)
+  def clear_follow_up_flag(patient, initiator_id, clear_flag_reason)
     # Prep data needed to create history items based on this update
     history_data = {
       created_by: current_user.email,
       patient: patient,
-      household_status: household_status,
+      initiator_id: initiator_id,
       clear_flag_reason: clear_flag_reason,
       follow_up_reason_before: patient.follow_up_reason
     }

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -490,6 +490,7 @@ class PatientsController < ApplicationController
         update_monitoring_fields(patient, update_params, non_dependent_patient_ids.include?(patient[:id]) ? patient.id : nil,
                                  update_params[:apply_to_household] ? :group : :none)
       end
+    end
   end
 
   # Updates to workflow/tracking status for a subject
@@ -535,7 +536,7 @@ class PatientsController < ApplicationController
   # params - The request params.
   # household - Indicates if the Patient was updated directly (household = :patient) or updated because their head of household was (household = :dependent)
   # propogation - Indicates why the updates are being propogated to the Patient.
-  def update_monitoring_fields(patient, params, household, propagation) 
+  def update_monitoring_fields(patient, params, household, propagation)
     # Figure out what exactly changed, and limit update to only those fields
     diff_state = params[:diffState]&.map(&:to_sym)
     permitted_params = if diff_state.nil?

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -498,23 +498,12 @@ class History < ApplicationRecord
   private_class_method def self.compose_explanation(history)
     if history[:initiator_id] == history[:patient].id && history[:propagation] == :group
       ' and applied that change to all household members'
-    elsif history[:initiator_id] == history[:patient].id && history[:propagation] == :group_cm
-      ' and applied that change to household members under continuous exposure'
     elsif history[:initiator_id] == history[:patient].responder_id && history[:propagation] == :group
       " by making that change for monitoree's head of household (Sara Alert ID: #{history[:initiator_id]})"\
       ' and for all household members'
-    elsif history[:initiator_id] == history[:patient].responder_id && history[:propagation] == :group_cm
-      " by making that change for monitoree's head of household (Sara Alert ID: #{history[:initiator_id]})"\
-      ' and for household members under continuous exposure'
     elsif history[:initiator_id] != history[:patient].id && history[:initiator_id] == history[:patient].responder_id
       " by making that change for monitoree's head of household (Sara Alert ID: #{history[:initiator_id]})"\
       ' and for this monitoree'
-    elsif history[:initiator_id] != history[:patient].id && history[:propagation] == :group
-      " by making that change for a household member (Sara Alert ID: #{history[:initiator_id]})"\
-      ' and applied that change to all household members'
-    elsif history[:initiator_id] != history[:patient].id && history[:propagation] == :group_cm
-      " by making that change for a household member (Sara Alert ID: #{history[:initiator_id]})"\
-      ' and for household members under continuous exposure'
     elsif history[:initiator_id] != history[:patient].id
       " by making that change for a household member (Sara Alert ID: #{history[:initiator_id]})"\
       ' and for this monitoree'

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -382,7 +382,7 @@ class History < ApplicationRecord
     }
     return if field[:old_value] == field[:new_value]
 
-    creator = history[:household_status] != nil ? 'User' : 'System'
+    creator = history[:household_status].nil? ? 'System' : 'User'
     comment = "#{creator} #{field[:new_value]} notifications for this monitoree#{compose_explanation(history, field)}."
     create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment, create: create)
   end
@@ -421,7 +421,7 @@ class History < ApplicationRecord
     }
     return if field[:old_value] == field[:new_value]
 
-    creator = history[:household_status] != nil ? 'User' : 'System'
+    creator = history[:household_status].nil? ? 'System' : 'User'
     comment = "#{creator} turned #{field[:new_value]} #{field[:name]}#{compose_explanation(history, field)}."
     create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment, create: create)
   end
@@ -480,7 +480,7 @@ class History < ApplicationRecord
   end
 
   private_class_method def self.compose_message(history, field)
-    creator = history[:household_status] != nil ? 'User' : 'System'
+    creator = history[:household_status].nil? ? 'System' : 'User'
     verb = field[:new_value].blank? ? 'cleared' : 'changed'
     from_text = field[:old_value].blank? ? 'blank' : "\"#{field[:old_value]}\""
     to_text = field[:new_value].blank? ? 'blank' : "\"#{field[:new_value]}\""
@@ -493,11 +493,11 @@ class History < ApplicationRecord
     comment
   end
 
-  private_class_method def self.compose_explanation(history, field)
+  private_class_method def self.compose_explanation(history, _field)
     if history[:household_status] == history[:patient].id && history[:propagation] == :group
-      " and applied that change to all household members"
+      ' and applied that change to all household members'
     elsif history[:household_status] == history[:patient].id && history[:propagation] == :group_cm
-      " and applied that change to household members under continuous exposure"
+      ' and applied that change to household members under continuous exposure'
     elsif history[:household_status] == history[:patient].id
       ''
     elsif history[:household_status] == history[:patient].responder_id && history[:propagation] == :group
@@ -509,13 +509,13 @@ class History < ApplicationRecord
     elsif history[:household_status] == history[:patient].responder_id
       " by making that change for monitoree's head of household (SARA Alert ID: #{history[:household_status]})
         and applying that change to this monitoree"
-    elsif history[:household_status] != nil && history[:propagation] == :group
+    elsif !history[:household_status].nil? && history[:propagation] == :group
       " by making that change for a household member (SARA ALERT ID: #{history[:household_status]})
         and applying that change to all household members"
-    elsif history[:household_status] != nil && history[:propagation] == :group_cm
+    elsif !history[:household_status].nil? && history[:propagation] == :group_cm
       " by making that change for for a household member (SARA ALERT ID: #{history[:household_status]})
         and applying that change to household members under continuous exposure"
-    elsif history[:household_status] != nil
+    elsif !history[:household_status].nil?
       " by making that change for a household member (SARA ALERT ID: #{history[:household_status]})
         and applying that change to this monitoree"
     else

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -499,14 +499,14 @@ class History < ApplicationRecord
     if history[:initiator_id] == history[:patient].id && history[:propagation] == :group
       ' and applied that change to all household members'
     elsif history[:initiator_id] == history[:patient].responder_id && history[:propagation] == :group
-      " by making that change for monitoree's head of household (Sara Alert ID: #{history[:initiator_id]})"\
-      ' and for all household members'
+      " by making that change to monitoree's Head of Household (Sara Alert ID: #{history[:initiator_id]})"\
+      ' and to all household members'
     elsif history[:initiator_id] != history[:patient].id && history[:initiator_id] == history[:patient].responder_id
-      " by making that change for monitoree's head of household (Sara Alert ID: #{history[:initiator_id]})"\
-      ' and for this monitoree'
+      " by making that change to monitoree's Head of Household (Sara Alert ID: #{history[:initiator_id]})"\
+      ' and to this monitoree'
     elsif history[:initiator_id] != history[:patient].id
-      " by making that change for a household member (Sara Alert ID: #{history[:initiator_id]})"\
-      ' and for this monitoree'
+      " by making that change to a household member (Sara Alert ID: #{history[:initiator_id]})"\
+      ' and to this monitoree'
     else
       ''
     end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -374,7 +374,7 @@ class History < ApplicationRecord
     create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field), create: create)
   end
 
-  def self.pause_notifications(history)
+  def self.pause_notifications(history, create: true)
     field = {
       name: 'Notification Status',
       old_value: history[:patient_before][:pause_notifications] ? 'paused' : 'resumed',
@@ -384,7 +384,7 @@ class History < ApplicationRecord
 
     creator = history[:initiator_id].nil? ? 'System' : 'User'
     comment = "#{creator} #{field[:new_value]} notifications for this monitoree#{compose_explanation(history)}."
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment)
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment, create: create)
   end
 
   def self.symptom_onset(history, create: true)
@@ -413,7 +413,7 @@ class History < ApplicationRecord
     create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field), create: create)
   end
 
-  def self.continuous_exposure(history)
+  def self.continuous_exposure(history, create: true)
     field = {
       name: 'Continuous Exposure',
       old_value: history[:patient_before][:continuous_exposure] ? 'on' : 'off',
@@ -423,7 +423,7 @@ class History < ApplicationRecord
 
     creator = history[:initiator_id].nil? ? 'System' : 'User'
     comment = "#{creator} turned #{field[:new_value]} #{field[:name]}#{compose_explanation(history)}."
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment)
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment, create: create)
   end
 
   def self.monitoring_reason(history, create: true)

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -374,7 +374,6 @@ class History < ApplicationRecord
     create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field), create: create)
   end
 
-  def self.pause_notifications(history, create: true)
     field = {
       name: 'Notification Status',
       old_value: history[:patient_before][:pause_notifications] ? 'paused' : 'resumed',
@@ -413,7 +412,7 @@ class History < ApplicationRecord
     create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field), create: create)
   end
 
-  def self.continuous_exposure(history, create: true)
+  def self.continuous_exposure(history)
     field = {
       name: 'Continuous Exposure',
       old_value: history[:patient_before][:continuous_exposure] ? 'on' : 'off',

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -453,8 +453,8 @@ class History < ApplicationRecord
     return if history[:follow_up_reason] == history[:follow_up_reason_before] && history[:follow_up_note] == history[:follow_up_note_before]
 
     comment = 'User flagged for follow-up'
-    comment += compose_explanation(history)
-    comment += ". Reason: \"#{history[:follow_up_reason]}"
+    comment += compose_explanation(history) + '.'
+    comment += " Reason: \"#{history[:follow_up_reason]}"
     comment += ": #{history[:follow_up_note]}" unless history[:follow_up_note].blank?
     comment += '"'
 
@@ -465,8 +465,8 @@ class History < ApplicationRecord
     return if history[:follow_up_reason_before].nil?
 
     comment = 'User cleared flag for follow-up'
-    comment += compose_explanation(history)
-    comment += ". Reason: #{history[:clear_flag_reason]}" unless history[:clear_flag_reason].blank?
+    comment += compose_explanation(history) + '.'
+    comment += " Reason: #{history[:clear_flag_reason]}" unless history[:clear_flag_reason].blank?
 
     create_history(history[:patient], history[:created_by], HISTORY_TYPES[:follow_up_flag], comment, create: create)
   end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -382,8 +382,8 @@ class History < ApplicationRecord
     }
     return if field[:old_value] == field[:new_value]
 
-    creator = history[:household_status].nil? ? 'System' : 'User'
-    comment = "#{creator} #{field[:new_value]} notifications for this monitoree#{compose_explanation(history, field)}."
+    creator = history[:initiator_id].nil? ? 'System' : 'User'
+    comment = "#{creator} #{field[:new_value]} notifications for this monitoree#{compose_explanation(history)}."
     create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment)
   end
 
@@ -421,8 +421,8 @@ class History < ApplicationRecord
     }
     return if field[:old_value] == field[:new_value]
 
-    creator = history[:household_status].nil? ? 'System' : 'User'
-    comment = "#{creator} turned #{field[:new_value]} #{field[:name]}#{compose_explanation(history, field)}."
+    creator = history[:initiator_id].nil? ? 'System' : 'User'
+    comment = "#{creator} turned #{field[:new_value]} #{field[:name]}#{compose_explanation(history)}."
     create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment)
   end
 
@@ -483,7 +483,7 @@ class History < ApplicationRecord
   end
 
   private_class_method def self.compose_message(history, field)
-    creator = history[:household_status].nil? ? 'System' : 'User'
+    creator = history[:initiator_id].nil? ? 'System' : 'User'
     verb = field[:new_value].blank? ? 'cleared' : 'changed'
     from_text = field[:old_value].blank? ? 'blank' : "\"#{field[:old_value]}\""
     to_text = field[:new_value].blank? ? 'blank' : "\"#{field[:new_value]}\""
@@ -497,28 +497,28 @@ class History < ApplicationRecord
   end
 
   private_class_method def self.compose_explanation(history)
-    if history[:household_status] == history[:patient].id && history[:propagation] == :group
+    if history[:initiator_id] == history[:patient].id && history[:propagation] == :group
       ' and applied that change to all household members'
-    elsif history[:household_status] == history[:patient].id && history[:propagation] == :group_cm
+    elsif history[:initiator_id] == history[:patient].id && history[:propagation] == :group_cm
       ' and applied that change to household members under continuous exposure'
-    elsif history[:household_status] == history[:patient].responder_id && history[:propagation] == :group
-      " by making that change for monitoree's head of household (Sara Alert ID: #{history[:household_status]})
-        and for all household members"
-    elsif history[:household_status] == history[:patient].responder_id && history[:propagation] == :group_cm
-      " by making that change for monitoree's head of household (Sara Alert ID: #{history[:household_status]})
-        and for household members under continuous exposure"
-    elsif history[:household_status] != history[:patient].id && history[:household_status] == history[:patient].responder_id
-      " by making that change for monitoree's head of household (Sara Alert ID: #{history[:household_status]})
-        and for this monitoree"
-    elsif history[:household_status] != history[:patient].id && !history[:household_status].nil? && history[:propagation] == :group
-      " by making that change for a household member (Sara Alert ID: #{history[:household_status]})
-        and applied that change to all household members"
-    elsif history[:household_status] != history[:patient].id && !history[:household_status].nil? && history[:propagation] == :group_cm
-      " by making that change for a household member (Sara Alert ID: #{history[:household_status]})
-        and for household members under continuous exposure"
-    elsif history[:household_status] != history[:patient].id && !history[:household_status].nil?
-      " by making that change for a household member (Sara Alert ID: #{history[:household_status]})
-        and for this monitoree"
+    elsif history[:initiator_id] == history[:patient].responder_id && history[:propagation] == :group
+      " by making that change for monitoree's head of household (Sara Alert ID: #{history[:initiator_id]})"\
+      ' and for all household members'
+    elsif history[:initiator_id] == history[:patient].responder_id && history[:propagation] == :group_cm
+      " by making that change for monitoree's head of household (Sara Alert ID: #{history[:initiator_id]})"\
+      ' and for household members under continuous exposure'
+    elsif history[:initiator_id] != history[:patient].id && history[:initiator_id] == history[:patient].responder_id
+      " by making that change for monitoree's head of household (Sara Alert ID: #{history[:initiator_id]})"\
+      ' and for this monitoree'
+    elsif history[:initiator_id] != history[:patient].id && !history[:initiator_id].nil? && history[:propagation] == :group
+      " by making that change for a household member (Sara Alert ID: #{history[:initiator_id]})"\
+      ' and applied that change to all household members'
+    elsif history[:initiator_id] != history[:patient].id && !history[:initiator_id].nil? && history[:propagation] == :group_cm
+      " by making that change for a household member (Sara Alert ID: #{history[:initiator_id]})"\
+      ' and for household members under continuous exposure'
+    elsif history[:initiator_id] != history[:patient].id && !history[:initiator_id].nil?
+      " by making that change for a household member (Sara Alert ID: #{history[:initiator_id]})"\
+      ' and for this monitoree'
     else
       ''
     end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -374,6 +374,7 @@ class History < ApplicationRecord
     create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field), create: create)
   end
 
+  def self.pause_notifications(history)
     field = {
       name: 'Notification Status',
       old_value: history[:patient_before][:pause_notifications] ? 'paused' : 'resumed',

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -483,12 +483,11 @@ class History < ApplicationRecord
   end
 
   private_class_method def self.compose_message(history, field)
-    creator = history[:initiator_id].nil? ? 'System' : 'User'
     verb = field[:new_value].blank? ? 'cleared' : 'changed'
     from_text = field[:old_value].blank? ? 'blank' : "\"#{field[:old_value]}\""
     to_text = field[:new_value].blank? ? 'blank' : "\"#{field[:new_value]}\""
 
-    comment = "#{creator} #{verb} #{field[:name]} from #{from_text} to #{to_text}"
+    comment = "User #{verb} #{field[:name]} from #{from_text} to #{to_text}"
     comment += compose_explanation(history)
     comment += history[:note] unless history[:note].blank?
     comment += '.'
@@ -510,13 +509,13 @@ class History < ApplicationRecord
     elsif history[:initiator_id] != history[:patient].id && history[:initiator_id] == history[:patient].responder_id
       " by making that change for monitoree's head of household (Sara Alert ID: #{history[:initiator_id]})"\
       ' and for this monitoree'
-    elsif history[:initiator_id] != history[:patient].id && !history[:initiator_id].nil? && history[:propagation] == :group
+    elsif history[:initiator_id] != history[:patient].id && history[:propagation] == :group
       " by making that change for a household member (Sara Alert ID: #{history[:initiator_id]})"\
       ' and applied that change to all household members'
-    elsif history[:initiator_id] != history[:patient].id && !history[:initiator_id].nil? && history[:propagation] == :group_cm
+    elsif history[:initiator_id] != history[:patient].id && history[:propagation] == :group_cm
       " by making that change for a household member (Sara Alert ID: #{history[:initiator_id]})"\
       ' and for household members under continuous exposure'
-    elsif history[:initiator_id] != history[:patient].id && !history[:initiator_id].nil?
+    elsif history[:initiator_id] != history[:patient].id
       " by making that change for a household member (Sara Alert ID: #{history[:initiator_id]})"\
       ' and for this monitoree'
     else

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -1143,17 +1143,17 @@ class PatientsControllerTest < ActionController::TestCase
     assert_match('Hospitalized', household_member_1.follow_up_reason)
     assert_match('Test Note', household_member_1.follow_up_note)
     assert_histories_contain(household_member_1, "User flagged for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
-                                                 " and applied that change to this monitoree. Reason: \"Hospitalized: Test Note\"")
+                                                 " and for this monitoree. Reason: \"Hospitalized: Test Note\"")
     household_member_2.reload
     assert_match('Hospitalized', household_member_2.follow_up_reason)
     assert_match('Test Note', household_member_2.follow_up_note)
     assert_histories_contain(household_member_2, "User flagged for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
-                                                 " and applied that change to this monitoree. Reason: \"Hospitalized: Test Note\"")
+                                                 " and for this monitoree. Reason: \"Hospitalized: Test Note\"")
     household_member_3.reload
     assert_nil household_member_3.follow_up_reason
     assert_nil household_member_3.follow_up_note
     assert_not_histories_contain(household_member_3, "User flagged for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
-                                                     " and applied that change to this monitoree. Reason: \"Hospitalized: Test Note\"")
+                                                     " and for this monitoree. Reason: \"Hospitalized: Test Note\"")
 
     post :update_follow_up_flag, params: {
       id: patient.id,
@@ -1174,17 +1174,17 @@ class PatientsControllerTest < ActionController::TestCase
     assert_nil household_member_1.follow_up_reason
     assert_nil household_member_1.follow_up_note
     assert_histories_contain(household_member_1, "User cleared flag for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
-                                                 " and applied that change to this monitoree. Reason: \"Test Note\"")
+                                                 " and for this monitoree. Reason: \"Test Note\"")
     household_member_2.reload
     assert_match('Hospitalized', household_member_2.follow_up_reason)
     assert_match('Test Note', household_member_2.follow_up_note)
     assert_not_histories_contain(household_member_2, "User cleared flag for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
-                                                     " and applied that change to this monitoree. Reason: \"Test Note\"")
+                                                     " and for this monitoree. Reason: \"Test Note\"")
     household_member_3.reload
     assert_nil household_member_3.follow_up_reason
     assert_nil household_member_3.follow_up_note
     assert_not_histories_contain(household_member_3, "User cleared flag for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
-                                                     " and applied that change to this monitoree. Reason: \"Test Note\"")
+                                                     " and for this monitoree. Reason: \"Test Note\"")
   end
 
   test 'bulk action for setting and clearing follow up flag for patients without applying update to household members' do

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -1143,17 +1143,17 @@ class PatientsControllerTest < ActionController::TestCase
     assert_match('Hospitalized', household_member_1.follow_up_reason)
     assert_match('Test Note', household_member_1.follow_up_note)
     assert_histories_contain(household_member_1, "User flagged for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
-                                                 " and for this monitoree. Reason: \"Hospitalized: Test Note\"")
+                                                 ' and for this monitoree. Reason: "Hospitalized: Test Note"')
     household_member_2.reload
     assert_match('Hospitalized', household_member_2.follow_up_reason)
     assert_match('Test Note', household_member_2.follow_up_note)
     assert_histories_contain(household_member_2, "User flagged for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
-                                                 " and for this monitoree. Reason: \"Hospitalized: Test Note\"")
+                                                 ' and for this monitoree. Reason: "Hospitalized: Test Note"')
     household_member_3.reload
     assert_nil household_member_3.follow_up_reason
     assert_nil household_member_3.follow_up_note
     assert_not_histories_contain(household_member_3, "User flagged for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
-                                                     " and for this monitoree. Reason: \"Hospitalized: Test Note\"")
+                                                     ' and for this monitoree. Reason: "Hospitalized: Test Note"')
 
     post :update_follow_up_flag, params: {
       id: patient.id,
@@ -1173,18 +1173,18 @@ class PatientsControllerTest < ActionController::TestCase
     household_member_1.reload
     assert_nil household_member_1.follow_up_reason
     assert_nil household_member_1.follow_up_note
-    assert_histories_contain(household_member_1, "User cleared flag for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
-                                                 " and for this monitoree. Reason: \"Test Note\"")
+    assert_histories_contain(household_member_1, 'User cleared flag for follow-up by making that change for a household member'\
+                                                 " (Sara Alert ID: #{patient.id}) and for this monitoree. Reason: \"Test Note\"")
     household_member_2.reload
     assert_match('Hospitalized', household_member_2.follow_up_reason)
     assert_match('Test Note', household_member_2.follow_up_note)
-    assert_not_histories_contain(household_member_2, "User cleared flag for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
-                                                     " and for this monitoree. Reason: \"Test Note\"")
+    assert_not_histories_contain(household_member_2, 'User cleared flag for follow-up by making that change for a household member'\
+                                                     " (Sara Alert ID: #{patient.id}) and for this monitoree. Reason: \"Test Note\"")
     household_member_3.reload
     assert_nil household_member_3.follow_up_reason
     assert_nil household_member_3.follow_up_note
-    assert_not_histories_contain(household_member_3, "User cleared flag for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
-                                                     " and for this monitoree. Reason: \"Test Note\"")
+    assert_not_histories_contain(household_member_3, 'User cleared flag for follow-up by making that change for a household member'\
+                                                     " (Sara Alert ID: #{patient.id}) and for this monitoree. Reason: \"Test Note\"")
   end
 
   test 'bulk action for setting and clearing follow up flag for patients without applying update to household members' do

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -1142,7 +1142,6 @@ class PatientsControllerTest < ActionController::TestCase
     household_member_1.reload
     assert_match('Hospitalized', household_member_1.follow_up_reason)
     assert_match('Test Note', household_member_1.follow_up_note)
-    puts household_member_1.histories.pluck(:comment)
     assert_histories_contain(household_member_1, "User flagged for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
                                                  ' and for this monitoree. Reason: "Hospitalized: Test Note"')
     household_member_2.reload
@@ -1175,17 +1174,17 @@ class PatientsControllerTest < ActionController::TestCase
     assert_nil household_member_1.follow_up_reason
     assert_nil household_member_1.follow_up_note
     assert_histories_contain(household_member_1, 'User cleared flag for follow-up by making that change for a household member'\
-                                                 " (Sara Alert ID: #{patient.id}) and for this monitoree. Reason: \"Test Note\"")
+                                                 " (Sara Alert ID: #{patient.id}) and for this monitoree. Reason: Test Note")
     household_member_2.reload
     assert_match('Hospitalized', household_member_2.follow_up_reason)
     assert_match('Test Note', household_member_2.follow_up_note)
     assert_not_histories_contain(household_member_2, 'User cleared flag for follow-up by making that change for a household member'\
-                                                     " (Sara Alert ID: #{patient.id}) and for this monitoree. Reason: \"Test Note\"")
+                                                     " (Sara Alert ID: #{patient.id}) and for this monitoree. Reason: Test Note")
     household_member_3.reload
     assert_nil household_member_3.follow_up_reason
     assert_nil household_member_3.follow_up_note
     assert_not_histories_contain(household_member_3, 'User cleared flag for follow-up by making that change for a household member'\
-                                                     " (Sara Alert ID: #{patient.id}) and for this monitoree. Reason: \"Test Note\"")
+                                                     " (Sara Alert ID: #{patient.id}) and for this monitoree. Reason: Test Note")
   end
 
   test 'bulk action for setting and clearing follow up flag for patients without applying update to household members' do

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -1142,18 +1142,18 @@ class PatientsControllerTest < ActionController::TestCase
     household_member_1.reload
     assert_match('Hospitalized', household_member_1.follow_up_reason)
     assert_match('Test Note', household_member_1.follow_up_note)
-    assert_histories_contain(household_member_1, "User flagged for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
-                                                 ' and for this monitoree. Reason: "Hospitalized: Test Note"')
+    assert_histories_contain(household_member_1, "User flagged for follow-up by making that change to a household member (Sara Alert ID: #{patient.id})"\
+                                                 ' and to this monitoree. Reason: "Hospitalized: Test Note"')
     household_member_2.reload
     assert_match('Hospitalized', household_member_2.follow_up_reason)
     assert_match('Test Note', household_member_2.follow_up_note)
-    assert_histories_contain(household_member_2, "User flagged for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
-                                                 ' and for this monitoree. Reason: "Hospitalized: Test Note"')
+    assert_histories_contain(household_member_2, "User flagged for follow-up by making that change to a household member (Sara Alert ID: #{patient.id})"\
+                                                 ' and to this monitoree. Reason: "Hospitalized: Test Note"')
     household_member_3.reload
     assert_nil household_member_3.follow_up_reason
     assert_nil household_member_3.follow_up_note
-    assert_not_histories_contain(household_member_3, "User flagged for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
-                                                     ' and for this monitoree. Reason: "Hospitalized: Test Note"')
+    assert_not_histories_contain(household_member_3, "User flagged for follow-up by making that change to a household member (Sara Alert ID: #{patient.id})"\
+                                                     ' and to this monitoree. Reason: "Hospitalized: Test Note"')
 
     post :update_follow_up_flag, params: {
       id: patient.id,
@@ -1173,18 +1173,18 @@ class PatientsControllerTest < ActionController::TestCase
     household_member_1.reload
     assert_nil household_member_1.follow_up_reason
     assert_nil household_member_1.follow_up_note
-    assert_histories_contain(household_member_1, 'User cleared flag for follow-up by making that change for a household member'\
-                                                 " (Sara Alert ID: #{patient.id}) and for this monitoree. Reason: Test Note")
+    assert_histories_contain(household_member_1, 'User cleared flag for follow-up by making that change to a household member'\
+                                                 " (Sara Alert ID: #{patient.id}) and to this monitoree. Reason: Test Note")
     household_member_2.reload
     assert_match('Hospitalized', household_member_2.follow_up_reason)
     assert_match('Test Note', household_member_2.follow_up_note)
-    assert_not_histories_contain(household_member_2, 'User cleared flag for follow-up by making that change for a household member'\
-                                                     " (Sara Alert ID: #{patient.id}) and for this monitoree. Reason: Test Note")
+    assert_not_histories_contain(household_member_2, 'User cleared flag for follow-up by making that change to a household member'\
+                                                     " (Sara Alert ID: #{patient.id}) and to this monitoree. Reason: Test Note")
     household_member_3.reload
     assert_nil household_member_3.follow_up_reason
     assert_nil household_member_3.follow_up_note
-    assert_not_histories_contain(household_member_3, 'User cleared flag for follow-up by making that change for a household member'\
-                                                     " (Sara Alert ID: #{patient.id}) and for this monitoree. Reason: Test Note")
+    assert_not_histories_contain(household_member_3, 'User cleared flag for follow-up by making that change to a household member'\
+                                                     " (Sara Alert ID: #{patient.id}) and to this monitoree. Reason: Test Note")
   end
 
   test 'bulk action for setting and clearing follow up flag for patients without applying update to household members' do

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -1142,6 +1142,7 @@ class PatientsControllerTest < ActionController::TestCase
     household_member_1.reload
     assert_match('Hospitalized', household_member_1.follow_up_reason)
     assert_match('Test Note', household_member_1.follow_up_note)
+    puts household_member_1.histories.pluck(:comment)
     assert_histories_contain(household_member_1, "User flagged for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
                                                  ' and for this monitoree. Reason: "Hospitalized: Test Note"')
     household_member_2.reload

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -1142,15 +1142,18 @@ class PatientsControllerTest < ActionController::TestCase
     household_member_1.reload
     assert_match('Hospitalized', household_member_1.follow_up_reason)
     assert_match('Test Note', household_member_1.follow_up_note)
-    assert_histories_contain(household_member_1, 'User flagged for follow-up. Reason: "Hospitalized: Test Note"')
+    assert_histories_contain(household_member_1, "User flagged for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
+                                                 " and applied that change to this monitoree. Reason: \"Hospitalized: Test Note\"")
     household_member_2.reload
     assert_match('Hospitalized', household_member_2.follow_up_reason)
     assert_match('Test Note', household_member_2.follow_up_note)
-    assert_histories_contain(household_member_2, 'User flagged for follow-up. Reason: "Hospitalized: Test Note"')
+    assert_histories_contain(household_member_2, "User flagged for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
+                                                 " and applied that change to this monitoree. Reason: \"Hospitalized: Test Note\"")
     household_member_3.reload
     assert_nil household_member_3.follow_up_reason
     assert_nil household_member_3.follow_up_note
-    assert_not_histories_contain(household_member_3, 'User flagged for follow-up. Reason: "Hospitalized: Test Note"')
+    assert_not_histories_contain(household_member_3, "User flagged for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
+                                                     " and applied that change to this monitoree. Reason: \"Hospitalized: Test Note\"")
 
     post :update_follow_up_flag, params: {
       id: patient.id,
@@ -1170,15 +1173,18 @@ class PatientsControllerTest < ActionController::TestCase
     household_member_1.reload
     assert_nil household_member_1.follow_up_reason
     assert_nil household_member_1.follow_up_note
-    assert_histories_contain(household_member_1, 'User cleared flag for follow-up. Reason: Test Note')
+    assert_histories_contain(household_member_1, "User cleared flag for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
+                                                 " and applied that change to this monitoree. Reason: \"Test Note\"")
     household_member_2.reload
     assert_match('Hospitalized', household_member_2.follow_up_reason)
     assert_match('Test Note', household_member_2.follow_up_note)
-    assert_not_histories_contain(household_member_2, 'User cleared flag for follow-up. Reason: Test Note')
+    assert_not_histories_contain(household_member_2, "User cleared flag for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
+                                                     " and applied that change to this monitoree. Reason: \"Test Note\"")
     household_member_3.reload
     assert_nil household_member_3.follow_up_reason
     assert_nil household_member_3.follow_up_note
-    assert_not_histories_contain(household_member_3, 'User cleared flag for follow-up. Reason: Test Note')
+    assert_not_histories_contain(household_member_3, "User cleared flag for follow-up by making that change for a household member (Sara Alert ID: #{patient.id})"\
+                                                     " and applied that change to this monitoree. Reason: \"Test Note\"")
   end
 
   test 'bulk action for setting and clearing follow up flag for patients without applying update to household members' do

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -1097,7 +1097,7 @@ class PatientsControllerTest < ActionController::TestCase
     patient.reload
     assert_match('Hospitalized', patient.follow_up_reason)
     assert_match('Test Note', patient.follow_up_note)
-    assert_histories_contain(patient, 'Flagged for Follow-up. Reason: "Hospitalized: Test Note"')
+    assert_histories_contain(patient, 'User flagged for follow-up. Reason: "Hospitalized: Test Note"')
 
     post :update_follow_up_flag, params: {
       id: patient.id,
@@ -1138,19 +1138,19 @@ class PatientsControllerTest < ActionController::TestCase
     patient.reload
     assert_match('Hospitalized', patient.follow_up_reason)
     assert_match('Test Note', patient.follow_up_note)
-    assert_histories_contain(patient, 'Flagged for Follow-up. Reason: "Hospitalized: Test Note"')
+    assert_histories_contain(patient, 'User flagged for follow-up. Reason: "Hospitalized: Test Note"')
     household_member_1.reload
     assert_match('Hospitalized', household_member_1.follow_up_reason)
     assert_match('Test Note', household_member_1.follow_up_note)
-    assert_histories_contain(household_member_1, 'Flagged for Follow-up. Reason: "Hospitalized: Test Note"')
+    assert_histories_contain(household_member_1, 'User flagged for follow-up. Reason: "Hospitalized: Test Note"')
     household_member_2.reload
     assert_match('Hospitalized', household_member_2.follow_up_reason)
     assert_match('Test Note', household_member_2.follow_up_note)
-    assert_histories_contain(household_member_2, 'Flagged for Follow-up. Reason: "Hospitalized: Test Note"')
+    assert_histories_contain(household_member_2, 'User flagged for follow-up. Reason: "Hospitalized: Test Note"')
     household_member_3.reload
     assert_nil household_member_3.follow_up_reason
     assert_nil household_member_3.follow_up_note
-    assert_not_histories_contain(household_member_3, 'Flagged for Follow-up. Reason: "Hospitalized: Test Note"')
+    assert_not_histories_contain(household_member_3, 'User flagged for follow-up. Reason: "Hospitalized: Test Note"')
 
     post :update_follow_up_flag, params: {
       id: patient.id,
@@ -1201,12 +1201,12 @@ class PatientsControllerTest < ActionController::TestCase
     patient_1.reload
     assert_match('In Need of Follow-up', patient_1.follow_up_reason)
     assert_match('Test Note', patient_1.follow_up_note)
-    assert_histories_contain(patient_1, 'Flagged for Follow-up. Reason: "In Need of Follow-up: Test Note"')
+    assert_histories_contain(patient_1, 'User flagged for follow-up. Reason: "In Need of Follow-up: Test Note"')
 
     patient_2.reload
     assert_match('In Need of Follow-up', patient_2.follow_up_reason)
     assert_match('Test Note', patient_2.follow_up_note)
-    assert_histories_contain(patient_2, 'Flagged for Follow-up. Reason: "In Need of Follow-up: Test Note"')
+    assert_histories_contain(patient_2, 'User flagged for follow-up. Reason: "In Need of Follow-up: Test Note"')
 
     post :bulk_update, params: {
       ids: [patient_1.id, patient_2.id],
@@ -1253,24 +1253,24 @@ class PatientsControllerTest < ActionController::TestCase
     household_1_hoh.reload
     assert_match('In Need of Follow-up', household_1_hoh.follow_up_reason)
     assert_match('Test Note', household_1_hoh.follow_up_note)
-    assert_histories_contain(household_1_hoh, 'Flagged for Follow-up. Reason: "In Need of Follow-up: Test Note"')
+    assert_histories_contain(household_1_hoh, 'User flagged for follow-up. Reason: "In Need of Follow-up: Test Note"')
     household_1_member_1.reload
     assert_match('In Need of Follow-up', household_1_member_1.follow_up_reason)
     assert_match('Test Note', household_1_member_1.follow_up_note)
-    assert_histories_contain(household_1_member_1, 'Flagged for Follow-up. Reason: "In Need of Follow-up: Test Note"')
+    assert_histories_contain(household_1_member_1, 'User flagged for follow-up. Reason: "In Need of Follow-up: Test Note"')
 
     household_2_member_1.reload
     assert_match('In Need of Follow-up', household_2_member_1.follow_up_reason)
     assert_match('Test Note', household_2_member_1.follow_up_note)
-    assert_histories_contain(household_2_member_1, 'Flagged for Follow-up. Reason: "In Need of Follow-up: Test Note"')
+    assert_histories_contain(household_2_member_1, 'User flagged for follow-up. Reason: "In Need of Follow-up: Test Note"')
     household_2_member_2.reload
     assert_nil household_2_member_2.follow_up_reason
     assert_nil household_2_member_2.follow_up_note
-    assert_not_histories_contain(household_2_member_2, 'Flagged for Follow-up. Reason: "In Need of Follow-up: Test Note"')
+    assert_not_histories_contain(household_2_member_2, 'User flagged for follow-up. Reason: "In Need of Follow-up: Test Note"')
     household_2_hoh.reload
     assert_nil household_2_hoh.follow_up_reason
     assert_nil household_2_hoh.follow_up_note
-    assert_not_histories_contain(household_2_hoh, 'Flagged for Follow-up. Reason: "In Need of Follow-up: Test Note"')
+    assert_not_histories_contain(household_2_hoh, 'User flagged for follow-up. Reason: "In Need of Follow-up: Test Note"')
 
     post :bulk_update, params: {
       ids: [household_1_hoh.id, household_2_member_1.id],


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-890](https://tracker.codev.mitre.org/browse/SARAALERT-890)

Modifies Monitoring_Change histories to indicate what patient record the change originated from when the change was made to an entire household or a subset of the household. 

## (Feature) Demo/Screenshots
![Screen Shot 2021-07-12 at 11 40 10 AM](https://user-images.githubusercontent.com/16108095/125339206-f0d89700-e305-11eb-9979-3db7037a3c56.png)


## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

app/models/history.rb: modifies the comment-generating code for Monitoring_Change histories to clearly and concisely describe not only what the change was, but where the change was made from and to whom in the household. To support this, also changes the contract of the function to take in the ID of the record where the change originated as a parameter. 
app/controllers/patients_controller.rb and app/controllers/fhir/r4/api_controller.rb: modifies both to have the instances where they call the monitoring_change history generation functions to match the new function contract. 

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@ngfreiter 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@timwongj :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
