### PR TITLE
close_patients_job: batch groups and bulk import histories

### DIFF
--- a/app/jobs/close_patients_job.rb
+++ b/app/jobs/close_patients_job.rb
@@ -31,69 +31,73 @@ class ClosePatientsJob < ApplicationJob
   def perform_batch(patients, monitoring_reason, jurisdiction_send_close, completed_message: false)
     closed = []
     not_closed = []
-    count = 0
+    histories = []
 
     # Close patients who are past the monitoring period (and are actually closable from above logic)
-    patients.each do |patient|
-      count += 1
-      # Update related fields
-      patient[:monitoring] = false
-      patient[:closed_at] = DateTime.now
-      patient[:monitoring_reason] = monitoring_reason
-      patient.save!
+    patients.find_in_batches(batch_size: 15_000).each do |group|
+      group.each do |patient|
+        # Update related fields
+        patient[:monitoring] = false
+        patient[:closed_at] = DateTime.now
+        patient[:monitoring_reason] = monitoring_reason
+        patient.save!
 
-      # Send closed notification to patient if they are a reporter, the closure reason warrants a close
-      # notification, and if the jurisdiction has opted-in to closed notifications.
-      #
-      # If 'sms texted weblink' or 'sms text-message' is preferred, then an SMS will be sent
-      # If 'e-mailed web link' is preferred, then an email will be sent
-      # If the preferred contact method is not supported for close notifications, then a history item will
-      # be created stating so.
-      #
-      # We are checking some of the same crieria here as in the patient mailer for closed messages.
-      # This is intentionally done to avoid enqueuing mail that is "destined to fail", as well as to cover the case
-      # where the patient record is modified between being enqueued and the mailer job actually being executed.
-      if completed_message && patient.self_reporter_or_proxy? && jurisdiction_send_close[patient.jurisdiction_id]
-        contact_method = patient.preferred_contact_method&.downcase
-        if ['sms texted weblink', 'sms text-message'].include? contact_method
-          # Do not enqueue if the contact method is blank or if SMS is blocked
-          if patient.blocked_sms
-            History.send_close_sms_blocked(patient: patient)
-          elsif patient.primary_telephone.blank?
-            History.send_close_conact_method_blank(patient: patient, type: 'primary phone number')
+        # Send closed notification to patient if they are a reporter, the closure reason warrants a close
+        # notification, and if the jurisdiction has opted-in to closed notifications.
+        #
+        # If 'sms texted weblink' or 'sms text-message' is preferred, then an SMS will be sent
+        # If 'e-mailed web link' is preferred, then an email will be sent
+        # If the preferred contact method is not supported for close notifications, then a history item will
+        # be created stating so.
+        #
+        # We are checking some of the same crieria here as in the patient mailer for closed messages.
+        # This is intentionally done to avoid enqueuing mail that is "destined to fail", as well as to cover the case
+        # where the patient record is modified between being enqueued and the mailer job actually being executed.
+        if completed_message && patient.self_reporter_or_proxy? && jurisdiction_send_close[patient.jurisdiction_id]
+          contact_method = patient.preferred_contact_method&.downcase
+          if ['sms texted weblink', 'sms text-message'].include? contact_method
+            # Do not enqueue if the contact method is blank or if SMS is blocked
+            if patient.blocked_sms
+              histories << History.send_close_sms_blocked(patient: patient, create: false)
+            elsif patient.primary_telephone.blank?
+              histories << History.send_close_conact_method_blank(patient: patient, type: 'primary phone number', create: false)
+            else
+              PatientMailer.closed_sms(patient).deliver_later(wait_until: patient.time_to_notify_closed)
+            end
+          elsif contact_method == 'e-mailed web link'
+            # Do not enqueue if the contact method is blank
+            if patient.email.blank?
+              histories << History.send_close_conact_method_blank(patient: patient, type: 'email', create: false)
+            else
+              PatientMailer.closed_email(patient).deliver_later(wait_until: patient.time_to_notify_closed)
+            end
           else
