### PR TITLE
SARAALERT-1543: Abbreviated RRR (Records Requiring Review) tab on small screens

### DIFF
--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -615,7 +615,9 @@ class PatientsTable extends React.Component {
               <Nav.Item key={tab}>
                 <Nav.Link eventKey={tab} onSelect={this.handleTabSelect} id={`${tab}_tab`}>
                   <span className="large-tab">{tabProps.label}</span>
-                  <span className="small-tab">{tabProps.abbreviatedLabel || tabProps.label}</span>
+                  <span className="small-tab" aria-label={tabProps.label}>
+                    {tabProps.abbreviatedLabel || tabProps.label}
+                  </span>
                   <Badge variant={tabProps.variant} className="badge-larger-font ml-1">
                     <span>{`${tab}Count` in this.state ? this.state[`${tab}Count`] : ''}</span>
                   </Badge>

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -614,7 +614,8 @@ class PatientsTable extends React.Component {
             return (
               <Nav.Item key={tab}>
                 <Nav.Link eventKey={tab} onSelect={this.handleTabSelect} id={`${tab}_tab`}>
-                  {tabProps.label}
+                  <span className="large-tab">{tabProps.label}</span>
+                  <span className="small-tab">{tabProps.abbreviatedLabel || tabProps.label}</span>
                   <Badge variant={tabProps.variant} className="badge-larger-font ml-1">
                     <span>{`${tab}Count` in this.state ? this.state[`${tab}Count`] : ''}</span>
                   </Badge>

--- a/app/javascript/packs/stylesheets/dashboard.scss
+++ b/app/javascript/packs/stylesheets/dashboard.scss
@@ -7,6 +7,10 @@
       border-color:#b5b5b5;
       background-color:white;
     }
+
+    .small-tab {
+      display: none !important;
+    }
   }
 
   .nav-item:last-child {
@@ -77,7 +81,7 @@
   .isolation-dashboard {
     .nav-tabs {
       .nav-link {
-        width: 300px;
+        width: 230px;
         border: 1px #dee2e6 solid;
         margin-bottom: -.05px;
 
@@ -91,6 +95,14 @@
 
         .badge {
           float: right !important
+        }
+
+        .small-tab {
+          display: inline !important;
+        }
+
+        .large-tab {
+          display: none !important;
         }
       }
     }

--- a/app/javascript/tests/mocks/mockTabs.js
+++ b/app/javascript/tests/mocks/mockTabs.js
@@ -73,6 +73,7 @@ const mockIsolationTabs = {
   requiring_review: {
     description: 'Cases who preliminarily meet the recovery definition and require review.',
     label: 'Records Requiring Review',
+    abbreviatedLabel: 'RRR',
     tooltip: 'isolation_records_requiring_review',
     variant: 'danger',
   },

--- a/app/javascript/tests/public_health/PatientsTable.test.js
+++ b/app/javascript/tests/public_health/PatientsTable.test.js
@@ -174,12 +174,42 @@ describe('PatientsTable', () => {
     const wrapper = getExposureWrapper();
     for (var key of Object.keys(mockExposureTabs)) {
       expect(wrapper.find('#' + key + '_tab').exists()).toBeTruthy();
-      expect(wrapper.find('#' + key + '_tab').find('.large-tab').exists()).toBeTruthy();
-      expect(wrapper.find('#' + key + '_tab').find('.large-tab').text()).toEqual(mockExposureTabs[`${key}`]['label']);
-      expect(wrapper.find('#' + key + '_tab').find('.small-tab').exists()).toBeTruthy();
-      expect(wrapper.find('#' + key + '_tab').find('.small-tab').text()).toEqual(mockExposureTabs[`${key}`]['abbreviatedLabel'] || mockExposureTabs[`${key}`]['label']);
-      expect(wrapper.find('#' + key + '_tab').find(Badge).exists()).toBeTruthy();
-      expect(wrapper.find('#' + key + '_tab').find(Badge).prop('variant')).toEqual(mockExposureTabs[`${key}`]['variant']);
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find('.large-tab')
+          .exists()
+      ).toBeTruthy();
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find('.large-tab')
+          .text()
+      ).toEqual(mockExposureTabs[`${key}`]['label']);
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find('.small-tab')
+          .exists()
+      ).toBeTruthy();
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find('.small-tab')
+          .text()
+      ).toEqual(mockExposureTabs[`${key}`]['abbreviatedLabel'] || mockExposureTabs[`${key}`]['label']);
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find(Badge)
+          .exists()
+      ).toBeTruthy();
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find(Badge)
+          .prop('variant')
+      ).toEqual(mockExposureTabs[`${key}`]['variant']);
     }
   });
 
