### PR TITLE
SARAALERT-1520: Isolation auto close

### DIFF
--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -66,7 +66,9 @@ class PatientMailer < ApplicationMailer
       url = new_patient_assessment_jurisdiction_lang_initials_url(dependent.submission_token, dependent.jurisdiction.unique_identifier, lang&.to_s,
                                                                   dependent&.initials_age)
       contents = "#{I18n.t('assessments.sms.weblink.intro', locale: lang)} #{dependent&.initials_age('-')}: #{url}"
-      patient.update(last_assessment_reminder_sent: DateTime.now) # Update last send attempt timestamp before Twilio call
+      # Update last send attempt timestamp before Twilio call
+      patient.last_assessment_reminder_sent = DateTime.now
+      patient.save(touch: false)
       threshold_hash = dependent.jurisdiction[:current_threshold_condition_hash]
       message = { prompt: contents, patient_submission_token: dependent.submission_token,
                   threshold_hash: threshold_hash }
@@ -111,8 +113,9 @@ class PatientMailer < ApplicationMailer
                try_again: I18n.t('assessments.sms.prompt.try-again', locale: lang),
                max_retries_message: I18n.t('assessments.sms.prompt.max_retries_message', locale: lang),
                thanks: I18n.t('assessments.sms.prompt.thanks', locale: lang) }
-
-    patient.update(last_assessment_reminder_sent: DateTime.now) # Update last send attempt timestamp before Twilio sms assessment
+    # Update last send attempt timestamp before Twilio sms assessment
+    patient.last_assessment_reminder_sent = DateTime.now
+    patient.save(touch: false)
     patient.active_dependents_and_self.each { |pat| add_success_history(pat) } if TwilioSender.start_studio_flow_assessment(patient, params)
   end
 
@@ -154,8 +157,9 @@ class PatientMailer < ApplicationMailer
                try_again: I18n.t('assessments.phone.try-again', locale: lang),
                max_retries_message: I18n.t('assessments.phone.max_retries_message', locale: lang),
                thanks: I18n.t('assessments.phone.thanks', locale: lang) }
-
-    patient.update(last_assessment_reminder_sent: DateTime.now) # Update last send attempt timestamp before Twilio call
+    # Update last send attempt timestamp before Twilio call
+    patient.last_assessment_reminder_sent = DateTime.now
+    patient.save(touch: false)
     patient.active_dependents_and_self.each { |pat| add_success_history(pat) } if TwilioSender.start_studio_flow_assessment(patient, params)
   end
 
@@ -175,14 +179,17 @@ class PatientMailer < ApplicationMailer
     @patients = patient.active_dependents.uniq.collect do |dependent|
       { patient: dependent, jurisdiction_unique_id: Jurisdiction.find_by_id(dependent.jurisdiction_id).unique_identifier }
     end
-
-    patient.update(last_assessment_reminder_sent: DateTime.now) # Update last send attempt timestamp before SMTP call
+    # Update last send attempt timestamp before SMTP call
+    patient.last_assessment_reminder_sent = DateTime.now
+    patient.save(touch: false)
     mail(to: patient.email&.strip, subject: I18n.t('assessments.email.reminder.subject', locale: @lang)) do |format|
       format.html { render layout: 'main_mailer' }
     end
     patient.active_dependents_and_self.each { |pat| add_success_history(pat) }
   rescue StandardError => e
-    patient.update(last_assessment_reminder_sent: nil) # Reset send attempt timestamp on failure
+    # Reset send attempt timestamp on failure
+    patient.last_assessment_reminder_sent = nil
+    patient.save(touch: false)
     raise "Failed to send email for patient id: #{patient.id}; #{e.message}"
   end
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1011,7 +1011,7 @@ class Patient < ApplicationRecord
 
     # Check last_assessment_reminder_sent before enqueueing to cover potential race condition of multiple reports
     # being sent out for the same monitoree.
