### PR TITLE
SARAALERT-1524: Remove Monitored Address Autofill on Enrollment

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -133,16 +133,6 @@ class PatientsController < ApplicationController
     # Add patient details that were collected from the form
     patient = Patient.new(allowed_params)
 
-    # Default to copying *required address into monitored address if monitored address is nil
-    if patient.monitored_address_line_1.nil? && patient.monitored_address_state.nil? &&
-       patient.monitored_address_city.nil? && patient.monitored_address_zip.nil?
-      patient.monitored_address_line_1 = patient.address_line_1
-      patient.monitored_address_line_2 = patient.address_line_2
-      patient.monitored_address_city = patient.address_city
-      patient.monitored_address_county = patient.address_county
-      patient.monitored_address_state = patient.address_state
-      patient.monitored_address_zip = patient.address_zip
-    end
     helpers.normalize_state_names(patient)
     # Set the responder for this patient, this will link patients that have duplicate primary contact info
     patient.responder = if params.permit(:responder_id)[:responder_id]

--- a/test/system/roles/public_health/dashboard/import_verifier.rb
+++ b/test/system/roles/public_health/dashboard/import_verifier.rb
@@ -161,12 +161,6 @@ class PublicHealthMonitoringImportVerifier < ApplicationSystemTestCase
           elsif international_address && field == :address_state
             assert_equal(normalize_state_field(row[index].to_s), patient[ImportController::FOREIGN_ADDRESS_MAPPINGS[field]].to_s,
                          "#{field} mismatch in row #{row_num}")
-          # copy over monitored address if address is nil
-          elsif !international_address && field == :monitored_address_state && row[index].nil?
-            assert_equal(normalize_state_field(row[EPI_X_FIELDS.index(EPI_X_MONITORED_ADDRESS_FIELDS[field])].to_s).to_s,
-                         patient[field].to_s, "#{field} mismatch in row #{row_num}")
-          elsif !international_address && %i[monitored_address_line_1 monitored_address_city].include?(field) && row[index].nil?
-            assert_equal(row[EPI_X_FIELDS.index(EPI_X_MONITORED_ADDRESS_FIELDS[field])].to_s, patient[field].to_s, "#{field} mismatch in row #{row_num}")
           # normalize state fields
           elsif field == :address_state || (field == :monitored_address_state && row[index].present?)
             assert_equal(normalize_state_field(row[index].to_s).to_s, patient[field].to_s, "#{field} mismatch in row #{row_num}")
@@ -210,10 +204,6 @@ class PublicHealthMonitoringImportVerifier < ApplicationSystemTestCase
             assert_equal(normalize_bool_field(row[index]).to_s, patient[field].to_s, "#{field} mismatch in row #{row_num}")
           elsif STATE_FIELDS.include?(field) || (field == :monitored_address_state && !row[index].nil?)
             assert_equal(normalize_state_field(row[index].to_s).to_s, patient[field].to_s, "#{field} mismatch in row #{row_num}")
-          elsif field == :monitored_address_state && row[index].nil? # copy over monitored address state if state is nil
-            assert_equal(normalize_state_field(row[index - 13].to_s), patient[field].to_s, "#{field} mismatch in row #{row_num}")
-          elsif MONITORED_ADDRESS_FIELDS.include?(field) & row[index].nil? # copy over address fields if address is nil
-            assert_equal(row[index - 13].to_s, patient[field].to_s, "#{field} mismatch in row #{row_num}")
           elsif field == :symptom_onset # isolation workflow specific field
             assert_equal(workflow == :isolation ? row[index].to_s : '', patient[field].to_s, "#{field} mismatch in row #{row_num}")
           # TODO: when workflow specific case status validation re-enabled: remove the next 3 lines


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1524](https://tracker.codev.mitre.org/browse/SARAALERT-1524)

Removes code within `patients_controller.rb` that will automatically set the monitored address to the provided home address upon enrollment.

## (Bugfix) How to Replicate
* Before this patch is applied (such as on the `master` branch), create a monitoree with a home address and no monitored address. Observe how the home address is automatically copied into the monitored address _after_ enrollment is complete. 

## (Bugfix) Solution
Removes code within `patients_controller.rb` that will automatically set the monitored address to the provided home address upon enrollment.

## Important Changes
`patients_controller.rb`
- Remove logic that checks if monitored address is blank and sets it based on home address

`import_verifier.rb`
- Remove logic that checks if monitored address is set based on home address

## Testing Recommendations
- Enroll a patient with and without monitoring address and ensure it is not set or not overwritten after submitting.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@ :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