@@ -187,12 +217,42 @@ describe('PatientsTable', () => {
     const wrapper = getIsolationWrapper();
     for (var key of Object.keys(mockIsolationTabs)) {
       expect(wrapper.find('#' + key + '_tab').exists()).toBeTruthy();
-      expect(wrapper.find('#' + key + '_tab').find('.large-tab').exists()).toBeTruthy();
-      expect(wrapper.find('#' + key + '_tab').find('.large-tab').text()).toEqual(mockIsolationTabs[`${key}`]['label']);
-      expect(wrapper.find('#' + key + '_tab').find('.small-tab').exists()).toBeTruthy();
-      expect(wrapper.find('#' + key + '_tab').find('.small-tab').text()).toEqual(mockIsolationTabs[`${key}`]['abbreviatedLabel'] || mockIsolationTabs[`${key}`]['label']);
-      expect(wrapper.find('#' + key + '_tab').find(Badge).exists()).toBeTruthy();
-      expect(wrapper.find('#' + key + '_tab').find(Badge).prop('variant')).toEqual(mockIsolationTabs[`${key}`]['variant']);
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find('.large-tab')
+          .exists()
+      ).toBeTruthy();
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find('.large-tab')
+          .text()
+      ).toEqual(mockIsolationTabs[`${key}`]['label']);
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find('.small-tab')
+          .exists()
+      ).toBeTruthy();
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find('.small-tab')
+          .text()
+      ).toEqual(mockIsolationTabs[`${key}`]['abbreviatedLabel'] || mockIsolationTabs[`${key}`]['label']);
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find(Badge)
+          .exists()
+      ).toBeTruthy();
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find(Badge)
+          .prop('variant')
+      ).toEqual(mockIsolationTabs[`${key}`]['variant']);
     }
   });
 
@@ -200,12 +260,42 @@ describe('PatientsTable', () => {
     const wrapper = getGlobalWrapper();
     for (var key of Object.keys(mockGlobalTabs)) {
       expect(wrapper.find('#' + key + '_tab').exists()).toBeTruthy();
-      expect(wrapper.find('#' + key + '_tab').find('.large-tab').exists()).toBeTruthy();
-      expect(wrapper.find('#' + key + '_tab').find('.large-tab').text()).toEqual(mockGlobalTabs[`${key}`]['label']);
-      expect(wrapper.find('#' + key + '_tab').find('.small-tab').exists()).toBeTruthy();
-      expect(wrapper.find('#' + key + '_tab').find('.small-tab').text()).toEqual(mockGlobalTabs[`${key}`]['abbreviatedLabel'] || mockGlobalTabs[`${key}`]['label']);
-      expect(wrapper.find('#' + key + '_tab').find(Badge).exists()).toBeTruthy();
-      expect(wrapper.find('#' + key + '_tab').find(Badge).prop('variant')).toEqual(mockGlobalTabs[`${key}`]['variant']);
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find('.large-tab')
+          .exists()
+      ).toBeTruthy();
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find('.large-tab')
+          .text()
+      ).toEqual(mockGlobalTabs[`${key}`]['label']);
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find('.small-tab')
+          .exists()
+      ).toBeTruthy();
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find('.small-tab')
+          .text()
+      ).toEqual(mockGlobalTabs[`${key}`]['abbreviatedLabel'] || mockGlobalTabs[`${key}`]['label']);
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find(Badge)
+          .exists()
+      ).toBeTruthy();
+      expect(
+        wrapper
+          .find('#' + key + '_tab')
+          .find(Badge)
+          .prop('variant')
+      ).toEqual(mockGlobalTabs[`${key}`]['variant']);
     }
   });
 });

--- a/app/javascript/tests/public_health/PatientsTable.test.js
+++ b/app/javascript/tests/public_health/PatientsTable.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import _ from 'lodash';
 import { shallow } from 'enzyme';
-import { DropdownButton, Dropdown } from 'react-bootstrap';
+import { Badge, DropdownButton, Dropdown } from 'react-bootstrap';
 import PatientsTable from '../../components/public_health/PatientsTable';
 import JurisdictionFilter from '../../components/public_health/query/JurisdictionFilter';
 import AssignedUserFilter from '../../components/public_health/query/AssignedUserFilter';
@@ -174,7 +174,12 @@ describe('PatientsTable', () => {
     const wrapper = getExposureWrapper();
     for (var key of Object.keys(mockExposureTabs)) {
       expect(wrapper.find('#' + key + '_tab').exists()).toBeTruthy();
-      expect(wrapper.find('#' + key + '_tab').text()).toEqual(mockExposureTabs[`${key}`]['label']);
+      expect(wrapper.find('#' + key + '_tab').find('.large-tab').exists()).toBeTruthy();
+      expect(wrapper.find('#' + key + '_tab').find('.large-tab').text()).toEqual(mockExposureTabs[`${key}`]['label']);
+      expect(wrapper.find('#' + key + '_tab').find('.small-tab').exists()).toBeTruthy();
+      expect(wrapper.find('#' + key + '_tab').find('.small-tab').text()).toEqual(mockExposureTabs[`${key}`]['abbreviatedLabel'] || mockExposureTabs[`${key}`]['label']);
+      expect(wrapper.find('#' + key + '_tab').find(Badge).exists()).toBeTruthy();
+      expect(wrapper.find('#' + key + '_tab').find(Badge).prop('variant')).toEqual(mockExposureTabs[`${key}`]['variant']);
     }
   });
 