-    return unless last_assessment_reminder_sent_eligible? || send_now
+    return unless last_assessment_reminder_sent_eligible?
 
     contact_method = preferred_contact_method&.downcase
     if contact_method == 'sms text-message' && ADMIN_OPTIONS['enable_sms']

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -694,9 +694,7 @@ class Patient < ApplicationRecord
   }
 
   # Patients are eligible to be automatically closed by the system IF:
-  #  - in exposure workflow
-  #     AND
-  #  - patient is non-reporting
+  #  - patient is non-reporting (in exposure or isolation)
   #    AND
   #  - patient has no recent activity
   #
@@ -718,7 +716,9 @@ class Patient < ApplicationRecord
 
     # If a patient record has been inactive for 30 days or more
     # in the exposure workflow and is non-reporting
-    no_recent_activity = non_reporting.where('updated_at <= ?', 30.days.ago)
+    no_recent_activity = isolation_non_reporting
+                         .where('updated_at <= ?', 30.days.ago)
+                         .or(exposure_non_reporting.where('updated_at <= ?', 30.days.ago))
 
     case reason
     when nil
@@ -992,8 +992,7 @@ class Patient < ApplicationRecord
     end
   end
 
-  # Send a daily assessment to this monitoree (if currently eligible). By setting send_now to true, an assessment
-  # will be sent immediately without any consideration of the monitoree's preferred_contact_time.
+  # Send a daily assessment to this monitoree (if currently eligible).
   def send_assessment
     # Return UNLESS:
     # - in exposure: NOT closed AND within monitoring period OR

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -718,9 +718,7 @@ class Patient < ApplicationRecord
 
     # If a patient record has been inactive for 30 days or more
     # in the exposure workflow and is non-reporting
-    no_recent_activity = where(isolation: false)
-                         .non_reporting
-                         .where('updated_at <= ?', 30.days.ago)
+    no_recent_activity = non_reporting.where('updated_at <= ?', 30.days.ago)
 
     case reason
     when nil

--- a/test/mailers/patient_mailer_test.rb
+++ b/test/mailers/patient_mailer_test.rb
@@ -25,6 +25,7 @@ class PatientMailerTest < ActionMailer::TestCase
     ENV['TWILLIO_API_KEY'] = 'test'
     ENV['TWILLIO_STUDIO_FLOW'] = 'test'
     ENV['TWILLIO_MESSAGING_SERVICE_SID'] = 'test_messaging_sid'
+    ADMIN_OPTIONS['job_run_email'] = 'test@test.com'
   end
 
   def teardown
@@ -569,5 +570,46 @@ class PatientMailerTest < ActionMailer::TestCase
     )
     assert_includes email_body, I18n.t('assessments.email.closed.footer', locale: @patient.primary_language)
     assert_histories_contain(@patient, 'Monitoring Complete message was sent.')
+  end
+
+  [
+    { preferred_contact_method: 'E-mailed Web Link', email: 'testpatient@example.com' },
+    { preferred_contact_method: 'SMS Texted Weblink', primary_telephone: '+12223334444' },
+    { preferred_contact_method: 'Telephone call', primary_telephone: '+12223334444' },
+    { preferred_contact_method: 'SMS Text-message', primary_telephone: '+12223334444' }
+  ].each do |attributes|
+    test "send_assessment does not touch updated_at for #{attributes} when sending an assessment" do
+      ActionMailer::Base.deliveries.clear
+      patient = create(:patient, { submission_token: SecureRandom.urlsafe_base64[0, 10], last_date_of_exposure: Date.yesterday }.merge(attributes))
+      patient.update(updated_at: 300.days.ago)
+      assert_nil patient.last_assessment_reminder_sent
+      # If a job is created, then ensure it executes now
+      patient.send_assessment&.perform_now
+      patient.reload
+      assert_not_nil patient.last_assessment_reminder_sent
+      assert patient.updated_at < 290.days.ago
+    end
+  end
+
+  [
+    { preferred_contact_method: 'E-mailed Web Link' },
+    { preferred_contact_method: 'SMS Texted Weblink' },
+    { preferred_contact_method: 'Telephone call' },
+    { preferred_contact_method: 'SMS Text-message' },
+    { preferred_contact_method: 'SMS Texted Weblink', primary_telephone: '+12223334444' },
+    { preferred_contact_method: 'SMS Text-message', primary_telephone: '+12223334444' }
+  ].each do |attributes|
+    test "send_assessment does not touch updated_at for #{attributes} when failing to send an assessment" do
+      BlockedNumber.create(phone_number: '+12223334444')
+      ActionMailer::Base.deliveries.clear
+      patient = create(:patient, { submission_token: SecureRandom.urlsafe_base64[0, 10], last_date_of_exposure: Date.yesterday }.merge(attributes))
+      patient.update(updated_at: 300.days.ago)
+      assert_nil patient.last_assessment_reminder_sent
+      # If a job is created, then ensure it executes now
+      patient.send_assessment&.perform_now
+      patient.reload
+      assert_nil patient.last_assessment_reminder_sent
+      assert patient.updated_at < 290.days.ago
+    end
   end
 end

