### PR TITLE
SARAALERT-1006: Patients Table Styling Update

### DIFF
--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -233,10 +233,7 @@ class CustomTable extends React.Component {
                         value = colData.filter(filterData);
                       }
                       return (
-                        <td
-                          key={colIndex}
-                          id={`${this.props.dataType}-${rowData.id ? rowData.id : `row-${rowIndex}`}`}
-                          className={colData.className ? colData.className : ''}>
+                        <td key={colIndex} className={colData.className ? colData.className : ''}>
                           {colData.onClick && <span onClick={() => (colData.onClick(rowData.id.toString()) ? colData.onClick : null)}>{value}</span>}
                           {!colData.onClick && value}
                         </td>

--- a/app/javascript/components/layout/CustomTable.js
+++ b/app/javascript/components/layout/CustomTable.js
@@ -233,7 +233,10 @@ class CustomTable extends React.Component {
                         value = colData.filter(filterData);
                       }
                       return (
-                        <td key={colIndex} id={`${this.props.dataType}-`} className={colData.className ? colData.className : ''}>
+                        <td
+                          key={colIndex}
+                          id={`${this.props.dataType}-${rowData.id ? rowData.id : `row-${rowIndex}`}`}
+                          className={colData.className ? colData.className : ''}>
                           {colData.onClick && <span onClick={() => (colData.onClick(rowData.id.toString()) ? colData.onClick : null)}>{value}</span>}
                           {!colData.onClick && value}
                         </td>

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -524,6 +524,9 @@ class PatientsTable extends React.Component {
     return `Monitoree ${rowData.name}`;
   };
 
+  // Adds the className `selected-row` to those rows who have been selected with the Bulk Action checkcbox
+  getRowClassName = rowData => (this.state.selectedPatients.filter(x => this.state.table.rowData[Number(x)].id === rowData.id).length ? 'selected-row' : null);
+
   createEligibilityTooltip = data => {
     const reportEligibility = data.value;
     const rowData = data.rowData;
@@ -724,27 +727,30 @@ class PatientsTable extends React.Component {
                   )}
                 </InputGroup>
               </Form>
-              <CustomTable
-                dataType="patients"
-                columnData={this.state.table.displayedColData}
-                rowData={this.state.table.rowData}
-                totalRows={this.state.table.totalRows}
-                handleTableUpdate={query => this.updateTable({ ...this.state.query, order: query.orderBy, page: query.page, direction: query.sortDirection })}
-                handleSelect={this.handleSelect}
-                handleEntriesChange={this.handleEntriesChange}
-                handlePageUpdate={this.handlePageUpdate}
-                getRowCheckboxAriaLabel={this.getRowCheckboxAriaLabel}
-                isSelectable={true}
-                isEditable={false}
-                isLoading={this.state.loading}
-                page={this.state.query.page}
-                selectedRows={this.state.selectedPatients}
-                selectAll={this.state.selectAll}
-                entryOptions={this.state.entryOptions}
-                entries={parseInt(this.state.query.entries)}
-                orderBy={this.state.query.order !== undefined ? this.state.query.order : ''}
-                sortDirection={this.state.query.direction !== undefined ? this.state.query.direction : ''}
-              />
+              <div className="patients-table">
+                <CustomTable
+                  dataType="patients"
+                  columnData={this.state.table.displayedColData}
+                  rowData={this.state.table.rowData}
+                  totalRows={this.state.table.totalRows}
+                  handleTableUpdate={query => this.updateTable({ ...this.state.query, order: query.orderBy, page: query.page, direction: query.sortDirection })}
+                  handleSelect={this.handleSelect}
+                  handleEntriesChange={this.handleEntriesChange}
+                  handlePageUpdate={this.handlePageUpdate}
+                  getRowCheckboxAriaLabel={this.getRowCheckboxAriaLabel}
+                  isSelectable={true}
+                  isEditable={false}
+                  isLoading={this.state.loading}
+                  page={this.state.query.page}
+                  selectedRows={this.state.selectedPatients}
+                  selectAll={this.state.selectAll}
+                  entryOptions={this.state.entryOptions}
+                  entries={parseInt(this.state.query.entries)}
+                  orderBy={this.state.query.order !== undefined ? this.state.query.order : ''}
+                  sortDirection={this.state.query.direction !== undefined ? this.state.query.direction : ''}
+                  getRowClassName={this.getRowClassName}
+                />
+              </div>
             </Card.Body>
           </Card>
         </TabContent>

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -525,7 +525,10 @@ class PatientsTable extends React.Component {
   };
 
   // Adds the className `selected-row` to those rows who have been selected with the Bulk Action checkcbox
-  getRowClassName = rowData => (this.state.selectedPatients.filter(x => this.state.table.rowData[Number(x)].id === rowData.id).length ? 'selected-row' : null);
+  getRowClassName = rowData => {
+    const isSelected = this.state.selectedPatients.filter(x => this.state.table.rowData[Number(x)].id === rowData.id).length;
+    return isSelected ? 'selected-row' : null;
+  };
 
   createEligibilityTooltip = data => {
     const reportEligibility = data.value;
@@ -737,6 +740,7 @@ class PatientsTable extends React.Component {
                   handleSelect={this.handleSelect}
                   handleEntriesChange={this.handleEntriesChange}
                   handlePageUpdate={this.handlePageUpdate}
+                  getRowClassName={this.getRowClassName}
                   getRowCheckboxAriaLabel={this.getRowCheckboxAriaLabel}
                   isSelectable={true}
                   isEditable={false}
@@ -748,7 +752,6 @@ class PatientsTable extends React.Component {
                   entries={parseInt(this.state.query.entries)}
                   orderBy={this.state.query.order !== undefined ? this.state.query.order : ''}
                   sortDirection={this.state.query.direction !== undefined ? this.state.query.direction : ''}
-                  getRowClassName={this.getRowClassName}
                 />
               </div>
             </Card.Body>

--- a/app/javascript/packs/stylesheets/custom_table.scss
+++ b/app/javascript/packs/stylesheets/custom_table.scss
@@ -54,3 +54,21 @@
 .table-smaller-font {
   font-size: 0.9em;
 }
+
+.patients-table .table-hover tbody tr:hover {
+  background-color: #e4e4e4 !important;
+}
+.patients-table .table-hover tbody tr:hover td {
+  border-color: white !important;
+}
+
+.selected-row {
+  background-color: #d4e7f7 !important;
+}
+
+.selected-row > td, .selected-row > th {
+  border: 1px solid white !important;
+}
+.selected-row:hover > td, .selected-row:hover > th {
+  background-color: #bcdcf5 !important;
+}

--- a/app/javascript/packs/stylesheets/custom_table.scss
+++ b/app/javascript/packs/stylesheets/custom_table.scss
@@ -55,20 +55,25 @@
   font-size: 0.9em;
 }
 
-.patients-table .table-hover tbody tr:hover {
-  background-color: #e4e4e4 !important;
-}
-.patients-table .table-hover tbody tr:hover td {
-  border-color: white !important;
+.patients-table tbody tr:hover {
+  background-color: #ddd;
+
+  td {
+    border-color: white;
+  }
+
 }
 
 .selected-row {
   background-color: #d4e7f7 !important;
-}
 
-.selected-row > td, .selected-row > th {
-  border: 1px solid white !important;
-}
-.selected-row:hover > td, .selected-row:hover > th {
-  background-color: #bcdcf5 !important;
+  td, th {
+    border: 1px solid white;
+  }
+
+  &:hover {
+    td, th {
+      background-color: #bcdcf5 ;
+    }
+  }
 }


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1006](https://tracker.codev.mitre.org/browse/SARAALERT-1006)

This Pull Request updates the styling for the Patients Table. It adds a better (and more obvious) hover color to the table. It also adds a custom class for selected rows, and a hover color for those rows that have been selected.

This PR also removes an incorret `id`s off each of the cells within each row of the Patients Table. The `id` on each row remains.

##  Demo/Screenshots

https://user-images.githubusercontent.com/17532163/122814770-a6ce3980-d2a2-11eb-8191-3cab8d9312f0.mov

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/javascript/components/layout/CustomTable.js`
- Removes `id` from each cell in the Patients Table. It had been unnecessary.

`app/javascript/components/public_health/PatientsTable.js`
- Efficiently adds custom `selected-row` class to selected rows of the Patients table

`app/javascript/packs/stylesheets/custom_table.scss`
- Adds the styling for this PR

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@sgober  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@timwongj  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