@@ -182,7 +187,12 @@ describe('PatientsTable', () => {
     const wrapper = getIsolationWrapper();
     for (var key of Object.keys(mockIsolationTabs)) {
       expect(wrapper.find('#' + key + '_tab').exists()).toBeTruthy();
-      expect(wrapper.find('#' + key + '_tab').text()).toEqual(mockIsolationTabs[`${key}`]['label']);
+      expect(wrapper.find('#' + key + '_tab').find('.large-tab').exists()).toBeTruthy();
+      expect(wrapper.find('#' + key + '_tab').find('.large-tab').text()).toEqual(mockIsolationTabs[`${key}`]['label']);
+      expect(wrapper.find('#' + key + '_tab').find('.small-tab').exists()).toBeTruthy();
+      expect(wrapper.find('#' + key + '_tab').find('.small-tab').text()).toEqual(mockIsolationTabs[`${key}`]['abbreviatedLabel'] || mockIsolationTabs[`${key}`]['label']);
+      expect(wrapper.find('#' + key + '_tab').find(Badge).exists()).toBeTruthy();
+      expect(wrapper.find('#' + key + '_tab').find(Badge).prop('variant')).toEqual(mockIsolationTabs[`${key}`]['variant']);
     }
   });
 
@@ -190,7 +200,12 @@ describe('PatientsTable', () => {
     const wrapper = getGlobalWrapper();
     for (var key of Object.keys(mockGlobalTabs)) {
       expect(wrapper.find('#' + key + '_tab').exists()).toBeTruthy();
-      expect(wrapper.find('#' + key + '_tab').text()).toEqual(mockGlobalTabs[`${key}`]['label']);
+      expect(wrapper.find('#' + key + '_tab').find('.large-tab').exists()).toBeTruthy();
+      expect(wrapper.find('#' + key + '_tab').find('.large-tab').text()).toEqual(mockGlobalTabs[`${key}`]['label']);
+      expect(wrapper.find('#' + key + '_tab').find('.small-tab').exists()).toBeTruthy();
+      expect(wrapper.find('#' + key + '_tab').find('.small-tab').text()).toEqual(mockGlobalTabs[`${key}`]['abbreviatedLabel'] || mockGlobalTabs[`${key}`]['label']);
+      expect(wrapper.find('#' + key + '_tab').find(Badge).exists()).toBeTruthy();
+      expect(wrapper.find('#' + key + '_tab').find(Badge).prop('variant')).toEqual(mockGlobalTabs[`${key}`]['variant']);
     }
   });
 });

--- a/app/views/public_health/isolation.html.erb
+++ b/app/views/public_health/isolation.html.erb
@@ -20,6 +20,7 @@
                       tabs: {
                         requiring_review: {
                           label: 'Records Requiring Review',
+                          abbreviatedLabel: 'RRR',
                           variant: 'danger',
                           tooltip: 'isolation_records_requiring_review',
                           description: 'Cases who preliminarily meet the recovery definition and require review.'

--- a/test/system/roles/public_health/dashboard/dashboard_verifier.rb
+++ b/test/system/roles/public_health/dashboard/dashboard_verifier.rb
@@ -83,7 +83,7 @@ class PublicHealthDashboardVerifier < ApplicationSystemTestCase
   end
 
   def patient_count_under_tab(tab)
-    find("##{tab}_tab").first(:xpath, './/span').text.to_i
+    find("##{tab}_tab").first(:xpath, './/span//span').text.to_i
   end
 
   def verify_patient_info(patient, workflow, tab)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1543](https://tracker.codev.mitre.org/browse/SARAALERT-1543)

The "Records Requiring Review" line list tab label in the Isolation workflow is fairly large and makes the line list tabs larger in width than they need to be. The tab name for this line list should be shortened when the tabs get into their 'responsive' state.

## (Feature) Demo/Screenshots
Before:
<img width="851" alt="Screen Shot 2021-07-14 at 3 23 11 PM" src="https://user-images.githubusercontent.com/35042815/125680713-6d568895-4ba1-4141-aacd-08aaa201bf52.png">

After:
<img width="855" alt="Screen Shot 2021-07-14 at 3 22 41 PM" src="https://user-images.githubusercontent.com/35042815/125680741-8528d8d3-3057-4795-9005-6da643d2881d.png">

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`PatientsTable.js`
- Added support for an abbreviated tab name and the necessary classes to show/hide appropriately

`dashboard.scss`
- Added styling that dynamically hides/shows the normal label or the abbreviated label.  This is only added for the isolation dashboard right now.  If additional abbreviated labels are added in different workflows, this will need to be updated as well as the fixed tab width

`isolation.html.erb`
- Added an abbreviated label field to the tabs that get populated to the dashboard.  This should only be defined if you want something else to be read on the small screen version of the tabs, thus it is only defined for `Records Requiring Review`

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@timwongj :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@DPC15038 :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@annmarieb1 :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