--- a/test/models/history_test.rb
+++ b/test/models/history_test.rb
@@ -92,4 +92,19 @@ class HistoryTest < ActiveSupport::TestCase
       create(:history, history_type: 'Comment').update(created_at: 15.days.ago)
     end
   end
+
+  test 'history types that should not touch the patient record' do
+    patient = create(:patient)
+    patient.update(updated_at: 100.days.ago)
+    assert patient.updated_at < 98.days.ago
+
+    History.report_reminder(patient: patient)
+    assert patient.updated_at < 98.days.ago
+
+    History.unsuccessful_report_reminder(patient: patient)
+    assert patient.updated_at < 98.days.ago
+
+    History.monitoree_data_downloaded(patient: patient)
+    assert patient.updated_at < 98.days.ago
+  end
 end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -7,6 +7,9 @@ class PatientTest < ActiveSupport::TestCase
   include PatientHelper
 
   def setup
+    ADMIN_OPTIONS['job_run_email'] = 'test@test.com'
+    ENV['TWILLIO_STUDIO_FLOW'] = 'test'
+    ENV['TWILLIO_SENDING_NUMBER'] = '+15555555555'
     @default_purgeable_after = ADMIN_OPTIONS['purgeable_after']
     @default_weekly_purge_warning_date = ADMIN_OPTIONS['weekly_purge_warning_date']
     @default_weekly_purge_date = ADMIN_OPTIONS['weekly_purge_date']
@@ -3446,6 +3449,45 @@ class PatientTest < ActiveSupport::TestCase
       assert_equal afternoon_patient.time_to_notify_closed.day, patient_local_time.tomorrow.day
       assert_equal evening_patient.time_to_notify_closed.day, patient_local_time.tomorrow.day
       assert_equal unspec_patient.time_to_notify_closed.day, patient_local_time.tomorrow.day
