### PR TITLE
SARAALERT-1548: Add read support for all exportable fields in API

### DIFF
--- a/app/controllers/fhir/r4/api_controller.rb
+++ b/app/controllers/fhir/r4/api_controller.rb
@@ -855,7 +855,7 @@ class Fhir::R4::ApiController < ApplicationApiController
 
   # Search for patients
   def search_patients(options)
-    query = accessible_patients
+    query = accessible_patients.includes(:jurisdiction, :creator, { transfers: %i[from_jurisdiction to_jurisdiction who] })
     options.each do |option, search|
       next unless search.present?
 
@@ -874,7 +874,7 @@ class Fhir::R4::ApiController < ApplicationApiController
         query = query.where(monitoring: search == 'true')
       end
     end
-    query.includes(:jurisdiction, :creator)
+    query
   end
 
   # Search for laboratories

--- a/app/helpers/fhir_helper.rb
+++ b/app/helpers/fhir_helper.rb
@@ -939,11 +939,9 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
                                   patient.healthcare_personnel_facility_name),
       to_risk_factor_subextension('member-of-a-common-exposure-cohort', 'member-of-a-common-exposure-cohort-type',
                                   patient.member_of_a_common_exposure_cohort, patient.member_of_a_common_exposure_cohort_type),
-      to_bool_extension(patient.travel_to_affected_country_or_area, 'travel-from-affected-country-or-area'),
-      to_bool_extension(patient.crew_on_passenger_or_cargo_flight, 'crew-on-passenger-or-cargo-flight')
+      to_bool_extension(patient.travel_to_affected_country_or_area || false, 'travel-from-affected-country-or-area'),
+      to_bool_extension(patient.crew_on_passenger_or_cargo_flight || false, 'crew-on-passenger-or-cargo-flight')
     ]