-            PatientMailer.closed_sms(patient).deliver_later(wait_until: patient.time_to_notify_closed)
+            history_friendly_method = patient.preferred_contact_method.blank? ? patient.preferred_contact_method : 'Unknown'
+            histories << History.monitoring_complete_message_sent(
+              patient: patient,
+              comment: 'The system was unable to send a monitoring complete message to this monitoree because their'\
+                       "preferred contact method, #{history_friendly_method}, is not supported for this message type.",
+              create: false
+            )
           end
-        elsif contact_method == 'e-mailed web link'
-          # Do not enqueue if the contact method is blank
-          if patient.email.blank?
-            History.send_close_conact_method_blank(patient: patient, type: 'email')
-          else
-            PatientMailer.closed_email(patient).deliver_later(wait_until: patient.time_to_notify_closed)
-          end
-        else
-          history_friendly_method = patient.preferred_contact_method.blank? ? patient.preferred_contact_method : 'Unknown'
-          History.monitoring_complete_message_sent(
-            patient: patient,
-            comment: 'The system was unable to send a monitoring complete message to this monitoree because their'\
-                     "preferred contact method, #{history_friendly_method}, is not supported for this message type."
-          )
         end
+
+        # History item for automatically closing the record
+        histories << History.record_automatically_closed(patient: patient, create: false)
+
+        closed << { id: patient.id }
+      rescue StandardError => e
+        not_closed << { id: patient.id, reason: e.message }
+        next
       end
-
-      # History item for automatically closing the record
-      History.record_automatically_closed(patient: patient)
-
-      closed << { id: patient.id }
-    rescue StandardError => e
-      not_closed << { id: patient.id, reason: e.message }
-      next
     end
+
+    History.import! histories
 
     {
       closed: closed,
       not_closed: not_closed,
-      count: count
+      count: closed.size + not_closed.size
     }
   end
 

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -167,84 +167,84 @@ class History < ApplicationRecord
     History.import! histories
   end
 