+    end
+  end
+
+  [
+    { preferred_contact_method: 'E-mailed Web Link', email: 'testpatient@example.com' },
+    { preferred_contact_method: 'SMS Texted Weblink', primary_telephone: '+12223334444' },
+    { preferred_contact_method: 'Telephone call', primary_telephone: '+12223334444' },
+    { preferred_contact_method: 'SMS Text-message', primary_telephone: '+12223334444' }
+  ].each do |attributes|
+    test "send_assessment does not touch updated_at for #{attributes} when sending an assessment" do
+      ActionMailer::Base.deliveries.clear
+      patient = create(:patient, { submission_token: SecureRandom.urlsafe_base64[0, 10], last_date_of_exposure: Date.yesterday }.merge(attributes))
+      patient.update(updated_at: 300.days.ago)
+      assert_nil patient.last_assessment_reminder_sent
+      patient.send_assessment
+      patient.reload
+      assert_not_nil patient.last_assessment_reminder_sent
+      assert patient.updated_at < 290.days.ago
+    end
+  end
+
+  [
+    { preferred_contact_method: 'E-mailed Web Link' },
+    { preferred_contact_method: 'SMS Texted Weblink' },
+    { preferred_contact_method: 'Telephone call' },
+    { preferred_contact_method: 'SMS Text-message' },
+    { preferred_contact_method: 'SMS Texted Weblink', primary_telephone: '+12223334444' },
+    { preferred_contact_method: 'SMS Text-message', primary_telephone: '+12223334444' }
+  ].each do |attributes|
+    test "send_assessment does not touch updated_at for #{attributes} when failing to send an assessment" do
+      BlockedNumber.create(phone_number: '+12223334444')
+      ActionMailer::Base.deliveries.clear
+      patient = create(:patient, { submission_token: SecureRandom.urlsafe_base64[0, 10], last_date_of_exposure: Date.yesterday }.merge(attributes))
+      patient.update(updated_at: 300.days.ago)
+      assert_nil patient.last_assessment_reminder_sent
+      patient.send_assessment
+      patient.reload
+      assert_nil patient.last_assessment_reminder_sent
+      assert patient.updated_at < 290.days.ago
     end
   end
 end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -3163,36 +3163,47 @@ class PatientTest < ActiveSupport::TestCase
   test 'no_recent_activity reason in close_eligible scope' do
     patient = create(:patient, isolation: false, monitoring: true, created_at: 100.days.ago)
 
+    # ineligible because upon creation the update_at is set to `now`
     assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
+    # ineligible because patient was updated too recently
     patient.update(updated_at: 1.day.ago)
     assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
+    # ineligible because patient was updated too recently
     patient.update(updated_at: 5.days.ago)
     assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
+    # ineligible because patient was updated too recently
     patient.update(updated_at: 10.days.ago)
     assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
+    # ineligible because patient was updated too recently
     patient.update(updated_at: 20.days.ago)
     assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
+    # ineligible because patient was updated too recently
     patient.update(updated_at: 29.days.ago)
     assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
+    # eligible because patient was updated exactly 30 days ago
     patient.update(updated_at: 30.days.ago)
     assert_not_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
+    # eligible because patient was updated over 30 days ago
     patient.update(updated_at: 31.days.ago)
     assert_not_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
+    # eligible because patient was updated over 30 days ago
     patient.update(updated_at: 300.days.ago)
     assert_not_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
+    # ineligible because patient 
     patient.update(isolation: true)
     patient.update(updated_at: 300.days.ago)
     assert_not_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
+    # ineligible because the patient must be monitoring to be non reporting
     patient.update(monitoring: false, updated_at: 300.days.ago)
     assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
   end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -3187,9 +3187,10 @@ class PatientTest < ActiveSupport::TestCase
     assert_not_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
     patient.update(isolation: true)
-    assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
+    patient.update(updated_at: 300.days.ago)
+    assert_not_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
-    patient.update(isolation: false, monitoring: false)
+    patient.update(monitoring: false, updated_at: 300.days.ago)
     assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
   end
 
@@ -3245,7 +3246,6 @@ class PatientTest < ActiveSupport::TestCase
   end
 
   [
-    { isolation: true },
     { isolation: false, monitoring: true, purged: false, public_health_action: 'Recommended medical evaluation of symptoms' },
     { isolation: false, monitoring: true, purged: true, public_health_action: 'None' },
     { isolation: false, monitoring: false, purged: false, public_health_action: 'None' },


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1520](https://tracker.codev.mitre.org/browse/SARAALERT-1520)

Implement auto-close logic on Non-reporting line list in the Isolation workflow. Auto-close if it's been at least 30 days since last record update**. The reason for record closure should be: "No record activity for 30 days (system)".

**This does not include an update made to a record as a result of the system sending the monitoree a symptom report notification.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`patient_mailer.rb`
- Do not touch patient `updated_at` when sending daily report reminders

`history.rb`
- Do not touch patient `updated_at` when sending daily report reminders

`patient.rb`
- Do not filter on `isolation: true` in `no_recent_activity` close eligble criteria

`patient_test.rb`
- update `no_recent_activity` test to include new criteria

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@holmesie  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@Bialogs  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@tstrass  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
