### PR TITLE
SARAALERT-1509: When a symptom report is edited, include the change in "Reporter" in the resulting history entry

### DIFF
--- a/app/controllers/assessments_controller.rb
+++ b/app/controllers/assessments_controller.rb
@@ -211,8 +211,8 @@ class AssessmentsController < ApplicationController
           delta << "#{symptom.label} (\"#{old_val}\" to \"#{new_val}\")"
         end
       end
-
       assessment.symptomatic = assessment.symptomatic?
+      old_reporter = assessment.who_reported
       # Monitorees can't edit their own assessments, so the last person to touch this assessment was current_user
       assessment.who_reported = current_user.email
 
@@ -220,7 +220,10 @@ class AssessmentsController < ApplicationController
       return unless assessment.save
 
       comment = 'User updated an existing report (ID: ' + assessment.id.to_s + ').'
-      comment += ' Symptom updates: ' + delta.join(', ') + '.' unless delta.empty?
+      unless delta.empty?
+        comment += ' Symptom updates: ' + delta.join(', ') + '.'
+        comment += " Reporter updated: (\"#{old_reporter}\" to \"#{current_user.email}\")." unless old_reporter == current_user.email
+      end
       History.report_updated(patient: patient, created_by: current_user.email, comment: comment)
     end
   end


### PR DESCRIPTION


# Description
Jira Ticket: [SARAALERT-1509](https://tracker.codev.mitre.org/browse/SARAALERT-1509)

When a symptom report is edited, there's currently no way to track changes to the reporter, which is always updated to the last person to change the record. This appends "Reporter updated("old_id" to "new_id")" to the end of the original comment of the update history so these changes are always tracked. 

## (Feature) Demo/Screenshots
![Screen Shot 2021-07-09 at 2 45 13 PM](https://user-images.githubusercontent.com/16108095/125138877-4b82b080-e0c4-11eb-9a36-5f1ffbb7ba52.png)

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/controllers/assessments_controller.rb`
- refactors update to, if changes were made to the assessment, adds the old who_reported value and the new who_reported to the end of the history comment iff they do not equal each other. 

## Testing Recommendations
Edge cases: If a user updates the same record twice, if two different users update the same record in sequence. 

# Checklists

**Submitter:**
- [ ] This PR describes why these changes were made.
- [ ] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA ticket reference.
- [ ] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [ ] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
