### PR TITLE
Increase the amount of backtraces remembered by NewRelic

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -46,3 +46,4 @@ staging:
 
 production:
   <<: *default_settings
+  error_collector.max_backtrace_frames: 125


### PR DESCRIPTION
Increases the remembered/visible backtraces by NewRelic from 50 to 125

https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration/#error_collector-max_backtrace_frames