### PR TITLE
SARAALERT-1420: Previously selected import file bugfix

### DIFF
--- a/app/javascript/components/public_health/PublicHealthHeader.js
+++ b/app/javascript/components/public_health/PublicHealthHeader.js
@@ -43,6 +43,7 @@ class PublicHealthHeader extends React.Component {
           this.setState({
             uploading: false,
             importData: response.data,
+            file: null,
             showUploadModal: false,
             showImportModal: true,
           });
@@ -119,7 +120,7 @@ class PublicHealthHeader extends React.Component {
 
   renderUploadModal() {
     return (
-      <Modal size="md" show={this.state.showUploadModal} onHide={() => this.setState({ showUploadModal: false, importType: null })}>
+      <Modal size="md" show={this.state.showUploadModal} onHide={() => this.setState({ showUploadModal: false, file: null, importType: null })}>
         <Modal.Header closeButton>
           {this.state.importType === 'epix' && <Modal.Title className="h5">{`Import Epi-X (${this.props.workflow})`}</Modal.Title>}
           {this.state.importType === 'saf' && <Modal.Title className="h5">{`Import Sara Alert Format (${this.props.workflow})`}</Modal.Title>}


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1420](https://tracker.codev.mitre.org/browse/SARAALERT-1420)

Ensure the "Upload" button is disabled in this situation so the user can't erroneously import a previously selected import file. Also verify if this behavior is an issue for the Epi-X import and resolve that if needed.

## (Bugfix) How to Replicate

1. Select the Sara Alert import option
2. In the import modal, select the file to import
3. Close the modal
4. Select the Sara Alert import option again
5. Observe that while no file is attached, the "Upload" button is enabled, and if you attempt to click the "Upload" button, the previously attached file is imported.

## (Bugfix) Solution

Reset the state of the file selected for import when the modal is closed

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`example_file.js`
- Example change (ex: refactored import function)

## Testing Recommendations

Try reproducing the bug by following the steps above before checking out this branch and then try it again after checking out the branch and confirm that the behavior has been fixed

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@sgober :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ashankland :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
