### PR TITLE
SARAALERT-1551: capitalizes "Head of Household" in patient minor notification. 

### DIFF
--- a/app/javascript/components/patient/Patient.js
+++ b/app/javascript/components/patient/Patient.js
@@ -244,7 +244,7 @@ class Patient extends React.Component {
                   <span className="text-danger">Monitoree is a minor</span>
                   {!this.props.details.head_of_household && this.props.hoh && (
                     <div>
-                      View contact info for head of household:
+                      View contact info for Head of Household:
                       <a className="pl-1" href={patientHref(this.props.hoh.id, this.props.workflow)}>
                         {formatName(this.props.hoh)}
                       </a>

--- a/app/javascript/tests/patient/Patient.test.js
+++ b/app/javascript/tests/patient/Patient.test.js
@@ -126,11 +126,10 @@ describe('Patient', () => {
   it('Properly renders contact information section when patient is a minor', () => {
     const wrapper = shallow(<Patient details={mockPatient5} hoh={mockPatient1} collapse={true} edit_mode={false} jurisdiction_paths={mockJurisdictionPaths} />);
     const section = wrapper.find('#contact-information');
-    const HOHLinkText = 'View contact info for Head of Household:' + mockPatient1.first_name + ' ' + mockPatient1.middle_name + ' ' + mockPatient1.last_name;
     expect(wrapper.find('#contact-information').find('.text-danger').exists()).toBeTruthy();
     expect(wrapper.find('#contact-information').find('.text-danger').text()).toEqual('Monitoree is a minor');
     expect(section.find('.item-group').find('a').exists()).toBeTruthy();
-    expect(section.find('.item-group').children().at(1).text()).toEqual(HOHLinkText);
+    expect(section.find('.item-group').children().at(1).text()).toEqual('View contact info for Head of Household:' + mockPatient1.first_name + ' ' + mockPatient1.middle_name + ' ' + mockPatient1.last_name);
     expect(section.find('.item-group').find('a').props().href).toContain('patients/' + mockPatient1.id);
     expect(section.find('.item-group').find('a').text()).toEqual(mockPatient1.first_name + ' ' + mockPatient1.middle_name + ' ' + mockPatient1.last_name);
   });

--- a/app/javascript/tests/patient/Patient.test.js
+++ b/app/javascript/tests/patient/Patient.test.js
@@ -129,7 +129,7 @@ describe('Patient', () => {
     expect(wrapper.find('#contact-information').find('.text-danger').exists()).toBeTruthy();
     expect(wrapper.find('#contact-information').find('.text-danger').text()).toEqual('Monitoree is a minor');
     expect(section.find('.item-group').find('a').exists()).toBeTruthy();
-    expect(section.find('.item-group').children().at(1).text()).toEqual('View contact info for Head of Household:' + mockPatient1.first_name + ' ' + mockPatient1.middle_name + ' ' + mockPatient1.last_name);
+    expect(section.find('.item-group').children().at(1).text()).toEqual(`View contact info for Head of Household:${mockPatient1.first_name} ${mockPatient1.middle_name} ${mockPatient1.last_name}`);
     expect(section.find('.item-group').find('a').props().href).toContain('patients/' + mockPatient1.id);
     expect(section.find('.item-group').find('a').text()).toEqual(mockPatient1.first_name + ' ' + mockPatient1.middle_name + ' ' + mockPatient1.last_name);
   });

--- a/app/javascript/tests/patient/Patient.test.js
+++ b/app/javascript/tests/patient/Patient.test.js
@@ -126,9 +126,11 @@ describe('Patient', () => {
   it('Properly renders contact information section when patient is a minor', () => {
     const wrapper = shallow(<Patient details={mockPatient5} hoh={mockPatient1} collapse={true} edit_mode={false} jurisdiction_paths={mockJurisdictionPaths} />);
     const section = wrapper.find('#contact-information');
+    const HOHLinkText = 'View contact info for Head of Household:' + mockPatient1.first_name + ' ' + mockPatient1.middle_name + ' ' + mockPatient1.last_name;
     expect(wrapper.find('#contact-information').find('.text-danger').exists()).toBeTruthy();
     expect(wrapper.find('#contact-information').find('.text-danger').text()).toEqual('Monitoree is a minor');
-    expect(section.find('a').exists()).toBeTruthy();
+    expect(section.find('.item-group').find('a').exists()).toBeTruthy();
+    expect(section.find('.item-group').children().at(1).text()).toEqual(HOHLinkText);
     expect(section.find('.item-group').find('a').props().href).toContain('patients/' + mockPatient1.id);
     expect(section.find('.item-group').find('a').text()).toEqual(mockPatient1.first_name + ' ' + mockPatient1.middle_name + ' ' + mockPatient1.last_name);
   });


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1551](https://tracker.codev.mitre.org/browse/SARAALERT-1551)

"Head of Household" is capitalized elsewhere in the patient view but not in the notification that a patient is a minor. This capitalizes the phrase in the notification to ensure it remains consistent. 

## (Bugfix) How to Replicate
Navigate to a patient record where the patient is a minor on another branch. The text should not capitalize "head of household" in the notification under the Contact Info Session.
## (Bugfix) Solution
Changes the text in patient.js to capitalize "Head of Household"
## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/javascript/components/patient/Patient.js`

## Testing Recommendations

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@sgober  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