-
-    return nil if subextensions.all?(&:nil?)
 
     FHIR::Extension.new(
       url: "#{SA_EXT_BASE_URL}exposure-risk-factors",
@@ -953,14 +951,12 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
 
   # Return a sub-extension which represents a certain risk factor bool/string pair
   def to_risk_factor_subextension(risk_factor_id, string_id, bool_value, string_value)
-    return nil if bool_value.nil? && string_value.blank?
-
     FHIR::Extension.new(
       url: "#{SA_EXT_BASE_URL}#{risk_factor_id}",
       extension: [
-        bool_value.nil? ? nil : FHIR::Extension.new(
+        FHIR::Extension.new(
           url: risk_factor_id,
-          valueBoolean: bool_value
+          valueBoolean: bool_value || false
         ),
         string_value.blank? ? nil : FHIR::Extension.new(
           url: string_id,

--- a/app/helpers/fhir_helper.rb
+++ b/app/helpers/fhir_helper.rb
@@ -36,7 +36,6 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
     FHIR::Patient.new(
       meta: FHIR::Meta.new(lastUpdated: patient.updated_at.strftime('%FT%T%:z')),
       contained: [FHIR::Provenance.new(
-        id: SecureRandom.uuid,
         # Would like to use a Rails URL Helper here, but we don't get one for this endpoint
         target: [FHIR::Reference.new(reference: "/fhir/r4/Patient/#{patient.id}")],
         agent: [
@@ -290,7 +289,6 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
     FHIR::Provenance.new(
       contained: history.deleted_by.nil? ? nil : [
         FHIR::Provenance.new(
-          id: SecureRandom.uuid,
           target: [FHIR::Reference.new(reference: "Provenance/#{history.id}")],
           agent: [
             FHIR::Provenance::Agent.new(

--- a/app/helpers/patient_details_helper.rb
+++ b/app/helpers/patient_details_helper.rb
@@ -39,6 +39,10 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
     :isolation_non_reporting
   end
 
+  def status_as_string
+    status&.to_s&.humanize&.downcase&.sub('exposure ', '')&.sub('isolation ', '')
+  end
+
   # Information about this subject (that is useful in a linelist)
   def linelist
     {

--- a/app/helpers/patient_details_helper.rb
+++ b/app/helpers/patient_details_helper.rb
@@ -39,6 +39,7 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
     :isolation_non_reporting
   end
 
+  # Current patient status as a string
   def status_as_string
     status&.to_s&.humanize&.downcase&.sub('exposure ', '')&.sub('isolation ', '')
   end

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -269,7 +269,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
         patient_details[:end_of_monitoring] = patient.end_of_monitoring if fields.include?(:end_of_monitoring)
         patient_details[:expected_purge_ts] = patient.expected_purge_date_exp if fields.include?(:expected_purge_ts)
         patient_details[:full_status] = patient.status&.to_s&.humanize&.downcase if fields.include?(:full_status)
-        patient_details[:status] =  patient.status_as_string if fields.include?(:status)
+        patient_details[:status] = patient.status_as_string if fields.include?(:status)
 
         # populate creator if requested
         patient_details[:creator] = patients_creators[patient.creator_id] if fields.include?(:creator)

--- a/app/lib/import_export.rb
+++ b/app/lib/import_export.rb
@@ -269,7 +269,7 @@ module ImportExport # rubocop:todo Metrics/ModuleLength
         patient_details[:end_of_monitoring] = patient.end_of_monitoring if fields.include?(:end_of_monitoring)
         patient_details[:expected_purge_ts] = patient.expected_purge_date_exp if fields.include?(:expected_purge_ts)
         patient_details[:full_status] = patient.status&.to_s&.humanize&.downcase if fields.include?(:full_status)
-        patient_details[:status] = patient.status&.to_s&.humanize&.downcase&.sub('exposure ', '')&.sub('isolation ', '') if fields.include?(:status)
+        patient_details[:status] =  patient.status_as_string if fields.include?(:status)
 
         # populate creator if requested
         patient_details[:creator] = patients_creators[patient.creator_id] if fields.include?(:creator)

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -5,6 +5,7 @@ class Assessment < ApplicationRecord
   extend OrderAsSpecified
   include PatientHelper
   include ExcelSanitizer
+  include FhirHelper
 
   columns.each do |column|
     case column.type
@@ -131,28 +132,7 @@ class Assessment < ApplicationRecord
   # Returns a representative FHIR::QuestionnaireResponse for an instance of a Sara Alert Assessment.
   # https://www.hl7.org/fhir/observation.html
   def as_fhir
-    FHIR::QuestionnaireResponse.new(
-      meta: FHIR::Meta.new(lastUpdated: updated_at.strftime('%FT%T%:z')),
-      id: id,
-      subject: FHIR::Reference.new(reference: "Patient/#{patient_id}"),
-      status: 'completed',
-      item: reported_condition.symptoms.enum_for(:each_with_index).collect do |s, index|
-        case s.type
-        when 'IntegerSymptom'
-          FHIR::QuestionnaireResponse::Item.new(text: s.name,
-                                                answer: FHIR::QuestionnaireResponse::Item::Answer.new(valueInteger: s.int_value),
-                                                linkId: index.to_s)
-        when 'FloatSymptom'
-          FHIR::QuestionnaireResponse::Item.new(text: s.name,
-                                                answer: FHIR::QuestionnaireResponse::Item::Answer.new(valueDecimal: s.float_value),
-                                                linkId: index.to_s)
-        when 'BoolSymptom'
-          FHIR::QuestionnaireResponse::Item.new(text: s.name,
-                                                answer: FHIR::QuestionnaireResponse::Item::Answer.new(valueBoolean: s.bool_value),
-                                                linkId: index.to_s)
-        end
-      end
-    )
+    assessment_as_fhir(self)
   end
 
   private

--- a/docs/api/fhir-api-specification.md
+++ b/docs/api/fhir-api-specification.md
@@ -1668,18 +1668,17 @@ Get a monitoree history via an id, e.g.:
   "contained": [
     {
       "id": "c1f6be4f-32ff-4fb8-b803-7bb8be7cb77b",
-      "extension": [
-        {
-          "url": "http://saraalert.org/StructureDefinition/delete-reason",
-          "valueString": "Entered in error"
-        }
-      ],
       "target": [
         {
           "reference": "Provenance/12554"
         }
       ],
       "recorded": "2021-07-21T00:07:30+00:00",
+      "reason": [
+        {
+          "text": "Entered in error"
+        }
+      ],
       "activity": {
         "coding": [
           {
@@ -1754,14 +1753,6 @@ The `http://saraalert.org/StructureDefinition/history-type` extension indicates 
 {
   "url": "http://saraalert.org/StructureDefinition/history-type", 
   "valueString": "Monitoring Change"
-}
-```
-
-The `http://saraalert.org/StructureDefinition/delete-reason` extension indicates the reason for which a history was deleted. This extension is read-only. This extension will be present on a Provenance resource in the `Provenance.contained` array, which is used to describe why a certain history was deleted.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/delete-reason",
-  "valueString": "Entered in error"
 }
 ```
 

--- a/docs/api/fhir-api-specification.md
+++ b/docs/api/fhir-api-specification.md
@@ -1665,6 +1665,42 @@ Get a monitoree history via an id, e.g.:
   "meta": {
     "lastUpdated": "2021-07-21T00:07:30+00:00"
   },
+  "contained": [
+    {
+      "id": "c1f6be4f-32ff-4fb8-b803-7bb8be7cb77b",
+      "extension": [
+        {
+          "url": "http://saraalert.org/StructureDefinition/delete-reason",
+          "valueString": "Entered in error"
+        }
+      ],
+      "target": [
+        {
+          "reference": "Provenance/12554"
+        }
+      ],
+      "recorded": "2021-07-21T00:07:30+00:00",
+      "activity": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v3-DataOperation",
+            "code": "DELETE",
+            "display": "delete"
+          }
+        ]
+      },
+      "agent": [
+        {
+          "who": {
+            "identifier": {
+              "value": "state1_epi_enroller@example.com"
+            }
+          }
+        }
+      ],
+      "resourceType": "Provenance"
+    }
+  ],
   "extension": [
     {
       "url": "http://saraalert.org/StructureDefinition/comment",
@@ -1673,14 +1709,6 @@ Get a monitoree history via an id, e.g.:
     {
       "url": "http://saraalert.org/StructureDefinition/history-type",
       "valueString": "Comment"
-    },
-    {
-      "url": "http://saraalert.org/StructureDefinition/deleted-by",
-      "valueString": "state1_epi_enroller@example.com"
-    },
-    {
-      "url": "http://saraalert.org/StructureDefinition/delete-reason",
-      "valueString": "Entered in error"
     },
     {
       "url": "http://saraalert.org/StructureDefinition/original-id",
@@ -1707,7 +1735,6 @@ Get a monitoree history via an id, e.g.:
   ],
   "resourceType": "Provenance"
 }
-
 ```
   </div>
 </details>
@@ -1730,18 +1757,10 @@ The `http://saraalert.org/StructureDefinition/history-type` extension indicates 
 }
 ```
 
-The `http://saraalert.org/StructureDefinition/deleted-by` extension indicates who a history was deleted by. This extension is read-only.
+The `http://saraalert.org/StructureDefinition/delete-reason` extension indicates the reason for which a history was deleted. This extension is read-only. This extension will be present on a Provenance resource in the `Provenance.contained` array, which is used to describe why a certain history was deleted.
 ```json
 {
-  "url": "http://saraalert.org/StructureDefinition/deleted-by",
-  "valueString": "epi_enroller_all@example.com"
-}
-```
-
-The `http://saraalert.org/StructureDefinition/deleted-reason` extension indicates the reason for which a history was deleted. This extension is read-only.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/deleted-reason",
+  "url": "http://saraalert.org/StructureDefinition/delete-reason",
   "valueString": "Entered in error"
 }
 ```

--- a/docs/api/fhir-api-specification.md
+++ b/docs/api/fhir-api-specification.md
@@ -427,10 +427,40 @@ Get a monitoree via an id, e.g.:
 
 ```json
 {
-  "id": 5,
+  "id": 43,
   "meta": {
-    "lastUpdated": "2020-05-29T00:19:18+00:00"
+    "lastUpdated": "2021-07-22T18:18:28+00:00"
   },
+  "contained": [
+    {
+      "target": [
+        {
+          "reference": "/fhir/r4/Patient/43"
+        }
+      ],
+      "recorded": "2021-06-23T09:03:19+00:00",
+      "activity": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v3-DataOperation",
+            "code": "CREATE",
+            "display": "create"
+          }
+        ]
+      },
+      "agent": [
+        {
+          "who": {
+            "identifier": {
+              "value": 6
+            },
+            "display": "locals2c4_enroller@example.com"
+          }
+        }
+      ],
+      "resourceType": "Provenance"
+    }
+  ],
   "extension": [
     {
       "extension": [
@@ -438,13 +468,37 @@ Get a monitoree via an id, e.g.:
           "url": "ombCategory",
           "valueCoding": {
             "system": "urn:oid:2.16.840.1.113883.6.238",
-            "code": "2054-5",
-            "display": "Black or African American"
+            "code": "2106-3",
+            "display": "White"
+          }
+        },
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "1002-5",
+            "display": "American Indian or Alaska Native"
+          }
+        },
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2076-8",
+            "display": "Native Hawaiian or Other Pacific Islander"
+          }
+        },
+        {
+          "url": "detailed",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "2131-1",
+            "display": "Other Race"
           }
         },
         {
           "url": "text",
-          "valueString": "Black or African American"
+          "valueString": "White, American Indian or Alaska Native, Native Hawaiian or Other Pacific Islander, Other"
         }
       ],
       "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
@@ -471,16 +525,157 @@ Get a monitoree via an id, e.g.:
       "valueCode": "M"
     },
     {
+      "extension": [
+        {
+          "url": "id",
+          "valuePositiveInt": 18
+        },
+        {
+          "url": "updated-at",
+          "valueDateTime": "2021-06-26T11:12:46+00:00"
+        },
+        {
+          "url": "created-at",
+          "valueDateTime": "2021-06-26T11:12:46+00:00"
+        },
+        {
+          "url": "who-initiated-transfer",
+          "valueString": "state1_epi@example.com"
+        },
+        {
+          "url": "from-jurisdiction",
+          "valueString": "USA, State 1, County 1"
+        },
+        {
+          "url": "to-jurisdiction",
+          "valueString": "USA, State 2"
+        }
+      ],
+      "url": "http://saraalert.org/StructureDefinition/transfer"
+    },
+    {
+      "extension": [
+        {
+          "url": "id",
+          "valuePositiveInt": 211
+        },
+        {
+          "url": "updated-at",
+          "valueDateTime": "2021-07-04T19:11:57+00:00"
+        },
+        {
+          "url": "created-at",
+          "valueDateTime": "2021-07-04T19:11:57+00:00"
+        },
+        {
+          "url": "who-initiated-transfer",
+          "valueString": "state2_epi@example.com"
+        },
+        {
+          "url": "from-jurisdiction",
+          "valueString": "USA, State 2"
+        },
+        {
+          "url": "to-jurisdiction",
+          "valueString": "USA, State 1"
+        }
+      ],
+      "url": "http://saraalert.org/StructureDefinition/transfer"
+    },
+    {
+      "extension": [
+        {
+          "extension": [
+            {
+              "url": "contact-of-known-case",
+              "valueBoolean": true
+            },
+            {
+              "url": "contact-of-known-case-id",
+              "valueString": "00929074, 01304440, 00162388"
+            }
+          ],
+          "url": "http://saraalert.org/StructureDefinition/contact-of-known-case"
+        },
+        {
+          "extension": [
+            {
+              "url": "was-in-health-care-facility-with-known-cases",
+              "valueBoolean": true
+            },
+            {
+              "url": "was-in-health-care-facility-with-known-cases-facility-name",
+              "valueString": "Facility123"
+            }
+          ],
+          "url": "http://saraalert.org/StructureDefinition/was-in-health-care-facility-with-known-cases"
+        },
+        {
+          "extension": [
+            {
+              "url": "laboratory-personnel",
+              "valueBoolean": true
+            },
+            {
+              "url": "laboratory-personnel-facility-name",
+              "valueString": "Facility123"
+            }
+          ],
+          "url": "http://saraalert.org/StructureDefinition/laboratory-personnel"
+        },
+        {
+          "extension": [
+            {
+              "url": "healthcare-personnel",
+              "valueBoolean": true
+            },
+            {
+              "url": "healthcare-personnel-facility-name",
+              "valueString": "Facility123"
+            }
+          ],
+          "url": "http://saraalert.org/StructureDefinition/healthcare-personnel"
+        },
+        {
+          "extension": [
+            {
+              "url": "member-of-a-common-exposure-cohort",
+              "valueBoolean": true
+            },
+            {
+              "url": "member-of-a-common-exposure-cohort-type",
+              "valueString": "Cruiseline cohort"
+            }
+          ],
+          "url": "http://saraalert.org/StructureDefinition/member-of-a-common-exposure-cohort"
+        },
+        {
+          "url": "http://saraalert.org/StructureDefinition/travel-from-affected-country-or-area",
+          "valueBoolean": false
+        },
+        {
+          "url": "http://saraalert.org/StructureDefinition/crew-on-passenger-or-cargo-flight",
+          "valueBoolean": false
+        }
+      ],
+      "url": "http://saraalert.org/StructureDefinition/exposure-risk-factors"
+    },
+    {
+      "extension": [
+        {
+          "url": "source-of-report",
+          "valueString": "Surveillance Screening"
+        }
+      ],
+      "url": "http://saraalert.org/StructureDefinition/source-of-report"
+    },
+    {
       "url": "http://saraalert.org/StructureDefinition/preferred-contact-method",
       "valueString": "E-mailed Web Link"
     },
     {
       "url": "http://saraalert.org/StructureDefinition/symptom-onset-date",
-      "valueDate": "2020-05-23"
-    },
-    {
-      "url": "http://saraalert.org/StructureDefinition/last-exposure-date",
-      "valueDate": "2020-05-18"
+      "valueDate": "2021-06-24"
     },
     {
       "url": "http://saraalert.org/StructureDefinition/isolation",
@@ -491,82 +686,169 @@ Get a monitoree via an id, e.g.:
       "valueString": "USA, State 1"
     },
     {
+      "url": "http://saraalert.org/StructureDefinition/monitoring-plan",
+      "valueString": "Daily active monitoring"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/assigned-user",
+      "valuePositiveInt": 205610
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-start-date",
+      "valueDate": "2021-06-24"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-end-date",
+      "valueDate": "2021-06-25"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/port-of-origin",
+      "valueString": "New Charleyhaven"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/port-of-entry-into-usa",
+      "valueString": "South Anamaria"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/date-of-departure",
+      "valueDate": "2021-06-23"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/flight-or-vessel-number",
+      "valueString": "V595"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/flight-or-vessel-carrier",
+      "valueString": "Clora Airlines"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/date-of-arrival",
+      "valueDate": "2021-06-23"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/travel-related-notes",
+      "valueString": "Pleasure in the job puts perfection in the work."
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-notes",
+      "valueString": "Chuck Norris hosting is 101% uptime guaranteed."
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/continuous-exposure",
+      "valueBoolean": true
+    },
+    {
       "url": "http://saraalert.org/StructureDefinition/end-of-monitoring",
-      "valueString": "2020-05-29"
+      "valueString": "Continuous Exposure"
     },
     {
       "url": "http://saraalert.org/StructureDefinition/exposure-risk-assessment",
-      "valueString": "Low"
+      "valueString": "No Identified Risk"
     },
     {
       "url": "http://saraalert.org/StructureDefinition/public-health-action",
-      "valueString": "Document results of medical evaluation"
-    },
-    {
-      "url": "http://saraalert.org/StructureDefinition/contact-of-known-case",
-      "valueBoolean": true
-    },
-    {
-      "url": "http://saraalert.org/StructureDefinition/contact-of-known-case-id",
-      "valueString": "case1"
+      "valueString": "None"
     },
     {
       "url": "http://saraalert.org/StructureDefinition/potential-exposure-location",
-      "valueString": "Collierview"
+      "valueString": "Arronton"
     },
     {
       "url": "http://saraalert.org/StructureDefinition/potential-exposure-country",
-      "valueString": "Angola"
+      "valueString": "Brazil"
     },
     {
       "url": "http://hl7.org/fhir/StructureDefinition/patient-interpreterRequired",
+      "valueBoolean": false
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-destination",
+      "valueString": "Pourosside"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-destination-state",
+      "valueString": "District of Columbia"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-port-of-departure",
+      "valueString": "New Natalia"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-type",
+      "valueString": "Domestic"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/case-status",
+      "valueString": "Confirmed"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/gender-identity",
+      "valueString": "Another"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/head-of-household",
       "valueBoolean": true
     },
     {
-      "url": "http://hl7.org/fhir/StructureDefinition/follow-up-reason",
-      "valueString": "Duplicate"
+      "url": "http://saraalert.org/StructureDefinition/id-of-reporter",
+      "valuePositiveInt": 43
     },
     {
-      "url": "http://hl7.org/fhir/StructureDefinition/follow-up-note",
-      "valueString": "This is a duplicate."
+      "url": "http://saraalert.org/StructureDefinition/last-assessment-reminder-sent",
+      "valueDateTime": "2021-06-20T04:00:00+00:00"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/paused-notifications",
+      "valueBoolean": false
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/status",
+      "valueString": "symptomatic"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/user-defined-symptom-onset",
+      "valueBoolean": false
+    }
+  ],
+  "identifier": [
+    {
+      "system": "http://saraalert.org/SaraAlert/cdc-id",
+      "value": "0952379687"
     }
   ],
   "active": true,
   "name": [
     {
-      "family": "O'Kon89",
-      "given": [
-        "Malcolm94",
-        "Bogan39"
-      ]
+      "family": "Johns78",
+      "given": ["Gerardo58", "Reinger57"]
     }
   ],
   "telecom": [
     {
-      "system": "phone",
-      "value": "(333) 333-3333",
-      "rank": 1
-    },
-    {
-      "system": "phone",
-      "value": "(333) 333-3333",
-      "rank": 2
-    },
-    {
       "system": "email",
-      "value": "2966977816fake@example.com",
+      "value": "3822316898fake@example.com",
       "rank": 1
     }
   ],
-  "birthDate": "1981-03-30",
+  "birthDate": "1981-10-15",
   "address": [
     {
-      "line": [
-        "22424 Daphne Key"
+      "line": ["8181 Diana Lodge"],
+      "district": "Royal Creek",
+      "state": "New Jersey",
+      "postalCode": "94336"
+    },
+    {
+      "extension": [
+        {
+          "url": "http://saraalert.org/StructureDefinition/address-type",
+          "valueString": "Monitored"
+        }
       ],
-      "city": "West Gabrielmouth",
-      "state": "Maine",
-      "postalCode": "24683"
+      "line": ["8181 Diana Lodge"],
+      "district": "Royal Creek",
+      "state": "New Jersey",
+      "postalCode": "94336"
     }
   ],
   "communication": [
@@ -579,7 +861,20 @@ Get a monitoree via an id, e.g.:
             "display": "English"
           }
         ]
-      }
+      },
+      "preferred": true
+    },
+    {
+      "language": {
+        "coding": [
+          {
+            "system": "urn:ietf:bcp:47",
+            "code": "bho",
+            "display": "Bhojpuri"
+          }
+        ]
+      },
+      "preferred": false
     }
   ],
   "resourceType": "Patient"
@@ -587,6 +882,294 @@ Get a monitoree via an id, e.g.:
 ```
   </div>
 </details>
+
+#### Read-Only Patient Extensions
+
+The `http://saraalert.org/StructureDefinition/end-of-monitoring` extension represents the system calculated end of monitoring period. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/end-of-monitoring",
+  "valueDate": "2021-06-15"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/expected-purge-date` extension represents the date and time that the monitoree's identifiers will be eligible to be purged from the system. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/expected-purge-date",
+  "valueDateTime": "2021-06-29T21:04:08+00:00"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/reason-for-closure` extension represents the reason a monitoree was closed by the user or system. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/reason-for-closure",
+  "valueString": "Completed Monitoring"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/additional-planned-travel-end-date` extension represents the end date for a monitoree's additional planned travel. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-end-date",
+  "valueDate": "2021-06-25"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/additional-planned-travel-destination` extension represents the destination for a monitoree's additional planned travel. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-destination",
+  "valueString": "Pourosside"
+}
+```
+
+
+The `http://saraalert.org/StructureDefinition/additional-planned-travel-destination-state` extension represents the destination state for a monitoree's additional planned travel. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-destination-state",
+  "valueString": "District of Columbia"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/additional-planned-travel-destination-country` extension represents the destination country for a monitoree's additional planned travel. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-destination-country",
+  "valueString": "Albania"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/additional-planned-travel-port-of-departure` extension represents the port of departure for a monitoree's additional planned travel. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-port-of-departure",
+  "valueString": "New Natalia"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/additional-planned-travel-type` extension represents the type of a monitoree's additional planned travel. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-type",
+  "valueString": "International"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/case-status` extension represents the case status of a monitoree. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/case-status",
+  "valueString": "Confirmed"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/closed-at` extension represents the time at which a monitoree was closed. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/closed-at",
+  "valueDateTime": "2021-07-07T18:10:47+00:00"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/gender-identity` extension represents the gender identity of a monitoree. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/gender-identity",
+  "valueString": "Another"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/sexual-orientation` extension represents the sexual orientation of a monitoree. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/sexual-orientation",
+  "valueString": "Choose not to disclose"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/head-of-household` extension represents whether the monitoree is the head of a household. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/head-of-household",
+  "valueBoolean": true
+}
+```
+
+The `http://saraalert.org/StructureDefinition/id-of-reporter` extension represents the ID of the monitoree responsible for reporting for this monitoree. If the monitoree is responsible for their own reporting, this will just be the monitoree's ID. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/id-of-reporter",
+  "valuePositiveInt": 43
+}
+```
+
+The `http://saraalert.org/StructureDefinition/last-assessment-reminder-sent` extension indicates the time at which the monitoree was last sent an assessment reminder. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/last-assessment-reminder-sent",
+  "valueDateTime": "2021-06-20T04:00:00+00:00"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/paused-notifications` extension represents whether notifications to the monitoree are paused. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/paused-notifications",
+  "valueBoolean": false
+}
+```
+
+The `http://saraalert.org/StructureDefinition/status` extension represents the current status of the monitoree. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/status",
+  "valueString": "symptomatic"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/user-defined-symptom-onset` extension indicates whether the symptom onset for this monitoree is user defined. This field is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/user-defined-symptom-onset",
+  "valueBoolean": false
+}
+```
+
+The complex `http://saraalert.org/StructureDefinition/transfer` extension represents a transfer that occurred for the monitoree. This field is read-only.
+```json
+{
+  "extension": [
+    {
+      "url": "id",
+      "valuePositiveInt": 18
+    },
+    {
+      "url": "updated-at",
+      "valueDateTime": "2021-06-26T11:12:46+00:00"
+    },
+    {
+      "url": "created-at",
+      "valueDateTime": "2021-06-26T11:12:46+00:00"
+    },
+    {
+      "url": "who-initiated-transfer",
+      "valueString": "state1_epi@example.com"
+    },
+    {
+      "url": "from-jurisdiction",
+      "valueString": "USA, State 1, County 1"
+    },
+    {
+      "url": "to-jurisdiction",
+      "valueString": "USA, State 2"
+    }
+  ],
+  "url": "http://saraalert.org/StructureDefinition/transfer"
+}
+```
+
+The complex `http://saraalert.org/StructureDefinition/exposure-risk-factors` extension represents the exposure risk factors that apply for the monitoree. This field is read-only.
+```json
+{
+  "extension": [
+    {
+      "extension": [
+        {
+          "url": "contact-of-known-case",
+          "valueBoolean": true
+        },
+        {
+          "url": "contact-of-known-case-id",
+          "valueString": "00929074, 01304440, 00162388"
+        }
+      ],
+      "url": "http://saraalert.org/StructureDefinition/contact-of-known-case"
+    },
+    {
+      "extension": [
+        {
+          "url": "was-in-health-care-facility-with-known-cases",
+          "valueBoolean": true
+        },
+        {
+          "url": "was-in-health-care-facility-with-known-cases-facility-name",
+          "valueString": "Facility123"
+        }
+      ],
+      "url": "http://saraalert.org/StructureDefinition/was-in-health-care-facility-with-known-cases"
+    },
+    {
+      "extension": [
+        {
+          "url": "laboratory-personnel",
+          "valueBoolean": true
+        },
+        {
+          "url": "laboratory-personnel-facility-name",
+          "valueString": "Facility123"
+        }
+      ],
+      "url": "http://saraalert.org/StructureDefinition/laboratory-personnel"
+    },
+    {
+      "extension": [
+        {
+          "url": "healthcare-personnel",
+          "valueBoolean": true
+        },
+        {
+          "url": "healthcare-personnel-facility-name",
+          "valueString": "Facility123"
+        }
+      ],
+      "url": "http://saraalert.org/StructureDefinition/healthcare-personnel"
+    },
+    {
+      "extension": [
+        {
+          "url": "member-of-a-common-exposure-cohort",
+          "valueBoolean": true
+        },
+        {
+          "url": "member-of-a-common-exposure-cohort-type",
+          "valueString": "Cruiseline cohort"
+        }
+      ],
+      "url": "http://saraalert.org/StructureDefinition/member-of-a-common-exposure-cohort"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/travel-from-affected-country-or-area",
+      "valueBoolean": false
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/crew-on-passenger-or-cargo-flight",
+      "valueBoolean": false
+    }
+  ],
+  "url": "http://saraalert.org/StructureDefinition/exposure-risk-factors"
+}
+```
+
+The complex `http://saraalert.org/StructureDefinition/source-of-report` extension represents the source of the report for a monitoree's arrival information. This field is read-only.
+```json
+{
+  "extension": [
+    {
+      "url": "source-of-report",
+      "valueString": "Other"
+    },
+    {
+      "url": "specify",
+      "valueString": "Pipey"
+    }
+  ],
+  "url": "http://saraalert.org/StructureDefinition/source-of-report"
+}
+```
+
 
 
 <a name="read-get-obs"/>
@@ -601,10 +1184,16 @@ Get a monitoree lab result via an id, e.g.:
 
 ```json
 {
-  "id": 11,
+  "id": 34,
   "meta": {
-    "lastUpdated": "2021-05-06T12:44:19+00:00"
+    "lastUpdated": "2021-06-23T13:25:48+00:00"
   },
+  "extension": [
+    {
+      "url": "http://saraalert.org/StructureDefinition/created-at",
+      "valueDateTime": "2021-06-23T13:25:48+00:00"
+    }
+  ],
   "status": "final",
   "category": [
     {
@@ -619,17 +1208,17 @@ Get a monitoree lab result via an id, e.g.:
   "code": {
     "coding": [
       {
-        "system": "http://loinc.org",
-        "code": "94564-2"
+        "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+        "code": "OTH"
       }
     ],
-    "text": "IgM Antibody"
+    "text": "Other"
   },
   "subject": {
-    "reference": "Patient/1"
+    "reference": "Patient/12"
   },
-  "effectiveDateTime": "2021-05-06",
-  "issued": "2021-05-07T00:00:00+00:00",
+  "effectiveDateTime": "2021-06-19",
+  "issued": "2021-06-23T00:00:00+00:00",
   "valueCodeableConcept": {
     "coding": [
       {
@@ -645,6 +1234,16 @@ Get a monitoree lab result via an id, e.g.:
   </div>
 </details>
 
+#### Read-Only Observation Extensions
+
+The `http://saraalert.org/StructureDefinition/created-at` extension indicates the time at which the laboratory was created. This extension is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/created-at",
+  "valueDateTime": "2021-06-23T23:34:35+00:00"
+}
+```
+
 
 <a name="read-get-que"/>
 
@@ -658,13 +1257,27 @@ Get a monitoree daily report via an id, e.g.:
 
 ```json
 {
-  "id": 3,
+  "id": 1,
   "meta": {
-    "lastUpdated": "2020-05-29T00:42:54+00:00"
+    "lastUpdated": "2021-06-27T20:51:51+00:00"
   },
+  "extension": [
+    {
+      "url": "http://saraalert.org/StructureDefinition/symptomatic",
+      "valueBoolean": false
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/created-at",
+      "valueDateTime": "2021-06-23T13:34:09+00:00"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/who-reported",
+      "valueString": "Monitoree"
+    }
+  ],
   "status": "completed",
   "subject": {
-    "reference": "Patient/3"
+    "reference": "Patient/20"
   },
   "item": [
     {
@@ -681,13 +1294,13 @@ Get a monitoree daily report via an id, e.g.:
       "text": "difficulty-breathing",
       "answer": [
         {
-          "valueBoolean": true
+          "valueBoolean": false
         }
       ]
     },
     {
       "linkId": "2",
-      "text": "fever",
+      "text": "new-loss-of-smell",
       "answer": [
         {
           "valueBoolean": false
@@ -696,16 +1309,16 @@ Get a monitoree daily report via an id, e.g.:
     },
     {
       "linkId": "3",
-      "text": "used-a-fever-reducer",
+      "text": "new-loss-of-taste",
       "answer": [
         {
-          "valueBoolean": true
+          "valueBoolean": false
         }
       ]
     },
     {
       "linkId": "4",
-      "text": "chills",
+      "text": "shortness-of-breath",
       "answer": [
         {
           "valueBoolean": false
@@ -714,16 +1327,16 @@ Get a monitoree daily report via an id, e.g.:
     },
     {
       "linkId": "5",
-      "text": "repeated-shaking-with-chills",
+      "text": "fever",
       "answer": [
         {
-          "valueBoolean": true
+          "valueBoolean": false
         }
       ]
     },
     {
       "linkId": "6",
-      "text": "muscle-pain",
+      "text": "used-a-fever-reducer",
       "answer": [
         {
           "valueBoolean": false
@@ -732,7 +1345,7 @@ Get a monitoree daily report via an id, e.g.:
     },
     {
       "linkId": "7",
-      "text": "headache",
+      "text": "chills",
       "answer": [
         {
           "valueBoolean": false
@@ -741,7 +1354,7 @@ Get a monitoree daily report via an id, e.g.:
     },
     {
       "linkId": "8",
-      "text": "sore-throat",
+      "text": "repeated-shaking-with-chills",
       "answer": [
         {
           "valueBoolean": false
@@ -750,19 +1363,100 @@ Get a monitoree daily report via an id, e.g.:
     },
     {
       "linkId": "9",
-      "text": "new-loss-of-taste-or-smell",
+      "text": "muscle-pain",
       "answer": [
         {
-          "valueBoolean": true
+          "valueBoolean": false
+        }
+      ]
+    },
+    {
+      "linkId": "10",
+      "text": "headache",
+      "answer": [
+        {
+          "valueBoolean": false
+        }
+      ]
+    },
+    {
+      "linkId": "11",
+      "text": "sore-throat",
+      "answer": [
+        {
+          "valueBoolean": false
+        }
+      ]
+    },
+    {
+      "linkId": "12",
+      "text": "nausea-or-vomiting",
+      "answer": [
+        {
+          "valueBoolean": false
+        }
+      ]
+    },
+    {
+      "linkId": "13",
+      "text": "diarrhea",
+      "answer": [
+        {
+          "valueBoolean": false
+        }
+      ]
+    },
+    {
+      "linkId": "14",
+      "text": "fatigue",
+      "answer": [
+        {
+          "valueBoolean": false
+        }
+      ]
+    },
+    {
+      "linkId": "15",
+      "text": "congestion-or-runny-nose",
+      "answer": [
+        {
+          "valueBoolean": false
         }
       ]
     }
   ],
   "resourceType": "QuestionnaireResponse"
 }
+
 ```
   </div>
 </details>
+
+#### Read-Only QuestionnaireResponse Extensions
+
+The `http://saraalert.org/StructureDefinition/created-at` extension indicates the time at which the assessment was created. This extension is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/created-at",
+  "valueDateTime": "2021-06-23T23:34:35+00:00"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/symptomatic` extension indicates whether an assessment indicates a symptomatic monitoree. This extension is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/symptomatic",
+  "valueBoolean": true
+}
+```
+
+The `http://saraalert.org/StructureDefinition/who-reported` extension indicates who reported the assessment. This extension is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/who-reported",
+  "valueString": "epi_enroller_all@example.com"
+}
+```
 
 <a name="read-get-related"/>
 
@@ -776,38 +1470,44 @@ Get a monitoree close contact via an id, e.g.:
 
 ```json
 {
-  "id": 950,
+  "id": 1,
   "meta": {
-    "lastUpdated": "2021-01-31T18:23:16+00:00"
+    "lastUpdated": "2021-06-23T23:34:35+00:00"
   },
   "extension": [
     {
-      "url": "http://saraalert.org/StructureDefinition/contact-attempts",
-      "valueUnsignedInt": 5
+      "url": "http://saraalert.org/StructureDefinition/notes",
+      "valueString": "Try to back up the EXE alarm, maybe it will override the virtual interface!"
     },
     {
-      "url": "http://saraalert.org/StructureDefinition/notes",
-      "valueString": "Parsing the panel won't do anything, we need to program the optical ib array!"
+      "url": "http://saraalert.org/StructureDefinition/enrolled-patient",
+      "valueReference": {
+        "reference": "Patient/9"
+      }
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/created-at",
+      "valueDateTime": "2021-06-23T23:34:35+00:00"
     }
   ],
   "patient": {
-    "reference": "Patient/222"
+    "reference": "Patient/23"
   },
   "name": [
     {
-      "family": "Pollich97",
-      "given": ["Nam32"]
+      "family": "Marvin72",
+      "given": ["Chris91"]
     }
   ],
   "telecom": [
     {
       "system": "phone",
-      "value": "+15555550104",
+      "value": "+15555550110",
       "rank": 1
     },
     {
       "system": "email",
-      "value": "1845823000fake@example.com",
+      "value": "3068326388fake@example.com",
       "rank": 1
     }
   ],
@@ -816,6 +1516,26 @@ Get a monitoree close contact via an id, e.g.:
 ```
   </div>
 </details>
+
+#### Read-Only RelatedPerson Extensions
+
+The `http://saraalert.org/StructureDefinition/created-at` extension indicates the time at which the close contact was created. This extension is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/created-at",
+  "valueDateTime": "2021-06-23T23:34:35+00:00"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/enrolled-patient` extension is used to reference the full Patient resource that corresponds to the close contact, if such a Patient exists. This extension is read-only. This field may only be updated by manually enrolling a new Patient for this close contact via the user interface.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/enrolled-patient",
+  "valueReference": {
+    "reference": "Patient/567"
+  }
+}
+```
 
 
 <a name="read-get-immunization"/>
@@ -830,29 +1550,35 @@ Get a monitoree vaccination via an id, e.g.:
 
 ```json
 {
-  "id": 32,
+  "id": 1,
   "meta": {
-    "lastUpdated": "2021-04-01T22:09:11+00:00"
+    "lastUpdated": "2021-06-23T10:40:04+00:00"
   },
+  "extension": [
+    {
+      "url": "http://saraalert.org/StructureDefinition/created-at",
+      "valueDateTime": "2021-06-23T10:40:04+00:00"
+    }
+  ],
   "status": "completed",
   "vaccineCode": [
     {
       "coding": [
         {
           "system": "http://hl7.org/fhir/sid/cvx",
-          "code": "207"
+          "code": "212"
         }
       ],
-      "text": "Moderna COVID-19 Vaccine"
+      "text": "Janssen (J&J) COVID-19 Vaccine"
     }
   ],
   "patient": {
-    "reference": "Patient/1"
+    "reference": "Patient/6"
   },
-  "occurrenceDateTime": "2021-03-30",
+  "occurrenceDateTime": "2021-06-19",
   "note": [
     {
-      "text": "Notes here"
+      "text": "Defy Noxus and taste your own blood."
     }
   ],
   "protocolApplied": [
@@ -867,15 +1593,25 @@ Get a monitoree vaccination via an id, e.g.:
           ],
           "text": "COVID-19"
         }
-      ],
-      "doseNumberString": "1"
+      ]
     }
   ],
   "resourceType": "Immunization"
 }
+
 ```
   </div>
 </details>
+
+#### Read-Only Immunization Extensions
+
+The `http://saraalert.org/StructureDefinition/created-at` extension indicates the time at which the vaccination was created. This extension is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/created-at",
+  "valueDateTime": "2021-06-23T23:34:35+00:00"
+}
+```
 
 <a name="read-get-provenance"/>
 
@@ -889,52 +1625,105 @@ Get a monitoree history via an id, e.g.:
 
 ```json
 {
-  "id": 2006, 
+  "id": 12554,
   "meta": {
-    "lastUpdated": "2021-05-20T02:09:38+00:00"
+    "lastUpdated": "2021-07-21T00:07:30+00:00"
   },
   "extension": [
     {
-      "url": "http://saraalert.org/StructureDefinition/comment", 
-      "valueString": "User changed latest public health action to \"Recommended medical evaluation of symptoms\". Reason: Lost to follow-up during monitoring period, details"
-    }, 
+      "url": "http://saraalert.org/StructureDefinition/comment",
+      "valueString": "test"
+    },
     {
-      "url": "http://saraalert.org/StructureDefinition/history_type", 
-      "valueString": "Monitoring Change"
+      "url": "http://saraalert.org/StructureDefinition/history-type",
+      "valueString": "Comment"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/deleted-by",
+      "valueString": "state1_epi_enroller@example.com"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/delete-reason",
+      "valueString": "Entered in error"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/original-id",
+      "valuePositiveInt": 12554
     }
-  ], 
+  ],
   "target": [
     {
-      "reference": "Patient/6"
+      "reference": "Patient/82"
     }
-  ], 
-  "recorded": "2021-05-20T02:09:38+00:00", 
+  ],
+  "recorded": "2021-07-21T00:07:18+00:00",
   "agent": [
     {
       "who": {
         "identifier": {
           "value": "state1_epi_enroller@example.com"
         }
-      }, 
+      },
       "onBehalfOf": {
-        "reference": "Patient/6"
+        "reference": "Patient/82"
       }
     }
-  ], 
+  ],
   "resourceType": "Provenance"
 }
+
 ```
   </div>
 </details>
 
+#### Read-Only Provenance Extensions
 
+The `http://saraalert.org/StructureDefinition/comment` extension represents the comment for a history. This extension is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/comment", 
+  "valueString": "User changed latest public health action to \"Recommended medical evaluation of symptoms\". Reason: Lost to follow-up during monitoring period, details"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/history-type` extension indicates the type of history that was created. This extension is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/history-type", 
+  "valueString": "Monitoring Change"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/deleted-by` extension indicates who a history was deleted by. This extension is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/deleted-by",
+  "valueString": "epi_enroller_all@example.com"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/deleted-reason` extension indicates the reason for which a history was deleted. This extension is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/deleted-reason",
+  "valueString": "Entered in error"
+}
+```
+
+The `http://saraalert.org/StructureDefinition/original-id` extension indicates the original ID of a history that has been edited. This extension is read-only.
+```json
+{
+  "url": "http://saraalert.org/StructureDefinition/original-id",
+  "valuePositiveInt": 12572
+}
+```
 
 
 <a name="read-get-all"/>
 
 ### GET `[base]/Patient/[:id]/$everything`
 
-Use this route to retrieve a FHIR Bundle containing the monitoree and all their lab results, daily reports, vaccinations, close contacts, and histories
+Use this route to retrieve a FHIR Bundle containing the monitoree and all their lab results, daily reports, vaccinations, close contacts, and histories. Note that the example below has had resources removed for brevity.
 
 <details>
   <summary>Click to expand JSON snippet</summary>
@@ -942,20 +1731,50 @@ Use this route to retrieve a FHIR Bundle containing the monitoree and all their 
 
 ```json
 {
-  "id": "96d2ff15-8c55-4d3e-bf04-d3f46064a7cd",
+  "id": "d8691bbb-e8b0-4ee9-8da1-b0a59f5e8030",
   "meta": {
-    "lastUpdated": "2020-05-28T20:52:15-04:00"
+    "lastUpdated": "2021-07-22T15:07:06-04:00"
   },
   "type": "searchset",
-  "total": 2,
+  "total": 67,
   "entry": [
     {
-      "fullUrl": "http://localhost:3000/fhir/r4/Patient/3",
+      "fullUrl": "http://localhost:3000/fhir/r4/Patient/43",
       "resource": {
-        "id": 3,
+        "id": 43,
         "meta": {
-          "lastUpdated": "2020-05-29T00:42:54+00:00"
+          "lastUpdated": "2021-07-22T18:18:28+00:00"
         },
+        "contained": [
+          {
+            "target": [
+              {
+                "reference": "/fhir/r4/Patient/43"
+              }
+            ],
+            "recorded": "2021-06-23T09:03:19+00:00",
+            "activity": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-DataOperation",
+                  "code": "CREATE",
+                  "display": "create"
+                }
+              ]
+            },
+            "agent": [
+              {
+                "who": {
+                  "identifier": {
+                    "value": 6
+                  },
+                  "display": "locals2c4_enroller@example.com"
+                }
+              }
+            ],
+            "resourceType": "Provenance"
+          }
+        ],
         "extension": [
           {
             "extension": [
@@ -963,13 +1782,37 @@ Use this route to retrieve a FHIR Bundle containing the monitoree and all their 
                 "url": "ombCategory",
                 "valueCoding": {
                   "system": "urn:oid:2.16.840.1.113883.6.238",
-                  "code": "2028-9",
-                  "display": "Asian"
+                  "code": "2106-3",
+                  "display": "White"
+                }
+              },
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "1002-5",
+                  "display": "American Indian or Alaska Native"
+                }
+              },
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "2076-8",
+                  "display": "Native Hawaiian or Other Pacific Islander"
+                }
+              },
+              {
+                "url": "detailed",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "2131-1",
+                  "display": "Other Race"
                 }
               },
               {
                 "url": "text",
-                "valueString": "Asian"
+                "valueString": "White, American Indian or Alaska Native, Native Hawaiian or Other Pacific Islander, Other"
               }
             ],
             "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
@@ -980,20 +1823,165 @@ Use this route to retrieve a FHIR Bundle containing the monitoree and all their 
                 "url": "ombCategory",
                 "valueCoding": {
                   "system": "urn:oid:2.16.840.1.113883.6.238",
-                  "code": "2135-2",
-                  "display": "Hispanic or Latino"
+                  "code": "2186-5",
+                  "display": "Not Hispanic or Latino"
                 }
               },
               {
                 "url": "text",
-                "valueString": "Hispanic or Latino"
+                "valueString": "Not Hispanic or Latino"
               }
             ],
             "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
           },
           {
             "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
-            "valueCode": "F"
+            "valueCode": "M"
+          },
+          {
+            "extension": [
+              {
+                "url": "id",
+                "valuePositiveInt": 18
+              },
+              {
+                "url": "updated-at",
+                "valueDateTime": "2021-06-26T11:12:46+00:00"
+              },
+              {
+                "url": "created-at",
+                "valueDateTime": "2021-06-26T11:12:46+00:00"
+              },
+              {
+                "url": "who-initiated-transfer",
+                "valueString": "state1_epi@example.com"
+              },
+              {
+                "url": "from-jurisdiction",
+                "valueString": "USA, State 1, County 1"
+              },
+              {
+                "url": "to-jurisdiction",
+                "valueString": "USA, State 2"
+              }
+            ],
+            "url": "http://saraalert.org/StructureDefinition/transfer"
+          },
+          {
+            "extension": [
+              {
+                "url": "id",
+                "valuePositiveInt": 211
+              },
+              {
+                "url": "updated-at",
+                "valueDateTime": "2021-07-04T19:11:57+00:00"
+              },
+              {
+                "url": "created-at",
+                "valueDateTime": "2021-07-04T19:11:57+00:00"
+              },
+              {
+                "url": "who-initiated-transfer",
+                "valueString": "state2_epi@example.com"
+              },
+              {
+                "url": "from-jurisdiction",
+                "valueString": "USA, State 2"
+              },
+              {
+                "url": "to-jurisdiction",
+                "valueString": "USA, State 1"
+              }
+            ],
+            "url": "http://saraalert.org/StructureDefinition/transfer"
+          },
+          {
+            "extension": [
+              {
+                "extension": [
+                  {
+                    "url": "contact-of-known-case",
+                    "valueBoolean": true
+                  },
+                  {
+                    "url": "contact-of-known-case-id",
+                    "valueString": "00929074, 01304440, 00162388"
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/contact-of-known-case"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "was-in-health-care-facility-with-known-cases",
+                    "valueBoolean": true
+                  },
+                  {
+                    "url": "was-in-health-care-facility-with-known-cases-facility-name",
+                    "valueString": "Facility123"
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/was-in-health-care-facility-with-known-cases"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "laboratory-personnel",
+                    "valueBoolean": true
+                  },
+                  {
+                    "url": "laboratory-personnel-facility-name",
+                    "valueString": "Facility123"
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/laboratory-personnel"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "healthcare-personnel",
+                    "valueBoolean": true
+                  },
+                  {
+                    "url": "healthcare-personnel-facility-name",
+                    "valueString": "Facility123"
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/healthcare-personnel"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "member-of-a-common-exposure-cohort",
+                    "valueBoolean": true
+                  },
+                  {
+                    "url": "member-of-a-common-exposure-cohort-type",
+                    "valueString": "Cruiseline cohort"
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/member-of-a-common-exposure-cohort"
+              },
+              {
+                "url": "http://saraalert.org/StructureDefinition/travel-from-affected-country-or-area",
+                "valueBoolean": false
+              },
+              {
+                "url": "http://saraalert.org/StructureDefinition/crew-on-passenger-or-cargo-flight",
+                "valueBoolean": false
+              }
+            ],
+            "url": "http://saraalert.org/StructureDefinition/exposure-risk-factors"
+          },
+          {
+            "extension": [
+              {
+                "url": "source-of-report",
+                "valueString": "Surveillance Screening"
+              }
+            ],
+            "url": "http://saraalert.org/StructureDefinition/source-of-report"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/preferred-contact-method",
@@ -1001,89 +1989,180 @@ Use this route to retrieve a FHIR Bundle containing the monitoree and all their 
           },
           {
             "url": "http://saraalert.org/StructureDefinition/symptom-onset-date",
-            "valueDate": "2020-05-16"
-          },
-          {
-            "url": "http://saraalert.org/StructureDefinition/last-exposure-date",
-            "valueDate": "2020-05-11"
+            "valueDate": "2021-06-24"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/isolation",
-            "valueBoolean": true
+            "valueBoolean": false
           },
           {
             "url": "http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path",
             "valueString": "USA, State 1"
           },
           {
+            "url": "http://saraalert.org/StructureDefinition/monitoring-plan",
+            "valueString": "Daily active monitoring"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/assigned-user",
+            "valuePositiveInt": 205610
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-start-date",
+            "valueDate": "2021-06-24"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-end-date",
+            "valueDate": "2021-06-25"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/port-of-origin",
+            "valueString": "New Charleyhaven"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/port-of-entry-into-usa",
+            "valueString": "South Anamaria"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/date-of-departure",
+            "valueDate": "2021-06-23"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/flight-or-vessel-number",
+            "valueString": "V595"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/flight-or-vessel-carrier",
+            "valueString": "Clora Airlines"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/date-of-arrival",
+            "valueDate": "2021-06-23"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/travel-related-notes",
+            "valueString": "Pleasure in the job puts perfection in the work."
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-notes",
+            "valueString": "Chuck Norris hosting is 101% uptime guaranteed."
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/continuous-exposure",
+            "valueBoolean": true
+          },
+          {
             "url": "http://saraalert.org/StructureDefinition/end-of-monitoring",
-            "valueString": "2020-05-29"
+            "valueString": "Continuous Exposure"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/exposure-risk-assessment",
-            "valueString": "Low"
+            "valueString": "No Identified Risk"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/public-health-action",
-            "valueString": "Document results of medical evaluation"
-          },
-          {
-            "url": "http://saraalert.org/StructureDefinition/contact-of-known-case",
-            "valueBoolean": true
-          },
-          {
-            "url": "http://saraalert.org/StructureDefinition/contact-of-known-case-id",
-            "valueString": "case1"
+            "valueString": "None"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/potential-exposure-location",
-            "valueString": "Collierview"
+            "valueString": "Arronton"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/potential-exposure-country",
-            "valueString": "Angola"
+            "valueString": "Brazil"
           },
           {
             "url": "http://hl7.org/fhir/StructureDefinition/patient-interpreterRequired",
+            "valueBoolean": false
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-destination",
+            "valueString": "Pourosside"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-destination-state",
+            "valueString": "District of Columbia"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-port-of-departure",
+            "valueString": "New Natalia"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-type",
+            "valueString": "Domestic"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/case-status",
+            "valueString": "Confirmed"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/gender-identity",
+            "valueString": "Another"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/head-of-household",
             "valueBoolean": true
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/id-of-reporter",
+            "valuePositiveInt": 43
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/last-assessment-reminder-sent",
+            "valueDateTime": "2021-06-20T04:00:00+00:00"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/paused-notifications",
+            "valueBoolean": false
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/status",
+            "valueString": "symptomatic"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/user-defined-symptom-onset",
+            "valueBoolean": false
+          }
+        ],
+        "identifier": [
+          {
+            "system": "http://saraalert.org/SaraAlert/cdc-id",
+            "value": "0952379687"
           }
         ],
         "active": true,
         "name": [
           {
-            "family": "Jakubowski48",
-            "given": [
-              "Lakeesha28",
-              "Bartell13"
-            ]
+            "family": "Johns78",
+            "given": ["Gerardo58", "Reinger57"]
           }
         ],
         "telecom": [
           {
-            "system": "phone",
-            "value": "(333) 333-3333",
-            "rank": 1
-          },
-          {
-            "system": "phone",
-            "value": "(333) 333-3333",
-            "rank": 2
-          },
-          {
             "system": "email",
-            "value": "7858879250fake@example.com",
+            "value": "3822316898fake@example.com",
             "rank": 1
           }
         ],
-        "birthDate": "1971-01-21",
+        "birthDate": "1981-10-15",
         "address": [
           {
-            "line": [
-              "3718 Nestor Unions"
+            "line": ["8181 Diana Lodge"],
+            "district": "Royal Creek",
+            "state": "New Jersey",
+            "postalCode": "94336"
+          },
+          {
+            "extension": [
+              {
+                "url": "http://saraalert.org/StructureDefinition/address-type",
+                "valueString": "Monitored"
+              }
             ],
-            "city": "Port Leigh",
-            "state": "Massachusetts",
-            "postalCode": "00423-5596"
+            "line": ["8181 Diana Lodge"],
+            "district": "Royal Creek",
+            "state": "New Jersey",
+            "postalCode": "94336"
           }
         ],
         "communication": [
@@ -1096,60 +2175,49 @@ Use this route to retrieve a FHIR Bundle containing the monitoree and all their 
                   "display": "English"
                 }
               ]
-            }
+            },
+            "preferred": true
+          },
+          {
+            "language": {
+              "coding": [
+                {
+                  "system": "urn:ietf:bcp:47",
+                  "code": "bho",
+                  "display": "Bhojpuri"
+                }
+              ]
+            },
+            "preferred": false
           }
         ],
         "resourceType": "Patient"
       }
     },
     {
-      "fullUrl": "http://localhost:3000/fhir/r4/Provenance/1262",
+      "fullUrl": "http://localhost:3000/fhir/r4/QuestionnaireResponse/21",
       "resource": {
-        "id": 1262,
+        "id": 21,
         "meta": {
-          "lastUpdated": "2021-05-19T02:13:54+00:00"
+          "lastUpdated": "2021-07-06T16:10:01+00:00"
         },
         "extension": [
           {
-            "url": "http://saraalert.org/StructureDefinition/comment",
-            "valueString": "User enrolled monitoree."
+            "url": "http://saraalert.org/StructureDefinition/symptomatic",
+            "valueBoolean": true
           },
           {
-            "url": "http://saraalert.org/StructureDefinition/history-type",
-            "valueString": "Enrollment"
+            "url": "http://saraalert.org/StructureDefinition/created-at",
+            "valueDateTime": "2021-06-24T11:51:44+00:00"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/who-reported",
+            "valueString": "Monitoree"
           }
         ],
-       "target": [
-         {
-            "reference": "Patient/3"
-          }
-        ],
-        "recorded": "2021-05-19T02:13:54+00:00",
-        "agent": [
-         {
-           "who": {
-             "identifier": {
-               "value": "state1_enroller@example.com"
-             }
-           },
-           "onBehalfOf": {
-              "reference": "Patient/3"
-           }
-          }
-        ],
-        "resourceType": "Provenance"
-      }
-    },
-    {
-      "fullUrl": "http://localhost:3000/fhir/r4/QuestionnaireResponse/3",
-      "resource": {
-        "id": 3,
-        "meta": {
-          "lastUpdated": "2020-05-29T00:42:54+00:00"
-        },
         "status": "completed",
         "subject": {
-          "reference": "Patient/3"
+          "reference": "Patient/43"
         },
         "item": [
           {
@@ -1172,16 +2240,16 @@ Use this route to retrieve a FHIR Bundle containing the monitoree and all their 
           },
           {
             "linkId": "2",
-            "text": "fever",
+            "text": "new-loss-of-smell",
             "answer": [
               {
-                "valueBoolean": false
+                "valueBoolean": true
               }
             ]
           },
           {
             "linkId": "3",
-            "text": "used-a-fever-reducer",
+            "text": "new-loss-of-taste",
             "answer": [
               {
                 "valueBoolean": true
@@ -1190,7 +2258,7 @@ Use this route to retrieve a FHIR Bundle containing the monitoree and all their 
           },
           {
             "linkId": "4",
-            "text": "chills",
+            "text": "shortness-of-breath",
             "answer": [
               {
                 "valueBoolean": false
@@ -1199,7 +2267,7 @@ Use this route to retrieve a FHIR Bundle containing the monitoree and all their 
           },
           {
             "linkId": "5",
-            "text": "repeated-shaking-with-chills",
+            "text": "fever",
             "answer": [
               {
                 "valueBoolean": true
@@ -1208,7 +2276,7 @@ Use this route to retrieve a FHIR Bundle containing the monitoree and all their 
           },
           {
             "linkId": "6",
-            "text": "muscle-pain",
+            "text": "used-a-fever-reducer",
             "answer": [
               {
                 "valueBoolean": false
@@ -1217,7 +2285,7 @@ Use this route to retrieve a FHIR Bundle containing the monitoree and all their 
           },
           {
             "linkId": "7",
-            "text": "headache",
+            "text": "chills",
             "answer": [
               {
                 "valueBoolean": false
@@ -1226,7 +2294,7 @@ Use this route to retrieve a FHIR Bundle containing the monitoree and all their 
           },
           {
             "linkId": "8",
-            "text": "sore-throat",
+            "text": "repeated-shaking-with-chills",
             "answer": [
               {
                 "valueBoolean": false
@@ -1235,15 +2303,255 @@ Use this route to retrieve a FHIR Bundle containing the monitoree and all their 
           },
           {
             "linkId": "9",
-            "text": "new-loss-of-taste-or-smell",
+            "text": "muscle-pain",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "10",
+            "text": "headache",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "11",
+            "text": "sore-throat",
             "answer": [
               {
                 "valueBoolean": true
               }
             ]
+          },
+          {
+            "linkId": "12",
+            "text": "nausea-or-vomiting",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "13",
+            "text": "diarrhea",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "14",
+            "text": "fatigue",
+            "answer": [
+              {
+                "valueBoolean": true
+              }
+            ]
+          },
+          {
+            "linkId": "15",
+            "text": "congestion-or-runny-nose",
+            "answer": [
+              {
+                "valueBoolean": true
+              }
+            ]
+          },
+          {
+            "linkId": "16",
+            "text": "pulse-ox",
+            "answer": [
+              {
+                "valueDecimal": 6.0
+              }
+            ]
           }
         ],
         "resourceType": "QuestionnaireResponse"
+      }
+    },
+    {
+      "fullUrl": "http://localhost:3000/fhir/r4/Observation/134",
+      "resource": {
+        "id": 134,
+        "meta": {
+          "lastUpdated": "2021-06-25T14:50:13+00:00"
+        },
+        "extension": [
+          {
+            "url": "http://saraalert.org/StructureDefinition/created-at",
+            "valueDateTime": "2021-06-25T14:50:13+00:00"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "94564-2"
+            }
+          ],
+          "text": "IgM Antibody"
+        },
+        "subject": {
+          "reference": "Patient/43"
+        },
+        "effectiveDateTime": "2021-06-24",
+        "issued": "2021-06-25T00:00:00+00:00",
+        "valueCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "10828004"
+            }
+          ],
+          "text": "positive"
+        },
+        "resourceType": "Observation"
+      }
+    },
+    {
+      "fullUrl": "http://localhost:3000/fhir/r4/RelatedPerson/13",
+      "resource": {
+        "id": 13,
+        "meta": {
+          "lastUpdated": "2021-06-24T14:28:06+00:00"
+        },
+        "extension": [
+          {
+            "url": "http://saraalert.org/StructureDefinition/created-at",
+            "valueDateTime": "2021-06-24T14:28:06+00:00"
+          }
+        ],
+        "patient": {
+          "reference": "Patient/43"
+        },
+        "name": [
+          {
+            "family": "Sipes28",
+            "given": ["Jeffrey23"]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+15555550150",
+            "rank": 1
+          },
+          {
+            "system": "email",
+            "value": "5842094680fake@example.com",
+            "rank": 1
+          }
+        ],
+        "resourceType": "RelatedPerson"
+      }
+    },
+    {
+      "fullUrl": "http://localhost:3000/fhir/r4/Immunization/57",
+      "resource": {
+        "id": 57,
+        "meta": {
+          "lastUpdated": "2021-06-27T19:54:16+00:00"
+        },
+        "extension": [
+          {
+            "url": "http://saraalert.org/StructureDefinition/created-at",
+            "valueDateTime": "2021-06-27T19:54:16+00:00"
+          }
+        ],
+        "status": "completed",
+        "vaccineCode": [
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/sid/cvx",
+                "code": "208"
+              }
+            ],
+            "text": "Pfizer-BioNTech COVID-19 Vaccine"
+          }
+        ],
+        "patient": {
+          "reference": "Patient/43"
+        },
+        "occurrenceDateTime": "2021-06-25",
+        "note": [
+          {
+            "text": "My profession?! You know, now that I think of it, I've always wanted to be a baker."
+          }
+        ],
+        "protocolApplied": [
+          {
+            "targetDisease": [
+              {
+                "coding": [
+                  {
+                    "system": "http://hl7.org/fhir/sid/cvx",
+                    "code": "213"
+                  }
+                ],
+                "text": "COVID-19"
+              }
+            ]
+          }
+        ],
+        "resourceType": "Immunization"
+      }
+    },
+    {
+      "fullUrl": "http://localhost:3000/fhir/r4/Provenance/141",
+      "resource": {
+        "id": 141,
+        "meta": {
+          "lastUpdated": "2021-06-23T09:03:19+00:00"
+        },
+        "extension": [
+          {
+            "url": "http://saraalert.org/StructureDefinition/comment",
+            "valueString": "User enrolled monitoree."
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/history-type",
+            "valueString": "Enrollment"
+          }
+        ],
+        "target": [
+          {
+            "reference": "Patient/43"
+          }
+        ],
+        "recorded": "2021-06-23T09:03:19+00:00",
+        "agent": [
+          {
+            "who": {
+              "identifier": {
+                "value": "locals2c3_enroller@example.com"
+              }
+            },
+            "onBehalfOf": {
+              "reference": "Patient/43"
+            }
+          }
+        ],
+        "resourceType": "Provenance"
       }
     }
   ],
@@ -1339,14 +2647,6 @@ To create a new monitoree, simply POST a FHIR Patient resource.
     {
       "url": "http://saraalert.org/StructureDefinition/public-health-action",
       "valueString": "Document results of medical evaluation"
-    },
-    {
-      "url": "http://saraalert.org/StructureDefinition/contact-of-known-case",
-      "valueBoolean": true
-    },
-    {
-      "url": "http://saraalert.org/StructureDefinition/contact-of-known-case-id",
-      "valueString": "case1"
     },
     {
       "url": "http://saraalert.org/StructureDefinition/potential-exposure-location",
@@ -1511,14 +2811,6 @@ On success, the server will return the newly created resource with an id. This i
     {
       "url": "http://saraalert.org/StructureDefinition/public-health-action",
       "valueString": "Document results of medical evaluation"
-    },
-    {
-      "url": "http://saraalert.org/StructureDefinition/contact-of-known-case",
-      "valueBoolean": true
-    },
-    {
-      "url": "http://saraalert.org/StructureDefinition/contact-of-known-case-id",
-      "valueString": "case1"
     },
     {
       "url": "http://saraalert.org/StructureDefinition/potential-exposure-location",
@@ -1756,30 +3048,6 @@ Use `http://saraalert.org/StructureDefinition/public-health-action` to specify t
 }
 ```
 
-Use `http://saraalert.org/StructureDefinition/contact-of-known-case` to specify if a monitoree has a known exposure to a confirmed or probable case.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/contact-of-known-case",
-  "valueBoolean": true
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/contact-of-known-case-id` to specify the case ID of the probable or confirmed case that a monitoree had exposure to. Any sort of identifier can be used here.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/contact-of-known-case-id",
-  "valueString": "1"
-}
-```
-
-Use `http://saraalert.org/StructureDefinition/common-exposure-cohort-name` to specify the name of a cohort that a monitoree shares common exposure with.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/common-exposure-cohort-name",
-  "valueString": "Example Cohort"
-}
-```
-
 Use `http://saraalert.org/StructureDefinition/potential-exposure-location` to specify a description of the location where the monitoree was potentially last exposed to a case.
 ```json
 {
@@ -1843,7 +3111,7 @@ Use `http://saraalert.org/StructureDefinition/phone-type` to specify the type of
 ]
 ```
 
-Use `http://saraalert.org/StructureDefinition/address-type` to specify the type of an address (options are: `USA` and `Foreign`). Note that this extension should be placed on an element in the `Patient.address` array. If this extension is not present on an address in the `Patient.address` array, the address is assumed to be a `USA` address.
+Use `http://saraalert.org/StructureDefinition/address-type` to specify the type of an address (options are: `USA`, `Foreign`, `Monitored`, and `ForeignMonitored`). Note that this extension should be placed on an element in the `Patient.address` array. If this extension is not present on an address in the `Patient.address` array, the address is assumed to be a `USA` address. Addresses of type `Monitored` or `ForeignMonitored` are read-only.
 ```json
 "address": [
   {
@@ -1867,48 +3135,6 @@ Use `http://saraalert.org/StructureDefinition/address-type` to specify the type 
     "postalCode": "05657",
   }
 ]
