### PR TITLE
SARAALERT-1541: Ignore purged in household bulk update

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -449,7 +449,7 @@ class PatientsController < ApplicationController
       dependent_ids = current_user.patients.where(responder_id: patient_ids).pluck(:id)
       # If apply_to_household was set, and there exists a patient that has dependents in a different
       # jurisdiction - one that the user may not have access to - those patients will get filtered out.
-      not_viewable = Patient.where(responder_id: patient_ids).pluck(:id) - dependent_ids
+      not_viewable = Patient.where(purged: false, responder_id: patient_ids).pluck(:id) - dependent_ids
 
       unless not_viewable.empty?
         responders = Patient.find(not_viewable).map(&:responder)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1541](https://tracker.codev.mitre.org/browse/SARAALERT-1541)

There was a bug where we were returning a 401 from the
patients/bulk_edit endpoint in the event that you bulk update a
household that has a purged member. The actual back end bulk update
wasn't broken, but the user got an erroneous and confusing error message
in the front end.

See [Slack context](https://mitrecorp.slack.com/archives/C01A6P94R9B/p1624979151021000) for more information and screenshots.

## How to Replicate
Find or manually create a scenario where an HoH has a household member that has been purged. Perform a bulk edit on that monitoree, with the apply to household toggle on.

## Solution
Add a condition to ignore purged household members.

## Important Changes
`patients_controller.rb`
- In `bulk_update` there's a check for households to identify when there are household members that are not viewable by the current user. That check was inadvertently lumping in purged household members with the non-viewable household members.


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@holmesie:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions


@ngfreiter:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions


@hackrm:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
