### PR TITLE
SARAALERT-1445: Remove Current Monitoree from Move-To-Household Modal

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -812,7 +812,7 @@ class PatientsController < ApplicationController
 
   # Fetches table data for viable HoH options.
   def head_of_household_options
-    patients_table_data(params)
+    render json: patients_table_data(params, current_user)
   end
 
   # Parameters allowed for saving to database

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -814,9 +814,7 @@ class PatientsController < ApplicationController
   def head_of_household_options
     begin
       patients = patients_table_data(params, current_user)
-    rescue ActionController::ParameterMissing
-      raise
-    rescue StandardError => e
+    rescue InvalidQueryError => e
       return render json: e, status: :bad_request
     end
 

--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -812,7 +812,15 @@ class PatientsController < ApplicationController
 
   # Fetches table data for viable HoH options.
   def head_of_household_options
-    render json: patients_table_data(params, current_user)
+    begin
+      patients = patients_table_data(params, current_user)
+    rescue ActionController::ParameterMissing
+      raise
+    rescue StandardError => e
+      return render json: e, status: :bad_request
+    end
+
+    render json: patients
   end
 
   # Parameters allowed for saving to database

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -10,9 +10,7 @@ class PublicHealthController < ApplicationController
   def patients
     begin
       patients = patients_table_data(params, current_user)
-    rescue ActionController::ParameterMissing
-      raise
-    rescue StandardError => e
+    rescue InvalidQueryError => e
       return render json: e, status: :bad_request
     end
 

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -10,11 +10,13 @@ class PublicHealthController < ApplicationController
   def patients
     begin
       patients = patients_table_data(params, current_user)
+    rescue ActionController::ParameterMissing
+      raise
     rescue StandardError => e
       return render json: e, status: :bad_request
     end
 
-    render json: patients_table_data(params, current_user)
+    render json: patients
   end
 
   def patients_count

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -8,6 +8,12 @@ class PublicHealthController < ApplicationController
   before_action :authenticate_user_role
 
   def patients
+    begin
+      patients = patients_table_data(params, current_user)
+    rescue StandardError => e
+      return render json: e, status: :bad_request
+    end
+
     render json: patients_table_data(params, current_user)
   end
 

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -8,7 +8,7 @@ class PublicHealthController < ApplicationController
   before_action :authenticate_user_role
 
   def patients
-    patients_table_data(params)
+    render json: patients_table_data(params, current_user)
   end
 
   def patients_count

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -22,6 +22,10 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     # Get filtered patients
     patients = patients_by_query(current_user, query)
 
+    # Filter out current monitoree if applicable
+    curr_monitoree_id = params[:patient_id]&.to_i || nil
+    patients = patients.where.not(id: curr_monitoree_id)
+
     # Paginate
     patients = patients.paginate(per_page: entries, page: page + 1)
 

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -21,7 +21,8 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
 
     # Filter out current monitoree if exclude_patient_id is defined
     exclude_patient_id = query[:exclude_patient_id]&.to_i || nil
-    raise InvalidQueryError.new(:exclude_patient_id, exclude_patient_id) unless exclude_patient_id.nil? or exclude_patient_id >= 0
+    raise InvalidQueryError.new(:exclude_patient_id, exclude_patient_id) unless exclude_patient_id.nil? || (exclude_patient_id >= 0)
+
     patients = patients.where.not(id: exclude_patient_id) if exclude_patient_id.present?
 
     # Paginate

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -23,7 +23,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     patients = patients_by_query(current_user, query)
 
     # Filter out current monitoree if exclude_patient_id is defined
-    exclude_patient_id = params[:exclude_patient_id]&.to_i || nil
+    exclude_patient_id = query[:exclude_patient_id]&.to_i || nil
     patients = patients.where.not(id: exclude_patient_id) unless exclude_patient_id.nil?
 
     # Paginate
@@ -35,7 +35,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
 
   def validate_patients_query(unsanitized_query)
     # Only allow permitted params