-  def self.record_edit(patient: nil, created_by: 'Sara Alert System', comment: 'User edited a record.')
-    create_history(patient, created_by, HISTORY_TYPES[:record_edit], comment)
+  def self.record_edit(patient: nil, created_by: 'Sara Alert System', comment: 'User edited a record.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:record_edit], comment, create: create)
   end
 
-  def self.report_created(patient: nil, created_by: 'Sara Alert System', comment: 'User created a new report.')
-    create_history(patient, created_by, HISTORY_TYPES[:report_created], comment)
+  def self.report_created(patient: nil, created_by: 'Sara Alert System', comment: 'User created a new report.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:report_created], comment, create: create)
   end
 
-  def self.report_updated(patient: nil, created_by: 'Sara Alert System', comment: 'User updated existing report.')
-    create_history(patient, created_by, HISTORY_TYPES[:report_updated], comment)
+  def self.report_updated(patient: nil, created_by: 'Sara Alert System', comment: 'User updated existing report.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:report_updated], comment, create: create)
   end
 
-  def self.enrollment(patient: nil, created_by: 'Sara Alert System', comment: 'User enrolled monitoree.')
-    create_history(patient, created_by, HISTORY_TYPES[:enrollment], comment)
+  def self.enrollment(patient: nil, created_by: 'Sara Alert System', comment: 'User enrolled monitoree.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:enrollment], comment, create: create)
   end
 
-  def self.monitoring_change(patient: nil, created_by: 'Sara Alert System', comment: 'User updated monitoree.')
-    create_history(patient, created_by, HISTORY_TYPES[:monitoring_change], comment)
+  def self.monitoring_change(patient: nil, created_by: 'Sara Alert System', comment: 'User updated monitoree.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:monitoring_change], comment, create: create)
   end
 
-  def self.monitoree_data_downloaded(patient: nil, created_by: 'Sara Alert System', comment: 'User downloaded monitoree\'s data in Excel Export.')
-    create_history(patient, created_by, HISTORY_TYPES[:monitoree_data_downloaded], comment)
+  def self.monitoree_data_downloaded(patient: nil, created_by: 'Sara Alert System', comment: 'User downloaded monitoree\'s data in Excel Export.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:monitoree_data_downloaded], comment, create: create)
   end
 
-  def self.reports_reviewed(patient: nil, created_by: 'Sara Alert System', comment: 'User reviewed all reports.')
-    create_history(patient, created_by, HISTORY_TYPES[:reports_reviewed], comment)
+  def self.reports_reviewed(patient: nil, created_by: 'Sara Alert System', comment: 'User reviewed all reports.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:reports_reviewed], comment, create: create)
   end
 
-  def self.report_reviewed(patient: nil, created_by: 'Sara Alert System', comment: 'User reviewed a report.')
-    create_history(patient, created_by, HISTORY_TYPES[:report_reviewed], comment)
+  def self.report_reviewed(patient: nil, created_by: 'Sara Alert System', comment: 'User reviewed a report.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:report_reviewed], comment, create: create)
   end
 
-  def self.report_reminder(patient: nil, created_by: 'Sara Alert System', comment: 'User sent a report reminder to the monitoree.')
-    create_history(patient, created_by, HISTORY_TYPES[:report_reminder], comment)
+  def self.report_reminder(patient: nil, created_by: 'Sara Alert System', comment: 'User sent a report reminder to the monitoree.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:report_reminder], comment, create: create)
   end
 
-  def self.unsuccessful_report_reminder(patient: nil, created_by: 'Sara Alert System', comment: 'Unsuccessful report reminder.')
-    create_history(patient, created_by, HISTORY_TYPES[:unsuccessful_report_reminder], comment)
+  def self.unsuccessful_report_reminder(patient: nil, created_by: 'Sara Alert System', comment: 'Unsuccessful report reminder.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:unsuccessful_report_reminder], comment, create: create)
   end
 
-  def self.vaccination(patient: nil, created_by: 'Sara Alert System', comment: 'User added a new vaccination.')
-    create_history(patient, created_by, HISTORY_TYPES[:vaccination], comment)
+  def self.vaccination(patient: nil, created_by: 'Sara Alert System', comment: 'User added a new vaccination.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:vaccination], comment, create: create)
   end
 
-  def self.vaccination_edit(patient: nil, created_by: 'Sara Alert System', comment: 'User edited a vaccination.')
-    create_history(patient, created_by, HISTORY_TYPES[:vaccination_edit], comment)
+  def self.vaccination_edit(patient: nil, created_by: 'Sara Alert System', comment: 'User edited a vaccination.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:vaccination_edit], comment, create: create)
   end
 
-  def self.lab_result(patient: nil, created_by: 'Sara Alert System', comment: 'User added a new lab result.')
-    create_history(patient, created_by, HISTORY_TYPES[:lab_result], comment)
+  def self.lab_result(patient: nil, created_by: 'Sara Alert System', comment: 'User added a new lab result.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:lab_result], comment, create: create)
   end
 
-  def self.lab_result_edit(patient: nil, created_by: 'Sara Alert System', comment: 'User edited a lab result.')
-    create_history(patient, created_by, HISTORY_TYPES[:lab_result_edit], comment)
+  def self.lab_result_edit(patient: nil, created_by: 'Sara Alert System', comment: 'User edited a lab result.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:lab_result_edit], comment, create: create)
   end
 
-  def self.close_contact(patient: nil, created_by: 'Sara Alert System', comment: 'User added a new close contact.')
-    create_history(patient, created_by, HISTORY_TYPES[:close_contact], comment)
+  def self.close_contact(patient: nil, created_by: 'Sara Alert System', comment: 'User added a new close contact.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:close_contact], comment, create: create)
   end
 
-  def self.close_contact_edit(patient: nil, created_by: 'Sara Alert System', comment: 'User edited a close contact.')
-    create_history(patient, created_by, HISTORY_TYPES[:close_contact_edit], comment)
+  def self.close_contact_edit(patient: nil, created_by: 'Sara Alert System', comment: 'User edited a close contact.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:close_contact_edit], comment, create: create)
   end
 
-  def self.contact_attempt(patient: nil, created_by: 'Sara Alert System', comment: 'The system attempted to make contact with the monitoree.')
-    create_history(patient, created_by, HISTORY_TYPES[:contact_attempt], comment)
+  def self.contact_attempt(patient: nil, created_by: 'Sara Alert System', comment: 'The system attempted to make contact with the monitoree.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:contact_attempt], comment, create: create)
   end
 
-  def self.welcome_message_sent(patient: nil, created_by: 'Sara Alert System', comment: 'Initial Sara Alert welcome message was sent.')
-    create_history(patient, created_by, HISTORY_TYPES[:welcome_message_sent], comment)
+  def self.welcome_message_sent(patient: nil, created_by: 'Sara Alert System', comment: 'Initial Sara Alert welcome message was sent.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:welcome_message_sent], comment, create: create)
   end
 
-  def self.record_automatically_closed(patient: nil, created_by: 'Sara Alert System', comment: 'Monitoree has completed monitoring.')
-    create_history(patient, created_by, HISTORY_TYPES[:record_automatically_closed], comment)
+  def self.record_automatically_closed(patient: nil, created_by: 'Sara Alert System', comment: 'Monitoree has completed monitoring.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:record_automatically_closed], comment, create: create)
   end
 
-  def self.monitoring_complete_message_sent(patient: nil, created_by: 'Sara Alert System', comment: 'Monitoring Complete message was sent.')
-    create_history(patient, created_by, HISTORY_TYPES[:monitoring_complete_message_sent], comment)
+  def self.monitoring_complete_message_sent(patient: nil, created_by: 'Sara Alert System', comment: 'Monitoring Complete message was sent.', create: true)
+    create_history(patient, created_by, HISTORY_TYPES[:monitoring_complete_message_sent], comment, create: create)
   end
 
   def self.calculated_symptom_onset(patient: nil, created_by: 'Sara Alert System', new_symptom_onset: nil, action: 'created')
@@ -261,21 +261,21 @@ class History < ApplicationRecord
                 because a report meeting the symptomatic logic was #{action}."
               end
 
-    create_history(patient, created_by, HISTORY_TYPES[:monitoring_change], comment)
+    create_history(patient, created_by, HISTORY_TYPES[:monitoring_change], comment, create: create)
   end
 
-  def self.send_close_conact_method_blank(patient: nil, created_by: 'Sara Alert System', type: 'Unknown')
+  def self.send_close_conact_method_blank(patient: nil, created_by: 'Sara Alert System', type: 'Unknown', create: true)
     comment = "The system was unable to send a monitoring complete message to this monitoree because their preferred contact method, #{type}, was blank."
-    create_history(patient, created_by, HISTORY_TYPES[:monitoring_complete_message_sent], comment)
+    create_history(patient, created_by, HISTORY_TYPES[:monitoring_complete_message_sent], comment, create: create)
   end
 
-  def self.send_close_sms_blocked(patient: nil, created_by: 'Sara Alert System')
+  def self.send_close_sms_blocked(patient: nil, created_by: 'Sara Alert System', create: true)
     comment = 'The system was unable to send a monitoring complete message to this monitoree'\
               ' because the recipient phone number blocked communication with Sara Alert'
-    create_history(patient, created_by, HISTORY_TYPES[:monitoring_complete_message_sent], comment)
+    create_history(patient, created_by, HISTORY_TYPES[:monitoring_complete_message_sent], comment, create: create)
   end
 
-  def self.monitoring_status(history)
+  def self.monitoring_status(history, create: true)
     field = {
       name: 'Monitoring Status',
       old_value: history[:patient_before][:monitoring] ? 'Monitoring' : 'Not Monitoring',
@@ -284,10 +284,10 @@ class History < ApplicationRecord
 
     return if field[:old_value] == field[:new_value]
 
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field))
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field), create: create)
   end
 
-  def self.exposure_risk_assessment(history)
+  def self.exposure_risk_assessment(history, create: true)
     field = {
       name: 'Exposure Risk Assessment',
       old_value: history[:patient_before][:exposure_risk_assessment],
@@ -295,10 +295,10 @@ class History < ApplicationRecord
     }
     return if field[:old_value] == field[:new_value]
 
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field))
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field), create: create)
   end
 
-  def self.monitoring_plan(history)
+  def self.monitoring_plan(history, create: true)
     field = {
       name: 'Monitoring Plan',
       old_value: history[:patient_before][:monitoring_plan],
@@ -306,10 +306,10 @@ class History < ApplicationRecord
     }
     return if field[:old_value] == field[:new_value]
 
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field))
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field), create: create)
   end
 
-  def self.case_status(history, diff_state)
+  def self.case_status(history, diff_state, create: true)
     field = {
       name: 'Case Status',
       old_value: history[:patient_before][:case_status],
@@ -325,10 +325,10 @@ class History < ApplicationRecord
       history[:note] = ', and chose to "Continue Monitoring in Isolation Workflow"'
     end
 
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field))
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field), create: create)
   end
 
-  def self.public_health_action(history)
+  def self.public_health_action(history, create: true)
     field = {
       name: 'Latest Public Health Action',
       old_value: history[:patient_before][:public_health_action],
@@ -336,10 +336,10 @@ class History < ApplicationRecord
     }
     return if field[:old_value] == field[:new_value]
 
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field))
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field), create: create)
   end
 
-  def self.jurisdiction(history)
+  def self.jurisdiction(history, create: true)
     field = {
       name: 'Jurisdiction',
       old_value: Jurisdiction.find(history[:patient_before][:jurisdiction_id])[:path],
@@ -347,10 +347,10 @@ class History < ApplicationRecord
     }
     return if field[:old_value] == field[:new_value]
 
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field))
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field), create: create)
   end
 
