### PR TITLE
SARAALERT-1494 - Include reason for closure in the record_automatically_closed history item

### DIFF
--- a/app/jobs/close_patients_job.rb
+++ b/app/jobs/close_patients_job.rb
@@ -83,7 +83,7 @@ class ClosePatientsJob < ApplicationJob
         end
 
         # History item for automatically closing the record
-        histories << History.record_automatically_closed(patient: patient, create: false)
+        histories << History.record_automatically_closed(patient: patient, reason: monitoring_reason, create: false)
 
         closed << { id: patient.id }
       rescue StandardError => e

--- a/app/jobs/close_patients_job.rb
+++ b/app/jobs/close_patients_job.rb
@@ -15,9 +15,10 @@ class ClosePatientsJob < ApplicationJob
     no_recent_activity = Patient.close_eligible(:no_recent_activity)
     completed_monitoring = Patient.close_eligible(:completed_monitoring)
     # Close patients using the scopes that have not been executed yet.
+    monitoring_period = ADMIN_OPTIONS['monitoring_period_days']
     results = combine_batch_results(
       [
-        perform_batch(enrolled_past_monitioring_period, 'Enrolled more than 14 days after last date of exposure (system)', juris_send_close),
+        perform_batch(enrolled_past_monitioring_period, "Enrolled more than #{monitoring_period} days after last date of exposure (system)", juris_send_close),
         perform_batch(enrolled_last_day_monitoring_period, 'Enrolled on last day of monitoring period (system)', juris_send_close),
         perform_batch(no_recent_activity, 'No record activity for 30 days (system)', juris_send_close),
         perform_batch(completed_monitoring, 'Completed Monitoring (system)', juris_send_close, completed_message: true)

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -245,7 +245,8 @@ class History < ApplicationRecord
     create_history(patient, created_by, HISTORY_TYPES[:welcome_message_sent], comment, create: create)
   end
 
-  def self.record_automatically_closed(patient: nil, created_by: 'Sara Alert System', comment: 'Monitoree has completed monitoring.', create: true)
+  def self.record_automatically_closed(patient: nil, created_by: 'Sara Alert System', comment: 'Monitoree has completed monitoring.', reason: nil, create: true)
+    comment = "#{comment} Reason: #{reason}" unless reason.nil?
     create_history(patient, created_by, HISTORY_TYPES[:record_automatically_closed], comment, create: create)
   end
 


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1494](https://tracker.codev.mitre.org/browse/SARAALERT-1494)

History items for manual and automatic closures don't currently include the text of the reason for closure. This PR adds that to the `record_automatically_closed` history item as an optional parameter. The close patients job now passes the `montioring_reason` to this optional argument.

## (Feature) Demo/Screenshots
<img width="1666" alt="Screen Shot 2021-07-20 at 7 00 59 AM" src="https://user-images.githubusercontent.com/24628687/126328514-9a2ba3b1-6460-4d88-a102-f07e54edfeb4.png">

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`history.rb`
- add optional reason argument to the `record_automatically_closed` History helper method.

`close_patients_job.rb`
- pass `monitoring_reason` to the new optional argument
`close_patients_job_test.rb`
- add tests to verify that the history change has the expected effect

## Testing Recommendations
Please list any recommendations regarding what reviewers should test and if there is any specific guidance on how to test certain aspects of the PR. Be sure to mention edge cases that should be tried, particularly in the UI.

Run the close patients job locally and verify that the reason for closure is present in the created history item. 
```ruby
ADMIN_OPTIONS['job_run_email'] = 'test@test.com'
Patient.limit(10).update_all(
      isolation: false,
      continuous_exposure: false,
      latest_assessment_at: DateTime.now,
      symptom_onset: nil,
      public_health_action: 'None',
      purged: false,
      monitoring: true,
      created_at: 100.days.ago,
      last_date_of_exposure: 100.days.ago
)
ClosePatientsJob.perform_now
```

# Checklists

**Submitter:**
- [ ] This PR describes why these changes were made.
- [ ] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA ticket reference.
- [ ] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [ ] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@Bialogs  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@holmesie  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@DPC15038  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.

