### PR TITLE
FIX: display LDE in isolation and set default cell of import guidance to A1

### DIFF
--- a/app/javascript/components/patient/assessment/actions/MonitoringPeriod.js
+++ b/app/javascript/components/patient/assessment/actions/MonitoringPeriod.js
@@ -19,10 +19,33 @@ class MonitoringPeriod extends React.Component {
     return eom === 'Continuous Exposure' ? eom : formatDate(eom);
   };
 
+  renderEndOfMonitoring = () => {
+    return (
+      <React.Fragment>
+        <span className="input-label">END OF MONITORING</span>
+        <InfoTooltip
+          getCustomText={() => {
+            return (
+              <div>
+                Calculated by the system as Last Date of Exposure + {this.props.monitoring_period_days} days
+                <div>
+                  <i>Only relevant for Exposure Workflow</i>
+                </div>
+              </div>
+            );
+          }}
+          location="right"></InfoTooltip>
+        <div id="end_of_monitoring_date" className="my-1">
+          {this.formatEndOfMonitoringDate()}
+        </div>
+      </React.Fragment>
+    );
+  };
+
   render() {
-    return this.props.patient.isolation ? (
+    return (
       <Row>
-        <Col sm={{ span: 12, order: 1 }} xs={{ span: 24, order: 1 }}>
+        <Col md={{ span: 8, order: 1 }} xs={{ span: 24, order: 1 }}>
           <SymptomOnset
             authenticity_token={this.props.authenticity_token}
             patient={this.props.patient}
@@ -31,29 +54,7 @@ class MonitoringPeriod extends React.Component {
             calculated_symptom_onset={this.props.calculated_symptom_onset}
           />
         </Col>
-        <Col sm={{ span: 12, order: 2 }} xs={{ span: 24, order: 3 }}>
-          <ExtendedIsolation authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
-        </Col>
-        {!this.props.patient.symptom_onset && !this.props.symptomatic_assessments_exist && this.props.num_pos_labs === 0 && (
-          <Col sm={{ span: 24, order: 3 }} xs={{ span: 24, order: 2 }}>
-            <Alert variant="warning" className="alert-warning-text">
-              <b>Warning: </b>This case does not have a Symptom Onset Date or positive lab result and may never become eligible to end monitoring
-            </Alert>
-          </Col>
-        )}
-      </Row>
-    ) : (
-      <Row>
-        <Col md={8}>
-          <SymptomOnset
-            authenticity_token={this.props.authenticity_token}
-            patient={this.props.patient}
-            symptomatic_assessments_exist={this.props.symptomatic_assessments_exist}
-            num_pos_labs={this.props.num_pos_labs}
-            calculated_symptom_onset={this.props.calculated_symptom_onset}
-          />
-        </Col>
-        <Col md={8}>
+        <Col md={{ span: 8, order: 2 }} xs={{ span: 24, order: 3 }}>
           <LastDateExposure
             household_members={this.props.household_members}
             authenticity_token={this.props.authenticity_token}
@@ -62,26 +63,20 @@ class MonitoringPeriod extends React.Component {
             jurisdiction_paths={this.props.jurisdiction_paths}
           />
         </Col>
-        <Col md={8}>
-          <React.Fragment>
-            <span className="input-label">END OF MONITORING</span>
-            <InfoTooltip
-              getCustomText={() => {
-                return (
-                  <div>
-                    Calculated by the system as Last Date of Exposure + {this.props.monitoring_period_days} days
-                    <div>
-                      <i>Only relevant for Exposure Workflow</i>
-                    </div>
-                  </div>
-                );
-              }}
-              location="right"></InfoTooltip>
-            <div id="end_of_monitoring_date" className="my-1">
-              {this.formatEndOfMonitoringDate()}
-            </div>
-          </React.Fragment>
+        <Col md={{ span: 8, order: 3 }} xs={{ span: 24, order: 4 }}>
+          {this.props.patient.isolation ? (
+            <ExtendedIsolation authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
+          ) : (
+            this.renderEndOfMonitoring()
+          )}
         </Col>
+        {!this.props.patient.symptom_onset && !this.props.symptomatic_assessments_exist && this.props.num_pos_labs === 0 && (
+          <Col md={{ span: 24, order: 4 }} xs={{ span: 24, order: 2 }}>
+            <Alert variant="warning" className="alert-warning-text">
+              <b>Warning: </b>This case does not have a Symptom Onset Date or positive lab result and may never become eligible to end monitoring
+            </Alert>
+          </Col>
+        )}
       </Row>
     );
   }

--- a/app/javascript/tests/patient/assessment/actions/MonitoringPeriod.test.js
+++ b/app/javascript/tests/patient/assessment/actions/MonitoringPeriod.test.js
@@ -18,7 +18,7 @@ describe('MonitoringPeriod', () => {
   it('Properly renders symptom onset and extended isolation when patient is in isolation workflow', () => {
     const wrapper = getWrapper(mockPatient1);
     expect(wrapper.find(SymptomOnset).exists()).toBeTruthy();
-    expect(wrapper.find(LastDateExposure).exists()).toBeFalsy();
+    expect(wrapper.find(LastDateExposure).exists()).toBeTruthy();
     expect(wrapper.find(ExtendedIsolation).exists()).toBeTruthy();
     expect(wrapper.find(InfoTooltip).exists()).toBeFalsy();
     expect(wrapper.find('#end_of_monitoring_date').exists()).toBeFalsy();

--- a/public/Sara Alert Import Format.xlsx
+++ b/public/Sara Alert Import Format.xlsx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:19f3a574b0b3c885c8ff47e4fe6a93bc4a24a627e216a436b7eb535bb287fe0b
-size 41436
+oid sha256:188f3aab763348f0b11f56d6b6ce3e6e3f49b463fec05fa06724397654026ed8
+size 41519


### PR DESCRIPTION
# Description
Jira Ticket: Follow-up on [SARAALERT-1436](https://tracker.codev.mitre.org/browse/SARAALERT-1436)

- display LDE in isolation
- set default cell of import guidance to A1 and default sheet to 1st sheet

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`example_file.js`
- Example change (ex: refactored import function)


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@sgober :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
