### PR TITLE
SARAALERT-NONE: 1.34.0 API Documentation Updates

### DIFF
--- a/docs/api/api-coming-soon.md
+++ b/docs/api/api-coming-soon.md
@@ -7,27 +7,8 @@ nav_order: 2
 
 **Below you will find a list of ongoing work that affects the Sara Alert™ API. This page will be updated regularly. If you have any questions on the information here, please email them to our API Help Desk, saraalert-interop@mitre.org. For past release notes, please see [API Release Notes](api-release-notes).**
 
-## Planned for 1.34\*:
+## Planned for 1.35\*:
 
-- Add support for additional fields which are not yet supported in the API. These fields include read and write support for:
-  - Exposure Risk Assessment
-  - Public Health Action
-  - Extended Isolation
-  - Contact of a Known Case
-  - Contact of a Known Case ID
-  - Member of a Common Exposure Cohort Type
-  - Potential Exposure Location
-  - Potential Exposure Country
-  - Secondary Language
-  - CDC ID
-  - NNDSS ID
-
-  The following fields will be added as read-only fields:
-  - End of Monitoring
-  - Expected Purge Date
-  - Monitoring Reason
-  - Latest Transfer At
-  - Latest Transfer From
 - Add support for bulk export via the API according to the FHIR bulk data [specification](https://hl7.org/fhir/uv/bulkdata/)
 
 ---


### PR DESCRIPTION
# Description
Jira Ticket: N/A

Update API docs for 1.34.0.


## Important Changes
`api-coming-soon.md`
- Few things to note, changed the coming soon to 1.34.0, and did not list the new fields as coming soon, since by my guess those will not make 1.35.0. Also although some new fields were supported in 1.34.0, I would prefer to leave that undocumented in the release notes for now, and just document all the fields together once additional new fields are added.