### PR TITLE
SARAALERT-1561 - Additional non-reporting auto closure case

### DIFF
--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -707,21 +707,18 @@ class Patient < ApplicationRecord
   }
 
   # Patients are eligible to be automatically closed by the system IF:
-  #  - patient is non-reporting (in exposure or isolation)
+  #  - patient is reporting (submitted today) and asymptomatic
+  #  - patient is in the exposure workflow
   #    AND
-  #  - patient has no recent activity
+  #  - patient is at the end of their monitoring period
   #
   #  OR
   #
-  #  - in exposure workflow
-  #     AND
-  #  - asymptomatic
-  #     AND
-  #  - submitted an assessment today already (based on their timezone)
-  #     AND
-  #  - not in continuous exposure
-  #     AND
-  #  - on the last day of or past their monitoring period
+  #  - non-reporting in exposure workflow (see below)
+  #
+  #  OR
+  #
+  #  - non-reporting in isolation workflow (see explanation below)
   scope :close_eligible, lambda { |reason = nil|
     base_scope = exposure_asymptomatic
                  .submitted_assessment_today
@@ -739,7 +736,23 @@ class Patient < ApplicationRecord
                                    .where('updated_at <= ?', 30.days.ago)
     # If a patient record has been inactive for 30 days or more
     # in the exposure workflow and is non-reporting
-    no_recent_activity_exposure = exposure_non_reporting.where('updated_at <= ?', 30.days.ago)
+    #
+    # For patient records in continuous exposure there needs to be an additional check that
+    # it has been at least one day past the LDoE because Sara Alert allows the LDoE to be set
+    # to a date in the future.
+    no_recent_activity_exposure = exposure_non_reporting
+                                  .where('updated_at <= ?', 30.days.ago)
+                                  .where(continuous_exposure: false)
+                                  .or(
+                                    exposure_non_reporting
+                                    .where('updated_at <= ?', 30.days.ago)
+                                    .where(continuous_exposure: true)
+                                    .where(
+                                      'patients.last_date_of_exposure IS NULL OR'\
+                                      ' patients.last_date_of_exposure <= DATE(CONVERT_TZ(?, "UTC", patients.time_zone))',
+                                      Time.now.utc - 1.days
+                                    )
+                                  )
     no_recent_activity = no_recent_activity_isolation.or(no_recent_activity_exposure)
 
     case reason

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -3340,18 +3340,19 @@ class PatientTest < ActiveSupport::TestCase
     patient.update(updated_at: 300.days.ago)
     assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
-    # ineligible because continuous exposure and LDoE is not at least 1 day ago
-    patient.update(monitoring: true, isolation: false, continuous_exposure: true, last_date_of_exposure: Date.today + 3.days)
+    # ineligible because continuous exposure
+    patient.update(monitoring: true, isolation: false, continuous_exposure: true, last_date_of_exposure: nil)
     patient.update(updated_at: 300.days.ago)
     assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
-    # eligible because continuous exposure and LDoE is yesterday
-    patient.update(last_date_of_exposure: Time.now.getlocal(patient.address_timezone_offset).to_date - 1.day)
+    # ineligible because end of monitoring has not elapsed
+    patient.update(continuous_exposure: false)
+    patient.update(last_date_of_exposure: Time.now.getlocal(patient.address_timezone_offset).to_date - ADMIN_OPTIONS['monitoring_period_days'] + 1)
     patient.update(updated_at: 300.days.ago)
-    assert_not_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
+    assert_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
 
-    # eligible because continuous exposure and LDoE is more than 1 day ago
-    patient.update(last_date_of_exposure: Date.today - 10.days)
+    # eligible because continuous exposure is false and end of monitoring has elapsed
+    patient.update(last_date_of_exposure: Time.now.getlocal(patient.address_timezone_offset).to_date - ADMIN_OPTIONS['monitoring_period_days'])
     patient.update(updated_at: 300.days.ago)
     assert_not_nil Patient.close_eligible(:no_recent_activity).find_by(id: patient.id)
   end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1561](https://tracker.codev.mitre.org/browse/SARAALERT-1561)

An edge case for the Exposure Non-Reporting line list auto-closure logic was identified now that auto-symptom assessment notifications will no longer count as a 'touch' on a monitoree. Monitorees who meet at least one of the following 2 conditions should not be eligible for auto-closure in the Non-Reporting Exposure line list:
 -   CE is true
 -   End of Monitoring date has not elapsed yet


## (Bugfix) How to Replicate
Before this change the previously mentioned edge case would allow continuous exposure patients to be closed earlier than they should. This can be replicated by creating a patient similar to this (in tests) and seeing that they are eligible for closure
```ruby
patient.update(monitoring: true, isolation: false, continuous_exposure: true, last_date_of_exposure: Date.today + 3.days)
patient.update(updated_at: 300.days.ago)
```
A quick way is just to copy-paste the added `patient_test.rb` test cases into master and run that test with `bundle exec rails test test/models/patient_test.rb -n test_no_recent_activity_reason_in_close_eligible_scope`

## (Bugfix) Solution
The `.end_of_monitoring_period` was was added to the `no_recent_activity_exposure` helper scope within `Patient.close_eligible`

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`patient.rb`
- Added additional case to close_eligible for non-reporting exposure patients in continuous montioring

`patient_test.rb`
- Added tests for the new logic for auto closure

## Testing Recommendations
Test closing out monitorees to verify that the following types of monitorees on the Exposure Non-Reporting line list are NOT closed out:
- Monitoree hasn't been updated for 30 days, but they have `continous_exposure` enabled
- Monitoree hasn't been updated for 30 days, but their `end_of_monitoring` date has not elapsed yet. 

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass   :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@holmesie  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@mayerm94  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
