### PR TITLE
SARAALERT-1554: Fix bug with changing HoH

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -407,7 +407,7 @@ class PatientsController < ApplicationController
 
     # If the current patient is not accessible, current_patient.dependents will be nil so
     # in that case we just include the current patient ID in the househld.
-    household_ids = current_patient&.dependents&.pluck(:id) || [current_patient_id]
+    household_ids = current_patient&.dependents&.where(purged: false)&.pluck(:id) || [current_patient_id]
 
     # ----- Error Checking -----
 
@@ -427,7 +427,7 @@ class PatientsController < ApplicationController
     redirect_to(root_url) && return if current_patient.responder_id == new_hoh_id
 
     # If the new head of household was removed from the household, don't allow the change
-    unless current_patient.dependents.pluck(:id).include?(new_hoh_id)
+    unless current_patient.dependents.where(purged: false).pluck(:id).include?(new_hoh_id)
       error_message = 'Change head of household action failed: selected Head of Household is no longer in household. Please refresh.'
       render(json: { error: error_message }, status: :bad_request) && return
     end


### PR DESCRIPTION


# Description
Jira Ticket: [SARAALERT-1554](https://tracker.codev.mitre.org/browse/SARAALERT-1554)

[Slack thread](https://mitrecorp.slack.com/archives/C01A6P94R9B/p1625848057089900) for context.

If you attempt to change an HoH in a household with purged monitoree(s), it would fail since the check for whether all the household members are viewable by the current user did not properly consider that monitorees could be purged.

This bug and fix are essentially the same as #973, just in a different place

## How to Replicate
Find or manually create a household with at least one purged household member. Attempt to change the head of household.

## Solution
Add a filter on unpurged monitorees when checking if the household members are viewable.

## Testing Recommendations

Confirm you can replicate on master, and then confirm you cannot replicate on this branch.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@holmesie:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR