### PR TITLE
SARAALERT-448: Change order of new columns in line list CSV export

### DIFF
--- a/app/helpers/patient_details_helper.rb
+++ b/app/helpers/patient_details_helper.rb
@@ -59,19 +59,19 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
       end_of_monitoring: (continuous_exposure ? 'Continuous Exposure' : end_of_monitoring) || '',
       exposure_risk_assessment: exposure_risk_assessment || '',
       monitoring_plan: monitoring_plan || '',
-      responder_id: responder_id || '',
       transferred_from: latest_transfer&.from_path || '',
       transferred_to: latest_transfer&.to_path || '',
       latest_assessment_at: latest_assessment_at || '',
       latest_transfer_at: latest_transfer_at || '',
       monitoring_reason: monitoring_reason || '',
       public_health_action: public_health_action || '',
-      workflow: isolation ? 'Isolation' : 'Exposure',
       status: status&.to_s&.humanize&.downcase&.sub('exposure ', '')&.sub('isolation ', '') || '',
       closed_at: closed_at || '',
       expected_purge_ts: expected_purge_date_exp || '',
       symptom_onset: symptom_onset&.strftime('%F') || '',
-      extended_isolation: extended_isolation || ''
+      extended_isolation: extended_isolation || '',
+      responder_id: responder_id || '',
+      workflow: isolation ? 'Isolation' : 'Exposure'
     }
   end
 

--- a/app/lib/import_export_constants.rb
+++ b/app/lib/import_export_constants.rb
@@ -29,12 +29,12 @@ module ImportExportConstants # rubocop:todo Metrics/ModuleLength
                      Notes].freeze
 
   LINELIST_FIELDS = %i[id name jurisdiction_name assigned_user user_defined_id_statelocal sex date_of_birth end_of_monitoring exposure_risk_assessment
-                       monitoring_plan responder_id latest_assessment_at latest_transfer_at monitoring_reason public_health_action closed_at workflow status
-                       transferred_from transferred_to expected_purge_ts symptom_onset extended_isolation].freeze
+                       monitoring_plan latest_assessment_at latest_transfer_at monitoring_reason public_health_action status closed_at transferred_from
+                       transferred_to expected_purge_ts symptom_onset extended_isolation responder_id workflow].freeze
 
   LINELIST_HEADERS = ['Patient ID', 'Monitoree', 'Jurisdiction', 'Assigned User', 'State/Local ID', 'Sex', 'Date of Birth', 'End of Monitoring', 'Risk Level',
-                      'Monitoring Plan', 'Reporter ID', 'Latest Report', 'Transferred At', 'Reason For Closure', 'Latest Public Health Action', 'Closed At',
-                      'Workflow', 'Status', 'Transferred From', 'Transferred To', 'Expected Purge Date', 'Symptom Onset', 'Extended Isolation'].freeze
+                      'Monitoring Plan', 'Latest Report', 'Transferred At', 'Reason For Closure', 'Latest Public Health Action', 'Status', 'Closed At',
+                      'Transferred From', 'Transferred To', 'Expected Purge Date', 'Symptom Onset', 'Extended Isolation', 'Reporter ID', 'Workflow'].freeze
 
   SARA_ALERT_FORMAT_FIELDS = %i[first_name middle_name last_name date_of_birth sex white black_or_african_american american_indian_or_alaska_native asian
                                 native_hawaiian_or_other_pacific_islander ethnicity primary_language secondary_language interpretation_required nationality


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-448](https://tracker.codev.mitre.org/browse/SARAALERT-448)

[Slack context](https://mitrecorp.slack.com/archives/C01A6P94R9B/p1624474474040600)

This is another follow-on to #937, #945, #960.

This just changes the order of the columns in the line list CSV export. I inserted the new columns, Reporter ID and Workflow, into the order of columns to mimic the order they exist in the dashboard. It was requested that they instead are tacked onto the end (columns V and W).

## Important Changes
`import_export_constants.rb`
- Changed the column order

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@holmesie:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions