### PR TITLE
SARAALERT-1494: Auto close history language change

### DIFF
--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -245,7 +245,7 @@ class History < ApplicationRecord
     create_history(patient, created_by, HISTORY_TYPES[:welcome_message_sent], comment, create: create)
   end
 
-  def self.record_automatically_closed(patient: nil, created_by: 'Sara Alert System', comment: 'Monitoree has completed monitoring.', reason: nil, create: true)
+  def self.record_automatically_closed(patient: nil, created_by: 'Sara Alert System', comment: 'Monitoree closed by the system.', reason: nil, create: true)
     comment = "#{comment} Reason: #{reason}" unless reason.nil?
     create_history(patient, created_by, HISTORY_TYPES[:record_automatically_closed], comment, create: create)
   end

--- a/test/jobs/close_patients_job_test.rb
+++ b/test/jobs/close_patients_job_test.rb
@@ -63,7 +63,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
     ClosePatientsJob.perform_now
     updated_patient = Patient.find_by(id: patient.id)
     assert_equal(updated_patient.histories.last.history_type, History::HISTORY_TYPES[:record_automatically_closed])
-    assert_histories_contain(patient, "Monitoree has completed monitoring. Reason: Enrolled more than #{@period} days after last date of exposure (system)")
+    assert_histories_contain(patient, "Monitoree closed by the system. Reason: Enrolled more than #{@period} days after last date of exposure (system)")
   end
 
   test 'creates correct monitoring reason when record has normally completed monitoring period' do
@@ -80,7 +80,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
     ClosePatientsJob.perform_now
     updated_patient = Patient.find_by(id: patient.id)
     assert_equal(updated_patient.monitoring_reason, 'Completed Monitoring (system)')
-    assert_histories_contain(patient, 'Monitoree has completed monitoring. Reason: Completed Monitoring (system)')
+    assert_histories_contain(patient, 'Monitoree closed by the system. Reason: Completed Monitoring (system)')
   end
 
   test 'creates correct monitoring reason when record was enrolled past their monitoring period' do
@@ -97,7 +97,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
     ClosePatientsJob.perform_now
     updated_patient = Patient.find_by(id: patient.id)
     assert_equal(updated_patient.monitoring_reason, "Enrolled more than #{@period} days after last date of exposure (system)")
-    assert_histories_contain(patient, "Monitoree has completed monitoring. Reason: Enrolled more than #{@period} days after last date of exposure (system)")
+    assert_histories_contain(patient, "Monitoree closed by the system. Reason: Enrolled more than #{@period} days after last date of exposure (system)")
   end
 
   test 'creates correct monitoring reason when record was enrolled on their last day of monitoring' do
@@ -115,7 +115,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
     ClosePatientsJob.perform_now
     updated_patient = Patient.find_by(id: patient.id)
     assert_equal(updated_patient.monitoring_reason, 'Enrolled on last day of monitoring period (system)')
-    assert_histories_contain(patient, 'Monitoree has completed monitoring. Reason: Enrolled on last day of monitoring period (system)')
+    assert_histories_contain(patient, 'Monitoree closed by the system. Reason: Enrolled on last day of monitoring period (system)')
   end
 
   test 'sends closed email if closed record is a reporter' do
@@ -146,7 +146,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
     assert_equal(closed_email.to[0], patient.email)
     assert_histories_contain(patient, 'Monitoring Complete message was sent.')
     assert_not_histories_contain(patient, 'because the monitoree email was blank.')
-    assert_histories_contain(patient, 'Monitoree has completed monitoring. Reason: Completed Monitoring (system)')
+    assert_histories_contain(patient, 'Monitoree closed by the system. Reason: Completed Monitoring (system)')
   end
 
   test 'does not send closed notification if jurisdiction send_close is false' do
@@ -163,7 +163,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
     patient.jurisdiction.update(send_close: false)
     ClosePatientsJob.perform_now
     assert_equal(ActionMailer::Base.deliveries.count, 1)
-    assert_histories_contain(patient, "Monitoree has completed monitoring. Reason: Enrolled more than #{@period} days after last date of exposure (system)")
+    assert_histories_contain(patient, "Monitoree closed by the system. Reason: Enrolled more than #{@period} days after last date of exposure (system)")
   end
 
   ['Telephone call', 'Opt-out', 'Unknown', nil, ''].each do |preferred_contact_method|
@@ -183,7 +183,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
       ClosePatientsJob.perform_now
       history_friendly_method = patient.preferred_contact_method.blank? ? patient.preferred_contact_method : 'Unknown'
       assert_histories_contain(patient, "#{history_friendly_method}, is not supported for this message type.")
-      assert_histories_contain(patient, 'Monitoree has completed monitoring. Reason: Completed Monitoring (system)')
+      assert_histories_contain(patient, 'Monitoree closed by the system. Reason: Completed Monitoring (system)')
     end
   end
 
@@ -203,7 +203,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
       ClosePatientsJob.perform_now
       method_text = preferred_contact_method == 'E-mailed Web Link' ? 'email' : 'primary phone number'
       assert_histories_contain(patient, "because their preferred contact method, #{method_text}, was blank.")
-      assert_histories_contain(patient, 'Monitoree has completed monitoring. Reason: Completed Monitoring (system)')
+      assert_histories_contain(patient, 'Monitoree closed by the system. Reason: Completed Monitoring (system)')
     end
 
     test "sends closed email if closed record is a reporter with #{preferred_contact_method} preferred" do
@@ -223,7 +223,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
       ClosePatientsJob.perform_now
       method_text = preferred_contact_method == 'E-mailed Web Link' ? 'email' : 'primary phone number'
       assert_not_histories_contain(patient, "because their preferred contact method, #{method_text}, was blank.")
-      assert_histories_contain(patient, 'Monitoree has completed monitoring. Reason: Completed Monitoring (system)')
+      assert_histories_contain(patient, 'Monitoree closed by the system. Reason: Completed Monitoring (system)')
       assert_histories_contain(patient, 'Monitoring Complete message was sent.')
     end
   end
@@ -250,7 +250,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
         ' because the recipient phone number blocked communication with Sara Alert'
       )
       assert_not_histories_contain(patient, "because their preferred contact method, #{method_text}, was blank.")
-      assert_histories_contain(patient, 'Monitoree has completed monitoring. Reason: Completed Monitoring (system)')
+      assert_histories_contain(patient, 'Monitoree closed by the system. Reason: Completed Monitoring (system)')
     end
   end
 


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1494](https://tracker.codev.mitre.org/browse/SARAALERT-1494)

This is related to https://github.com/SaraAlert/SaraAlert/pull/1014 and brings in a language change that was requested in addition to the changes made in that PR. The request is: `Change the first sentence of the History message for system-closed records (“Monitoree has completed monitoring”) to “Monitoree closed by the system.”`

## Important Changes

`history.rb`
- Changed the default comment for the `record_automatically_closed` history item to use the newly requested language.

`close_patients_job_test.rb`
- Changed the test cases that involve this auto-close language to account of the new history comment change.

## Testing Recommendations
`bundle exec rails test test/jobs/close_patients_job_test.rb` and/or run the close patients job in you local environment:
```ruby
ADMIN_OPTIONS['job_run_email'] = 'test@test.com'
Patient.limit(10).update_all(
      isolation: false,
      continuous_exposure: false,
      latest_assessment_at: DateTime.now,
      symptom_onset: nil,
      public_health_action: 'None',
      purged: false,
      monitoring: true,
      created_at: 100.days.ago,
      last_date_of_exposure: 100.days.ago
)
ClosePatientsJob.perform_now
```

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@holmesie  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@Bialogs  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