-```
-
-The `http://saraalert.org/StructureDefinition/end-of-monitoring` extension represents the system calculated end of monitoring period. This field is read-only.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/end-of-monitoring",
-  "valueDate": "2021-06-15"
-}
-```
-
-The `http://saraalert.org/StructureDefinition/expected-purge-date` extension represents the date and time that the monitoree's identifiers will be eligible to be purged from the system. This field is read-only.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/expected-purge-date",
-  "valueDateTime": "2021-06-29T21:04:08+00:00"
-}
-```
-
-The `http://saraalert.org/StructureDefinition/reason-for-closure` extension represents the reason a monitoree was closed by the user or system. This field is read-only.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/reason-for-closure",
-  "valueString": "Completed Monitoring"
-}
-```
-
-The complex `http://saraalert.org/StructureDefinition/latest-transfer` extension represents the latest transfer that occurred for the monitoree. This field is read-only.
-```json
-
-{
-  "extension": [
-    {
-      "url": "http://saraalert.org/StructureDefinition/transferred-at",
-      "valueDateTime": "2021-05-20T22:54:57+00:00"
-    },
-    {
-      "url": "http://saraalert.org/StructureDefinition/transferred-from",
-      "valueString": "USA, State 1, County 1"
-    }
-  ],
-  "url": "http://saraalert.org/StructureDefinition/latest-transfer"
-}
 ```
 
 ### POST `[base]/RelatedPerson`