-  def self.assigned_user(history)
+  def self.assigned_user(history, create: true)
     field = {
       name: 'Assigned User',
       old_value: history[:patient_before][:assigned_user],
@@ -358,10 +358,10 @@ class History < ApplicationRecord
     }
     return if field[:old_value] == field[:new_value]
 
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field))
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field), create: create)
   end
 
-  def self.pause_notifications(history)
+  def self.pause_notifications(history, create: true)
     field = {
       name: 'Notification Status',
       old_value: history[:patient_before][:pause_notifications] ? 'paused' : 'resumed',
@@ -371,10 +371,10 @@ class History < ApplicationRecord
 
     creator = history[:household_status] == :patient ? 'User' : 'System'
     comment = "#{creator} #{field[:new_value]} notifications for this monitoree#{compose_explanation(history, field)}."
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment)
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment, create: create)
   end
 
-  def self.symptom_onset(history)
+  def self.symptom_onset(history, create: true)
     field = {
       name: 'Symptom Onset Date',
       type: 'date',
@@ -385,10 +385,10 @@ class History < ApplicationRecord
 
     comment = compose_message(history, field)
     comment += ' The system will now populate this date.' if field[:new_value].nil?
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment)
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment, create: create)
   end
 
-  def self.last_date_of_exposure(history)
+  def self.last_date_of_exposure(history, create: true)
     field = {
       name: 'Last Date of Exposure',
       type: 'date',
@@ -397,10 +397,10 @@ class History < ApplicationRecord
     }
     return if field[:old_value] == field[:new_value]
 
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field))
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field), create: create)
   end
 
