### PR TITLE
SARAALERT-NONE: Fix nginx.conf for requests to /api

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -97,6 +97,16 @@ http {
       proxy_set_header  X-Forwarded-Port $server_port;
       proxy_set_header  X-Forwarded-Host $host;
     }
+
+    location /api {
+      proxy_pass        http://sara-alert-api:3000;
+      proxy_set_header  Host $host;
+      proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header  X-Forwarded-Proto $scheme;
+      proxy_set_header  X-Forwarded-Ssl on;
+      proxy_set_header  X-Forwarded-Port $server_port;
+      proxy_set_header  X-Forwarded-Host $host;
+    }
   }
 
   server {


### PR DESCRIPTION
# Description
Jira Ticket:  N/A

We have an `api/nbs/patient` endpoint that client applications can use to get data in the PHDC format. I noticed recently that the requests to this endpoint actually go to the enrollment container, since only requests that start with `/fhir` or `/oauth` go to the api container. This fixes that by now sending requests that start with `api/` to the api container.

**NOTE:** This is an area I'm not super familiar with, it seemed to me from following the previous examples that what I am doing should work, but I don't totally know how to locally test it. So if one of the reviewers does have things set up to easily test this, I would appreciate it, or since you reviewers know more about this than me, if one of you could point me in the right direction for how I should test this, I would appreciate that too.

## Important Changes
`nginx.conf`
- Add an item to send requests to `api/` to the `nginx.conf` container.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)


@jkufro 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@Bialogs 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