@@ -2000,15 +3226,6 @@ Use `http://saraalert.org/StructureDefinition/contact-attempts` to specify the n
 }
 ```
 
-The `http://saraalert.org/StructureDefinition/enrolled-patient` extension is used to reference the full Patient resource that corresponds to the close contact, if such a Patient exists. Note that this extension is read-only. This field may only be updated by manually enrolling a new Patient for this close contact via the user interface.
-```json
-{
-  "url": "http://saraalert.org/StructureDefinition/enrolled-patient",
-  "valueReference": {
-    "reference": "Patient/567"
-  }
-}
-```
 
 ### POST `[base]/Immunization`
 
@@ -2196,14 +3413,6 @@ An update request creates a new current version for an existing resource.
       "valueString": "Document results of medical evaluation"
     },
     {
-      "url": "http://saraalert.org/StructureDefinition/contact-of-known-case",
-      "valueBoolean": true
-    },
-    {
-      "url": "http://saraalert.org/StructureDefinition/contact-of-known-case-id",
-      "valueString": "case1"
-    },
-    {
       "url": "http://saraalert.org/StructureDefinition/potential-exposure-location",
       "valueString": "Collierview"
     },
@@ -2366,14 +3575,6 @@ On success, the server will update the existing resource given the id.
     {
       "url": "http://saraalert.org/StructureDefinition/public-health-action",
       "valueString": "Document results of medical evaluation"
-    },
-    {
-      "url": "http://saraalert.org/StructureDefinition/contact-of-known-case",
-      "valueBoolean": true
-    },
-    {
-      "url": "http://saraalert.org/StructureDefinition/contact-of-known-case-id",
-      "valueString": "case1"
     },
     {
       "url": "http://saraalert.org/StructureDefinition/potential-exposure-location",
@@ -2700,14 +3901,6 @@ On success, the server will update the attributes indicated by the request.
       "valueString": "Document results of medical evaluation"
     },
     {
-      "url": "http://saraalert.org/StructureDefinition/contact-of-known-case",
-      "valueBoolean": true
-    },
-    {
-      "url": "http://saraalert.org/StructureDefinition/contact-of-known-case-id",
-      "valueString": "case1"
-    },
-    {
       "url": "http://saraalert.org/StructureDefinition/potential-exposure-location",
       "valueString": "Collierview"
     },