-  def self.continuous_exposure(history)
+  def self.continuous_exposure(history, create: true)
     field = {
       name: 'Continuous Exposure',
       old_value: history[:patient_before][:continuous_exposure] ? 'on' : 'off',
@@ -410,10 +410,10 @@ class History < ApplicationRecord
 
     creator = history[:household_status] == :patient ? 'User' : 'System'
     comment = "#{creator} turned #{field[:new_value]} #{field[:name]}#{compose_explanation(history, field)}."
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment)
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], comment, create: create)
   end
 
-  def self.monitoring_reason(history)
+  def self.monitoring_reason(history, create: true)
     field = {
       name: 'Reason for Closure',
       old_value: history[:patient_before][:monitoring_reason],
@@ -421,10 +421,10 @@ class History < ApplicationRecord
     }
     return if field[:old_value] == field[:new_value]
 
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field))
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field), create: create)
   end
 
-  def self.extended_isolation(history)
+  def self.extended_isolation(history, create: true)
     field = {
       name: 'Extended Isolation',
       type: 'date',
@@ -433,33 +433,37 @@ class History < ApplicationRecord
     }
     return if field[:old_value] == field[:new_value]
 
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field))
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:monitoring_change], compose_message(history, field), create: create)
   end
 
-  def self.follow_up_flag_edit(history)
+  def self.follow_up_flag_edit(history, create: true)
     return if history[:follow_up_reason] == history[:follow_up_reason_before] && history[:follow_up_note] == history[:follow_up_note_before]
 
     comment = "Flagged for Follow-up. Reason: \"#{history[:follow_up_reason]}"
     comment += ": #{history[:follow_up_note]}" unless history[:follow_up_note].blank?
     comment += '"'
 
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:follow_up_flag], comment)
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:follow_up_flag], comment, create: create)
   end
 
