### PR TITLE
Hotfix/table-styling

### DIFF
--- a/app/javascript/packs/stylesheets/custom_table.scss
+++ b/app/javascript/packs/stylesheets/custom_table.scss
@@ -58,9 +58,9 @@
 .admin-table, .patients-table {
   tbody tr:hover {
     background-color: #ddd;
-  }
-  td {
-    border-color: white;
+    td {
+      border-color: white;
+    }
   }
 }
 


### PR DESCRIPTION
This PR fixes the styling for the hovered row in the admin and patient table.

The white-border was accidentally be applied everywhere, instead of the hovered row.

**OLD**
<img width="1617" alt="image" src="https://user-images.githubusercontent.com/17532163/125967860-ea295937-581e-49ee-adf6-338b3c9421d0.png">

**NEW**
<img width="1655" alt="image" src="https://user-images.githubusercontent.com/17532163/125967889-ca28260d-7d92-4cc3-915f-0a235c64b7cc.png">