@@ -2862,20 +4055,50 @@ GET `[base]/Patient?given=john&family=doe`
 
 ```json
 {
-  "id": "8d4291fa-4d32-4136-be28-9cbdd2461378",
+  "id": "aa7c4d39-a256-4c77-b7f9-6b0931134449",
   "meta": {
-    "lastUpdated": "2020-05-28T21:07:11-04:00"
+    "lastUpdated": "2021-07-22T15:11:17-04:00"
   },
   "type": "searchset",
   "total": 1,
   "entry": [
     {
-      "fullUrl": "http://localhost:3000/fhir/r4/Patient/3",
+      "fullUrl": "http://localhost:3000/fhir/r4/Patient/43",
       "resource": {
-        "id": 3,
+        "id": 43,
         "meta": {
-          "lastUpdated": "2020-05-29T00:42:54+00:00"
+          "lastUpdated": "2021-07-22T18:18:28+00:00"
         },
+        "contained": [
+          {
+            "target": [
+              {
+                "reference": "/fhir/r4/Patient/43"
+              }
+            ],
+            "recorded": "2021-06-23T09:03:19+00:00",
+            "activity": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-DataOperation",
+                  "code": "CREATE",
+                  "display": "create"
+                }
+              ]
+            },
+            "agent": [
+              {
+                "who": {
+                  "identifier": {
+                    "value": 6
+                  },
+                  "display": "locals2c4_enroller@example.com"
+                }
+              }
+            ],
+            "resourceType": "Provenance"
+          }
+        ],
         "extension": [
           {
             "extension": [
@@ -2883,13 +4106,37 @@ GET `[base]/Patient?given=john&family=doe`
                 "url": "ombCategory",
                 "valueCoding": {
                   "system": "urn:oid:2.16.840.1.113883.6.238",
-                  "code": "2028-9",
-                  "display": "Asian"
+                  "code": "2106-3",
+                  "display": "White"
+                }
+              },
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "1002-5",
+                  "display": "American Indian or Alaska Native"
+                }
+              },
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "2076-8",
+                  "display": "Native Hawaiian or Other Pacific Islander"
+                }
+              },
+              {
+                "url": "detailed",
+                "valueCoding": {
+                  "system": "urn:oid:2.16.840.1.113883.6.238",
+                  "code": "2131-1",
+                  "display": "Other Race"
                 }
               },
               {
                 "url": "text",
-                "valueString": "Asian"
+                "valueString": "White, American Indian or Alaska Native, Native Hawaiian or Other Pacific Islander, Other"
               }
             ],
             "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
@@ -2900,20 +4147,165 @@ GET `[base]/Patient?given=john&family=doe`
                 "url": "ombCategory",
                 "valueCoding": {
                   "system": "urn:oid:2.16.840.1.113883.6.238",
-                  "code": "2135-2",
-                  "display": "Hispanic or Latino"
+                  "code": "2186-5",
+                  "display": "Not Hispanic or Latino"
                 }
               },
               {
                 "url": "text",
-                "valueString": "Hispanic or Latino"
+                "valueString": "Not Hispanic or Latino"
               }
             ],
             "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
           },
           {
             "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
-            "valueCode": "F"
+            "valueCode": "M"
+          },
+          {
+            "extension": [
+              {
+                "url": "id",
+                "valuePositiveInt": 18
+              },
+              {
+                "url": "updated-at",
+                "valueDateTime": "2021-06-26T11:12:46+00:00"
+              },
+              {
+                "url": "created-at",
+                "valueDateTime": "2021-06-26T11:12:46+00:00"
+              },
+              {
+                "url": "who-initiated-transfer",
+                "valueString": "state1_epi@example.com"
+              },
+              {
+                "url": "from-jurisdiction",
+                "valueString": "USA, State 1, County 1"
+              },
+              {
+                "url": "to-jurisdiction",
+                "valueString": "USA, State 2"
+              }
+            ],
+            "url": "http://saraalert.org/StructureDefinition/transfer"
+          },
+          {
+            "extension": [
+              {
+                "url": "id",
+                "valuePositiveInt": 211
+              },
+              {
+                "url": "updated-at",
+                "valueDateTime": "2021-07-04T19:11:57+00:00"
+              },
+              {
+                "url": "created-at",
+                "valueDateTime": "2021-07-04T19:11:57+00:00"
+              },
+              {
+                "url": "who-initiated-transfer",
+                "valueString": "state2_epi@example.com"
+              },
+              {
+                "url": "from-jurisdiction",
+                "valueString": "USA, State 2"
+              },
+              {
+                "url": "to-jurisdiction",
+                "valueString": "USA, State 1"
+              }
+            ],
+            "url": "http://saraalert.org/StructureDefinition/transfer"
+          },
+          {
+            "extension": [
+              {
+                "extension": [
+                  {
+                    "url": "contact-of-known-case",
+                    "valueBoolean": true
+                  },
+                  {
+                    "url": "contact-of-known-case-id",
+                    "valueString": "00929074, 01304440, 00162388"
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/contact-of-known-case"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "was-in-health-care-facility-with-known-cases",
+                    "valueBoolean": true
+                  },
+                  {
+                    "url": "was-in-health-care-facility-with-known-cases-facility-name",
+                    "valueString": "Facility123"
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/was-in-health-care-facility-with-known-cases"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "laboratory-personnel",
+                    "valueBoolean": true
+                  },
+                  {
+                    "url": "laboratory-personnel-facility-name",
+                    "valueString": "Facility123"
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/laboratory-personnel"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "healthcare-personnel",
+                    "valueBoolean": true
+                  },
+                  {
+                    "url": "healthcare-personnel-facility-name",
+                    "valueString": "Facility123"
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/healthcare-personnel"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "member-of-a-common-exposure-cohort",
+                    "valueBoolean": true
+                  },
+                  {
+                    "url": "member-of-a-common-exposure-cohort-type",
+                    "valueString": "Cruiseline cohort"
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/member-of-a-common-exposure-cohort"
+              },
+              {
+                "url": "http://saraalert.org/StructureDefinition/travel-from-affected-country-or-area",
+                "valueBoolean": false
+              },
+              {
+                "url": "http://saraalert.org/StructureDefinition/crew-on-passenger-or-cargo-flight",
+                "valueBoolean": false
+              }
+            ],
+            "url": "http://saraalert.org/StructureDefinition/exposure-risk-factors"
+          },
+          {
+            "extension": [
+              {
+                "url": "source-of-report",
+                "valueString": "Surveillance Screening"
+              }
+            ],
+            "url": "http://saraalert.org/StructureDefinition/source-of-report"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/preferred-contact-method",
@@ -2921,89 +4313,180 @@ GET `[base]/Patient?given=john&family=doe`
           },
           {
             "url": "http://saraalert.org/StructureDefinition/symptom-onset-date",
-            "valueDate": "2020-05-16"
-          },
-          {
-            "url": "http://saraalert.org/StructureDefinition/last-exposure-date",
-            "valueDate": "2020-05-11"
+            "valueDate": "2021-06-24"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/isolation",
-            "valueBoolean": true
+            "valueBoolean": false
           },
           {
             "url": "http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path",
             "valueString": "USA, State 1"
           },
           {
+            "url": "http://saraalert.org/StructureDefinition/monitoring-plan",
+            "valueString": "Daily active monitoring"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/assigned-user",
+            "valuePositiveInt": 205610
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-start-date",
+            "valueDate": "2021-06-24"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-end-date",
+            "valueDate": "2021-06-25"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/port-of-origin",
+            "valueString": "New Charleyhaven"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/port-of-entry-into-usa",
+            "valueString": "South Anamaria"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/date-of-departure",
+            "valueDate": "2021-06-23"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/flight-or-vessel-number",
+            "valueString": "V595"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/flight-or-vessel-carrier",
+            "valueString": "Clora Airlines"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/date-of-arrival",
+            "valueDate": "2021-06-23"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/travel-related-notes",
+            "valueString": "Pleasure in the job puts perfection in the work."
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-notes",
+            "valueString": "Chuck Norris hosting is 101% uptime guaranteed."
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/continuous-exposure",
+            "valueBoolean": true
+          },
+          {
             "url": "http://saraalert.org/StructureDefinition/end-of-monitoring",
-            "valueString": "2020-05-29"
+            "valueString": "Continuous Exposure"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/exposure-risk-assessment",
-            "valueString": "Low"
+            "valueString": "No Identified Risk"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/public-health-action",
-            "valueString": "Document results of medical evaluation"
-          },
-          {
-            "url": "http://saraalert.org/StructureDefinition/contact-of-known-case",
-            "valueBoolean": true
-          },
-          {
-            "url": "http://saraalert.org/StructureDefinition/contact-of-known-case-id",
-            "valueString": "case1"
+            "valueString": "None"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/potential-exposure-location",
-            "valueString": "Collierview"
+            "valueString": "Arronton"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/potential-exposure-country",
-            "valueString": "Angola"
+            "valueString": "Brazil"
           },
           {
             "url": "http://hl7.org/fhir/StructureDefinition/patient-interpreterRequired",
+            "valueBoolean": false
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-destination",
+            "valueString": "Pourosside"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-destination-state",
+            "valueString": "District of Columbia"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-port-of-departure",
+            "valueString": "New Natalia"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-type",
+            "valueString": "Domestic"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/case-status",
+            "valueString": "Confirmed"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/gender-identity",
+            "valueString": "Another"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/head-of-household",
             "valueBoolean": true
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/id-of-reporter",
+            "valuePositiveInt": 43
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/last-assessment-reminder-sent",
+            "valueDateTime": "2021-06-20T04:00:00+00:00"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/paused-notifications",
+            "valueBoolean": false
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/status",
+            "valueString": "symptomatic"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/user-defined-symptom-onset",
+            "valueBoolean": false
+          }
+        ],
+        "identifier": [
+          {
+            "system": "http://saraalert.org/SaraAlert/cdc-id",
+            "value": "0952379687"
           }
         ],
         "active": true,
         "name": [
           {
-            "family": "mctest",
-            "given": [
-              "Lakeesha28",
-              "testy"
-            ]
+            "family": "Johns78",
+            "given": ["Gerardo58", "Reinger57"]
           }
         ],
         "telecom": [
           {
-            "system": "phone",
-            "value": "(333) 333-3333",
-            "rank": 1
-          },
-          {
-            "system": "phone",
-            "value": "(333) 333-3333",
-            "rank": 2
-          },
-          {
             "system": "email",
-            "value": "7858879250fake@example.com",
+            "value": "3822316898fake@example.com",
             "rank": 1
           }
         ],
-        "birthDate": "1971-01-21",
+        "birthDate": "1981-10-15",
         "address": [
           {
-            "line": [
-              "3718 Nestor Unions"
+            "line": ["8181 Diana Lodge"],
+            "district": "Royal Creek",
+            "state": "New Jersey",
+            "postalCode": "94336"
+          },
+          {
+            "extension": [
+              {
+                "url": "http://saraalert.org/StructureDefinition/address-type",
+                "valueString": "Monitored"
+              }
             ],
-            "city": "Port Leigh",
-            "state": "Massachusetts",
-            "postalCode": "00423-5596"
+            "line": ["8181 Diana Lodge"],
+            "district": "Royal Creek",
+            "state": "New Jersey",
+            "postalCode": "94336"
           }
         ],
         "communication": [
@@ -3016,7 +4499,20 @@ GET `[base]/Patient?given=john&family=doe`
                   "display": "English"
                 }
               ]
-            }
+            },
+            "preferred": true
+          },
+          {
+            "language": {
+              "coding": [
+                {
+                  "system": "urn:ietf:bcp:47",
+                  "code": "bho",
+                  "display": "Bhojpuri"
+                }
+              ]
+            },
+            "preferred": false
           }
         ],
         "resourceType": "Patient"
@@ -3042,170 +4538,189 @@ GET `[base]/QuestionnaireResponse?subject=Patient/[:id]`
 
 ```json
 {
-  "id": 1,
+  "id": "1b4158ff-d68c-4bbc-b808-3a395cbaef3a",
   "meta": {
-      "lastUpdated": "2020-10-05T21:48:43+00:00"
+    "lastUpdated": "2021-07-22T15:22:46-04:00"
   },
-  "status": "completed",
-  "subject": {
-      "reference": "Patient/231"
-  },
-  "item": [
+  "type": "searchset",
+  "total": 1,
+  "entry": [
     {
-      "linkId": "0",
-      "text": "cough",
-      "answer": [
-        {
-          "valueBoolean": false
-        }
-      ]
-    },
-    {
-      "linkId": "1",
-      "text": "difficulty-breathing",
-      "answer": [
-        {
-          "valueBoolean": true
-        }
-      ]
-    },
-    {
-      "linkId": "2",
-      "text": "new-loss-of-smell",
-      "answer": [
-        {
-          "valueBoolean": false
-        }
-      ]
-    },
-    {
-      "linkId": "3",
-      "text": "new-loss-of-taste",
-      "answer": [
-        {
-          "valueBoolean": false
-        }
-      ]
-    },
-    {
-      "linkId": "4",
-      "text": "shortness-of-breath",
-      "answer": [
-        {
-          "valueBoolean": true
-        }
-      ]
-    },
-    {
-      "linkId": "5",
-      "text": "fever",
-      "answer": [
-        {
-          "valueBoolean": false
-        }
-      ]
-    },
-    {
-      "linkId": "6",
-      "text": "used-a-fever-reducer",
-      "answer": [
-        {
-          "valueBoolean": false
-        }
-      ]
-    },
-    {
-      "linkId": "7",
-      "text": "chills",
-      "answer": [
-        {
-          "valueBoolean": true
-        }
-      ]
-    },
-    {
-      "linkId": "8",
-      "text": "repeated-shaking-with-chills",
-      "answer": [
-        {
-          "valueBoolean": false
-        }
-      ]
-    },
-    {
-      "linkId": "9",
-      "text": "muscle-pain",
-      "answer": [
-        {
-          "valueBoolean": true
-        }
-      ]
-    },
-    {
-      "linkId": "10",
-      "text": "headache",
-      "answer": [
-        {
-          "valueBoolean": true
-        }
-      ]
-    },
-    {
-      "linkId": "11",
-      "text": "sore-throat",
-      "answer": [
-        {
-          "valueBoolean": true
-        }
-      ]
-    },
-    {
-      "linkId": "12",
-      "text": "nausea-or-vomiting",
-      "answer": [
-        {
-          "valueBoolean": true
-        }
-      ]
-    },
-    {
-      "linkId": "13",
-      "text": "diarrhea",
-      "answer": [
-        {
-          "valueBoolean": true
-        }
-      ]
-    },
-    {
-      "linkId": "14",
-      "text": "fatigue",
-      "answer": [
-        {
-          "valueBoolean": true
-        }
-      ]
-    },
-    {
-      "linkId": "15",
-      "text": "congestion-or-runny-nose",
-      "answer": [
-        {
-          "valueBoolean": true
-        }
-      ]
-    },
-    {
-      "linkId": "16",
-      "text": "pulse-ox",
-      "answer": [
-        {
-          "valueDecimal": -4.0
-        }
-      ]
+      "fullUrl": "http://localhost:3000/fhir/r4/QuestionnaireResponse/1",
+      "resource": {
+        "id": 1,
+        "meta": {
+          "lastUpdated": "2021-06-27T20:51:51+00:00"
+        },
+        "extension": [
+          {
+            "url": "http://saraalert.org/StructureDefinition/symptomatic",
+            "valueBoolean": false
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/created-at",
+            "valueDateTime": "2021-06-23T13:34:09+00:00"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/who-reported",
+            "valueString": "Monitoree"
+          }
+        ],
+        "status": "completed",
+        "subject": {
+          "reference": "Patient/20"
+        },
+        "item": [
+          {
+            "linkId": "0",
+            "text": "cough",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "1",
+            "text": "difficulty-breathing",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "2",
+            "text": "new-loss-of-smell",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "3",
+            "text": "new-loss-of-taste",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "4",
+            "text": "shortness-of-breath",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "5",
+            "text": "fever",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "6",
+            "text": "used-a-fever-reducer",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "7",
+            "text": "chills",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "8",
+            "text": "repeated-shaking-with-chills",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "9",
+            "text": "muscle-pain",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "10",
+            "text": "headache",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "11",
+            "text": "sore-throat",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "12",
+            "text": "nausea-or-vomiting",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "13",
+            "text": "diarrhea",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "14",
+            "text": "fatigue",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          },
+          {
+            "linkId": "15",
+            "text": "congestion-or-runny-nose",
+            "answer": [
+              {
+                "valueBoolean": false
+              }
+            ]
+          }
+        ],
+        "resourceType": "QuestionnaireResponse"
+      }
     }
   ],
-  "resourceType": "QuestionnaireResponse"
+  "resourceType": "Bundle"
 }
 ```
   </div>
@@ -3225,20 +4740,26 @@ GET `[base]/Observation?subject=Patient/[:id]`
 
 ```json
 {
-  "id": "6b62097c-eb38-4098-ae2b-6f56a20ec658",
+  "id": "eb4abf5e-7c66-40be-875a-e42359202dc2",
   "meta": {
-    "lastUpdated": "2020-05-28T21:09:07-04:00"
+    "lastUpdated": "2021-07-22T15:19:00-04:00"
   },
   "type": "searchset",
   "total": 1,
   "entry": [
     {
-      "fullUrl": "http://localhost:3000/fhir/r4/Observation/11",
+      "fullUrl": "http://localhost:3000/fhir/r4/Observation/34",
       "resource": {
-        "id": 11,
+        "id": 34,
         "meta": {
-          "lastUpdated": "2021-05-06T12:44:19+00:00"
+          "lastUpdated": "2021-06-23T13:25:48+00:00"
         },
+        "extension": [
+          {
+            "url": "http://saraalert.org/StructureDefinition/created-at",
+            "valueDateTime": "2021-06-23T13:25:48+00:00"
+          }
+        ],
         "status": "final",
         "category": [
           {
@@ -3253,17 +4774,17 @@ GET `[base]/Observation?subject=Patient/[:id]`
         "code": {
           "coding": [
             {
-              "system": "http://loinc.org",
-              "code": "94564-2"
+              "system": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+              "code": "OTH"
             }
           ],
-          "text": "IgM Antibody"
+          "text": "Other"
         },
         "subject": {
-          "reference": "Patient/1"
+          "reference": "Patient/12"
         },
-        "effectiveDateTime": "2021-05-06",
-        "issued": "2021-05-07T00:00:00+00:00",
+        "effectiveDateTime": "2021-06-19",
+        "issued": "2021-06-23T00:00:00+00:00",
         "valueCodeableConcept": {
           "coding": [
             {
@@ -3297,48 +4818,47 @@ GET `[base]/RelatedPerson?patient=Patient/[:id]`
 
 ```json
 {
-  "id": "f37cc7ac-3543-4ded-8902-841d0076a9bd",
+  "id": "667f6d14-0abb-405e-8a28-04310bfae922",
   "meta": {
-    "lastUpdated": "2021-03-04T17:04:29-05:00"
+    "lastUpdated": "2021-07-22T15:15:40-04:00"
   },
   "type": "searchset",
   "total": 1,
   "entry": [
     {
-      "fullUrl": "http://localhost:3000/fhir/r4/RelatedPerson/950",
+      "fullUrl": "http://localhost:3000/fhir/r4/RelatedPerson/7",
       "resource": {
-        "id": 950,
+        "id": 7,
         "meta": {
-          "lastUpdated": "2021-01-31T18:23:16+00:00"
+          "lastUpdated": "2021-06-23T21:11:57+00:00"
         },
         "extension": [
           {
             "url": "http://saraalert.org/StructureDefinition/contact-attempts",
-            "valueUnsignedInt": 5
+            "valueUnsignedInt": 2
           },
           {
             "url": "http://saraalert.org/StructureDefinition/notes",
-            "valueString": "Parsing the panel won't do anything, we need to program the optical ib array!"
+            "valueString": "You can't back up the alarm without parsing the cross-platform SSL capacitor!"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/created-at",
+            "valueDateTime": "2021-06-23T21:11:57+00:00"
           }
         ],
         "patient": {
-          "reference": "Patient/222"
+          "reference": "Patient/9"
         },
         "name": [
           {
-            "family": "Pollich97",
-            "given": ["Nam32"]
+            "family": "Heller03",
+            "given": ["Betsy81"]
           }
         ],
         "telecom": [
           {
-            "system": "phone",
-            "value": "+15555550104",
-            "rank": 1
-          },
-          {
             "system": "email",
-            "value": "1845823000fake@example.com",
+            "value": "8089736791fake@example.com",
             "rank": 1
           }
         ],
@@ -3366,39 +4886,45 @@ GET `[base]/Immunization?patient=Patient/[:id]`
 
 ```json
 {
-  "id": "18dca7c0-692e-4819-b70b-2b342741567c",
+  "id": "59a223a8-1724-4217-8c15-c02fdc3838ec",
   "meta": {
-    "lastUpdated": "2021-04-01T18:17:29-04:00"
+    "lastUpdated": "2021-07-22T15:17:16-04:00"
   },
   "type": "searchset",
   "total": 1,
   "entry": [
     {
-      "fullUrl": "http://localhost:3000/fhir/r4/Immunization/35",
+      "fullUrl": "http://localhost:3000/fhir/r4/Immunization/1",
       "resource": {
-        "id": 35,
+        "id": 1,
         "meta": {
-          "lastUpdated": "2021-04-01T22:17:14+00:00"
+          "lastUpdated": "2021-06-23T10:40:04+00:00"
         },
+        "extension": [
+          {
+            "url": "http://saraalert.org/StructureDefinition/created-at",
+            "valueDateTime": "2021-06-23T10:40:04+00:00"
+          }
+        ],
         "status": "completed",
         "vaccineCode": [
           {
             "coding": [
               {
                 "system": "http://hl7.org/fhir/sid/cvx",
-                "code": "207"
+                "code": "212"
               }
             ],
-            "text": "Moderna COVID-19 Vaccine"
+            "text": "Janssen (J&J) COVID-19 Vaccine"
           }
         ],
         "patient": {
-          "reference": "Patient/111"
+          "reference": "Patient/6"
         },
-        "occurrenceDateTime": "2021-03-30",
+        "occurrenceDateTime": "2021-06-19",
         "note": [
           {
-            "text": "Notes here"
+            "text": "Defy Noxus and taste your own blood."
           }
         ],
         "protocolApplied": [
@@ -3413,8 +4939,7 @@ GET `[base]/Immunization?patient=Patient/[:id]`
                 ],
                 "text": "COVID-19"
               }
-            ],
-            "doseNumberString": "1"
+            ]
           }
         ],
         "resourceType": "Immunization"
@@ -3423,7 +4948,6 @@ GET `[base]/Immunization?patient=Patient/[:id]`
   ],
   "resourceType": "Bundle"
 }
-
 ```
   </div>
 </details>
@@ -3442,55 +4966,54 @@ GET `[base]/Provenance?patient=Patient/[:id]`
 
 ```json
 {
-    "id": "83890c54-0871-4801-bbdf-b4b29f6c400a",
-    "meta": {
-        "lastUpdated": "2021-05-28T16:37:43-04:00"
-    },
-    "type": "searchset",
-    "total": 1,
-    "entry": [
-        {
-            "fullUrl": "http://localhost:3000/fhir/r4/Provenance/10183",
-            "resource": {
-                "id": 10183,
-                "meta": {
-                    "lastUpdated": "2021-05-26T15:51:19+00:00"
-                },
-                "extension": [
-                    {
-                        "url": "http://saraalert.org/StructureDefinition/comment",
-                        "valueString": "User enrolled monitoree."
-                    },
-                    {
-                        "url": "http://saraalert.org/StructureDefinition/history-type",
-                        "valueString": "Enrollment"
-                    }
-                ],
-                "target": [
-                    {
-                        "reference": "Patient/954"
-                    }
-                ],
-                "recorded": "2021-05-26T15:51:19+00:00",
-                "agent": [
-                    {
-                        "who": {
-                            "identifier": {
-                                "value": "locals2c4_enroller@example.com"
-                            }
-                        },
-                        "onBehalfOf": {
-                            "reference": "Patient/954"
-                        }
-                    }
-                ],
-                "resourceType": "Provenance"
+  "id": "6004987d-775b-4d4b-9f9a-7c19bd432e4a",
+  "meta": {
+    "lastUpdated": "2021-07-22T15:20:57-04:00"
+  },
+  "type": "searchset",
+  "total": 1,
+  "entry": [
+    {
+      "fullUrl": "http://localhost:3000/fhir/r4/Provenance/326",
+      "resource": {
+        "id": 326,
+        "meta": {
+          "lastUpdated": "2021-06-24T23:17:02+00:00"
+        },
+        "extension": [
+          {
+            "url": "http://saraalert.org/StructureDefinition/comment",
+            "valueString": "User enrolled monitoree."
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/history-type",
+            "valueString": "Enrollment"
+          }
+        ],
+        "target": [
+          {
+            "reference": "Patient/82"
+          }
+        ],
+        "recorded": "2021-06-24T23:17:02+00:00",
+        "agent": [
+          {
+            "who": {
+              "identifier": {
+                "value": "state2_enroller@example.com"
+              }
+            },
+            "onBehalfOf": {
+              "reference": "Patient/82"
             }
-        }
-    ],
-    "resourceType": "Bundle"
+          }
+        ],
+        "resourceType": "Provenance"
+      }
+    }
+  ],
+  "resourceType": "Bundle"
 }
-
 ```
   </div>
 </details>
@@ -3509,12 +5032,12 @@ GET `[base]/Patient?_count=2`
 
 ```json
 {
-  "id": "803eeebb-be5b-44e8-8430-0021d122cb77",
+  "id": "e4d8973c-2e50-4416-84e0-6c4930048654",
   "meta": {
-    "lastUpdated": "2020-05-28T21:03:28-04:00"
+    "lastUpdated": "2021-07-22T15:12:34-04:00"
   },
   "type": "searchset",
-  "total": 472,
+  "total": 1048,
   "link": [
     {
       "relation": "next",
@@ -3522,31 +5045,431 @@ GET `[base]/Patient?_count=2`
     },
     {
       "relation": "last",
-      "url": "http://localhost:3000/fhir/r4/Patient?_count=2&page=236"
+      "url": "http://localhost:3000/fhir/r4/Patient?_count=2&page=524"
     }
   ],
   "entry": [
     {
-      "fullUrl": "http://localhost:3000/fhir/r4/Patient/12",
+      "fullUrl": "http://localhost:3000/fhir/r4/Patient/1",
       "resource": {
-        "id": 12,
+        "id": 1,
         "meta": {
-          "lastUpdated": "2020-05-29T00:43:06+00:00"
+          "lastUpdated": "2021-07-20T21:53:24+00:00"
         },
+        "contained": [
+          {
+            "target": [
+              {
+                "reference": "/fhir/r4/Patient/1"
+              }
+            ],
+            "recorded": "2021-06-22T21:47:14+00:00",
+            "activity": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-DataOperation",
+                  "code": "CREATE",
+                  "display": "create"
+                }
+              ]
+            },
+            "agent": [
+              {
+                "who": {
+                  "identifier": {
+                    "value": 6
+                  },
+                  "display": "locals2c4_enroller@example.com"
+                }
+              }
+            ],
+            "resourceType": "Provenance"
+          }
+        ],
         "extension": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode": "asked-declined"
+              },
+              {
+                "url": "text",
+                "valueString": "Refused to Answer"
+              }
+            ],
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+          },
           {
             "extension": [
               {
                 "url": "ombCategory",
                 "valueCoding": {
                   "system": "urn:oid:2.16.840.1.113883.6.238",
-                  "code": "2106-3",
-                  "display": "White"
+                  "code": "2135-2",
+                  "display": "Hispanic or Latino"
                 }
               },
               {
                 "url": "text",
-                "valueString": "White"
+                "valueString": "Hispanic or Latino"
+              }
+            ],
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+          },
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+            "valueCode": "F"
+          },
+          {
+            "extension": [
+              {
+                "url": "id",
+                "valuePositiveInt": 30
+              },
+              {
+                "url": "updated-at",
+                "valueDateTime": "2021-06-27T12:35:55+00:00"
+              },
+              {
+                "url": "created-at",
+                "valueDateTime": "2021-06-27T12:35:55+00:00"
+              },
+              {
+                "url": "who-initiated-transfer",
+                "valueString": "locals2c4_epi@example.com"
+              },
+              {
+                "url": "from-jurisdiction",
+                "valueString": "USA, State 2"
+              },
+              {
+                "url": "to-jurisdiction",
+                "valueString": "USA, State 1"
+              }
+            ],
+            "url": "http://saraalert.org/StructureDefinition/transfer"
+          },
+          {
+            "extension": [
+              {
+                "extension": [
+                  {
+                    "url": "contact-of-known-case",
+                    "valueBoolean": true
+                  },
+                  {
+                    "url": "contact-of-known-case-id",
+                    "valueString": "08716266, 07336309"
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/contact-of-known-case"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "was-in-health-care-facility-with-known-cases",
+                    "valueBoolean": true
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/was-in-health-care-facility-with-known-cases"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "laboratory-personnel",
+                    "valueBoolean": false
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/laboratory-personnel"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "healthcare-personnel",
+                    "valueBoolean": false
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/healthcare-personnel"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "member-of-a-common-exposure-cohort",
+                    "valueBoolean": false
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/member-of-a-common-exposure-cohort"
+              },
+              {
+                "url": "http://saraalert.org/StructureDefinition/travel-from-affected-country-or-area",
+                "valueBoolean": false
+              },
+              {
+                "url": "http://saraalert.org/StructureDefinition/crew-on-passenger-or-cargo-flight",
+                "valueBoolean": false
+              }
+            ],
+            "url": "http://saraalert.org/StructureDefinition/exposure-risk-factors"
+          },
+          {
+            "extension": [
+              {
+                "url": "source-of-report",
+                "valueString": "Other"
+              },
+              {
+                "url": "specify",
+                "valueString": "Audacious"
+              }
+            ],
+            "url": "http://saraalert.org/StructureDefinition/source-of-report"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/preferred-contact-method",
+            "valueString": "Telephone call"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/preferred-contact-time",
+            "valueString": "Evening"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/isolation",
+            "valueBoolean": true
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path",
+            "valueString": "USA, State 2"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/assigned-user",
+            "valuePositiveInt": 976134
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-start-date",
+            "valueDate": "2021-06-26"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-end-date",
+            "valueDate": "2021-06-27"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/port-of-origin",
+            "valueString": "Eufemiamouth"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/port-of-entry-into-usa",
+            "valueString": "Murazikfurt"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/date-of-departure",
+            "valueDate": "2021-06-22"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/flight-or-vessel-number",
+            "valueString": "H420"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/flight-or-vessel-carrier",
+            "valueString": "Frances Airlines"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/date-of-arrival",
+            "valueDate": "2021-06-22"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/travel-related-notes",
+            "valueString": "The mind is not a vessel to be filled but a fire to be kindled."
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-notes",
+            "valueString": "Chuck Norris' beard is immutable."
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/continuous-exposure",
+            "valueBoolean": false
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/end-of-monitoring",
+            "valueString": "2021-07-06"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/exposure-risk-assessment",
+            "valueString": "High"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/public-health-action",
+            "valueString": "None"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/potential-exposure-location",
+            "valueString": "Huelville"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/potential-exposure-country",
+            "valueString": "United Arab Emirates"
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/patient-interpreterRequired",
+            "valueBoolean": false
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/follow-up-reason",
+            "valueString": "Deceased"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-destination",
+            "valueString": "West Raymundo"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-destination-country",
+            "valueString": "Marshall Islands"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-port-of-departure",
+            "valueString": "Gradychester"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-type",
+            "valueString": "International"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/case-status",
+            "valueString": "Probable"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/gender-identity",
+            "valueString": "Transgender Male (Female-to-Male [FTM])"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/sexual-orientation",
+            "valueString": "Choose not to disclose"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/id-of-reporter",
+            "valuePositiveInt": 1
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/paused-notifications",
+            "valueBoolean": false
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/status",
+            "valueString": "asymp non test based"
+          }
+        ],
+        "identifier": [
+          {
+            "system": "http://saraalert.org/SaraAlert/state-local-id",
+            "value": "EX-773460"
+          }
+        ],
+        "active": true,
+        "name": [
+          {
+            "family": "McCullough24",
+            "given": ["Eulah20"]
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "+15555550162",
+            "rank": 1
+          }
+        ],
+        "birthDate": "1969-09-19",
+        "address": [
+          {
+            "extension": [
+              {
+                "url": "http://saraalert.org/StructureDefinition/address-type",
+                "valueString": "Foreign"
+              }
+            ],
+            "line": ["2224 Jerrod Extension", "Suite 257"],
+            "city": "Bishkek",
+            "postalCode": "03602-0784",
+            "country": "Hungary"
+          },
+          {
+            "extension": [
+              {
+                "url": "http://saraalert.org/StructureDefinition/address-type",
+                "valueString": "ForeignMonitored"
+              }
+            ],
+            "line": ["97299 Schroeder Loop"],
+            "city": "Praia Bangui",
+            "district": "Vernon",
+            "state": "Wisconsin",
+            "postalCode": "72075"
+          }
+        ],
+        "communication": [
+          {
+            "language": {
+              "coding": [
+                {
+                  "system": "urn:ietf:bcp:47",
+                  "code": "en",
+                  "display": "English"
+                }
+              ]
+            },
+            "preferred": true
+          }
+        ],
+        "resourceType": "Patient"
+      }
+    },
+    {
+      "fullUrl": "http://localhost:3000/fhir/r4/Patient/2",
+      "resource": {
+        "id": 2,
+        "meta": {
+          "lastUpdated": "2021-07-06T16:10:55+00:00"
+        },
+        "contained": [
+          {
+            "target": [
+              {
+                "reference": "/fhir/r4/Patient/2"
+              }
+            ],
+            "recorded": "2021-06-22T22:24:58+00:00",
+            "activity": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-DataOperation",
+                  "code": "CREATE",
+                  "display": "create"
+                }
+              ]
+            },
+            "agent": [
+              {
+                "who": {
+                  "identifier": {
+                    "value": 5
+                  },
+                  "display": "locals2c3_enroller@example.com"
+                }
+              }
+            ],
+            "resourceType": "Provenance"
+          }
+        ],
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                "valueCode": "asked-declined"
+              },
+              {
+                "url": "text",
+                "valueString": "Refused to Answer"
               }
             ],
             "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
@@ -3570,31 +5493,154 @@ GET `[base]/Patient?_count=2`
           },
           {
             "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
-            "valueCode": "M"
+            "valueCode": "UNK"
           },
           {
-            "url": "http://saraalert.org/StructureDefinition/preferred-contact-method",
-            "valueString": "E-mailed Web Link"
+            "extension": [
+              {
+                "url": "id",
+                "valuePositiveInt": 186
+              },
+              {
+                "url": "updated-at",
+                "valueDateTime": "2021-07-04T02:04:33+00:00"
+              },
+              {
+                "url": "created-at",
+                "valueDateTime": "2021-07-04T02:04:33+00:00"
+              },
+              {
+                "url": "who-initiated-transfer",
+                "valueString": "locals2c3_epi@example.com"
+              },
+              {
+                "url": "from-jurisdiction",
+                "valueString": "USA"
+              },
+              {
+                "url": "to-jurisdiction",
+                "valueString": "USA, State 1, County 1"
+              }
+            ],
+            "url": "http://saraalert.org/StructureDefinition/transfer"
+          },
+          {
+            "extension": [
+              {
+                "extension": [
+                  {
+                    "url": "contact-of-known-case",
+                    "valueBoolean": false
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/contact-of-known-case"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "was-in-health-care-facility-with-known-cases",
+                    "valueBoolean": false
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/was-in-health-care-facility-with-known-cases"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "laboratory-personnel",
+                    "valueBoolean": false
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/laboratory-personnel"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "healthcare-personnel",
+                    "valueBoolean": false
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/healthcare-personnel"
+              },
+              {
+                "extension": [
+                  {
+                    "url": "member-of-a-common-exposure-cohort",
+                    "valueBoolean": false
+                  }
+                ],
+                "url": "http://saraalert.org/StructureDefinition/member-of-a-common-exposure-cohort"
+              },
+              {
+                "url": "http://saraalert.org/StructureDefinition/travel-from-affected-country-or-area",
+                "valueBoolean": false
+              },
+              {
+                "url": "http://saraalert.org/StructureDefinition/crew-on-passenger-or-cargo-flight",
+                "valueBoolean": false
+              }
+            ],
+            "url": "http://saraalert.org/StructureDefinition/exposure-risk-factors"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/preferred-contact-time",
+            "valueString": "Afternoon"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/symptom-onset-date",
-            "valueDate": "2020-05-18"
-          },
-          {
-            "url": "http://saraalert.org/StructureDefinition/last-exposure-date",
-            "valueDate": "2020-05-12"
+            "valueDate": "2021-07-03"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/isolation",
-            "valueBoolean": false
+            "valueBoolean": true
           },
           {
             "url": "http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path",
-            "valueString": "USA, State 1"
+            "valueString": "USA, State 1, County 1"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/assigned-user",
+            "valuePositiveInt": 232046
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/port-of-origin",
+            "valueString": "North Pearliechester"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/port-of-entry-into-usa",
+            "valueString": "Januaryfurt"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/date-of-departure",
+            "valueDate": "2021-06-22"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/flight-or-vessel-number",
+            "valueString": "I280"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/flight-or-vessel-carrier",
+            "valueString": "Emery Airlines"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/date-of-arrival",
+            "valueDate": "2021-06-22"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/exposure-notes",
+            "valueString": "Tonight we hunt!"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/travel-related-notes",
+            "valueString": "Most people would rather give than get affection."
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/continuous-exposure",
+            "valueBoolean": false
           },
           {
             "url": "http://saraalert.org/StructureDefinition/end-of-monitoring",
-            "valueString": "2020-05-29"
+            "valueString": "2021-07-06"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/exposure-risk-assessment",
@@ -3602,65 +5648,105 @@ GET `[base]/Patient?_count=2`
           },
           {
             "url": "http://saraalert.org/StructureDefinition/public-health-action",
-            "valueString": "Document results of medical evaluation"
-          },
-          {
-            "url": "http://saraalert.org/StructureDefinition/contact-of-known-case",
-            "valueBoolean": true
-          },
-          {
-            "url": "http://saraalert.org/StructureDefinition/contact-of-known-case-id",
-            "valueString": "case1"
+            "valueString": "None"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/potential-exposure-location",
-            "valueString": "Collierview"
+            "valueString": "Port Edisonberg"
           },
           {
             "url": "http://saraalert.org/StructureDefinition/potential-exposure-country",
-            "valueString": "Angola"
+            "valueString": "Guinea"
           },
           {
             "url": "http://hl7.org/fhir/StructureDefinition/patient-interpreterRequired",
+            "valueBoolean": false
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/follow-up-reason",
+            "valueString": "In Need of Follow-up"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/follow-up-note",
+            "valueString": "Most people would rather give than get affection."
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/case-status",
+            "valueString": "Confirmed"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/sexual-orientation",
+            "valueString": "Don’t know"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/id-of-reporter",
+            "valuePositiveInt": 2
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/paused-notifications",
+            "valueBoolean": false
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/status",
+            "valueString": "symp non test based"
+          },
+          {
+            "url": "http://saraalert.org/StructureDefinition/user-defined-symptom-onset",
             "valueBoolean": true
+          }
+        ],
+        "identifier": [
+          {
+            "system": "http://saraalert.org/SaraAlert/state-local-id",
+            "value": "EX-066922"
           }
         ],
         "active": true,
         "name": [
           {
-            "family": "Waelchi90",
-            "given": [
-              "Dwight94",
-              "Schulist42"
-            ]
+            "family": "Konopelski65",
+            "given": ["Kirby47", "Batz46"]
           }
         ],
         "telecom": [
           {
+            "extension": [
+              {
+                "url": "http://saraalert.org/StructureDefinition/phone-type",
+                "valueString": "Plain Cell"
+              }
+            ],
             "system": "phone",
-            "value": "(333) 333-3333",
+            "value": "+15555550172",
             "rank": 1
           },
           {
             "system": "phone",
-            "value": "(333) 333-3333",
+            "value": "+15555550182",
             "rank": 2
-          },
-          {
-            "system": "email",
-            "value": "3898888718fake@example.com",
-            "rank": 1
           }
         ],
-        "birthDate": "1946-12-05",
+        "birthDate": "2008-09-12",
         "address": [
           {
-            "line": [
-              "2338 Letisha Center"
+            "line": ["78342 Howell View"],
+            "city": "Wildermanmouth",
+            "district": "Paradise Place",
+            "state": "Vermont",
+            "postalCode": "58562"
+          },
+          {
+            "extension": [
+              {
+                "url": "http://saraalert.org/StructureDefinition/address-type",
+                "valueString": "Monitored"
+              }
             ],
-            "city": "Hegmannside",
-            "state": "Arizona",
-            "postalCode": "33245-0671"
+            "line": ["78342 Howell View"],
+            "city": "Wildermanmouth",
+            "district": "Paradise Place",
+            "state": "Vermont",
+            "postalCode": "58562"
           }
         ],
         "communication": [
@@ -3673,128 +5759,8 @@ GET `[base]/Patient?_count=2`
                   "display": "English"
                 }
               ]
-            }
-          }
-        ],
-        "resourceType": "Patient"
-      }
-    },
-    {
-      "fullUrl": "http://localhost:3000/fhir/r4/Patient/26",
-      "resource": {
-        "id": 26,
-        "meta": {
-          "lastUpdated": "2020-05-29T00:43:14+00:00"
-        },
-        "extension": [
-          {
-            "extension": [
-              {
-                "url": "ombCategory",
-                "valueCoding": {
-                  "system": "urn:oid:2.16.840.1.113883.6.238",
-                  "code": "2076-8",
-                  "display": "Native Hawaiian or Other Pacific Islander"
-                }
-              },
-              {
-                "url": "text",
-                "valueString": "Native Hawaiian or Other Pacific Islander"
-              }
-            ],
-            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
-          },
-          {
-            "extension": [
-              {
-                "url": "ombCategory",
-                "valueCoding": {
-                  "system": "urn:oid:2.16.840.1.113883.6.238",
-                  "code": "2186-5",
-                  "display": "Not Hispanic or Latino"
-                }
-              },
-              {
-                "url": "text",
-                "valueString": "Not Hispanic or Latino"
-              }
-            ],
-            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
-          },
-          {
-            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
-            "valueCode": "M"
-          },
-          {
-            "url": "http://saraalert.org/StructureDefinition/preferred-contact-method",
-            "valueString": "E-mailed Web Link"
-          },
-          {
-            "url": "http://saraalert.org/StructureDefinition/symptom-onset-date",
-            "valueDate": "2020-05-19"
-          },
-          {
-            "url": "http://saraalert.org/StructureDefinition/last-exposure-date",
-            "valueDate": "2020-05-15"
-          },
-          {
-            "url": "http://saraalert.org/StructureDefinition/isolation",
-            "valueBoolean": true
-          },
-          {
-            "url": "http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path",
-            "valueString": "USA, State 1"
-          }
-        ],
-        "active": true,
-        "name": [
-          {
-            "family": "Connelly52",
-            "given": [
-              "Kenton63",
-              "Kuhlman78"
-            ]
-          }
-        ],
-        "telecom": [
-          {
-            "system": "phone",
-            "value": "(333) 333-3333",
-            "rank": 1
-          },
-          {
-            "system": "phone",
-            "value": "(333) 333-3333",
-            "rank": 2
-          },
-          {
-            "system": "email",
-            "value": "8065771328fake@example.com",
-            "rank": 1
-          }
-        ],
-        "birthDate": "2014-10-04",
-        "address": [
-          {
-            "line": [
-              "7842 Luke Fork"
-            ],
-            "city": "Millshaven",
-            "state": "Rhode Island",
-            "postalCode": "79857"
-          }
-        ],
-        "communication": [
-          {
-            "language": {
-              "coding": [
-                {
-                  "system": "urn:ietf:bcp:47",
-                  "code": "en",
-                  "display": "English"
-                }
-              ]
-            }
+            },
+            "preferred": true
           }
         ],
         "resourceType": "Patient"

--- a/docs/api/fhir-api-specification.md
+++ b/docs/api/fhir-api-specification.md
@@ -429,7 +429,7 @@ Get a monitoree via an id, e.g.:
 {
   "id": 43,
   "meta": {
-    "lastUpdated": "2021-07-22T18:18:28+00:00"
+    "lastUpdated": "2021-07-27T15:31:08+00:00"
   },
   "contained": [
     {
@@ -691,7 +691,7 @@ Get a monitoree via an id, e.g.:
     },
     {
       "url": "http://saraalert.org/StructureDefinition/assigned-user",
-      "valuePositiveInt": 205610
+      "valuePositiveInt": 1234
     },
     {
       "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-start-date",
@@ -735,11 +735,15 @@ Get a monitoree via an id, e.g.:
     },
     {
       "url": "http://saraalert.org/StructureDefinition/continuous-exposure",
-      "valueBoolean": true
+      "valueBoolean": false
     },
     {
       "url": "http://saraalert.org/StructureDefinition/end-of-monitoring",
-      "valueString": "Continuous Exposure"
+      "valueString": "2021-07-07"
+    },
+    {
+      "url": "http://saraalert.org/StructureDefinition/expected-purge-date",
+      "valueDateTime": "2021-08-10T15:31:08+00:00"
     },
     {
       "url": "http://saraalert.org/StructureDefinition/exposure-risk-assessment",
@@ -762,6 +766,10 @@ Get a monitoree via an id, e.g.:
       "valueBoolean": false
     },
     {
+      "url": "http://saraalert.org/StructureDefinition/reason-for-closure",
+      "valueString": "Meets Case Definition"
+    },
+    {
       "url": "http://saraalert.org/StructureDefinition/additional-planned-travel-destination",
       "valueString": "Pourosside"
     },
@@ -782,8 +790,20 @@ Get a monitoree via an id, e.g.:
       "valueString": "Confirmed"
     },
     {
-      "url": "http://saraalert.org/StructureDefinition/gender-identity",
-      "valueString": "Another"
+      "url": "http://saraalert.org/StructureDefinition/closed-at",
+      "valueDateTime": "2021-07-27T15:29:34+00:00"
+    },
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/patient-genderIdentity",
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://hl7.org/fhir/gender-identity",
+            "code": "transgender-female"
+          }
+        ],
+        "text": "Transgender Female (Male-to-Female [MTF])"
+      }
     },
     {
       "url": "http://saraalert.org/StructureDefinition/head-of-household",
@@ -803,7 +823,7 @@ Get a monitoree via an id, e.g.:
     },
     {
       "url": "http://saraalert.org/StructureDefinition/status",
-      "valueString": "symptomatic"
+      "valueString": "closed"
     },
     {
       "url": "http://saraalert.org/StructureDefinition/user-defined-symptom-onset",
@@ -816,7 +836,7 @@ Get a monitoree via an id, e.g.:
       "value": "0952379687"
     }
   ],