-  def self.clear_follow_up_flag(history)
+  def self.clear_follow_up_flag(history, create: true)
     return if history[:follow_up_reason_before].nil?
 
     comment = 'User cleared flag for follow-up.'
     comment += " Reason: #{history[:clear_flag_reason]}" unless history[:clear_flag_reason].blank?
 
-    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:follow_up_flag], comment)
+    create_history(history[:patient], history[:created_by], HISTORY_TYPES[:follow_up_flag], comment, create: create)
   end
 
-  private_class_method def self.create_history(patient, created_by, type, comment)
+  private_class_method def self.create_history(patient, created_by, type, comment, create: true)
     return if patient.nil?
 
     patient = patient.id if patient.respond_to?(:id)
-    History.create!(created_by: created_by, comment: comment, patient_id: patient, history_type: type)
+    if create
+      History.create!(created_by: created_by, comment: comment, patient_id: patient, history_type: type)
+    else
+      History.new(created_by: created_by, comment: comment, patient_id: patient, history_type: type)
+    end
   end
 
   private_class_method def self.compose_message(history, field)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1423](https://tracker.codev.mitre.org/browse/SARAALERT-1423)

Improves performance of close_patients_job by using batching and bulk import of histories.

This is a newer version of [this PR](https://github.com/SaraAlert/SaraAlert/pull/810) but does not bypass validations on patient records

### Performance Testing Data
[GitHub_Actions_Performance_Data_1626196344.xlsx](https://github.com/SaraAlert/SaraAlert/files/6810841/GitHub_Actions_Performance_Data_1626196344.xlsx)


## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`close_patients_job.rb`
- find patients in batches similar to send assessments job
- build all histories and import all at once for each batch

`history.rb`
- allow passing `create: false` to history methods to build but not create histories

## Testing Recommendations
Please list any recommendations regarding what reviewers should test and if there is any specific guidance on how to test certain aspects of the PR. Be sure to mention edge cases that should be tried, particularly in the UI.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@Bialogs  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@holmesie  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
