### PR TITLE
SARAALERT-1559: Do not allow the future-dating of Symptom Onset Date

### DIFF
--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -207,7 +207,7 @@ class Exposure extends React.Component {
         ...staticValidations,
         symptom_onset: yup
           .date('Date must correspond to the "mm/dd/yyyy" format.')
-          .max(moment().add(30, 'days').toDate(), 'Date can not be more than 30 days in the future.')
+          .max(moment().toDate(), 'Date can not be in the future.')
           .required('Please enter a Symptom Onset Date AND/OR a positive lab result.')
           .nullable(),
       });
@@ -216,17 +216,14 @@ class Exposure extends React.Component {
         ...staticValidations,
         symptom_onset: yup
           .date('Date must correspond to the "mm/dd/yyyy" format.')
-          .max(moment().add(30, 'days').toDate(), 'Date can not be more than 30 days in the future.')
+          .max(moment().toDate(), 'Date can not be in the future.')
           .required('Please enter a Symptom Onset Date AND/OR a positive lab result.')
           .nullable(),
       });
     } else {
       schema = yup.object().shape({
         ...staticValidations,
-        symptom_onset: yup
-          .date('Date must correspond to the "mm/dd/yyyy" format.')
-          .max(moment().add(30, 'days').toDate(), 'Date can not be more than 30 days in the future.')
-          .nullable(),
+        symptom_onset: yup.date('Date must correspond to the "mm/dd/yyyy" format.').max(moment().toDate(), 'Date can not be in the future.').nullable(),
       });
     }
     this.setState(state => {

--- a/app/javascript/components/enrollment/steps/Exposure.js
+++ b/app/javascript/components/enrollment/steps/Exposure.js
@@ -320,7 +320,7 @@ class Exposure extends React.Component {
               aria-label="Symptom Onset Date"
               date={this.state.current.patient.symptom_onset}
               minDate={'2020-01-01'}
-              maxDate={moment().add(30, 'days').format('YYYY-MM-DD')}
+              maxDate={moment().format('YYYY-MM-DD')}
               onChange={date => this.handleDateChange('symptom_onset', date)}
               placement="bottom"
               isInvalid={!!this.state.errors['symptom_onset']}

--- a/app/javascript/components/patient/assessment/actions/ClearAssessments.js
+++ b/app/javascript/components/patient/assessment/actions/ClearAssessments.js
@@ -120,7 +120,7 @@ class ClearAssessments extends React.Component {
                   id="symptom_onset_mark_as_reviewed"
                   date={this.state.symptom_onset}
                   minDate={'2020-01-01'}
-                  maxDate={moment().add(30, 'days').format('YYYY-MM-DD')}
+                  maxDate={moment().format('YYYY-MM-DD')}
                   onChange={date =>
                     this.setState({
                       symptom_onset: date,

--- a/app/javascript/components/patient/assessment/actions/SymptomOnset.js
+++ b/app/javascript/components/patient/assessment/actions/SymptomOnset.js
@@ -141,7 +141,7 @@ class SymptomOnset extends React.Component {
             id="symptom_onset"
             date={this.state.symptom_onset}
             minDate={'2020-01-01'}
-            maxDate={moment().add(30, 'days').format('YYYY-MM-DD')}
+            maxDate={moment().format('YYYY-MM-DD')}
             onChange={this.openModal}
             placement="bottom"
             isClearable={this.props.patient.user_defined_symptom_onset}

--- a/app/javascript/components/patient/laboratory/LaboratoryModal.js
+++ b/app/javascript/components/patient/laboratory/LaboratoryModal.js
@@ -148,7 +148,7 @@ class LaboratoryModal extends React.Component {
                     id="symptom_onset_lab"
                     date={this.state.symptom_onset}
                     minDate={'2020-01-01'}
-                    maxDate={moment().add(30, 'days').format('YYYY-MM-DD')}
+                    maxDate={moment().format('YYYY-MM-DD')}
                     onChange={date => this.setState({ symptom_onset: date })}
                     isClearable={true}
                     placement="bottom"

--- a/app/javascript/components/util/DeleteDialog.js
+++ b/app/javascript/components/util/DeleteDialog.js
@@ -92,7 +92,7 @@ class DeleteDialog extends React.Component {
                 id="symptom_onset_delete_dialog"
                 date={this.state.symptom_onset}
                 minDate={'2020-01-01'}
-                maxDate={moment().add(30, 'days').format('YYYY-MM-DD')}
+                maxDate={moment().format('YYYY-MM-DD')}
                 onChange={date => this.setState({ symptom_onset: date })}
                 isClearable={true}
                 placement="bottom"

--- a/app/models/concerns/patient_date_validator.rb
+++ b/app/models/concerns/patient_date_validator.rb
@@ -8,9 +8,11 @@ class PatientDateValidator < ActiveModel::Validator
     year_start = Date.new(2020, 1, 1)
     month_ahead = 30.days.from_now.to_date
     month_behind = 30.days.ago.to_date
-    validate_between_dates(record, :date_of_birth, Date.new(1900, 1, 1), Time.now.to_date) if record.date_of_birth_changed?
+    # This is to handle the edge case when certain time zones such as Samoa are on the new day before UTC
+    earliest_tz_today = Time.now.in_time_zone(ActiveSupport::TimeZone.all.last).to_date
+    validate_between_dates(record, :date_of_birth, Date.new(1900, 1, 1), earliest_tz_today) if record.date_of_birth_changed?
     validate_between_dates(record, :last_date_of_exposure, year_start, month_ahead) if record.last_date_of_exposure_changed?
-    validate_between_dates(record, :symptom_onset, year_start, month_ahead) if record.symptom_onset_changed?
+    validate_between_dates(record, :symptom_onset, year_start, earliest_tz_today) if record.symptom_onset_changed?
     validate_between_dates(record, :extended_isolation, month_behind, month_ahead) if record.extended_isolation_changed?
     validate_between_dates(record, :date_of_departure, year_start, month_ahead) if record.date_of_departure_changed?
     validate_between_dates(record, :date_of_arrival, year_start, month_ahead) if record.date_of_arrival_changed?

--- a/app/models/concerns/patient_date_validator.rb
+++ b/app/models/concerns/patient_date_validator.rb
@@ -6,17 +6,20 @@ class PatientDateValidator < ActiveModel::Validator
 
   def validate(record)
     year_start = Date.new(2020, 1, 1)
-    month_ahead = 30.days.from_now.to_date
-    month_behind = 30.days.ago.to_date
+    # NOTE: Commented out for rubocop until other validations are uncommented
+    # month_ahead = 30.days.from_now.to_date
+    # month_behind = 30.days.ago.to_date
     # This is to handle the edge case when certain time zones such as Samoa are on the new day before UTC
     earliest_tz_today = Time.now.in_time_zone(ActiveSupport::TimeZone.all.last).to_date
-    validate_between_dates(record, :date_of_birth, Date.new(1900, 1, 1), earliest_tz_today) if record.date_of_birth_changed?
-    validate_between_dates(record, :last_date_of_exposure, year_start, month_ahead) if record.last_date_of_exposure_changed?
     validate_between_dates(record, :symptom_onset, year_start, earliest_tz_today) if record.symptom_onset_changed?
-    validate_between_dates(record, :extended_isolation, month_behind, month_ahead) if record.extended_isolation_changed?
-    validate_between_dates(record, :date_of_departure, year_start, month_ahead) if record.date_of_departure_changed?
-    validate_between_dates(record, :date_of_arrival, year_start, month_ahead) if record.date_of_arrival_changed?
-    validate_between_dates(record, :additional_planned_travel_start_date, year_start, month_ahead) if record.additional_planned_travel_start_date_changed?
-    validate_between_dates(record, :additional_planned_travel_end_date, year_start, month_ahead) if record.additional_planned_travel_end_date_changed?
+
+    # NOTE: Commented out until additional testing
+    # validate_between_dates(record, :date_of_birth, Date.new(1900, 1, 1), earliest_tz_today) if record.date_of_birth_changed?
+    # validate_between_dates(record, :last_date_of_exposure, year_start, month_ahead) if record.last_date_of_exposure_changed?
+    # validate_between_dates(record, :extended_isolation, month_behind, month_ahead) if record.extended_isolation_changed?
+    # validate_between_dates(record, :date_of_departure, year_start, month_ahead) if record.date_of_departure_changed?
+    # validate_between_dates(record, :date_of_arrival, year_start, month_ahead) if record.date_of_arrival_changed?
+    # validate_between_dates(record, :additional_planned_travel_start_date, year_start, month_ahead) if record.additional_planned_travel_start_date_changed?
+    # validate_between_dates(record, :additional_planned_travel_end_date, year_start, month_ahead) if record.additional_planned_travel_end_date_changed?
   end
 end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -109,9 +109,7 @@ class Patient < ApplicationRecord
   validates_with RequiredAddressValidator, on: :api
   validates_with TimeZoneValidator
   validates_with IsolationSymptomOnsetValidator, on: %i[api_create]
-
-  # NOTE: Commented out until additional testing
-  # validates_with PatientDateValidator
+  validates_with PatientDateValidator
 
   belongs_to :responder, class_name: 'Patient'
   belongs_to :creator, class_name: 'User'

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -1888,9 +1888,10 @@ class PatientTest < ActiveSupport::TestCase
     patient = valid_patient
 
     patient.last_date_of_exposure = 25.years.ago
-    assert_not patient.valid?(:api)
-    assert_not patient.valid?(:import)
-    assert_not patient.valid?
+    # NOTE: these should be invalid once validation is enforced
+    assert patient.valid?(:api)
+    assert patient.valid?(:import)
+    assert patient.valid?
 
     patient.last_date_of_exposure = '01-15-2000'
     assert_not patient.valid?(:api)
@@ -1941,9 +1942,10 @@ class PatientTest < ActiveSupport::TestCase
     patient = valid_patient
 
     patient.additional_planned_travel_start_date = 25.years.ago
-    assert_not patient.valid?(:api)
-    assert_not patient.valid?(:import)
-    assert_not patient.valid?
+    # NOTE: these should be invalid once validation is enforced
+    assert patient.valid?(:api)
+    assert patient.valid?(:import)
+    assert patient.valid?
 
     patient.additional_planned_travel_start_date = '01-15-2000'
     assert_not patient.valid?(:api)
@@ -1965,9 +1967,10 @@ class PatientTest < ActiveSupport::TestCase
     patient = valid_patient
 
     patient.additional_planned_travel_end_date = 25.years.ago
-    assert_not patient.valid?(:api)
-    assert_not patient.valid?(:import)
-    assert_not patient.valid?
+    # NOTE: these should be invalid once validation is enforced
+    assert patient.valid?(:api)
+    assert patient.valid?(:import)
+    assert patient.valid?
 
     patient.additional_planned_travel_end_date = '01-15-2000'
     assert_not patient.valid?(:api)
@@ -1989,9 +1992,10 @@ class PatientTest < ActiveSupport::TestCase
     patient = valid_patient
 
     patient.date_of_departure = 25.years.ago
-    assert_not patient.valid?(:api)
-    assert_not patient.valid?(:import)
-    assert_not patient.valid?
+    # NOTE: these should be invalid once validation is enforced
+    assert patient.valid?(:api)
+    assert patient.valid?(:import)
+    assert patient.valid?
 
     patient.date_of_departure = '01-15-2000'
     assert_not patient.valid?(:api)
@@ -2013,9 +2017,10 @@ class PatientTest < ActiveSupport::TestCase
     patient = valid_patient
 
     patient.date_of_arrival = 25.years.ago
-    assert_not patient.valid?(:api)
-    assert_not patient.valid?(:import)
-    assert_not patient.valid?
+    # NOTE: these should be invalid once validation is enforced
+    assert patient.valid?(:api)
+    assert patient.valid?(:import)
+    assert patient.valid?
 
     patient.date_of_arrival = '01-15-2000'
     assert_not patient.valid?(:api)
@@ -2038,9 +2043,10 @@ class PatientTest < ActiveSupport::TestCase
     patient.isolation = true
 
     patient.extended_isolation = 25.years.ago
-    assert_not patient.valid?(:api)
-    assert_not patient.valid?(:import)
-    assert_not patient.valid?
+    # NOTE: these should be invalid once validation is enforced
+    assert patient.valid?(:api)
+    assert patient.valid?(:import)
+    assert patient.valid?
 
     patient.extended_isolation = '01-15-2000'
     assert_not patient.valid?(:api)
@@ -2053,9 +2059,10 @@ class PatientTest < ActiveSupport::TestCase
     assert_nil patient.extended_isolation
 
     patient.extended_isolation = 2.months.ago
-    assert_not patient.valid?(:api)
-    assert_not patient.valid?(:import)
-    assert_not patient.valid?
+    # NOTE: these should be invalid once validation is enforced
+    assert patient.valid?(:api)
+    assert patient.valid?(:import)
+    assert patient.valid?
 
     patient.extended_isolation = 3.days.from_now
     assert patient.valid?(:api)

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -58,13 +58,13 @@ class PatientTest < ActiveSupport::TestCase
     assert patient.valid?(:import)
     patient.date_of_birth = 20_210_101
     assert_not patient.valid?(:import)
-    assert_equal ['is not a valid date, please use the \'YYYY-MM-DD\' format'], patient.errors[:date_of_birth]
+    assert_equal 'is not a valid date, please use the \'YYYY-MM-DD\' format', patient.errors[:date_of_birth].first
     patient.date_of_birth = 20_210_001
     assert_not patient.valid?(:import)
-    assert_equal ['is not a valid date, please use the \'YYYY-MM-DD\' format'], patient.errors[:date_of_birth]
+    assert_equal 'is not a valid date, please use the \'YYYY-MM-DD\' format', patient.errors[:date_of_birth].first
     patient.date_of_birth = 20_210_101.001
     assert_not patient.valid?(:import)
-    assert_equal ['is not a valid date, please use the \'YYYY-MM-DD\' format'], patient.errors[:date_of_birth]
+    assert_equal 'is not a valid date, please use the \'YYYY-MM-DD\' format', patient.errors[:date_of_birth].first
   end
 
   test 'active dependents does NOT include dependents that are purged' do
@@ -1888,16 +1888,23 @@ class PatientTest < ActiveSupport::TestCase
     patient = valid_patient
 
     patient.last_date_of_exposure = 25.years.ago
-    assert patient.valid?(:api)
-    assert patient.valid?(:import)
+    assert_not patient.valid?(:api)
+    assert_not patient.valid?(:import)
+    assert_not patient.valid?
 
     patient.last_date_of_exposure = '01-15-2000'
     assert_not patient.valid?(:api)
     assert_not patient.valid?(:import)
+    assert_nil patient.last_date_of_exposure
 
     patient.last_date_of_exposure = '2000-13-13'
     assert_not patient.valid?(:api)
     assert_not patient.valid?(:import)
+    assert_nil patient.last_date_of_exposure
+
+    patient.last_date_of_exposure = '2020-12-12'
+    assert patient.valid?(:api)
+    assert patient.valid?(:import)
     assert patient.valid?
   end
 
@@ -1905,33 +1912,52 @@ class PatientTest < ActiveSupport::TestCase
     patient = valid_patient
 
     patient.symptom_onset = 25.years.ago
+    assert_not patient.valid?(:api)
+    assert_not patient.valid?(:import)
+    assert_not patient.valid?
+
+    patient.symptom_onset = 11.hours.from_now
     assert patient.valid?(:api)
     assert patient.valid?(:import)
+    assert patient.valid?
 
     patient.symptom_onset = '01-15-2000'
     assert_not patient.valid?(:api)
     assert_not patient.valid?(:import)
+    assert_nil patient.symptom_onset
+
+    patient.symptom_onset = 3.days.from_now
+    assert_not patient.valid?(:api)
+    assert_not patient.valid?(:import)
+    assert_not patient.valid?
 
     patient.symptom_onset = '2000-13-13'
     assert_not patient.valid?(:api)
     assert_not patient.valid?(:import)
-    assert patient.valid?
+    assert_nil patient.symptom_onset
   end
 
   test 'validates additional_planned_travel_start_date is a valid date in api and import context' do
     patient = valid_patient
 
     patient.additional_planned_travel_start_date = 25.years.ago
-    assert patient.valid?(:api)
-    assert patient.valid?(:import)
+    assert_not patient.valid?(:api)
+    assert_not patient.valid?(:import)
+    assert_not patient.valid?
 
     patient.additional_planned_travel_start_date = '01-15-2000'
     assert_not patient.valid?(:api)
     assert_not patient.valid?(:import)
+    assert_nil patient.additional_planned_travel_start_date
 
     patient.additional_planned_travel_start_date = '2000-13-13'
     assert_not patient.valid?(:api)
     assert_not patient.valid?(:import)
+    assert_nil patient.additional_planned_travel_start_date
+
+    patient.additional_planned_travel_start_date = '2020-12-12'
+    assert patient.valid?(:api)
+    assert patient.valid?(:import)
     assert patient.valid?
   end
 
@@ -1939,16 +1965,23 @@ class PatientTest < ActiveSupport::TestCase
     patient = valid_patient
 
     patient.additional_planned_travel_end_date = 25.years.ago
-    assert patient.valid?(:api)
-    assert patient.valid?(:import)
+    assert_not patient.valid?(:api)
+    assert_not patient.valid?(:import)
+    assert_not patient.valid?
 
     patient.additional_planned_travel_end_date = '01-15-2000'
     assert_not patient.valid?(:api)
     assert_not patient.valid?(:import)
+    assert_nil patient.additional_planned_travel_end_date
 
     patient.additional_planned_travel_end_date = '2000-13-13'
     assert_not patient.valid?(:api)
     assert_not patient.valid?(:import)
+    assert_nil patient.additional_planned_travel_end_date
+
+    patient.additional_planned_travel_end_date = '2020-11-11'
+    assert patient.valid?(:api)
+    assert patient.valid?(:import)
     assert patient.valid?
   end
 
@@ -1956,16 +1989,23 @@ class PatientTest < ActiveSupport::TestCase
     patient = valid_patient
 
     patient.date_of_departure = 25.years.ago
-    assert patient.valid?(:api)
-    assert patient.valid?(:import)
+    assert_not patient.valid?(:api)
+    assert_not patient.valid?(:import)
+    assert_not patient.valid?
 
     patient.date_of_departure = '01-15-2000'
     assert_not patient.valid?(:api)
     assert_not patient.valid?(:import)
+    assert_nil patient.date_of_departure
 
     patient.date_of_departure = '2000-13-13'
     assert_not patient.valid?(:api)
     assert_not patient.valid?(:import)
+    assert_nil patient.date_of_departure
+
+    patient.date_of_departure = '2020-12-12'
+    assert patient.valid?(:api)
+    assert patient.valid?(:import)
     assert patient.valid?
   end
 
@@ -1973,16 +2013,23 @@ class PatientTest < ActiveSupport::TestCase
     patient = valid_patient
 
     patient.date_of_arrival = 25.years.ago
-    assert patient.valid?(:api)
-    assert patient.valid?(:import)
+    assert_not patient.valid?(:api)
+    assert_not patient.valid?(:import)
+    assert_not patient.valid?
 
     patient.date_of_arrival = '01-15-2000'
     assert_not patient.valid?(:api)
     assert_not patient.valid?(:import)
+    assert_nil patient.date_of_arrival
 
     patient.date_of_arrival = '2000-13-13'
     assert_not patient.valid?(:api)
     assert_not patient.valid?(:import)
+    assert_nil patient.date_of_arrival
+
+    patient.date_of_arrival = '2020-12-12'
+    assert patient.valid?(:api)
+    assert patient.valid?(:import)
     assert patient.valid?
   end
 
@@ -1991,14 +2038,28 @@ class PatientTest < ActiveSupport::TestCase
     patient.isolation = true
 
     patient.extended_isolation = 25.years.ago
-    assert patient.valid?(:api)
+    assert_not patient.valid?(:api)
+    assert_not patient.valid?(:import)
+    assert_not patient.valid?
 
     patient.extended_isolation = '01-15-2000'
     assert_not patient.valid?(:api)
-    assert patient.valid?
+    assert_not patient.valid?(:import)
+    assert_nil patient.extended_isolation
 
     patient.extended_isolation = '2000-13-13'
     assert_not patient.valid?(:api)
+    assert_not patient.valid?(:import)
+    assert_nil patient.extended_isolation
+
+    patient.extended_isolation = 2.months.ago
+    assert_not patient.valid?(:api)
+    assert_not patient.valid?(:import)
+    assert_not patient.valid?
+
+    patient.extended_isolation = 3.days.from_now
+    assert patient.valid?(:api)
+    assert patient.valid?(:import)
     assert patient.valid?
   end
 

--- a/test/system/roles/enroller/enrollment/form_validator.rb
+++ b/test/system/roles/enroller/enrollment/form_validator.rb
@@ -21,63 +21,63 @@ class EnrollmentFormValidator < ApplicationSystemTestCase
 
   def verify_input_validation_for_identification(identification)
     @@system_test_utils.go_to_next_page
-    verify_text_displayed('Please enter a First Name')
-    verify_text_displayed('Please enter a Last Name')
-    verify_text_displayed('Please enter a Date of Birth')
+    page.assert_text('Please enter a First Name')
+    page.assert_text('Please enter a Last Name')
+    page.assert_text('Please enter a Date of Birth')
     @@enrollment_form.populate_enrollment_step(:identification, identification)
-    verify_text_not_displayed('Please enter a First Name')
-    verify_text_not_displayed('Please enter a Last Name')
-    verify_text_not_displayed('Please enter a Date of Birth')
+    page.assert_no_text('Please enter a First Name')
+    page.assert_no_text('Please enter a Last Name')
+    page.assert_no_text('Please enter a Date of Birth')
   end
 
   def verify_input_validation_for_address(address)
     @@system_test_utils.go_to_next_page
-    verify_text_displayed('Please enter first line of address')
-    verify_text_displayed('Please enter city of address')
-    verify_text_displayed('Please enter state of address')
-    verify_text_displayed('Please enter zip code of address')
-    verify_text_not_displayed('Please enter country of address')
+    page.assert_text('Please enter first line of address')
+    page.assert_text('Please enter city of address')
+    page.assert_text('Please enter state of address')
+    page.assert_text('Please enter zip code of address')
+    page.assert_no_text('Please enter country of address')
     click_on 'Home Address Outside USA (Foreign)'
     click_on 'Next'
-    verify_text_not_displayed('Please enter first line of address')
-    verify_text_displayed('Please enter city of address')
-    verify_text_not_displayed('Please enter state of address')
-    verify_text_not_displayed('Please enter zip code of address')
-    verify_text_displayed('Please enter country of address')
+    page.assert_no_text('Please enter first line of address')
+    page.assert_text('Please enter city of address')
+    page.assert_no_text('Please enter state of address')
+    page.assert_no_text('Please enter zip code of address')
+    page.assert_text('Please enter country of address')
     click_on 'Home Address Within USA'
     @@enrollment_form.populate_enrollment_step(:address, address)
-    verify_text_not_displayed('Please enter first line of address')
-    verify_text_not_displayed('Please enter city of address')
-    verify_text_not_displayed('Please enter state of address')
-    verify_text_not_displayed('Please enter zip code of address')
-    verify_text_not_displayed('Please enter country of address')
+    page.assert_no_text('Please enter first line of address')
+    page.assert_no_text('Please enter city of address')
+    page.assert_no_text('Please enter state of address')
+    page.assert_no_text('Please enter zip code of address')
+    page.assert_no_text('Please enter country of address')
   end
 
   def verify_input_validation_for_contact_information(contact_information)
     select 'Telephone call', from: 'preferred_contact_method'
     click_on 'Next'
-    verify_text_not_displayed('Please provide an Email or change Preferred Reporting Method')
-    verify_text_not_displayed('Please confirm Email')
-    verify_text_displayed('Please provide a Primary Telephone Number, or change Preferred Reporting Method.')
+    page.assert_no_text('Please provide an Email or change Preferred Reporting Method')
+    page.assert_no_text('Please confirm Email')
+    page.assert_text('Please provide a Primary Telephone Number, or change Preferred Reporting Method.')
     select 'SMS Text-message', from: 'preferred_contact_method'
     click_on 'Next'
-    verify_text_not_displayed('Please provide an Email or change Preferred Reporting Method')
-    verify_text_not_displayed('Please confirm Email')
-    verify_text_displayed('Please provide a Primary Telephone Number, or change Preferred Reporting Method.')
+    page.assert_no_text('Please provide an Email or change Preferred Reporting Method')
+    page.assert_no_text('Please confirm Email')
+    page.assert_text('Please provide a Primary Telephone Number, or change Preferred Reporting Method.')
     select 'E-mailed Web Link', from: 'preferred_contact_method'
     click_on 'Next'
-    verify_text_displayed('Please provide an Email or change Preferred Reporting Method')
-    verify_text_displayed('Please confirm Email')
-    verify_text_not_displayed('Please provide a Primary Telephone Number, or change Preferred Reporting Method.')
+    page.assert_text('Please provide an Email or change Preferred Reporting Method')
+    page.assert_text('Please confirm Email')
+    page.assert_no_text('Please provide a Primary Telephone Number, or change Preferred Reporting Method.')
     fill_in 'email', with: 'email@eample.com'
     click_on 'Next'
-    verify_text_not_displayed('Please provide an Email or change Preferred Reporting Method')
-    verify_text_displayed('Please confirm Email')
-    verify_text_not_displayed('Please provide a Primary Telephone Number, or change Preferred Reporting Method.')
+    page.assert_no_text('Please provide an Email or change Preferred Reporting Method')
+    page.assert_text('Please confirm Email')
+    page.assert_no_text('Please provide a Primary Telephone Number, or change Preferred Reporting Method.')
     @@enrollment_form.populate_enrollment_step(:contact_information, contact_information)
-    verify_text_not_displayed('Please provide an Email or change Preferred Reporting Method')
-    verify_text_not_displayed('Please confirm Email')
-    verify_text_not_displayed('Please provide a Primary Telephone Number, or change Preferred Reporting Method.')
+    page.assert_no_text('Please provide an Email or change Preferred Reporting Method')
+    page.assert_no_text('Please confirm Email')
+    page.assert_no_text('Please provide a Primary Telephone Number, or change Preferred Reporting Method.')
   end
 
   def verify_input_validation_for_arrival_information(arrival_information)
@@ -90,23 +90,23 @@ class EnrollmentFormValidator < ApplicationSystemTestCase
 
   def verify_input_validation_for_potential_exposure_information(potential_exposure_information)
     @@system_test_utils.go_to_next_page
-    verify_text_displayed('Please enter a Last Date of Exposure OR turn on Continuous Exposure')
+    page.assert_text('Please enter a Last Date of Exposure OR turn on Continuous Exposure')
     fill_in 'last_date_of_exposure', with: 5.days.ago.strftime('%m/%d/%Y')
     fill_in 'jurisdiction_id', with: '' # clear out jurisdiction to so that there is at least one validation error
     click_on 'Next'
-    verify_text_not_displayed('Please enter a Last Date of Exposure OR turn on Continuous Exposure')
+    page.assert_no_text('Please enter a Last Date of Exposure OR turn on Continuous Exposure')
     fill_in 'last_date_of_exposure', with: ''
     click_on 'Next'
-    verify_text_displayed('Please enter a Last Date of Exposure OR turn on Continuous Exposure')
+    page.assert_text('Please enter a Last Date of Exposure OR turn on Continuous Exposure')
     page.find('label', text: 'CONTINUOUS EXPOSURE').click
-    verify_text_not_displayed('Please enter a Last Date of Exposure OR turn on Continuous Exposure')
-    verify_text_displayed('Please enter a valid Assigned Jurisdiction')
+    page.assert_no_text('Please enter a Last Date of Exposure OR turn on Continuous Exposure')
+    page.assert_text('Please enter a valid Assigned Jurisdiction')
     fill_in 'jurisdiction_id', with: 'fake jurisdiction'
     click_on 'Next'
-    verify_text_displayed('Please enter a valid Assigned Jurisdiction')
+    page.assert_text('Please enter a valid Assigned Jurisdiction')
     fill_in 'jurisdiction_id', with: 'USA'
     click_on 'Next'
-    verify_text_displayed('Please enter a valid Assigned Jurisdiction')
+    page.assert_text('Please enter a valid Assigned Jurisdiction')
     fill_in 'jurisdiction_id', with: 'USA, State 1, County 1'
     fill_in 'assigned_user', with: '-8.5'
     assert_not_equal('-8.5', page.find_field('assigned_user').value)
@@ -118,7 +118,7 @@ class EnrollmentFormValidator < ApplicationSystemTestCase
     assert_not_equal('W(#*&R#(W&', page.find_field('assigned_user').value)
     @@enrollment_form.populate_enrollment_step(:potential_exposure_information, potential_exposure_information)
     click_on 'OK' # confirm jurisdiction change
-    verify_text_not_displayed('Please enter a Last Date of Exposure OR turn on Continuous Exposure')
+    page.assert_no_text('Please enter a Last Date of Exposure OR turn on Continuous Exposure')
 
     # isolation fields
     @@system_test_utils.wait_for_enrollment_page_transition
@@ -130,32 +130,21 @@ class EnrollmentFormValidator < ApplicationSystemTestCase
     click_on 'edit-potential_exposure_information-btn'
     fill_in 'jurisdiction_id', with: '' # clear out jurisdiction to so that there is at least one validation error
     click_on 'Next'
-    verify_text_displayed('Please enter a Symptom Onset Date AND/OR a positive lab result.')
-    fill_in 'symptom_onset', with: 1.day.from_now.strftime('%m/%d/%Y')
-    click_on 'Next'
-    verify_text_displayed('Date can not be in the future.')
+    page.assert_text('Please enter a Symptom Onset Date AND/OR a positive lab result.')
     fill_in 'symptom_onset', with: 3.days.ago.strftime('%m/%d/%Y')
     click_on 'Next'
-    verify_text_not_displayed('Please enter a Symptom Onset Date AND/OR a positive lab result.')
+    page.assert_no_text('Please enter a Symptom Onset Date AND/OR a positive lab result.')
     fill_in 'symptom_onset', with: ''
     click_on 'Next'
-    verify_text_displayed('Please enter a Symptom Onset Date AND/OR a positive lab result.')
+    page.assert_text('Please enter a Symptom Onset Date AND/OR a positive lab result.')
     click_on 'Enter Lab Result'
     assert page.has_button?('Create', disabled: true)
     fill_in 'specimen_collection', with: 2.days.ago.strftime('%m/%d/%Y')
     click_on 'Create'
     click_on 'Next'
-    verify_text_not_displayed('Please enter a Symptom Onset Date AND/OR a positive lab result.')
+    page.assert_no_text('Please enter a Symptom Onset Date AND/OR a positive lab result.')
     fill_in 'symptom_onset', with: 3.days.ago.strftime('%m/%d/%Y')
     click_on 'Next'
-    verify_text_not_displayed('Please enter a Symptom Onset Date AND/OR a positive lab result.')
-  end
-
-  def verify_text_displayed(text)
-    assert page.has_content?(text), "Monitoree enrollment input validation - should display error message: #{text}"
-  end
-
-  def verify_text_not_displayed(text)
-    assert page.has_no_content?(text), "Monitoree enrollment input validation - should not display error message: #{text}"
+    page.assert_no_text('Please enter a Symptom Onset Date AND/OR a positive lab result.')
   end
 end

--- a/test/system/roles/enroller/enrollment/form_validator.rb
+++ b/test/system/roles/enroller/enrollment/form_validator.rb
@@ -131,6 +131,9 @@ class EnrollmentFormValidator < ApplicationSystemTestCase
     fill_in 'jurisdiction_id', with: '' # clear out jurisdiction to so that there is at least one validation error
     click_on 'Next'
     verify_text_displayed('Please enter a Symptom Onset Date AND/OR a positive lab result.')
+    fill_in 'symptom_onset', with: 1.day.from_now.strftime('%m/%d/%Y')
+    click_on 'Next'
+    verify_text_displayed('Date can not be in the future.')
     fill_in 'symptom_onset', with: 3.days.ago.strftime('%m/%d/%Y')
     click_on 'Next'
     verify_text_not_displayed('Please enter a Symptom Onset Date AND/OR a positive lab result.')


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1559](https://tracker.codev.mitre.org/browse/SARAALERT-1559)

Currently, users are allowed to future-date a monitoree's Symptom Onset Date by up to 30 days. When the Extend Isolation To date was implemented, this addressed the primary use case that was reference for the future-dating of Symptom Onset Date. So at this point, the system should no longer allow the user to future-date the Symptom Onset Date

Definition of Done:
- Prevent the user from being able to future-date a monitoree's Symptom Onset Date
- Prevent the user from importing a moniotree with a future-dated Symptom Onset Date.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`example_file.js`
- Example change (ex: refactored import function)

## Testing Recommendations
Please list any recommendations regarding what reviewers should test and if there is any specific guidance on how to test certain aspects of the PR. Be sure to mention edge cases that should be tried, particularly in the UI.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@ngfreiter :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@sgober :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