-    query = unsanitized_query.permit(:workflow, :tab, :jurisdiction, :scope, :user, :search, :entries, :page, :order, :direction, :tz_offset,
+    query = unsanitized_query.permit(:workflow, :tab, :jurisdiction, :scope, :user, :search, :entries, :page, :order, :direction, :tz_offset, :exclude_patient_id,
                                      filter: [:value, :numberOption, :dateOption, :relativeOption, :additionalFilterOption, { filterOption: {}, value: {} }])
 
     # Validate workflow

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -12,6 +12,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     # Validate pagination params
     entries = params.require(:query)[:entries]&.to_i || 25
     raise InvalidQueryError.new(:entries, entries) unless entries >= 0
+
     page = params.require(:query)[:page]&.to_i || 0
     raise InvalidQueryError.new(:page, page) unless page >= 0
 
@@ -31,8 +32,10 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
 
   def validate_patients_query(unsanitized_query)
     # Only allow permitted params
-    query = unsanitized_query.permit(:workflow, :tab, :jurisdiction, :scope, :user, :search, :entries, :page, :order, :direction, :tz_offset, :exclude_patient_id,
-                                     filter: [:value, :numberOption, :dateOption, :relativeOption, :additionalFilterOption, { filterOption: {}, value: {} }])
+    query = unsanitized_query.permit(:workflow, :tab, :jurisdiction, :scope, :user, :search, :entries,
+                                     :page, :order, :direction, :tz_offset, :exclude_patient_id,
+                                     filter: [:value, :numberOption, :dateOption, :relativeOption,
+                                              :additionalFilterOption, { filterOption: {}, value: {} }])
 
     # Validate workflow
     workflow = query[:workflow]&.to_sym || :global

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -22,9 +22,9 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     # Get filtered patients
     patients = patients_by_query(current_user, query)
 
-    # Filter out current monitoree if applicable
-    curr_monitoree_id = params[:patient_id]&.to_i || nil
-    patients = patients.where.not(id: curr_monitoree_id)
+    # Filter out current monitoree if exclude_patient_id is defined
+    exclude_patient_id = params[:exclude_patient_id]&.to_i || nil
+    patients = patients.where.not(id: exclude_patient_id)
 
     # Paginate
     patients = patients.paginate(per_page: entries, page: page + 1)

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -10,8 +10,8 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     # Validate filter and sorting params
     begin
       query = validate_patients_query(params.require(:query))
-    rescue StandardError => e
-      return render json: e, status: :bad_request
+    rescue StandardError
+      raise
     end
 
     # Validate pagination params

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -7,17 +7,13 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     workflow = params.require(:query).require(:workflow).to_sym
     tab = params.require(:query).require(:tab).to_sym
 
-    # Validate filter and sorting params
-    begin
-      query = validate_patients_query(params.require(:query))
-    rescue StandardError
-      raise
-    end
+    query = validate_patients_query(params.require(:query))
 
     # Validate pagination params
     entries = params.require(:query)[:entries]&.to_i || 25
+    raise InvalidQueryError.new(:entries, entries) unless entries >= 0
     page = params.require(:query)[:page]&.to_i || 0
-    return render json: { error: 'Invalid entries or page' }, status: :bad_request unless entries >= 0 && page >= 0
+    raise InvalidQueryError.new(:page, page) unless page >= 0
 
     # Get filtered patients
     patients = patients_by_query(current_user, query)

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -24,7 +24,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
 
     # Filter out current monitoree if exclude_patient_id is defined
     exclude_patient_id = params[:exclude_patient_id]&.to_i || nil
-    patients = patients.where.not(id: exclude_patient_id)
+    patients = patients.where.not(id: exclude_patient_id) unless exclude_patient_id.nil?
 
     # Paginate
     patients = patients.paginate(per_page: entries, page: page + 1)

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -21,7 +21,8 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
 
     # Filter out current monitoree if exclude_patient_id is defined
     exclude_patient_id = query[:exclude_patient_id]&.to_i || nil
-    patients = patients.where.not(id: exclude_patient_id) unless exclude_patient_id.nil?
+    raise InvalidQueryError.new(:exclude_patient_id, exclude_patient_id) unless exclude_patient_id.nil? or exclude_patient_id >= 0
+    patients = patients.where.not(id: exclude_patient_id) if exclude_patient_id.present?
 
     # Paginate
     patients = patients.paginate(per_page: entries, page: page + 1)

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -2,7 +2,7 @@
 
 # Helper methods for filtering through patients
 module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
-  def patients_table_data(params)
+  def patients_table_data(params, current_user)
     # Require workflow and tab params
     workflow = params.require(:query).require(:workflow).to_sym
     tab = params.require(:query).require(:tab).to_sym
@@ -30,7 +30,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     patients = patients.paginate(per_page: entries, page: page + 1)
 
     # Extract only relevant fields to be displayed by workflow and tab
-    render json: linelist(patients, workflow, tab)
+    linelist(patients, workflow, tab)
   end
 
   def validate_patients_query(unsanitized_query)

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -20,8 +20,8 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     patients = patients_by_query(current_user, query)
 
     # Filter out current monitoree if exclude_patient_id is defined
-    exclude_patient_id = query[:exclude_patient_id]&.to_i || nil
-    raise InvalidQueryError.new(:exclude_patient_id, exclude_patient_id) unless exclude_patient_id.nil? || (exclude_patient_id >= 0)
+    exclude_patient_id = query[:exclude_patient_id]&.to_i
+    raise InvalidQueryError.new(:exclude_patient_id, exclude_patient_id) if exclude_patient_id.present? && exclude_patient_id.negative?
 
     patients = patients.where.not(id: exclude_patient_id) if exclude_patient_id.present?
 

--- a/app/javascript/components/patient/household/actions/MoveToHousehold.js
+++ b/app/javascript/components/patient/household/actions/MoveToHousehold.js
@@ -206,7 +206,7 @@ class MoveToHousehold extends React.Component {
     axios
       .post(window.BASE_PATH + '/patients/head_of_household_options', {
         query,
-        patient_id: this.props.patient.id,
+        exclude_patient_id: this.props.patient.id,
         cancelToken: this.state.cancelToken.token,
       })
       .catch(error => {

--- a/app/javascript/components/patient/household/actions/MoveToHousehold.js
+++ b/app/javascript/components/patient/household/actions/MoveToHousehold.js
@@ -34,6 +34,7 @@ class MoveToHousehold extends React.Component {
         tab: 'all',
         scope: 'all',
         tz_offset: new Date().getTimezoneOffset(),
+        exclude_patient_id: this.props.patient.id,
         // This query should always filter out records that are not self-reporters
         filter: [
           {
@@ -206,7 +207,6 @@ class MoveToHousehold extends React.Component {
     axios
       .post(window.BASE_PATH + '/patients/head_of_household_options', {
         query,
-        exclude_patient_id: this.props.patient.id,
         cancelToken: this.state.cancelToken.token,
       })
       .catch(error => {

--- a/app/javascript/components/patient/household/actions/MoveToHousehold.js
+++ b/app/javascript/components/patient/household/actions/MoveToHousehold.js
@@ -206,6 +206,7 @@ class MoveToHousehold extends React.Component {
     axios
       .post(window.BASE_PATH + '/patients/head_of_household_options', {
         query,
+        patient_id: this.props.patient.id,
         cancelToken: this.state.cancelToken.token,
       })
       .catch(error => {

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -136,23 +136,10 @@ class PatientsControllerTest < ActionController::TestCase
     exclude_patient_id = current_patient.id
     post :head_of_household_options, params: {
       query: {
-        search: '',
         entries: 5,
         workflow: 'global',
         tab: 'all',
-        scope: 'all',
-        tz_offset: 240,
-        exclude_patient_id: exclude_patient_id,
-        filter: [{
-          dateOption: nil,
-          filterOption: {
-            description: 'Monitorees that are a Head of Household or self-reporter',
-            name: 'hoh',
-            title: 'Daily Reporters (Boolean)',
-            type: 'boolean'
-          },
-          value: true
-        }]
+        exclude_patient_id: exclude_patient_id
       }
     }
 

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -138,7 +138,7 @@ class PatientsControllerTest < ActionController::TestCase
       query: {
         search: "",
         entries: 5,
-        workflow: "all",
+        workflow: "global",
         tab: "all",
         scope: "all",
         tz_offset: 240,

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -125,31 +125,31 @@ class PatientsControllerTest < ActionController::TestCase
 
   test 'head_of_household_options filters out exclude_patient_id from table' do
     user = create(:public_health_enroller_user)
-    patient_1 = create(:patient, creator: user)
-    patient_2 = create(:patient, creator: user)
-    patient_3 = create(:patient, creator: user)
-    patient_4 = create(:patient, creator: user)
-    patient_5 = create(:patient, creator: user)
+    current_patient = create(:patient, creator: user)
+    create(:patient, creator: user)
+    create(:patient, creator: user)
+    create(:patient, creator: user)
+    create(:patient, creator: user)
 
     sign_in user
 
-    exclude_patient_id = patient_1.id
+    exclude_patient_id = current_patient.id
     post :head_of_household_options, params: {
       query: {
-        search: "",
+        search: '',
         entries: 5,
-        workflow: "global",
-        tab: "all",
-        scope: "all",
+        workflow: 'global',
+        tab: 'all',
+        scope: 'all',
         tz_offset: 240,
         exclude_patient_id: exclude_patient_id,
         filter: [{
           dateOption: nil,
           filterOption: {
-            description: "Monitorees that are a Head of Household or self-reporter",
-            name: "hoh",
-            title: "Daily Reporters (Boolean)",
-            type: "boolean"
+            description: 'Monitorees that are a Head of Household or self-reporter',
+            name: 'hoh',
+            title: 'Daily Reporters (Boolean)',
+            type: 'boolean'
           },
           value: true
         }]

--- a/test/helpers/patient_query_helper_test.rb
+++ b/test/helpers/patient_query_helper_test.rb
@@ -905,40 +905,37 @@ class PatientQueryHelperTest < ActionView::TestCase
   test 'patients table data filters out current monitoree' do
     Patient.destroy_all
     user = create(:public_health_enroller_user)
+    exclude_patient = create(:patient, creator: user)
+    create(:patient, creator: user)
+    create(:patient, creator: user)
 
-    patient_1 = create(:patient, creator: user)
-    patient_2 = create(:patient, creator: user)
-    patient_3 = create(:patient, creator: user)
-
-    patients = Patient.all
-
-    exclude_patient_id = patient_1.id
+    exclude_patient_id = exclude_patient.id
     params = ActionController::Parameters.new({
-      query: {
-        search: "",
-        entries: 5,
-        workflow: "global",
-        tab: "all",
-        scope: "all",
-        tz_offset: 240,
-        exclude_patient_id: exclude_patient_id,
-        filter: [{
-          dateOption: nil,
-          filterOption: {
-            description: "Monitorees that are a Head of Household or self-reporter",
-            name: "hoh",
-            title: "Daily Reporters (Boolean)",
-            type: "boolean"
-          },
-          value: true
-        }]
-      }
-    })
+                                                query: {
+                                                  search: '',
+                                                  entries: 5,
+                                                  workflow: 'global',
+                                                  tab: 'all',
+                                                  scope: 'all',
+                                                  tz_offset: 240,
+                                                  exclude_patient_id: exclude_patient_id,
+                                                  filter: [{
+                                                    dateOption: nil,
+                                                    filterOption: {
+                                                      description: 'Monitorees that are a Head of Household or self-reporter',
+                                                      name: 'hoh',
+                                                      title: 'Daily Reporters (Boolean)',
+                                                      type: 'boolean'
+                                                    },
+                                                    value: true
+                                                  }]
+                                                }
+                                              })
 
     # Check for monitorees that are HoH or self-reporter
-    patients = patients_table_data(params, user)
-    patients_array = [ patient_2, patient_3 ]
-    assert_equal patients_array.map { |p| p[:id] }, patients[:linelist]&.pluck(:id)
+    filtered_patients = patients_table_data(params, user)
+    filtered_patients_array = [patient_2, patient_3]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients[:linelist]&.pluck(:id)
 
     # Check that current monitoree is not in patients list
     patients_by_id = patients[:linelist]&.pluck(:id)
@@ -948,76 +945,70 @@ class PatientQueryHelperTest < ActionView::TestCase
   test 'patients table data returns patients when exclude_patient_id is nil' do
     Patient.destroy_all
     user = create(:public_health_enroller_user)
-
-    patient_1 = create(:patient, creator: user)
-    patient_2 = create(:patient, creator: user)
-    patient_3 = create(:patient, creator: user)
-
-    patients = Patient.all
+    create(:patient, creator: user)
+    create(:patient, creator: user)
+    create(:patient, creator: user)
 
     params = ActionController::Parameters.new({
-      query: {
-        search: "",
-        entries: 5,
-        workflow: "global",
-        tab: "all",
-        scope: "all",
-        tz_offset: 240,
-        filter: [{
-          dateOption: nil,
-          filterOption: {
-            description: "Monitorees that are a Head of Household or self-reporter",
-            name: "hoh",
-            title: "Daily Reporters (Boolean)",
-            type: "boolean"
-          },
-          value: true
-        }]
-      }
-    })
+                                                query: {
+                                                  search: '',
+                                                  entries: 5,
+                                                  workflow: 'global',
+                                                  tab: 'all',
+                                                  scope: 'all',
+                                                  tz_offset: 240,
+                                                  filter: [{
+                                                    dateOption: nil,
+                                                    filterOption: {
+                                                      description: 'Monitorees that are a Head of Household or self-reporter',
+                                                      name: 'hoh',
+                                                      title: 'Daily Reporters (Boolean)',
+                                                      type: 'boolean'
+                                                    },
+                                                    value: true
+                                                  }]
+                                                }
+                                              })
 
     # Check for monitorees that are HoH or self-reporter
-    patients = patients_table_data(params, user)
-    patients_array = [ patient_1, patient_2, patient_3 ]
-    assert_equal patients_array.map { |p| p[:id] }, patients[:linelist]&.pluck(:id)
+    filtered_patients = patients_table_data(params, user)
+    filtered_patients_array = [patient_1, patient_2, patient_3]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients[:linelist]&.pluck(:id)
   end
 
   test 'patients table data returns patients when exclude_patient_id is not valid' do
     Patient.destroy_all
     user = create(:public_health_enroller_user)
-
-    patient_1 = create(:patient, creator: user)
-    patient_2 = create(:patient, creator: user)
-    patient_3 = create(:patient, creator: user)
-
-    patients = Patient.all
+    create(:patient, creator: user)
+    create(:patient, creator: user)
+    create(:patient, creator: user)
 
     params = ActionController::Parameters.new({
-      query: {
-        search: "",
-        entries: 5,
-        workflow: "global",
-        tab: "all",
-        scope: "all",
-        tz_offset: 240,
-        exclude_patient_id: -1,
-        filter: [{
-          dateOption: nil,
-          filterOption: {
-            description: "Monitorees that are a Head of Household or self-reporter",
-            name: "hoh",
-            title: "Daily Reporters (Boolean)",
-            type: "boolean"
-          },
-          value: true
-        }]
-      }
-    })
+                                                query: {
+                                                  search: '',
+                                                  entries: 5,
+                                                  workflow: 'global',
+                                                  tab: 'all',
+                                                  scope: 'all',
+                                                  tz_offset: 240,
+                                                  exclude_patient_id: -1,
+                                                  filter: [{
+                                                    dateOption: nil,
+                                                    filterOption: {
+                                                      description: 'Monitorees that are a Head of Household or self-reporter',
+                                                      name: 'hoh',
+                                                      title: 'Daily Reporters (Boolean)',
+                                                      type: 'boolean'
+                                                    },
+                                                    value: true
+                                                  }]
+                                                }
+                                              })
 
     # Check for monitorees that are HoH or self-reporter
-    patients = patients_table_data(params, user)
-    patients_array = [ patient_1, patient_2, patient_3 ]
-    assert_equal patients_array.map { |p| p[:id] }, patients[:linelist]&.pluck(:id)
+    filtered_patients = patients_table_data(params, user)
+    filtered_patients_array = [patient_1, patient_2, patient_3]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients[:linelist]&.pluck(:id)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/test/helpers/patient_query_helper_test.rb
+++ b/test/helpers/patient_query_helper_test.rb
@@ -915,28 +915,24 @@ class PatientQueryHelperTest < ActionView::TestCase
     exclude_patient_id = patient_1.id
     params = ActionController::Parameters.new({
       query: {
-        "page"=>0,
-        "search"=>"",
-        "entries"=>5,
-        "workflow"=>"all",
-        "tab"=>"all",
-        "scope"=>"all",
-        "tz_offset"=>240,
-        "exclude_patient_id"=>exclude_patient_id,
-        "filter"=>[{
-          "dateOption"=>nil,
-          "filterOption"=>{
-            "description"=>"Monitorees that are a Head of Household or self-reporter",
-            "name"=>"hoh",
-            "title"=>"Daily Reporters (Boolean)",
-            "type"=>"boolean"
+        search: "",
+        entries: 5,
+        workflow: "global",
+        tab: "all",
+        scope: "all",
+        tz_offset: 240,
+        exclude_patient_id: exclude_patient_id,
+        filter: [{
+          dateOption: nil,
+          filterOption: {
+            description: "Monitorees that are a Head of Household or self-reporter",
+            name: "hoh",
+            title: "Daily Reporters (Boolean)",
+            type: "boolean"
           },
-          "value"=>true
+          value: true
         }]
-      },
-      cancelToken: {
-        "promise"=>{}
-      }, # , "controller"=>"patients", "action"=>"head_of_household_options", "patient"=>{},
+      }
     })
 
     # Check for monitorees that are HoH or self-reporter
@@ -961,27 +957,23 @@ class PatientQueryHelperTest < ActionView::TestCase
 
     params = ActionController::Parameters.new({
       query: {
-        "page"=>0,
-        "search"=>"",
-        "entries"=>5,
-        "workflow"=>"all",
-        "tab"=>"all",
-        "scope"=>"all",
-        "tz_offset"=>240,
-        "filter"=>[{
-          "dateOption"=>nil,
-          "filterOption"=>{
-            "description"=>"Monitorees that are a Head of Household or self-reporter",
-            "name"=>"hoh",
-            "title"=>"Daily Reporters (Boolean)",
-            "type"=>"boolean"
+        search: "",
+        entries: 5,
+        workflow: "global",
+        tab: "all",
+        scope: "all",
+        tz_offset: 240,
+        filter: [{
+          dateOption: nil,
+          filterOption: {
+            description: "Monitorees that are a Head of Household or self-reporter",
+            name: "hoh",
+            title: "Daily Reporters (Boolean)",
+            type: "boolean"
           },
-          "value"=>true
+          value: true
         }]
-      },
-      cancelToken: {
-        "promise"=>{}
-      },
+      }
     })
 
     # Check for monitorees that are HoH or self-reporter
@@ -1002,28 +994,24 @@ class PatientQueryHelperTest < ActionView::TestCase
 
     params = ActionController::Parameters.new({
       query: {
-        "page"=>0,
-        "search"=>"",
-        "entries"=>5,
-        "workflow"=>"all",
-        "tab"=>"all",
-        "scope"=>"all",
-        "tz_offset"=>240,
-        "exclude_patient_id"=>0,
-        "filter"=>[{
-          "dateOption"=>nil,
-          "filterOption"=>{
-            "description"=>"Monitorees that are a Head of Household or self-reporter",
-            "name"=>"hoh",
-            "title"=>"Daily Reporters (Boolean)",
-            "type"=>"boolean"
+        search: "",
+        entries: 5,
+        workflow: "global",
+        tab: "all",
+        scope: "all",
+        tz_offset: 240,
+        exclude_patient_id: -1,
+        filter: [{
+          dateOption: nil,
+          filterOption: {
+            description: "Monitorees that are a Head of Household or self-reporter",
+            name: "hoh",
+            title: "Daily Reporters (Boolean)",
+            type: "boolean"
           },
-          "value"=>true
+          value: true
         }]
-      },
-      cancelToken: {
-        "promise"=>{}
-      },
+      }
     })
 
     # Check for monitorees that are HoH or self-reporter

--- a/test/helpers/patient_query_helper_test.rb
+++ b/test/helpers/patient_query_helper_test.rb
@@ -935,9 +935,7 @@ class PatientQueryHelperTest < ActionView::TestCase
   test 'patients table data returns patients when exclude_patient_id is nil' do
     Patient.destroy_all
     user = create(:public_health_enroller_user)
-    create(:patient, creator: user)
-    create(:patient, creator: user)
-    create(:patient, creator: user)
+    3.times { create(:patient, creator: user) }
 
     patients = Patient.all
 
@@ -957,12 +955,10 @@ class PatientQueryHelperTest < ActionView::TestCase
     assert_equal patients.map { |p| p[:id] }, filtered_patients[:linelist]&.pluck(:id)
   end
 
-  test 'patients table data returns patients when exclude_patient_id is not valid' do
+  test 'patients table data raises InvalidQueryError when exclude_patient_id is not valid' do
     Patient.destroy_all
     user = create(:public_health_enroller_user)
-    create(:patient, creator: user)
-    create(:patient, creator: user)
-    create(:patient, creator: user)
+    3.times { create(:patient, creator: user) }
 
     params = ActionController::Parameters.new({
                                                 query: {


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1445](https://tracker.codev.mitre.org/browse/SARAALERT-1445)

If a monitoree is not part of a household, they can be enrolled in one by using the Move-To-Household modal. You are currently able to select the current Monitoree to be their own HoH.

For example, if you're on Monitoree Bob Smith, you can find Bob Smith in the list of Monitorees to assign as Bob Smith's HoH.

If you select Bob Smith to be his own HoH, the page refreshes and nothing changes, so there is no error in functionality, but the current monitoree should probably be filtered from the list.

## (Feature) Demo/Screenshots
<img width="870" alt="Screen Shot 2021-06-28 at 5 17 32 PM" src="https://user-images.githubusercontent.com/55925276/123705329-cfbb7500-d834-11eb-823f-ced3b57d8b93.png">

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`MoveToHousehold.js`
- Add `exclude_patient_id` to query

`patient_query_helper.rb`
- Redefine arguments and what is returned for `patients_table_data`
- Filter out current monitoree
- Raise errors in `patients_table_data` if query is in valid

`patients_controller.rb`
- Refactor `head_of_household_options` to render json and handle errors

`public_health_controller.rb`
- Refactor `patients` to render json and handle errors

`patient_query_helper_test.rb`
`patients_controller_test.rb`
- Add tests


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@sgober :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@timwongj :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@holmesie :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