-  "active": true,
+  "active": false,
   "name": [
     {
       "family": "Johns78",
@@ -974,11 +994,19 @@ The `http://saraalert.org/StructureDefinition/closed-at` extension represents th
 }
 ```
 
-The `http://saraalert.org/StructureDefinition/gender-identity` extension represents the gender identity of a monitoree. This field is read-only.
+The `http://hl7.org/fhir/StructureDefinition/patient-genderIdentity` extension represents the gender identity of a monitoree. This field is read-only.
 ```json
 {
-  "url": "http://saraalert.org/StructureDefinition/gender-identity",
-  "valueString": "Another"
+  "url": "http://hl7.org/fhir/StructureDefinition/patient-genderIdentity",
+  "valueCodeableConcept": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/gender-identity",
+        "code": "transgender-female"
+      }
+    ],
+    "text": "Transgender Female (Male-to-Female [MTF])"
+  }
 }
 ```
 
@@ -986,7 +1014,15 @@ The `http://saraalert.org/StructureDefinition/sexual-orientation` extension repr
 ```json
 {
   "url": "http://saraalert.org/StructureDefinition/sexual-orientation",
-  "valueString": "Choose not to disclose"
+  "valueCodeableConcept": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "38628009"
+      }
+    ],
+    "text": "Lesbian, Gay, or Homosexual"
+  }
 }
 ```
 
@@ -2096,8 +2132,16 @@ Use this route to retrieve a FHIR Bundle containing the monitoree and all their 
             "valueString": "Confirmed"
           },
           {
-            "url": "http://saraalert.org/StructureDefinition/gender-identity",
-            "valueString": "Another"
+            "url": "http://hl7.org/fhir/StructureDefinition/patient-genderIdentity",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/gender-identity",
+                  "code": "transgender-female"
+                }
+              ],
+              "text": "Transgender Female (Male-to-Female [MTF])"
+            }
           },
           {
             "url": "http://saraalert.org/StructureDefinition/head-of-household",
@@ -4420,8 +4464,16 @@ GET `[base]/Patient?given=john&family=doe`
             "valueString": "Confirmed"
           },
           {
-            "url": "http://saraalert.org/StructureDefinition/gender-identity",
-            "valueString": "Another"
+            "url": "http://hl7.org/fhir/StructureDefinition/patient-genderIdentity",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/gender-identity",
+                  "code": "transgender-female"
+                }
+              ],
+              "text": "Transgender Female (Male-to-Female [MTF])"
+            }
           },
           {
             "url": "http://saraalert.org/StructureDefinition/head-of-household",
@@ -5338,12 +5390,28 @@ GET `[base]/Patient?_count=2`
             "valueString": "Probable"
           },
           {
-            "url": "http://saraalert.org/StructureDefinition/gender-identity",
-            "valueString": "Transgender Male (Female-to-Male [FTM])"
+            "url": "http://hl7.org/fhir/StructureDefinition/patient-genderIdentity",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/gender-identity",
+                  "code": "transgender-female"
+                }
+              ],
+              "text": "Transgender Female (Male-to-Female [MTF])"
+            }
           },
           {
             "url": "http://saraalert.org/StructureDefinition/sexual-orientation",
-            "valueString": "Choose not to disclose"
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "38628009"
+                }
+              ],
+              "text": "Lesbian, Gay, or Homosexual"
+            }
           },
           {
             "url": "http://saraalert.org/StructureDefinition/id-of-reporter",
@@ -5676,7 +5744,15 @@ GET `[base]/Patient?_count=2`
           },
           {
             "url": "http://saraalert.org/StructureDefinition/sexual-orientation",
-            "valueString": "Don’t know"
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "38628009"
+                }
+              ],
+              "text": "Lesbian, Gay, or Homosexual"
+            }
           },
           {
             "url": "http://saraalert.org/StructureDefinition/id-of-reporter",

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -34,35 +34,45 @@ The API exists to allow other software systems to **read** and **write** Sara Al
 The examples above are in terms of Monitorees, but the API also supports reading/writing of Close Contacts, Vaccinations, and Lab Results and reading of Symptom Reports.
 
 ### For Monitorees
-**A client can read and write the following data elements:**<br>Workflow, First Name, Middle Name, Last Name, Date of Birth, Sex, White, Black or African American, American Indian or Alaskan Native, Asian, Native Hawaiian or Other Pacific Islander, Ethnicity, Primary Language, Secondary Language, Interpretation Requirement, Address 1, Address 2, Town/City, State, Zip, County, Address 1 (Foreign), Address 2 (Foreign), Address 3 (Foreign), Town/City (Foreign), State/Province (Foreign), Postal Code (Foreign), Country (Foreign), Preferred Reporting Method, Preferred Contact Time, Primary Telephone Number, Secondary Telephone Number, E-mail Address, Last Date of Exposure, Symptom Onset Date, Monitoring Status, Assigned Jurisdiction, Monitoring Plan, Assigned User, Additional Planned Travel Start Date, Additional Planned Travel Notes, Port of Origin, Date of Departure, Flight or Vessel Number, Flight or Vessel Carrier, Date of Arrival, Travel Related Notes, Exposure Notes, Primary Telephone Type, Secondary Telephone Type, State/Local ID, CDC ID, NNDSS ID, Close Contact with a Known Case, Contact of Known Case ID, Common Exposure Cohort Name, Exposure Location, Exposure Country, Risk Assessment, Latest Public Health Action, Extend Isolation To, Follow-up Reason, Follow-up Note
+**A client can read and write the following data elements:**<br>Workflow, First Name, Middle Name, Last Name, Date of Birth, Sex, White, Black or African American, American Indian or Alaskan Native, Asian, Native Hawaiian or Other Pacific Islander, Ethnicity, Primary Language, Secondary Language, Interpretation Requirement, Address 1, Address 2, Town/City, State, Zip, County, Address 1 (Foreign), Address 2 (Foreign), Address 3 (Foreign), Town/City (Foreign), State/Province (Foreign), Postal Code (Foreign), Country (Foreign), Preferred Reporting Method, Preferred Contact Time, Primary Telephone Number, Secondary Telephone Number, E-mail Address, Last Date of Exposure, Symptom Onset Date, Monitoring Status, Assigned Jurisdiction, Monitoring Plan, Assigned User, Additional Planned Travel Start Date, Additional Planned Travel Notes, Port of Origin, Date of Departure, Flight or Vessel Number, Flight or Vessel Carrier, Date of Arrival, Travel Related Notes, Exposure Notes, Primary Telephone Type, Secondary Telephone Type, State/Local ID, CDC ID, NNDSS ID, Exposure Location, Exposure Country, Risk Assessment, Latest Public Health Action, Extend Isolation To, Follow-up Reason, Follow-up Note
 
-**A client can read (but not write) the following data elements:**<br>End of Monitoring, Transfer Created Date, From Jurisdiction, Eligible for Purge After, Reason for Closure
+**A client can read (but not write) the following data elements:**<br>End of Monitoring, Eligible for Purge After, Reason for Closure, Address 1 (Monitored), Address 2 (Monitored), Town/City (Monitored), State (Monitored), Zip (Monitored), County (Monitored), Address 1 (Foreign Monitored), Address 2 (Foreign Monitored), Town/City (Foreign Monitored), State (Foreign Monitored), Zip (Foreign Monitored), County (Foreign Monitored), Transfer Created Date, Transfer Updated Date, Transfer From Jurisdiction, Transfer To Jurisdiction, Transfer ID, Who Initiated Transfer, Close Contact with a Known Case, Contact of Known Case ID, Member of a Common Exposure Cohort, Common Exposure Cohort Name, Laboratory Personnel, Laboratory Personnel Facility Name, Health Care Personnel, Health Care Personnel Facility Name, Was in Health Care Facility With Known Cases, Health Care Facility with Known Cases Name, Travel from Affected Country or Area, Crew on Passenger or Cargo Flight, Source of Report, Source of Report Specify, Additional Planned Travel Destination, Additional Planned Travel Destination Country, Additional Planned Travel Destination State, Additional Planned Travel End Date, Additional Planned Travel Port of Departure, Additional Planned Travel Type, Port of Entry Into USA, Case Status, Closed At, Gender Identity, Sexual Orientation, Head of Household, ID of Reporter, Last Assessment Reminder Sent, Paused Notifications, Status, User Defined Symptom Onset
 
 **A client can search by the following data elements:**<br>First Name, Last Name, Primary Telephone Number, E-mail Address, Monitoring Status
 
 ### For Close Contacts
 **A client can read and write the following data elements:**<br>First Name, Last Name, Primary Telephone, Email, Notes, Enrolled ID, Contact Attempts, Last Date of Exposure, Assigned User, Patient ID
 
+**A client can read (but not write) the following data elements:**<br>Created Date
+
 **A client can search by the following data elements:**<br>ID, Patient ID
 
 ### For Vaccinations
 **A client can read and write the following data elements:**<br>Vaccine Group, Product Name, Administration Date, Dose Number, Notes, Patient ID
+
+**A client can read (but not write) the following data elements:**<br>Created Date
 
 **A client can search by the following data elements:**<br>ID, Patient ID
 
 ### For Histories
 **A client can read the following data elements:**<br>Patient ID, Comment, History Type, Created By
 
+**A client can read (but not write) the following data elements:**<br>Deleted By, Delete Reason, Original Comment ID
+
 **A client can search by the following data elements:**<br>ID, Patient ID
 
 ### For Symptom Reports
-**A client can read the following data elements:**<br>Name, Answer
+**A client can read the following data elements:**<br>Name, Answer, Patient ID
+
+**A client can read (but not write) the following data elements:**<br>Created Date, Symptomatic, Who Reported
 
 **A client can search by the following data elements:**<br>ID, Patient ID
 
 
 ### For Lab Results
 **A client can read and write the following data elements:**<br>Report Date, Specimen Collection Date, Lab Type, Result, Patient ID
+
+**A client can read (but not write) the following data elements:**<br>Created Date
 
 **A client can search by the following data elements:**<br>ID, Patient ID
 

--- a/test/controllers/fhir/r4/immunization_test.rb
+++ b/test/controllers/fhir/r4/immunization_test.rb
@@ -68,7 +68,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     end
 
     # Verify that the JSON response matches the original as FHIR
-    assert_equal JSON.parse(@vaccine_1.as_fhir.to_json).except('id', 'meta'), json_response.except('id', 'meta')
+    assert_equal JSON.parse(created_vac.as_fhir.to_json).except('id', 'meta'), json_response.except('id', 'meta')
 
     histories = History.where(patient: created_vac.patient_id)
     assert_equal(1, histories.count)

--- a/test/controllers/fhir/r4/observation_test.rb
+++ b/test/controllers/fhir/r4/observation_test.rb
@@ -57,7 +57,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     end
 
     # Verify that the JSON response matches the original as FHIR
-    assert_equal JSON.parse(@lab_1.as_fhir.to_json).except('id', 'meta'), json_response.except('id', 'meta')
+    assert_equal JSON.parse(created_lab.as_fhir.to_json).except('id', 'meta'), json_response.except('id', 'meta')
 
     histories = History.where(patient: created_lab.patient_id)
     assert_equal(1, histories.count)

--- a/test/controllers/fhir/r4/patient_test.rb
+++ b/test/controllers/fhir/r4/patient_test.rb
@@ -284,7 +284,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     json_response = JSON.parse(response.body)
     issues = json_response['issue']
 
-    assert_equal 19, issues.length
+    assert_equal 18, issues.length
     monitoring_plan_iss = issues.find { |e| /Invalid.*Monitoring Plan/.match(e['diagnostics']) }
     assert(FHIRPath.evaluate(monitoring_plan_iss['expression'].first, json_patient) == 'Invalid')
     state_iss = issues.find { |e| /Old York.*State/.match(e['diagnostics']) }
@@ -663,8 +663,8 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should differentiate USA and Foreign addresses in update' do
-    @patient_1.address << FHIR::Address.new(line: ['123 First Ave', 'Unit 22', 'Sector B'], city: 'Northland', state: 'Quebec', postalCode: '77658-0950',
-                                            country: 'Canada')
+    @patient_1.address[1] = FHIR::Address.new(line: ['123 First Ave', 'Unit 22', 'Sector B'], city: 'Northland', state: 'Quebec', postalCode: '77658-0950',
+                                              country: 'Canada')
     @patient_1.address[1].extension << FHIR::Extension.new(url: 'http://saraalert.org/StructureDefinition/address-type', valueString: 'Foreign')
 
     put(
@@ -692,7 +692,8 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal @patient_1.address[1].country, patient.foreign_address_country
 
     # Test that the response is as expected
-    assert_equal JSON.parse(@patient_1.address.to_json), json_response['address']
+    assert_equal JSON.parse(@patient_1.address[0].to_json), json_response['address'][0]
+    assert_equal JSON.parse(@patient_1.address[1].to_json), json_response['address'][1]
   end
 
   test 'should update address fields from an explicit USA address' do
@@ -764,7 +765,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
 
     # Test that the response is as expected
     assert_equal JSON.parse(@patient_1.address[0].to_json), json_response['address'][0]
-    assert_nil json_response['address'][1]
+    assert_nil(json_response['address'].find { |a| a['extension'] && a['extension'][0]['valueString'] == 'Foreign' })
   end
 
   test 'should be unprocessable entity via update with validation errors' do
@@ -779,7 +780,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     json_response = JSON.parse(response.body)
     issues = json_response['issue']
 
-    assert_equal 19, issues.length
+    assert_equal 18, issues.length
     monitoring_plan_iss = issues.find { |e| /Invalid.*Monitoring Plan/.match(e['diagnostics']) }
     assert(FHIRPath.evaluate(monitoring_plan_iss['expression'].first, json_patient) == 'Invalid')
     state_iss = issues.find { |e| /Old York.*State/.match(e['diagnostics']) }

--- a/test/controllers/fhir/r4/related_person_test.rb
+++ b/test/controllers/fhir/r4/related_person_test.rb
@@ -71,7 +71,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     end
 
     # Verify that the JSON response matches the original as FHIR
-    assert_equal JSON.parse(@close_contact_1.as_fhir.to_json).except('meta'), json_response.except('id', 'meta')
+    assert_equal JSON.parse(created_cc.as_fhir.to_json).except('meta', 'id'), json_response.except('id', 'meta')
 
     histories = History.where(patient: created_cc.patient_id)
     assert_equal(1, histories.count)

--- a/test/controllers/fhir/r4/transaction_test.rb
+++ b/test/controllers/fhir/r4/transaction_test.rb
@@ -203,11 +203,13 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     patient_json = json_response['entry'][0]['resource']
     original_json = JSON.parse(@bundle.to_json)['entry'][0]['resource']
     assert_equal original_json.except('id', 'meta', 'contained', 'extension'), patient_json.except('id', 'meta', 'contained', 'extension')
+    # Response JSON may include additional extensions, but should contain every original extension
     original_json['extension'].all? { |e| patient_json['extension'].include?(e) }
 
     observation_json = json_response['entry'][1]['resource']
     original_json = JSON.parse(@bundle.to_json)['entry'][1]['resource']
     assert_equal original_json.except('id', 'meta', 'subject', 'extension'), observation_json.except('id', 'meta', 'subject', 'extension')
+    # Response JSON may include additional extensions, but should contain every original extension
     original_json['extension'].all? { |e| observation_json['extension'].include?(e) || observation_json['extension']['url'] == 'created-at' }
 
     created_patient_id = patient_json['id']
@@ -232,6 +234,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     patient_json = json_response['entry'][0]['resource']
     original_json = JSON.parse(@bundle.to_json)['entry'][0]['resource']
     assert_equal original_json.except('id', 'meta', 'contained', 'extension'), patient_json.except('id', 'meta', 'contained', 'extension')
+    # Response JSON may include additional extensions, but should contain every original extension
     original_json['extension'].all? { |e| patient_json['extension'].include?(e) }
 
     created_patient_id = patient_json['id']

--- a/test/controllers/fhir/r4/transaction_test.rb
+++ b/test/controllers/fhir/r4/transaction_test.rb
@@ -202,7 +202,8 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
 
     patient_json = json_response['entry'][0]['resource']
     original_json = JSON.parse(@bundle.to_json)['entry'][0]['resource']
-    assert_equal original_json.except('id', 'meta', 'contained'), patient_json.except('id', 'meta', 'contained')
+    assert_equal original_json.except('id', 'meta', 'contained', 'extension'), patient_json.except('id', 'meta', 'contained', 'extension')
+    original_json['extension'].all? { |e| patient_json['extension'].include?(e) }
 
     observation_json = json_response['entry'][1]['resource']
     original_json = JSON.parse(@bundle.to_json)['entry'][1]['resource']
@@ -229,7 +230,8 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
 
     patient_json = json_response['entry'][0]['resource']
     original_json = JSON.parse(@bundle.to_json)['entry'][0]['resource']
-    assert_equal original_json.except('id', 'meta', 'contained'), patient_json.except('id', 'meta', 'contained')
+    assert_equal original_json.except('id', 'meta', 'contained', 'extension'), patient_json.except('id', 'meta', 'contained', 'extension')
+    original_json['extension'].all? { |e| patient_json['extension'].include?(e) }
 
     created_patient_id = patient_json['id']
     created_patient = Patient.find_by(id: created_patient_id.to_i)

--- a/test/controllers/fhir/r4/transaction_test.rb
+++ b/test/controllers/fhir/r4/transaction_test.rb
@@ -207,7 +207,8 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
 
     observation_json = json_response['entry'][1]['resource']
     original_json = JSON.parse(@bundle.to_json)['entry'][1]['resource']
-    assert_equal original_json.except('id', 'meta', 'subject'), observation_json.except('id', 'meta', 'subject')
+    assert_equal original_json.except('id', 'meta', 'subject', 'extension'), observation_json.except('id', 'meta', 'subject', 'extension')
+    original_json['extension'].all? { |e| observation_json['extension'].include?(e) || observation_json['extension']['url'] == 'created-at' }
 
     created_patient_id = patient_json['id']
     created_lab_id = observation_json['id']

--- a/test/controllers/fhir/r4/transaction_test.rb
+++ b/test/controllers/fhir/r4/transaction_test.rb
@@ -19,7 +19,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
   end
 
   def patient_entry(first_name, last_name)
-    patient_as_fhir = create(
+    patient = create(
       :patient,
       address_state: 'Oregon',
       date_of_birth: 25.years.ago,
@@ -28,7 +28,8 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       last_date_of_exposure: 4.days.ago.to_date,
       symptom_onset: 4.days.ago.to_date,
       creator: User.find_by(id: @system_everything_app.user_id)
-    ).as_fhir
+    )
+    patient.responder_id = nil
 
     FHIR::Bundle::Entry.new(
       fullUrl: "urn:uuid:#{SecureRandom.uuid}",
@@ -36,7 +37,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
         method: 'POST',
         url: 'Patient'
       ),
-      resource: patient_as_fhir
+      resource: patient.as_fhir
     )
   end
 
@@ -204,13 +205,11 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     original_json = JSON.parse(@bundle.to_json)['entry'][0]['resource']
     assert_equal original_json.except('id', 'meta', 'contained', 'extension'), patient_json.except('id', 'meta', 'contained', 'extension')
     # Response JSON may include additional extensions, but should contain every original extension
-    original_json['extension'].all? { |e| patient_json['extension'].include?(e) }
+    assert(original_json['extension'].all? { |e| patient_json['extension'].include?(e) })
 
     observation_json = json_response['entry'][1]['resource']
     original_json = JSON.parse(@bundle.to_json)['entry'][1]['resource']
     assert_equal original_json.except('id', 'meta', 'subject', 'extension'), observation_json.except('id', 'meta', 'subject', 'extension')
-    # Response JSON may include additional extensions, but should contain every original extension
-    original_json['extension'].all? { |e| observation_json['extension'].include?(e) || observation_json['extension']['url'] == 'created-at' }
 
     created_patient_id = patient_json['id']
     created_lab_id = observation_json['id']
@@ -235,7 +234,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     original_json = JSON.parse(@bundle.to_json)['entry'][0]['resource']
     assert_equal original_json.except('id', 'meta', 'contained', 'extension'), patient_json.except('id', 'meta', 'contained', 'extension')
     # Response JSON may include additional extensions, but should contain every original extension
-    original_json['extension'].all? { |e| patient_json['extension'].include?(e) }
+    assert(original_json['extension'].all? { |e| patient_json['extension'].include?(e) })
 
     created_patient_id = patient_json['id']
     created_patient = Patient.find_by(id: created_patient_id.to_i)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1548](https://tracker.codev.mitre.org/browse/SARAALERT-1548)

There are several fields which were available via manual Excel exports, which were not supported as readable via the API. This PR is meant to fill that gap and ensure that all fields which can be read via manual exports can be read via the API. This meant adding support for reading the following fields via the API:

**Patient**
* Monitored address fields  - `Patient.address`
* Foreign monitored address fields - `Patient.address`
* Transfers - complex extension in `Patient.extension`
  * Created date
  * Updated date
  * ID
  * To jurisdiction
  * From jurisdiction
  * Who initiated transfer
* Report source and report source specify - complex extension in `Patient.extension`
* Additional planned travel fields - simple extension in `Patient.extension`
* Exposure risk factors - complex extension in `Patient.extension`
* Port of entry into USA - simple extension in `Patient.extension`
* Case status - simple extension in `Patient.extension`
* Closed at - simple extension in `Patient.extension`
* Gender identity - simple extension in `Patient.extension`
* Sexual orientation - simple extension in `Patient.extension`
* Head of household - simple extension in `Patient.extension`
* ID of reporter - simple extension in `Patient.extension`
* Last assessment reminder sent - simple extension in `Patient.extension`
* Paused notifications - simple extension in `Patient.extension`
* Status - simple extension in `Patient.extension`
* User defined symptom onset - simple extension in `Patient.extension`

**RelatedPerson**
* Created at - simple extension in `RelatedPerson.extension`

**Provenance**
* Delete by - simple extension in `Provenance.extension`
* Delete reason - simple extension in `Provenance.extension`
* Original comment ID - simple extension in `Provenance.extension`

**Immunization**
* Created at - simple extension in `Immunization.extension`

**Observation**
* Created at - simple extension in `Observation.extension`

## Important Changes
`fhir_helper.rb`
- Add support for the fields described above. Several fields such as transfers and risk factors are grouped into complex extensions, which is sort of a pattern we didn't use before, but it seems logical given how closely tied these fields are.
- Remove autofill of monitored address to match the changes made in https://github.com/SaraAlert/SaraAlert/pull/985.
- Remove individual support for `contact-of-known-case`, `contact-of-known-case-id` and `common-exposure-cohort-name` since these fields are now handled on the `exposure-risk-factors` extension.
- Move `assessment_as_fhir` into this file.

## Testing Recommendations
* All exportable fields are readable via the API. This is very important to double check, since there are many fields, and I could've missed some.
* All of the resources described above still work and appear valid via GET
* A monitorees transfers are correctly represented in their `Patient.extension` array
* A monitoree with all 4 address groups completely set has 4 addresses in the `Patient.address` array, and the corresponding elements of that array are removed if an address group is deleted.
* A monitoree only has an `exposure-risk-factors` extension if they have non-`nil` values for these fields, and the extension is accurate.
* It is less important to focus on testing the simple extensions, but spot check a few of those and ensure they have the expected value

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x]  (N/A) If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@holmesie 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@dubem7 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
