### PR TITLE
SARAALERT-1188: Add history item when PatientMailer#assessment_email errors

### DIFF
--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -283,7 +283,7 @@ class History < ApplicationRecord
 
   def self.assessment_email_error(patient: nil,
                                   created_by: 'Sara Alert System',
-                                  comment: 'Sara Alert was unable to send a daily assessment email because of an error.',
+                                  comment: 'Sara Alert was unable to send a report email to the monitoree because of an unexpected error.',
                                   create: true)
     create_history(patient, created_by, HISTORY_TYPES[:assessment_email_error], comment, create: create)
   end

--- a/test/mailers/patient_mailer_test.rb
+++ b/test/mailers/patient_mailer_test.rb
@@ -616,6 +616,7 @@ class PatientMailerTest < ActionMailer::TestCase
   test 'assessment_email creates an assessment_email_error history when it fails' do
     ActionMailer::Base.deliveries.clear
     patient = create(:patient,
+                     submission_token: SecureRandom.urlsafe_base64[0, 10],
                      preferred_contact_method: 'E-mailed Web Link',
                      email: 'testpatient@example.com')
     original_updated_at = patient.updated_at
@@ -632,8 +633,10 @@ class PatientMailerTest < ActionMailer::TestCase
   test 'assessment_email logs to sentry when it fails' do
     ActionMailer::Base.deliveries.clear
     patient = create(:patient,
+                     submission_token: SecureRandom.urlsafe_base64[0, 10],
                      preferred_contact_method: 'E-mailed Web Link',
                      email: 'testpatient@example.com')
+    allow_any_instance_of(Patient).to(receive(:select_language).and_raise('Testing assessment_email'))
     allow(Raven).to receive(:capture_exception)
     PatientMailer.assessment_email(patient).deliver_now
     expect(Raven).to have_received(:capture_exception)

--- a/test/mailers/patient_mailer_test.rb
+++ b/test/mailers/patient_mailer_test.rb
@@ -612,4 +612,31 @@ class PatientMailerTest < ActionMailer::TestCase
       assert patient.updated_at < 290.days.ago
     end
   end
+
+  test 'assessment_email creates an assessment_email_error history when it fails' do
+    ActionMailer::Base.deliveries.clear
+    patient = create(:patient,
+                     preferred_contact_method: 'E-mailed Web Link',
+                     email: 'testpatient@example.com')
+    original_updated_at = patient.updated_at
+    allow_any_instance_of(Patient).to(receive(:select_language).and_raise('Testing assessment_email'))
+    assert_difference 'patient.histories.length', 1 do
+      PatientMailer.assessment_email(patient).deliver_now
+      patient.reload
+      assert_equal('Assessment Email Error', patient.histories.first.history_type)
+      assert_equal(patient.updated_at, original_updated_at)
+      assert_equal(ActionMailer::Base.deliveries.length, 0)
+    end
+  end
+
+  test 'assessment_email logs to sentry when it fails' do
+    ActionMailer::Base.deliveries.clear
+    patient = create(:patient,
+                     preferred_contact_method: 'E-mailed Web Link',
+                     email: 'testpatient@example.com')
+    allow(Raven).to receive(:capture_exception)
+    PatientMailer.assessment_email(patient).deliver_now
+    expect(Raven).to have_received(:capture_exception)
+    assert_equal(ActionMailer::Base.deliveries.length, 0)
+  end
 end

--- a/test/models/history_test.rb
+++ b/test/models/history_test.rb
@@ -106,5 +106,8 @@ class HistoryTest < ActiveSupport::TestCase
 
     History.monitoree_data_downloaded(patient: patient)
     assert patient.updated_at < 98.days.ago
+
+    History.assessment_email_error(patient: patient)
+    assert patient.updated_at < 98.days.ago
   end
 end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1188](https://tracker.codev.mitre.org/browse/SARAALERT-1188)

* Adds a history item if any error is raised during the execution of `PatientMailer#assessment_email`. 
* Logs the error to Sentry (Raven).

## (Feature) Demo/Screenshots
New History Item in Action:

<img width="1607" alt="Screen Shot 2021-07-08 at 08 33 52" src="https://user-images.githubusercontent.com/3009651/124967006-c5d60680-dfd8-11eb-940d-240c12920ad4.png">

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`patient_mailer.rb`
- Do not bubble error up to diagnostic email.
- Comment logic
- Create History and log to Sentry

`history.rb`
- Create new `:assessment_email_error` History item
- Prevent `:assessment_email_error` from changing an associated model's `updated_at` attr

`patient_mailer_test.rb`
- Test to ensure error is passed to sentry gem
- Test to ensure history item is created

`history_test.rb`
- Test to ensure the history item does not change associated model's `updated_at` attr

## Testing Recommendations
Getting `PatientMailer#assessment_email` to error is pretty difficult, which I guess is why we have this all wrapped in catching `StandardError` because something that goes wrong is out of our control at this point, such as mail failing to send.

So the way I like to test it is to add a new line that is explicit: `raise 'Test'` within `PatientMailer#assessment_email` and observe the behavior.

I would appreciate any additional thoughts on test cases or edge-cases.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@jkufro :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ : @DPC15038 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
