### PR TITLE
SARAALERT-1470: Rubocop Rails and Performance Plugin (config and tests)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -189,86 +189,124 @@ Style/QuotedSymbols: # (new in 1.16)
 Style/StringChars: # (new in 1.12)
   Enabled: true
 Rails/FilePath:
-  Enabled: true
+  Enabled: false
   EnforcedStyle: arguments
 Style/SafeNavigation:
   Enabled: false
 Rails/WhereNot:
-  Enabled: true
+  Enabled: false
 Rails/WhereEquals:
-  Enabled: true
+  Enabled: false
 Rails/ShortI18n:
-  Enabled: true
+  Enabled: false
 Rails/Pluck:
-  Enabled: true
+  Enabled: false
 Rails/FindById:
-  Enabled: true
+  Enabled: false
 Rails/I18nLocaleAssignment:
-  Enabled: true
+  Enabled: false
 Rails/UnusedIgnoredColumns:
-  Enabled: true
+  Enabled: false
 Rails/TimeZoneAssignment:
-  Enabled: true
+  Enabled: false
 Rails/Inquiry:
-  Enabled: true
+  Enabled: false
 Rails/NegateInclude:
-  Enabled: true
+  Enabled: false
 Rails/RenderInline:
-  Enabled: true
+  Enabled: false
 Rails/SquishedSQLHeredocs:
-  Enabled: true
+  Enabled: false
 Rails/ActiveRecordCallbacksOrder:
-  Enabled: true
+  Enabled: false
 Rails/AfterCommitOverride:
-  Enabled: true
+  Enabled: false
 Rails/AddColumnIndex:
-  Enabled: true
+  Enabled: false
 Rails/RenderPlainText:
-  Enabled: true
+  Enabled: false
 Rails/MailerName:
-  Enabled: true
+  Enabled: false
 Rails/ExpandedDateRange:
-  Enabled: true
+  Enabled: false
 Rails/EagerEvaluationLogMessage:
-  Enabled: true
+  Enabled: false
 Rails/MatchRoute:
-  Enabled: true
+  Enabled: false
 Rails/PluckInWhere:
   Enabled: false
 Rails/WhereExists:
   Enabled: false
 Rails/AttributeDefaultBlockValue:
-  Enabled: true
+  Enabled: false
 Performance/Sum:
-  Enabled: true
+  Enabled: false
 Performance/StringInclude:
-  Enabled: true
+  Enabled: false
 Performance/Squeeze:
-  Enabled: true
+  Enabled: false
 Performance/SortReverse:
-  Enabled: true
+  Enabled: false
 Performance/ReverseFirst:
-  Enabled: true
+  Enabled: false
 Performance/RedundantStringChars:
-  Enabled: true
+  Enabled: false
 Performance/RedundantSplitRegexpArgument:
-  Enabled: true
+  Enabled: false
 Performance/MethodObjectAsBlock:
-  Enabled: true
+  Enabled: false
 Performance/RedundantSortBlock:
-  Enabled: true
+  Enabled: false
 Performance/MapCompact:
-  Enabled: true
+  Enabled: false
 Performance/BigDecimalWithNumericArgument:
-  Enabled: true
+  Enabled: false
 Performance/BlockGivenWithExplicitBlock:
-  Enabled: true
+  Enabled: false
 Performance/RedundantEqualityComparisonBlock:
-  Enabled: true
+  Enabled: false
 Performance/CollectionLiteralInLoop:
-  Enabled: true
+  Enabled: false
   MinSize: 4
 Performance/ConstantRegexp:
-  Enabled: true
+  Enabled: false
 Performance/AncestorsInclude:
-  Enabled: true
+  Enabled: false
+Performance/InefficientHashSearch:
+  Enabled: false
+Rails/Present:
+  Enabled: false
+Rails/DynamicFindBy:
+  Enabled: false
+Rails/Presence:
+  Enabled: false
+Performance/Casecmp:
+  Enabled: false
+Rails/Blank:
+  Enabled: false
+Rails/HttpStatus:
+  Enabled: false
+Rails/TimeZone:
+  Enabled: false
+Rails/Date:
+  Enabled: false
+Rails/Rails/HasManyOrHasOneDependent:
+  Enabled: false
+Lint/RedundantCopDisableDirective:
+  Enabled: false
+Rails/InverseOf:
+  Enabled: false
+Performance/Count:
+  Enabled: false
+Performance/RangeInclude:
+  Enabled: false
+Rails/SkipsModelValidations:
+  Enabled: false
+Rails/IndexBy:
+  Enabled: false
+Rails/IndexWith:
+  Enabled: false
+Performance/StringReplacement:
+  Enabled: false
+Performance/ReverseEach:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -290,7 +290,7 @@ Rails/TimeZone:
   Enabled: false
 Rails/Date:
   Enabled: false
-Rails/Rails/HasManyOrHasOneDependent:
+Rails/HasManyOrHasOneDependent:
   Enabled: false
 Lint/RedundantCopDisableDirective:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-performance
+  - rubocop-rails
 AllCops:
   TargetRubyVersion: 2.7
   Exclude:
@@ -184,4 +187,88 @@ Style/MultilineInPatternThen: # (new in 1.16)
 Style/QuotedSymbols: # (new in 1.16)
   Enabled: true
 Style/StringChars: # (new in 1.12)
+  Enabled: true
+Rails/FilePath:
+  Enabled: true
+  EnforcedStyle: arguments
+Style/SafeNavigation:
+  Enabled: false
+Rails/WhereNot:
+  Enabled: true
+Rails/WhereEquals:
+  Enabled: true
+Rails/ShortI18n:
+  Enabled: true
+Rails/Pluck:
+  Enabled: true
+Rails/FindById:
+  Enabled: true
+Rails/I18nLocaleAssignment:
+  Enabled: true
+Rails/UnusedIgnoredColumns:
+  Enabled: true
+Rails/TimeZoneAssignment:
+  Enabled: true
+Rails/Inquiry:
+  Enabled: true
+Rails/NegateInclude:
+  Enabled: true
+Rails/RenderInline:
+  Enabled: true
+Rails/SquishedSQLHeredocs:
+  Enabled: true
+Rails/ActiveRecordCallbacksOrder:
+  Enabled: true
+Rails/AfterCommitOverride:
+  Enabled: true
+Rails/AddColumnIndex:
+  Enabled: true
+Rails/RenderPlainText:
+  Enabled: true
+Rails/MailerName:
+  Enabled: true
+Rails/ExpandedDateRange:
+  Enabled: true
+Rails/EagerEvaluationLogMessage:
+  Enabled: true
+Rails/MatchRoute:
+  Enabled: true
+Rails/PluckInWhere:
+  Enabled: false
+Rails/WhereExists:
+  Enabled: false
+Rails/AttributeDefaultBlockValue:
+  Enabled: true
+Performance/Sum:
+  Enabled: true
+Performance/StringInclude:
+  Enabled: true
+Performance/Squeeze:
+  Enabled: true
+Performance/SortReverse:
+  Enabled: true
+Performance/ReverseFirst:
+  Enabled: true
+Performance/RedundantStringChars:
+  Enabled: true
+Performance/RedundantSplitRegexpArgument:
+  Enabled: true
+Performance/MethodObjectAsBlock:
+  Enabled: true
+Performance/RedundantSortBlock:
+  Enabled: true
+Performance/MapCompact:
+  Enabled: true
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+Performance/RedundantEqualityComparisonBlock:
+  Enabled: true
+Performance/CollectionLiteralInLoop:
+  Enabled: true
+  MinSize: 4
+Performance/ConstantRegexp:
+  Enabled: true
+Performance/AncestorsInclude:
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -118,6 +118,8 @@ group :development, :test do
   gem 'memory_profiler'
   gem 'octokit', '~> 4.0'
   gem 'rubocop'
+  gem 'rubocop-performance'
+  gem 'rubocop-rails'
   gem 'ruby-jmeter'
   gem 'stackprof'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,6 +363,13 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.7.0)
       parser (>= 3.0.1.1)
+    rubocop-performance (1.11.4)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.11.3)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.7.0, < 2.0)
     ruby-jmeter (3.1.08)
       nokogiri
       rest-client
@@ -513,6 +520,8 @@ DEPENDENCIES
   roo
   rspec-mocks
   rubocop
+  rubocop-performance
+  rubocop-rails
   ruby-jmeter
   rubyzip
   sara-schema

--- a/performance/assert_jmeter_results.rb
+++ b/performance/assert_jmeter_results.rb
@@ -53,7 +53,9 @@ class Array
     column_sizes = reduce([]) do |lengths, row|
       row.each_with_index.map { |iterand, index| [lengths[index] || 0, iterand.to_s.length].max }
     end
+    # rubocop:disable Performance/Sum
     puts head = '-' * (column_sizes.inject(&:+) + (3 * column_sizes.count) + 1)
+    # rubocop:enable Performance/Sum
     each do |row|
       row.fill(nil, row.size..(column_sizes.size - 1))
       row = row.each_with_index.map { |v, i| v.to_s + ' ' * (column_sizes[i] - v.to_s.length) }
@@ -65,11 +67,11 @@ end
 
 def rows_stats(rows)
   {
-    avg_latency: rows.map { |row| row['Latency'].to_i }.sum / rows.size,
+    avg_latency: (rows.sum { |row| row['Latency'].to_i }) / rows.size,
     max_latency: rows.map { |row| row['Latency'].to_i }.max,
-    avg_elapsed: rows.map { |row| row['elapsed'].to_i }.sum / rows.size,
+    avg_elapsed: (rows.sum { |row| row['elapsed'].to_i }) / rows.size,
     max_elapsed: rows.map { |row| row['elapsed'].to_i }.max,
-    failure_percent: rows.filter { |row| row['success'] != 'true' }.size / rows.size
+    failure_percent: (rows.count { |row| row['success'] != 'true' }) / rows.size
   }
 end
 

--- a/performance/benchmark.rb
+++ b/performance/benchmark.rb
@@ -45,10 +45,10 @@ def benchmark(name: nil, time_threshold: 3600, setup: nil, teardown: nil, no_exi
 
   timestamp = Time.now.utc.iso8601
   FileUtils.mkdir_p('performance/benchmarks/output') # Create the folder if it doesn't exist already
-  stackprof_file = "performance/benchmarks/output/#{name}_#{timestamp}_CPU.dump".gsub(':', '-')
-  flamegraph_file = "performance/benchmarks/output/#{name}_#{timestamp}_FLM".gsub(':', '-')
-  memprof_file = "performance/benchmarks/output/#{name}_#{timestamp}_MEM.log".gsub(':', '-')
-  benchmark_file = "performance/benchmarks/output/#{name}_#{timestamp}_BCM.log".gsub(':', '-')
+  stackprof_file = "performance/benchmarks/output/#{name}_#{timestamp}_CPU.dump".tr(':', '-')
+  flamegraph_file = "performance/benchmarks/output/#{name}_#{timestamp}_FLM".tr(':', '-')
+  memprof_file = "performance/benchmarks/output/#{name}_#{timestamp}_MEM.log".tr(':', '-')
+  benchmark_file = "performance/benchmarks/output/#{name}_#{timestamp}_BCM.log".tr(':', '-')
   $stdout = File.new(benchmark_file, 'w') if ENV['CAP_STDOUT']
   $stdout.sync = true if ENV['CAP_STDOUT']
 
@@ -63,9 +63,7 @@ def benchmark(name: nil, time_threshold: 3600, setup: nil, teardown: nil, no_exi
   Benchmark.bm(20) do |x|
     MemoryProfiler.start unless ENV['NO_MEMPROF']
     StackProf.start(mode: :wall, out: stackprof_file, interval: 1000, raw: true) unless ENV['NO_STACKPROF']
-    benchmark_report = x.report(name) do
-      block.call
-    end
+    benchmark_report = x.report(name, &block)
     StackProf.stop unless ENV['NO_STACKPROF']
     MemoryProfiler.stop.pretty_print(normalize_paths: true, scale_bytes: true, to_file: memprof_file) unless ENV['NO_MEMPROF']
   end

--- a/performance/benchmarks/close_patients_job_benchmark.rb
+++ b/performance/benchmarks/close_patients_job_benchmark.rb
@@ -14,7 +14,9 @@ benchmark(
     # Due to the `no_recent_activity` criteria of the close_eligible scope
     # it is necessary to change the updated_at of all patients so that
     # we do not go over `max_num_to_close`
-    Patient.update_all(updated_at: Time.now)
+    # Skip model validations as they are not needed in the benchmark.
+    # rubocop:disable Rails/SkipsModelValidations
+    Patient.update_all(updated_at: DateTime.now)
     Patient.limit(max_num_to_close).update_all(
       isolation: false,
       continuous_exposure: false,
@@ -26,5 +28,6 @@ benchmark(
       created_at: 100.days.ago,
       last_date_of_exposure: 100.days.ago
     )
+    # rubocop:enable Rails/SkipsModelValidations
   }
 ) { ClosePatientsJob.perform_now }

--- a/performance/benchmarks/micro_benchmarks.rb
+++ b/performance/benchmarks/micro_benchmarks.rb
@@ -86,7 +86,9 @@ micro_results << benchmark(
     # Due to the `no_recent_activity` criteria of the close_eligible scope
     # it is necessary to change the updated_at of all patients so that
     # we do not go over `max_num_to_close`
-    Patient.update_all(updated_at: Time.now)
+    # Skip model validations as they are not needed in the benchmark.
+    # rubocop:disable Rails/SkipsModelValidations
+    Patient.update_all(updated_at: DateTime.now)
     Patient.limit(max_num_to_close).update_all(
       isolation: false,
       continuous_exposure: false,
@@ -100,6 +102,7 @@ micro_results << benchmark(
       email: 'testpatient@example.com',
       primary_telephone: '+12223334444'
     )
+    # rubocop:enable Rails/SkipsModelValidations
   }
 ) { Patient.close_eligible.count }
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -5,7 +5,7 @@ require 'system_test_case'
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driver = ENV['APP_IN_CI'] ? :gitlab_chrome_headless : :chrome
 
-  download_path = Rails.root.join('tmp/downloads')
+  download_path = Rails.root.join('tmp', 'downloads')
   FileUtils.rm_rf(download_path) if File.exist?(download_path)
 
   Capybara.register_driver(driver) do |app|

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -380,7 +380,7 @@ class AdminControllerTest < ActionController::TestCase
 
     User.where(id: user_ids).each do |u|
       assert u.authy_id.nil?
-      assert !u.authy_enabled
+      assert_not u.authy_enabled
     end
 
     sign_out user
@@ -449,7 +449,7 @@ class AdminControllerTest < ActionController::TestCase
     assert_response :bad_request
 
     # Lock the first user
-    User.first.update!(locked_at: Time.now)
+    User.first.update!(locked_at: DateTime.now)
 
     # Test email is sent for all unlocked users
     assert_no_difference 'User.count' do

--- a/test/controllers/api/api_export_controller_test.rb
+++ b/test/controllers/api/api_export_controller_test.rb
@@ -170,7 +170,7 @@ class ApiExportControllerTest < ActionDispatch::IntegrationTest
       end
     end
     expected_ids = Jurisdiction
-                   .find_by_id(@shadow_user_jurisdiction)
+                   .find_by(id: @shadow_user_jurisdiction)
                    .all_patients_excluding_purged
                    .where(scope)
                    .pluck(:id)

--- a/test/controllers/close_contacts_controller_test.rb
+++ b/test/controllers/close_contacts_controller_test.rb
@@ -177,7 +177,7 @@ class CloseContactsControllerTest < ActionController::TestCase
 
     close_contact.reload
     assert_response(:success)
-    assert_in_delta(Time.now, close_contact.updated_at, 1) # assert updated
+    assert_in_delta(Time.now.getlocal, close_contact.updated_at, 1) # assert updated
     assert_equal(1, patient.histories.count)
 
     close_contact = CloseContact.find(close_contact.id)

--- a/test/controllers/fhir/r4/api_controller_test.rb
+++ b/test/controllers/fhir/r4/api_controller_test.rb
@@ -968,7 +968,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get Bundle via all' do
-    patient = Patient.find_by_id(1)
+    patient = Patient.find_by(id: 1)
     get(
       '/fhir/r4/Patient/1/$everything',
       headers: { Authorization: "Bearer #{@system_everything_token.token}", Accept: 'application/fhir+json' }
@@ -977,12 +977,12 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     json_response = JSON.parse(response.body)
     assert_equal 'Bundle', json_response['resourceType']
     assert_equal patient.assessments.length + patient.laboratories.length + patient.close_contacts.length + patient.vaccines.length + 1, json_response['total']
-    assert_equal 1, json_response['entry'].filter { |e| e['resource']['resourceType'] == 'Patient' }.count
-    assert_equal patient.assessments.length, json_response['entry'].filter { |e| e['resource']['resourceType'] == 'QuestionnaireResponse' }.count
-    assert_equal patient.laboratories.length, json_response['entry'].filter { |e| e['resource']['resourceType'] == 'Observation' }.count
-    assert_equal patient.close_contacts.length, json_response['entry'].filter { |e| e['resource']['resourceType'] == 'RelatedPerson' }.count
-    assert_equal patient.vaccines.length, json_response['entry'].filter { |e| e['resource']['resourceType'] == 'Immunization' }.count
-    assert_equal 'Patient/1', json_response['entry'].filter { |e| e['resource']['resourceType'] == 'Observation' }.first['resource']['subject']['reference']
+    assert_equal(1, json_response['entry'].count { |e| e['resource']['resourceType'] == 'Patient' })
+    assert_equal(patient.assessments.length, json_response['entry'].count { |e| e['resource']['resourceType'] == 'QuestionnaireResponse' })
+    assert_equal(patient.laboratories.length, json_response['entry'].count { |e| e['resource']['resourceType'] == 'Observation' })
+    assert_equal(patient.close_contacts.length, json_response['entry'].count { |e| e['resource']['resourceType'] == 'RelatedPerson' })
+    assert_equal(patient.vaccines.length, json_response['entry'].count { |e| e['resource']['resourceType'] == 'Immunization' })
+    assert_equal 'Patient/1', json_response['entry'].detect { |e| e['resource']['resourceType'] == 'Observation' }['resource']['subject']['reference']
     assert_equal 1, json_response['entry'].first['resource']['id']
   end
 

--- a/test/controllers/fhir/r4/immunization_test.rb
+++ b/test/controllers/fhir/r4/immunization_test.rb
@@ -18,8 +18,8 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       administration_date: 2.days.ago,
       dose_number: 1,
       notes: 'Foo',
-      created_at: 1.days.ago,
-      updated_at: 1.days.ago
+      created_at: 1.day.ago,
+      updated_at: 1.day.ago
     )
   end
   #----- show tests -----
@@ -31,7 +31,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       headers: { Authorization: "Bearer #{@system_everything_token.token}", Accept: 'application/fhir+json' }
     )
     assert_response :ok
-    assert_equal JSON.parse(Vaccine.find_by_id(vaccine_id).as_fhir.to_json), JSON.parse(response.body)
+    assert_equal JSON.parse(Vaccine.find_by(id: vaccine_id).as_fhir.to_json), JSON.parse(response.body)
   end
 
   test 'should be forbidden via show for inaccessible Immunization' do
@@ -137,7 +137,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       headers: { Authorization: "Bearer #{@system_everything_token.token}", 'Content-Type': 'application/fhir+json' }
     )
     assert_response :ok
-    updated_v = Vaccine.find_by_id(@vaccine_1.id)
+    updated_v = Vaccine.find_by(id: @vaccine_1.id)
 
     # Verify that the updated Vaccine matches the original outside of updated fields
     %i[patient_id
@@ -169,7 +169,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       headers: { Authorization: "Bearer #{@system_everything_token.token}", 'Content-Type': 'application/json-patch+json' }
     )
     assert_response :ok
-    updated_v = Vaccine.find_by_id(@vaccine_1.id)
+    updated_v = Vaccine.find_by(id: @vaccine_1.id)
 
     # Verify that the updated Vaccine matches the original outside of updated fields
     %i[patient_id
@@ -241,7 +241,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
   test 'should find Immunizations for a Patient via search' do
     @vaccine_1.patient_id = 2
     @vaccine_1.save
-    patient = Patient.find_by_id(@vaccine_1.patient_id)
+    patient = Patient.find_by(id: @vaccine_1.patient_id)
     get(
       "/fhir/r4/Immunization?patient=Patient/#{@vaccine_1.patient_id}",
       headers: { Authorization: "Bearer #{@system_everything_token.token}", Accept: 'application/fhir+json' }

--- a/test/controllers/fhir/r4/observation_test.rb
+++ b/test/controllers/fhir/r4/observation_test.rb
@@ -11,7 +11,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
   end
 
   def setup_labs
-    patient_1 = create(:patient, creator: User.find_by_id(@system_everything_app.user_id))
+    patient_1 = create(:patient, creator: User.find_by(id: @system_everything_app.user_id))
     @lab_1 = create(
       :laboratory,
       lab_type: Laboratory::LAB_TYPE_TO_CODE.keys.sample,

--- a/test/controllers/fhir/r4/patient_test.rb
+++ b/test/controllers/fhir/r4/patient_test.rb
@@ -22,11 +22,11 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal 'Patient', json_response['resourceType']
     assert_equal 3, json_response['telecom'].count
     assert_equal 'Boehm62', json_response['name'].first['family']
-    assert_equal 'Telephone call', json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-method' }.first['valueString']
-    assert_equal 'Morning', json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-time' }.first['valueString']
-    assert_equal 45.days.ago.strftime('%Y-%m-%d'), json_response['extension'].filter { |e| e['url'].include? 'last-date-of-exposure' }.first['valueDate']
-    assert_equal 5.days.ago.strftime('%Y-%m-%d'), json_response['extension'].filter { |e| e['url'].include? 'symptom-onset-date' }.first['valueDate']
-    assert_not json_response['extension'].filter { |e| e['url'].include? 'isolation' }.first['valueBoolean']
+    assert_equal 'Telephone call', json_response['extension'].detect { |e| e['url'].include? 'preferred-contact-method' }['valueString']
+    assert_equal 'Morning', json_response['extension'].detect { |e| e['url'].include? 'preferred-contact-time' }['valueString']
+    assert_equal 45.days.ago.strftime('%Y-%m-%d'), json_response['extension'].detect { |e| e['url'].include? 'last-date-of-exposure' }['valueDate']
+    assert_equal 5.days.ago.strftime('%Y-%m-%d'), json_response['extension'].detect { |e| e['url'].include? 'symptom-onset-date' }['valueDate']
+    assert_not json_response['extension'].detect { |e| e['url'].include? 'isolation' }['valueBoolean']
     assert_equal resource_path, json_response['contained'].first['target'].first['reference']
     assert_equal Patient.find_by(id: patient_id).creator_id, json_response['contained'].first['agent'].first['who']['identifier']['value']
     assert_equal Patient.find_by(id: patient_id).creator.email, json_response['contained'].first['agent'].first['who']['display']
@@ -403,12 +403,12 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert p.asian
     assert_equal 'Patient', json_response['resourceType']
     assert_equal 'Kirlin44', json_response['name'].first['family']
-    assert_equal 'SMS Texted Weblink', json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-method' }.first['valueString']
-    assert_equal 'Afternoon', json_response['extension'].filter { |e| e['url'].include? 'preferred-contact-time' }.first['valueString']
-    assert json_response['extension'].filter { |e| e['url'].include? 'continuous-exposure' }.first['valueBoolean']
-    assert_equal 3.days.ago.strftime('%Y-%m-%d'), json_response['extension'].filter { |e| e['url'].include? 'symptom-onset-date' }.first['valueDate']
+    assert_equal 'SMS Texted Weblink', json_response['extension'].detect { |e| e['url'].include? 'preferred-contact-method' }['valueString']
+    assert_equal 'Afternoon', json_response['extension'].detect { |e| e['url'].include? 'preferred-contact-time' }['valueString']
+    assert json_response['extension'].detect { |e| e['url'].include? 'continuous-exposure' }['valueBoolean']
+    assert_equal 3.days.ago.strftime('%Y-%m-%d'), json_response['extension'].detect { |e| e['url'].include? 'symptom-onset-date' }['valueDate']
     assert p.user_defined_symptom_onset
-    assert json_response['extension'].filter { |e| e['url'].include? 'isolation' }.first['valueBoolean']
+    assert json_response['extension'].detect { |e| e['url'].include? 'isolation' }['valueBoolean']
     assert_equal 'USA, State 1, County 1',
                  json_response['extension'].find { |e| e['url'] == 'http://saraalert.org/StructureDefinition/full-assigned-jurisdiction-path' }['valueString']
     assert_equal resource_path, json_response['contained'].first['target'].first['reference']
@@ -829,7 +829,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     )
     assert_response :success
     json_response = JSON.parse(response.body)
-    assert_equal 'USA, State 2', json_response['extension'].filter { |e| e['url'].include? 'full-assigned-jurisdiction-path' }.first['valueString']
+    assert_equal 'USA, State 2', json_response['extension'].detect { |e| e['url'].include? 'full-assigned-jurisdiction-path' }['valueString']
     t = Transfer.find_by(patient_id: @patient_1.id)
     assert_equal Jurisdiction.find_by(path: 'USA, State 1').id, t.from_jurisdiction_id
     assert_equal Jurisdiction.find_by(path: 'USA, State 2').id, t.to_jurisdiction_id
@@ -845,7 +845,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     )
     assert_response :success
     json_response = JSON.parse(response.body)
-    assert_equal 'USA, State 2', json_response['extension'].filter { |e| e['url'].include? 'full-assigned-jurisdiction-path' }.first['valueString']
+    assert_equal 'USA, State 2', json_response['extension'].detect { |e| e['url'].include? 'full-assigned-jurisdiction-path' }['valueString']
     t = Transfer.find_by(patient_id: @patient_1.id)
     assert_equal Jurisdiction.find_by(path: 'USA, State 1').id, t.from_jurisdiction_id
     assert_equal Jurisdiction.find_by(path: 'USA, State 2').id, t.to_jurisdiction_id

--- a/test/controllers/fhir/r4/provenance_test.rb
+++ b/test/controllers/fhir/r4/provenance_test.rb
@@ -14,7 +14,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       headers: { Authorization: "Bearer #{@system_provenance_token_r.token}", Accept: 'application/fhir+json' }
     )
     assert_response :ok
-    assert_equal JSON.parse(History.find_by_id(history_id).as_fhir.to_json), JSON.parse(response.body)
+    assert_equal JSON.parse(History.find_by(id: history_id).as_fhir.to_json), JSON.parse(response.body)
   end
 
   test 'should be forbidden via show for inaccessible Provenance' do
@@ -28,7 +28,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
   #----- search tests -----
 
   test 'should find Provenances for a Patient via search' do
-    patient = Patient.find_by_id(6)
+    patient = Patient.find_by(id: 6)
     get(
       '/fhir/r4/Provenance?patient=Patient/6',
       headers: { Authorization: "Bearer #{@system_everything_token.token}", Accept: 'application/fhir+json' }

--- a/test/controllers/fhir/r4/related_person_test.rb
+++ b/test/controllers/fhir/r4/related_person_test.rb
@@ -32,7 +32,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       headers: { Authorization: "Bearer #{@system_everything_token.token}", Accept: 'application/fhir+json' }
     )
     assert_response :ok
-    assert_equal JSON.parse(CloseContact.find_by_id(1).as_fhir.to_json), JSON.parse(response.body)
+    assert_equal JSON.parse(CloseContact.find_by(id: 1).as_fhir.to_json), JSON.parse(response.body)
   end
 
   test 'should be forbidden via show for inaccessible RelatedPerson' do
@@ -133,7 +133,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
   #----- update tests -----
 
   test 'should update RelatedPerson via update' do
-    cc = CloseContact.find_by_id(1)
+    cc = CloseContact.find_by(id: 1)
     original_cc = cc.dup
     cc.notes = 'Some new notes'
     cc.first_name = 'FarContact1'
@@ -143,7 +143,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       headers: { Authorization: "Bearer #{@system_everything_token.token}", 'Content-Type': 'application/fhir+json' }
     )
     assert_response :ok
-    updated_cc = CloseContact.find_by_id(1)
+    updated_cc = CloseContact.find_by(id: 1)
 
     # Verify that the created Close Contact matches the original outside of updated fields
     %i[patient_id
@@ -167,7 +167,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should update RelatedPerson via patch update' do
-    cc = CloseContact.find_by_id(1)
+    cc = CloseContact.find_by(id: 1)
     original_cc = cc.dup
     patch = [
       { op: 'replace', path: '/name/0/given/0', value: 'FarContact1' }
@@ -178,7 +178,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       headers: { Authorization: "Bearer #{@system_everything_token.token}", 'Content-Type': 'application/json-patch+json' }
     )
     assert_response :ok
-    updated_cc = CloseContact.find_by_id(1)
+    updated_cc = CloseContact.find_by(id: 1)
 
     # Verify that the created Close Contact matches the original outside of updated fields
     %i[patient_id
@@ -247,7 +247,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
   #----- search tests -----
 
   test 'should find RelatedPersons for a Patient via search' do
-    patient_1 = Patient.find_by_id(1)
+    patient_1 = Patient.find_by(id: 1)
     get(
       '/fhir/r4/RelatedPerson?patient=Patient/1',
       headers: { Authorization: "Bearer #{@system_everything_token.token}", Accept: 'application/fhir+json' }

--- a/test/controllers/fhir/r4/transaction_test.rb
+++ b/test/controllers/fhir/r4/transaction_test.rb
@@ -27,7 +27,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
       last_name: last_name,
       last_date_of_exposure: 4.days.ago.to_date,
       symptom_onset: 4.days.ago.to_date,
-      creator: User.find_by_id(@system_everything_app.user_id)
+      creator: User.find_by(id: @system_everything_app.user_id)
     ).as_fhir
 
     FHIR::Bundle::Entry.new(
@@ -210,7 +210,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
 
     created_patient_id = patient_json['id']
     created_lab_id = observation_json['id']
-    created_patient = Patient.find_by_id(created_patient_id.to_i)
+    created_patient = Patient.find_by(id: created_patient_id.to_i)
     assert_not_nil created_patient
     assert_equal 1, created_patient.laboratories.count
     assert_equal created_lab_id, created_patient.laboratories[0].id
@@ -232,7 +232,7 @@ class ApiControllerTest < ActionDispatch::IntegrationTest
     assert_equal original_json.except('id', 'meta', 'contained'), patient_json.except('id', 'meta', 'contained')
 
     created_patient_id = patient_json['id']
-    created_patient = Patient.find_by_id(created_patient_id.to_i)
+    created_patient = Patient.find_by(id: created_patient_id.to_i)
     assert_not_nil created_patient
     assert_equal 2, created_patient.laboratories.count
   end

--- a/test/controllers/laboratories_controller_test.rb
+++ b/test/controllers/laboratories_controller_test.rb
@@ -184,7 +184,7 @@ class LaboratoriesControllerTest < ActionController::TestCase
 
     lab.reload
     assert_response(:success)
-    assert_in_delta(Time.now, lab.updated_at, 1) # assert updated
+    assert_in_delta(Time.now.getlocal, lab.updated_at, 1) # assert updated
     assert_equal(1, patient.histories.count)
 
     lab = Laboratory.find(lab.id)

--- a/test/controllers/patients_controller_test.rb
+++ b/test/controllers/patients_controller_test.rb
@@ -307,7 +307,8 @@ class PatientsControllerTest < ActionController::TestCase
     patient = create(:patient, creator: user)
 
     # Create invalid record and skip validation
-    patient.update_attribute('assigned_user', -1)
+    patient.assigned_user = -1
+    patient.save(validate: false)
     patient.reload
 
     sign_in user
@@ -412,7 +413,8 @@ class PatientsControllerTest < ActionController::TestCase
     dependent = create(:patient, creator: user, responder_id: hoh.id)
 
     # Create invalid record and skip validation
-    dependent.update_attribute('assigned_user', -1)
+    dependent.assigned_user = -1
+    dependent.save(validate: false)
     dependent.reload
 
     sign_in user
@@ -609,7 +611,8 @@ class PatientsControllerTest < ActionController::TestCase
     dependent = create(:patient, creator: user, responder_id: hoh.id)
 
     # Create invalid record and skip validation
-    dependent.update_attribute('assigned_user', -1)
+    dependent.assigned_user = -1
+    dependent.save(validate: false)
     dependent.reload
 
     sign_in user
@@ -1057,7 +1060,7 @@ class PatientsControllerTest < ActionController::TestCase
     user = create(:public_health_enroller_user)
     sign_in user
     patient = create(:patient, symptom_onset: DateTime.now - 1.day, creator: user)
-    earliest_symptomatic_assessment_timestamp = DateTime.now - 2.day
+    earliest_symptomatic_assessment_timestamp = DateTime.now - 2.days
     create(:assessment, patient_id: patient.id, symptomatic: true, created_at: earliest_symptomatic_assessment_timestamp)
 
     post :update, params: {

--- a/test/controllers/public_health_controller_test.rb
+++ b/test/controllers/public_health_controller_test.rb
@@ -284,7 +284,7 @@ class PublicHealthControllerTest < ActionController::TestCase
       assert patient['assigned_user'].blank?
     end
 
-    assigned_user = user.viewable_patients.where.not(assigned_user: nil).distinct.pluck(:assigned_user).first
+    assigned_user = user.viewable_patients.where.not(assigned_user: nil).distinct.pick(:assigned_user)
 
     post :patients, params: { query: { workflow: 'exposure', tab: 'all', user: assigned_user } }, as: :json
     JSON.parse(response.body)['linelist'].each do |patient|
@@ -502,7 +502,7 @@ class PublicHealthControllerTest < ActionController::TestCase
     assessment = create(:assessment, patient: patient, symptomatic: false)
     (10..15).to_a.each do |lde|
       patient.update(last_date_of_exposure: Time.now.getlocal(patient.address_timezone_offset) - lde.days)
-      assessment.update(created_at: 1.days.ago) if lde == 14
+      assessment.update(created_at: 1.day.ago) if lde == 14
       assessment.update(created_at: 2.days.ago) if lde == 15
       patients = @controller.send(:advanced_filter_quarantine_option, user.viewable_patients, { value: true }, :ten_day)
       assert_equal(patients.count, 1)

--- a/test/controllers/vaccines_controller_test.rb
+++ b/test/controllers/vaccines_controller_test.rb
@@ -2,6 +2,8 @@
 
 require 'test_case'
 
+# IMPORTANT NOTE ON CHANGES TO Time.now CALLS IN THIS FILE
+# Updated Time.now to Time.now.getlocal for Rails/TimeZone because Time.now defaulted to a zone. In this case it was the developer machine or CI/CD server zone.
 class VaccinesControllerTest < ActionController::TestCase
   def setup; end
 
@@ -336,7 +338,7 @@ class VaccinesControllerTest < ActionController::TestCase
 
     vaccine.reload
     assert_response(:success)
-    assert_in_delta(Time.now, vaccine.updated_at, 1) # assert updated
+    assert_in_delta(Time.now.getlocal, vaccine.updated_at, 1) # assert updated
     assert_equal(1, patient.histories.count)
 
     vaccine = Vaccine.find(vaccine.id)

--- a/test/helpers/patient_helper_test.rb
+++ b/test/helpers/patient_helper_test.rb
@@ -2,6 +2,9 @@
 
 require 'test_case'
 
+# IMPORTANT NOTE ON CHANGES TO Time.local CALLS IN THIS FILE
+# Updated Time.local to Time.local.getlocal for Rails/TimeZone because Time.local defaulted to a zone.
+# In this case it was the developer machine or CI/CD server zone.
 class PatientHelperTest < ActionView::TestCase
   test 'State names are normalized' do
     test_subject = Patient.new(monitored_address_state: 'New  Hampshire', address_state: 'new Hampshire',
@@ -14,12 +17,13 @@ class PatientHelperTest < ActionView::TestCase
 
   test 'time zone offset for state ' do
     # DST starts 2nd Sunday in March so pick a date in May to ensure DST.
-    Timecop.freeze(Time.local(2008, 5, 1, 12, 0, 0))
+    Timecop.freeze(Time.local(2008, 5, 1, 12, 0, 0).getlocal)
     assert_equal('-04:00', time_zone_offset_for_state('Massachusetts'))
     # ST
-    Timecop.freeze(Time.local(2008, 2, 1, 12, 0, 0))
+    Timecop.freeze(Time.local(2008, 2, 1, 12, 0, 0).getlocal)
     assert_equal('-05:00', time_zone_offset_for_state('Massachusetts'))
     Timecop.return
+    DateTime.now
   end
 
   test 'time zone offset for state returns data' do

--- a/test/helpers/patient_query_helper_test.rb
+++ b/test/helpers/patient_query_helper_test.rb
@@ -25,13 +25,13 @@ class PatientQueryHelperTest < ActionView::TestCase
     filters[0][:value] = true
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_2]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
 
     # Check for monitorees who have NOT blocked the system
     filters[0][:value] = false
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_3]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter ineligible for any recovery definition' do
@@ -70,13 +70,13 @@ class PatientQueryHelperTest < ActionView::TestCase
     filters[0][:value] = true
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_4, patient_5, patient_6, patient_7, patient_8]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
 
     # Check for monitorees who are NOT ineligible for any recovery definition
     filters[0][:value] = false
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_2, patient_3]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   # --- SEARCH ADVANCED FILTER QUERIES --- #
@@ -104,7 +104,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     tz_offset = 300
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_2, patient_3, patient_4, patient_5, patient_6, patient_7, patient_8]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter close contact with known case id exact match multiple value' do
@@ -129,7 +129,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     tz_offset = 300
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_2, patient_3, patient_4, patient_5, patient_6, patient_7, patient_8]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter close contact with known case id contains single value' do
@@ -156,7 +156,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_2, patient_3, patient_4, patient_5, patient_6, patient_7, patient_8, patient_9, patient_10, patient_11,
                                patient_12]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter close contact with known case id contains multiple value' do
@@ -181,7 +181,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     tz_offset = 300
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_2, patient_3, patient_4, patient_5, patient_6, patient_7, patient_8, patient_9, patient_10, patient_11]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   # --- MULTI ADVANCED FILTER QUERIES --- #
@@ -216,13 +216,13 @@ class PatientQueryHelperTest < ActionView::TestCase
     # Check for monitorees who have a blank result
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_7, patient_3, patient_5]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
 
     # Check for monitorees who have a non-blank result
     filters[0][:value][0][:value] = 'positive'
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_4, patient_6]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter laboratory single filter option test type' do
@@ -255,13 +255,13 @@ class PatientQueryHelperTest < ActionView::TestCase
     # Check for monitorees who have a blank lab type
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_3, patient_5, patient_7]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
 
     # Check for monitorees who have a non-blank lab type
     filters[0][:value][0][:value] = 'PCR'
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_4, patient_6]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter laboratory single filter option specimen collection date' do
@@ -295,19 +295,19 @@ class PatientQueryHelperTest < ActionView::TestCase
     # Check for monitorees who have a blank specimen collection date
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_7]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
 
     # Check for monitorees who have a specimen collection date "before"
     filters[0][:value][0][:value] = { when: 'before', date: '2021-03-25' }
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_2, patient_5]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
 
     # Check for monitorees who have a specimen collection date "after"
     filters[0][:value][0][:value] = { when: 'after', date: '2021-03-25' }
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_4, patient_6]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter laboratory single filter option report date' do
@@ -341,19 +341,19 @@ class PatientQueryHelperTest < ActionView::TestCase
     # Check for monitorees who have a blank report date
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_7]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
 
     # Check for monitorees who have a specimen collection date "before"
     filters[0][:value][0][:value] = { when: 'before', date: '2021-03-25' }
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_2, patient_5]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
 
     # Check for monitorees who have a specimen collection date "after"
     filters[0][:value][0][:value] = { when: 'after', date: '2021-03-25' }
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_4, patient_6]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter laboratory single filter option muliple values' do
@@ -384,7 +384,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     tz_offset = 300
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_5]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter laboratory single filter option all values' do
@@ -433,7 +433,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     tz_offset = 300
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_5]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter laboratory multiple filter options some values' do
@@ -475,7 +475,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     tz_offset = 300
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_6]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter laboratory multiple filter options all values' do
@@ -536,7 +536,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     tz_offset = 300
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_6]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter vaccination single filter option vaccine group' do
@@ -555,7 +555,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     tz_offset = 300
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_2]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter vaccination single filter option product name' do
@@ -584,7 +584,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     tz_offset = 300
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_3, patient_6]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter vaccination single filter option administration date' do
@@ -621,19 +621,19 @@ class PatientQueryHelperTest < ActionView::TestCase
     # Check for monitorees who have a blank report date
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_7, patient_8]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
 
     # Check for monitorees who have a report date "before"
     filters[0][:value][0][:value] = { when: 'before', date: '2021-03-25' }
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_2, patient_5, patient_8]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
 
     # Check for monitorees who have a report date "after"
     filters[0][:value][0][:value] = { when: 'after', date: '2021-03-25' }
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_4, patient_6]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter vaccination single filter option dose number' do
@@ -667,13 +667,13 @@ class PatientQueryHelperTest < ActionView::TestCase
     # Check for monitorees who have a blank dose number
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_3, patient_4, patient_5, patient_6]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
 
     # Check for monitorees who have a non-blank dose number
     filters[0][:value][0][:value] = '1'
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_6]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter vaccination single filter option muliple values' do
@@ -706,7 +706,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     tz_offset = 300
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_5, patient_7]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter vaccination single filter option all values' do
@@ -754,7 +754,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     tz_offset = 300
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_5, patient_7]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter vaccination multiple filter options some values' do
@@ -790,7 +790,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     tz_offset = 300
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_5]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter vaccination multiple filter options all values' do
@@ -867,7 +867,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     tz_offset = 300
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_4, patient_7]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   test 'advanced filter flagged for follow up filters those marked as flagged for follow up' do
@@ -891,13 +891,13 @@ class PatientQueryHelperTest < ActionView::TestCase
 
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_2, patient_3, patient_4]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
 
     # Check for monitorees who have a specific follow-up flag reason
     filters[0][:value] = 'Lost to Follow-up'
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_4]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
   # --- PATIENTS TABLE DATA TESTS --- #
@@ -925,7 +925,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     # Check for monitorees that are HoH or self-reporter
     filtered_patients = patients_table_data(params, user)
     filtered_patients_array = [patient_2, patient_3]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients[:linelist]&.pluck(:id)
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients[:linelist]&.pluck(:id)
 
     # Check that current monitoree is not in patients list
     patients_by_id = filtered_patients[:linelist]&.pluck(:id)
@@ -952,7 +952,7 @@ class PatientQueryHelperTest < ActionView::TestCase
 
     # Check that no patients were filtered out
     filtered_patients = patients_table_data(params, user)
-    assert_equal patients.map { |p| p[:id] }, filtered_patients[:linelist]&.pluck(:id)
+    assert_equal patients.pluck(:id), filtered_patients[:linelist]&.pluck(:id)
   end
 
   test 'patients table data raises InvalidQueryError when exclude_patient_id is not valid' do

--- a/test/jobs/purge_job_test.rb
+++ b/test/jobs/purge_job_test.rb
@@ -138,7 +138,7 @@ class PurgeJobTest < ActiveSupport::TestCase
     assert_not(patient_attributes.delete('continuous_exposure'))
     patient.attributes.each do |attribute|
       if PurgeJob.send(:attributes_to_keep).include?(attribute[0])
-        assert(!attribute[1].nil?)
+        assert_not(attribute[1].nil?)
       else
         assert_nil(attribute[1])
       end

--- a/test/jobs/send_purge_warnings_job_test.rb
+++ b/test/jobs/send_purge_warnings_job_test.rb
@@ -13,7 +13,7 @@ class SendPurgeWarningsJobTest < ActiveSupport::TestCase
 
   test 'sends an purge notification job email with user IDs of users sent notification email' do
     email = SendPurgeWarningsJob.perform_now
-    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    email_body = email.parts.first.body.to_s.tr("\n", ' ')
     assert_not ActionMailer::Base.deliveries.empty?
     assert_includes(email_body, 'Sara Alert Send Purge Warnings Job Results')
   end

--- a/test/mailers/patient_mailer_test.rb
+++ b/test/mailers/patient_mailer_test.rb
@@ -38,7 +38,7 @@ class PatientMailerTest < ActionMailer::TestCase
 
   test 'enrollment email contents' do
     email = PatientMailer.enrollment_email(@patient).deliver_now
-    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    email_body = email.parts.first.body.to_s.tr("\n", ' ')
     assert_not ActionMailer::Base.deliveries.empty?
     assert_equal [@patient.email], email.to
     assert_equal [PatientMailer.default[:from]], email.from
@@ -66,14 +66,14 @@ class PatientMailerTest < ActionMailer::TestCase
     dependent = create(:patient)
     dependent.update(responder_id: @patient.id, submission_token: SecureRandom.urlsafe_base64[0, 10])
     email = PatientMailer.enrollment_email(@patient).deliver_now
-    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    email_body = email.parts.first.body.to_s.tr("\n", ' ')
     assert_not ActionMailer::Base.deliveries.empty?
     assert_includes email_body, @patient.submission_token
     assert_includes email_body, dependent.submission_token
 
     dependent.update(monitoring: false)
     email = PatientMailer.enrollment_email(@patient).deliver_now
-    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    email_body = email.parts.first.body.to_s.tr("\n", ' ')
     assert_not ActionMailer::Base.deliveries.empty?
     assert_includes email_body, @patient.submission_token
     assert_not_includes email_body, dependent.submission_token
@@ -481,7 +481,7 @@ class PatientMailerTest < ActionMailer::TestCase
 
   test 'assessment email contents' do
     email = PatientMailer.assessment_email(@patient).deliver_now
-    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    email_body = email.parts.first.body.to_s.tr("\n", ' ')
     assert_not ActionMailer::Base.deliveries.empty?
     assert_equal [@patient.email], email.to
     assert_equal [PatientMailer.default[:from]], email.from
@@ -503,7 +503,7 @@ class PatientMailerTest < ActionMailer::TestCase
     patient_history_count = @patient.histories.count
 
     email = PatientMailer.assessment_email(@patient).deliver_now
-    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    email_body = email.parts.first.body.to_s.tr("\n", ' ')
     assert_not ActionMailer::Base.deliveries.empty?
     assert_includes email_body, @patient.submission_token
     assert_includes email_body, dependent.submission_token
@@ -511,7 +511,7 @@ class PatientMailerTest < ActionMailer::TestCase
     @patient.update(last_assessment_reminder_sent: nil)
     dependent.update(monitoring: false)
     email = PatientMailer.assessment_email(@patient).deliver_now
-    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    email_body = email.parts.first.body.to_s.tr("\n", ' ')
     assert_not ActionMailer::Base.deliveries.empty?
     assert_includes email_body, @patient.submission_token
     assert_not_includes email_body, dependent.submission_token
@@ -540,14 +540,14 @@ class PatientMailerTest < ActionMailer::TestCase
     dependent.update(responder_id: @patient.id, submission_token: SecureRandom.urlsafe_base64[0, 10])
 
     email = PatientMailer.enrollment_email(@patient).deliver_now
-    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    email_body = email.parts.first.body.to_s.tr("\n", ' ')
     assert_not ActionMailer::Base.deliveries.empty?
     assert_includes email_body, @patient.submission_token
     assert_includes email_body, dependent.submission_token
 
     dependent.update(monitoring: false)
     email = PatientMailer.enrollment_email(@patient).deliver_now
-    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    email_body = email.parts.first.body.to_s.tr("\n", ' ')
     assert_not ActionMailer::Base.deliveries.empty?
     assert_includes email_body, @patient.submission_token
     assert_not_includes email_body, dependent.submission_token
@@ -556,7 +556,7 @@ class PatientMailerTest < ActionMailer::TestCase
   test 'closed email contents' do
     @patient.update(closed_at: DateTime.now)
     email = PatientMailer.closed_email(@patient).deliver_now
-    email_body = email.parts.first.body.to_s.gsub("\n", ' ').gsub("\r", ' ')
+    email_body = email.parts.first.body.to_s.tr("\n", ' ').tr("\r", ' ')
     assert_not ActionMailer::Base.deliveries.empty?
     assert_equal [@patient.email], email.to
     assert_equal [PatientMailer.default[:from]], email.from

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -15,7 +15,7 @@ class UserMailerTest < ActionMailer::TestCase
   test 'download email no lookups' do
     # When no monitorees match export criteria lookups = []
     email = UserMailer.download_email(@user, 'Export Label', []).deliver_now
-    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    email_body = email.parts.first.body.to_s.tr("\n", ' ')
     assert_not(ActionMailer::Base.deliveries.empty?)
     assert_includes(email_body, 'Export Label')
     assert_includes(email_body, 'no monitorees or monitoree data matched the selected export criteria')
@@ -26,13 +26,13 @@ class UserMailerTest < ActionMailer::TestCase
       [{ id: 9999 }],
       { current: 1, total: 1 },
       {
-        start_time: 2.minute.ago,
+        start_time: 2.minutes.ago,
         end_time: 1.minute.ago,
         not_purged_count: 0,
         purged_count: 1
       }
     ).deliver_now
-    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    email_body = email.parts.first.body.to_s.tr("\n", ' ')
     assert_not(ActionMailer::Base.deliveries.empty?)
     assert_includes(email_body, 'Purged during this job run: 1')
     assert_includes(email_body, '9999')
@@ -43,13 +43,13 @@ class UserMailerTest < ActionMailer::TestCase
       [{ id: 9999, reason: 'StandardError' }],
       { current: 1, total: 1 },
       {
-        start_time: 2.minute.ago,
+        start_time: 2.minutes.ago,
         end_time: 1.minute.ago,
         not_purged_count: 1,
         purged_count: 0
       }
     ).deliver_now
-    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    email_body = email.parts.first.body.to_s.tr("\n", ' ')
     assert_not(ActionMailer::Base.deliveries.empty?)
     assert_includes(email_body, 'Purged during this job run: 0')
     assert_includes(email_body, 'Not purged during this job run: 1')
@@ -61,13 +61,13 @@ class UserMailerTest < ActionMailer::TestCase
       [],
       { current: 1, total: 1 },
       {
-        start_time: 2.minute.ago,
+        start_time: 2.minutes.ago,
         end_time: 1.minute.ago,
         not_purged_count: 0,
         purged_count: 0
       }
     ).deliver_now
-    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    email_body = email.parts.first.body.to_s.tr("\n", ' ')
     assert_not(ActionMailer::Base.deliveries.empty?)
     assert_includes(email_body, 'Purged during this job run: 0')
     assert_includes(email_body, 'Not purged during this job run: 0')
@@ -78,13 +78,13 @@ class UserMailerTest < ActionMailer::TestCase
       [{ id: 9998 }, { id: 9999, reason: 'StandardError' }],
       { current: 1, total: 1 },
       {
-        start_time: 2.minute.ago,
+        start_time: 2.minutes.ago,
         end_time: 1.minute.ago,
         not_purged_count: 1,
         purged_count: 1
       }
     ).deliver_now
-    email_body = email.parts.first.body.to_s.gsub("\n", ' ')
+    email_body = email.parts.first.body.to_s.tr("\n", ' ')
     assert_not(ActionMailer::Base.deliveries.empty?)
     assert_includes(email_body, 'Purged during this job run: 1')
     assert_includes(email_body, 'Not purged during this job run: 1')

--- a/test/models/assessment_test.rb
+++ b/test/models/assessment_test.rb
@@ -161,7 +161,7 @@ class AssessmentTest < ActiveSupport::TestCase
     assert_nil patient.latest_fever_or_fever_reducer_at
 
     # Create assessment 4 with fever
-    timestamp_4 = DateTime.now.utc - 1.days
+    timestamp_4 = DateTime.now.utc - 1.day
     assessment_4 = create(:assessment, patient: patient, symptomatic: true, created_at: timestamp_4)
     reported_condition_4 = create(:reported_condition, assessment_id: assessment_4.id)
     symptom_4 = create(:symptom, condition_id: reported_condition_4.id, type: 'BoolSymptom', name: 'fever', bool_value: true)

--- a/test/models/jwt_identifier_test.rb
+++ b/test/models/jwt_identifier_test.rb
@@ -2,6 +2,8 @@
 
 require 'test_case'
 
+# IMPORTANT NOTE ON CHANGES TO Time.now CALLS IN THIS FILE
+# Updated Time.now to Time.now.getlocal for Rails/TimeZone because Time.now defaulted to a zone. In this case it was the developer machine or CI/CD server zone.
 class JwtIdentifierTest < ActiveSupport::TestCase
   def setup
     @oauth_app = OauthApplication.create!(name: 'test-app', redirect_uri: 'urn:ietf:wg:oauth:2.0:oob')
@@ -12,27 +14,27 @@ class JwtIdentifierTest < ActiveSupport::TestCase
   end
 
   test 'create JWT Identifier' do
-    assert create(:jwt_identifier, value: 'a', expiration_date: Time.now, application_id: @oauth_app.id)
+    assert create(:jwt_identifier, value: 'a', expiration_date: Time.now.getlocal, application_id: @oauth_app.id)
   end
 
   test 'purge eligible scope' do
     # JWT that expired two minutes ago SHOULD be purge eligible
-    create(:jwt_identifier, value: 'a', expiration_date: Time.now - 2.minutes, application_id: @oauth_app.id)
+    create(:jwt_identifier, value: 'a', expiration_date: Time.now.getlocal - 2.minutes, application_id: @oauth_app.id)
     assert_equal(1, JwtIdentifier.purge_eligible.count)
 
     # JWT that expired now SHOULD be purge eligible
-    create(:jwt_identifier, value: 'b', expiration_date: Time.now, application_id: @oauth_app.id)
+    create(:jwt_identifier, value: 'b', expiration_date: Time.now.getlocal, application_id: @oauth_app.id)
     assert_equal(2, JwtIdentifier.purge_eligible.count)
 
     # Delete purge eligible before the next steps
     JwtIdentifier.delete_all
 
     # JWT that expires in 30 seconds should NOT be purge eligible
-    create(:jwt_identifier, value: 'c', expiration_date: Time.now + 30.seconds, application_id: @oauth_app.id)
+    create(:jwt_identifier, value: 'c', expiration_date: Time.now.getlocal + 30.seconds, application_id: @oauth_app.id)
     assert_equal(0, JwtIdentifier.purge_eligible.count)
 
     # JWT that expires in 5 minutes should NOT be purge eligible
-    create(:jwt_identifier, value: 'd', expiration_date: Time.now + 1.day, application_id: @oauth_app.id)
+    create(:jwt_identifier, value: 'd', expiration_date: Time.now.getlocal + 1.day, application_id: @oauth_app.id)
     assert_equal(0, JwtIdentifier.purge_eligible.count)
   end
 end

--- a/test/models/laboratory_test.rb
+++ b/test/models/laboratory_test.rb
@@ -2,6 +2,8 @@
 
 require 'test_case'
 
+# IMPORTANT NOTE ON CHANGES TO Time.now CALLS IN THIS FILE
+# Updated Time.now to Time.now.getlocal for Rails/TimeZone because Time.now defaulted to a zone. In this case it was the developer machine or CI/CD server zone.
 class LaboratoryTest < ActiveSupport::TestCase
   def setup; end
 
@@ -24,7 +26,7 @@ class LaboratoryTest < ActiveSupport::TestCase
     assert laboratory.valid?(:api)
     assert laboratory.valid?(:import)
 
-    laboratory = build(:laboratory, report: Time.now)
+    laboratory = build(:laboratory, report: Time.now.getlocal)
     assert laboratory.valid?(:api)
     assert laboratory.valid?(:import)
 
@@ -48,7 +50,7 @@ class LaboratoryTest < ActiveSupport::TestCase
     assert laboratory.valid?(:api)
     assert laboratory.valid?(:import)
 
-    laboratory = build(:laboratory, specimen_collection: Time.now)
+    laboratory = build(:laboratory, specimen_collection: Time.now.getlocal)
     assert laboratory.valid?(:api)
     assert laboratory.valid?(:import)
 
@@ -61,11 +63,11 @@ class LaboratoryTest < ActiveSupport::TestCase
     assert_not laboratory.valid?(:import)
 
     # Ensure specimen collection date is before report date
-    laboratory = build(:laboratory, specimen_collection: 1.days.ago, report: 2.days.ago)
+    laboratory = build(:laboratory, specimen_collection: 1.day.ago, report: 2.days.ago)
     assert_not laboratory.valid?(:api)
     assert_not laboratory.valid?(:import)
 
-    laboratory = build(:laboratory, specimen_collection: 2.days.ago, report: 1.days.ago)
+    laboratory = build(:laboratory, specimen_collection: 2.days.ago, report: 1.day.ago)
     assert laboratory.valid?(:api)
     assert laboratory.valid?(:import)
   end
@@ -194,7 +196,7 @@ class LaboratoryTest < ActiveSupport::TestCase
   test 'validates specimen_collection is a valid date' do
     lab = create(:laboratory)
 
-    lab.specimen_collection = Time.now - 1.day
+    lab.specimen_collection = Time.now.getlocal - 1.day
     assert lab.valid?(:api)
     assert lab.valid?(:import)
 
@@ -245,7 +247,7 @@ class LaboratoryTest < ActiveSupport::TestCase
   test 'validates report is a valid date' do
     lab = create(:laboratory)
 
-    lab.report = Time.now - 1.day
+    lab.report = Time.now.getlocal - 1.day
     assert lab.valid?(:api)
     assert lab.valid?(:import)
 

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -3,6 +3,8 @@
 require 'test_case'
 
 # rubocop:disable Metrics/ClassLength
+# IMPORTANT NOTE ON CHANGES TO Time.now CALLS IN THIS FILE
+# Updated Time.now to Time.now.getlocal for Rails/TimeZone because Time.now defaulted to a zone. In this case it was the developer machine or CI/CD server zone.
 class PatientTest < ActiveSupport::TestCase
   include PatientHelper
 
@@ -341,10 +343,10 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(1, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(1, Patient.close_eligible.count { |p| p.id == patient.id })
 
     # Test with purged set to true
     patient = create(:patient,
@@ -353,10 +355,10 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(0, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(0, Patient.close_eligible.count { |p| p.id == patient.id })
   end
 
   test 'close eligible does not include records in isolation' do
@@ -367,10 +369,10 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(1, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(1, Patient.close_eligible.count { |p| p.id == patient.id })
 
     # Test with isolation set to true
     patient = create(:patient,
@@ -379,10 +381,10 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(0, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(0, Patient.close_eligible.count { |p| p.id == patient.id })
   end
 
   test 'close eligible does not include symptomatic records' do
@@ -393,10 +395,10 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(1, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(1, Patient.close_eligible.count { |p| p.id == patient.id })
 
     # Test with non-nil symptom onset
     patient = create(:patient,
@@ -405,10 +407,10 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: 1.day.ago,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(0, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(0, Patient.close_eligible.count { |p| p.id == patient.id })
   end
 
   test 'close eligible does not include already closed records' do
@@ -419,10 +421,10 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(1, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(1, Patient.close_eligible.count { |p| p.id == patient.id })
 
     # Test with monitoring set to false
     patient = create(:patient,
@@ -431,10 +433,10 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: false,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(0, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(0, Patient.close_eligible.count { |p| p.id == patient.id })
   end
 
   test 'close eligible does not include records in continuous exposure' do
@@ -446,10 +448,10 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(1, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(1, Patient.close_eligible.count { |p| p.id == patient.id })
 
     # Test with continuous exposure set to true
     patient = create(:patient,
@@ -459,10 +461,10 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(0, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(0, Patient.close_eligible.count { |p| p.id == patient.id })
   end
 
   test 'close eligible does not include records that have NOT reported in the last 24 hours and were created more than 24 hours ago' do
@@ -473,11 +475,11 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      created_at: 2.days.ago,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(1, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(1, Patient.close_eligible.count { |p| p.id == patient.id })
 
     # Test with latest_assessment_at set to two days ago and create_at set to two days ago
     patient = create(:patient,
@@ -490,7 +492,7 @@ class PatientTest < ActiveSupport::TestCase
                      created_at: 2.days.ago,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(0, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(0, Patient.close_eligible.count { |p| p.id == patient.id })
   end
 
   test 'close eligible does NOT include records that have never reported' do
@@ -505,7 +507,7 @@ class PatientTest < ActiveSupport::TestCase
                      created_at: 2.days.ago,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(1, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(1, Patient.close_eligible.count { |p| p.id == patient.id })
 
     patient = create(:patient,
                      purged: false,
@@ -517,7 +519,7 @@ class PatientTest < ActiveSupport::TestCase
                      created_at: 2.days.ago,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(0, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(0, Patient.close_eligible.count { |p| p.id == patient.id })
   end
 
   test 'close eligible does NOT include records that have NOT reported today (based on their timezone)' do
@@ -532,7 +534,7 @@ class PatientTest < ActiveSupport::TestCase
                      created_at: 2.days.ago,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(1, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(1, Patient.close_eligible.count { |p| p.id == patient.id })
 
     patient = create(:patient,
                      purged: false,
@@ -544,7 +546,7 @@ class PatientTest < ActiveSupport::TestCase
                      created_at: 2.days.ago,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(0, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(0, Patient.close_eligible.count { |p| p.id == patient.id })
   end
 
   test 'close eligible does not include records still within their monitoring period' do
@@ -555,10 +557,10 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(1, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(1, Patient.close_eligible.count { |p| p.id == patient.id })
 
     # Test where patient is still within their monitoring period
     patient = create(:patient,
@@ -567,10 +569,10 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      last_date_of_exposure: 2.days.ago)
 
-    assert_equal(0, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(0, Patient.close_eligible.count { |p| p.id == patient.id })
   end
 
   test 'close eligible includes records on their last day of monitoring' do
@@ -581,10 +583,10 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      last_date_of_exposure: 20.days.ago)
 
-    assert_equal(1, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(1, Patient.close_eligible.count { |p| p.id == patient.id })
 
     # Test where patient is on the last day of their monitoring period
     patient = create(:patient,
@@ -593,10 +595,10 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      last_date_of_exposure: 14.days.ago)
 
-    assert_equal(1, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(1, Patient.close_eligible.count { |p| p.id == patient.id })
   end
 
   test 'close eligible includes records past their last day of monitoring' do
@@ -607,11 +609,11 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      last_date_of_exposure: 15.days.ago,
                      created_at: 5.days.ago)
 
-    assert_equal(1, Patient.close_eligible.select { |p| p.id == patient.id }.count)
+    assert_equal(1, Patient.close_eligible.count { |p| p.id == patient.id })
   end
 
   test 'close eligible includes records that have been inactive for 30+ days' do
@@ -820,7 +822,7 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      preferred_contact_method: 'Telephone call',
                      primary_telephone: '+13333333333',
-                     latest_assessment_at: Time.now)
+                     latest_assessment_at: Time.now.getlocal)
 
     assert_equal(0, Patient.reminder_eligible.where(id: patient.id).count)
   end
@@ -962,14 +964,14 @@ class PatientTest < ActiveSupport::TestCase
     assert_equal 1, Patient.purge_eligible.count
 
     # If the patient was last updated within the purgeable_after timeframe, do not purge
-    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
-    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + 2.5.days + 1.minute).strftime('%A %l:%M%p')
+    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now.getlocal + 1.minute).strftime('%A %l:%M%p')
+    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now.getlocal + 2.5.days + 1.minute).strftime('%A %l:%M%p')
     patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after'].minutes - 900.minutes).ago)
     assert_equal 0, Patient.purge_eligible.count
 
     # If the patient was last updated exactly at the purgeable_after timeframe, they should not be purgeable
-    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now + 1.minute).strftime('%A %l:%M%p')
-    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now + 1.minute - 2.5.days).strftime('%A %l:%M%p')
+    ADMIN_OPTIONS['weekly_purge_date'] = (Time.now.getlocal + 1.minute).strftime('%A %l:%M%p')
+    ADMIN_OPTIONS['weekly_purge_warning_date'] = (Time.now.getlocal + 1.minute - 2.5.days).strftime('%A %l:%M%p')
     patient.update!(updated_at: (ADMIN_OPTIONS['purgeable_after']).minutes.ago)
     assert_equal 0, Patient.purge_eligible.count
   end
@@ -977,7 +979,7 @@ class PatientTest < ActiveSupport::TestCase
   test 'continuous_exposure never purge eligible' do
     patient = create(:patient, purged: false, monitoring: false, continuous_exposure: true)
     patient.update!(updated_at: (2 * ADMIN_OPTIONS['purgeable_after']).minutes.ago)
-    assert_nil Patient.purge_eligible.find_by_id(patient.id)
+    assert_nil Patient.purge_eligible.find_by(id: patient.id)
   end
 
   test 'purged' do
@@ -1394,7 +1396,7 @@ class PatientTest < ActiveSupport::TestCase
     patient = create(:patient, date_of_birth: number.years.ago)
     age = patient.calc_current_age
 
-    birth_year = Date.today.year - age
+    birth_year = Date.current.year - age
 
     assert_equal age, Patient.calc_current_age_fhir("#{birth_year}-01-01")
     assert_equal age, Patient.calc_current_age_fhir("#{birth_year}-01")
@@ -2218,7 +2220,7 @@ class PatientTest < ActiveSupport::TestCase
 
     patient.isolation = false
     patient.continuous_exposure = false
-    patient.last_date_of_exposure = Time.now - 1.day
+    patient.last_date_of_exposure = Time.now.getlocal - 1.day
     assert patient.valid?(:api)
 
     patient.isolation = false
@@ -2241,7 +2243,7 @@ class PatientTest < ActiveSupport::TestCase
     assert patient.valid?(:api)
 
     patient.continuous_exposure = true
-    patient.last_date_of_exposure = Time.now - 1.day
+    patient.last_date_of_exposure = Time.now.getlocal - 1.day
     assert_not patient.valid?(:api)
   end
 
@@ -2365,7 +2367,7 @@ class PatientTest < ActiveSupport::TestCase
 
     # LDE + 15 days: in range as long as assessments are in range
     patient = create(:patient, last_date_of_exposure: 15.days.ago.utc.to_date)
-    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: 2.day.ago)
+    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: 2.days.ago)
     scoped_patients = Patient.ten_day_quarantine_candidates
     assert scoped_patients.where(id: patient.id).present?
   end
@@ -2405,19 +2407,19 @@ class PatientTest < ActiveSupport::TestCase
 
     # LDE + 12 days: in range
     patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
-    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 2.day)
+    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 2.days)
     scoped_patients = Patient.ten_day_quarantine_candidates
     assert scoped_patients.where(id: patient.id).present?
 
     # LDE + 13 days: in range
     patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
-    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 3.day)
+    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 3.days)
     scoped_patients = Patient.ten_day_quarantine_candidates
     assert scoped_patients.where(id: patient.id).present?
 
     # LDE + 1 days: too late
     patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
-    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 4.day)
+    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 4.days)
     scoped_patients = Patient.ten_day_quarantine_candidates
     assert_not scoped_patients.where(id: patient.id).present?
   end
@@ -2560,14 +2562,14 @@ class PatientTest < ActiveSupport::TestCase
 
     # # LDE + 9 days: in range
     patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
-    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 2.day)
+    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 2.days)
     create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates
     assert scoped_patients.where(id: patient.id).present?
 
     # # LDE + 10 days: too late
     patient = create(:patient, last_date_of_exposure: 7.days.ago.utc.to_date)
-    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 3.day)
+    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: DateTime.now.utc + 3.days)
     create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: DateTime.now.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates
     assert_not scoped_patients.where(id: patient.id).present?
@@ -2619,7 +2621,7 @@ class PatientTest < ActiveSupport::TestCase
   test 'seven_day_quarantine_candidates scope asserts lab results specimen_collection within correct range around LDE' do
     # LDE + 4 days: too early
     patient = create(:patient, last_date_of_exposure: 10.days.ago.utc.to_date)
-    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: 4.day.ago.utc)
+    create(:assessment, patient_id: patient.id, symptomatic: false, created_at: 4.days.ago.utc)
     create(:laboratory, patient_id: patient.id, result: 'negative', lab_type: 'PCR', specimen_collection: 6.days.ago.utc.to_date)
     scoped_patients = Patient.seven_day_quarantine_candidates
     assert_not scoped_patients.where(id: patient.id).present?
@@ -3053,13 +3055,14 @@ class PatientTest < ActiveSupport::TestCase
       1440 * 21
     ].each do |reporting_period|
       ADMIN_OPTIONS['reporting_period_minutes'] = reporting_period
-      [
+      state_params_array = [
         { monitored_address_state: nil, address_state: nil },
         { monitored_address_state: 'california', address_state: nil },
         { monitored_address_state: nil, address_state: 'minnesota' },
         { monitored_address_state: 'montana', address_state: nil },
         { monitored_address_state: nil, address_state: 'florida' }
-      ].each do |state_params|
+      ]
+      state_params_array.each do |state_params|
         patient = create(:patient, state_params)
         # Patient with no reports (latest_report_at is NULL)
         assert_not_nil Patient.has_not_reported_recently.find_by(id: patient.id)
@@ -3110,13 +3113,14 @@ class PatientTest < ActiveSupport::TestCase
       60
     ].each do |monitoring_period|
       ADMIN_OPTIONS['monitoring_period_days'] = monitoring_period
-      [
+      state_params_array = [
         { monitored_address_state: nil, address_state: nil },
         { monitored_address_state: 'minnesota', address_state: nil },
         { monitored_address_state: nil, address_state: 'minnesota' },
         { monitored_address_state: 'montana', address_state: nil },
         { monitored_address_state: nil, address_state: 'florida' }
-      ].each do |state_params|
+      ]
+      state_params_array.each do |state_params|
         # Created now should be in the monitoring period
         patient = create(:patient, state_params)
         assert_not_nil Patient.is_being_monitored.find_by(id: patient.id)
@@ -3223,13 +3227,14 @@ class PatientTest < ActiveSupport::TestCase
       60
     ].each do |monitoring_period|
       ADMIN_OPTIONS['monitoring_period_days'] = monitoring_period
-      [
+      state_params_array = [
         { monitored_address_state: nil, address_state: nil },
         { monitored_address_state: 'minnesota', address_state: nil },
         { monitored_address_state: nil, address_state: 'minnesota' },
         { monitored_address_state: 'montana', address_state: nil },
         { monitored_address_state: nil, address_state: 'florida' }
-      ].each do |state_params|
+      ]
+      state_params_array.each do |state_params|
         # Created now should be in the monitoring period
         patient = create(:patient, state_params)
         assert_nil Patient.end_of_monitoring_period.find_by(id: patient.id)
@@ -3298,13 +3303,14 @@ class PatientTest < ActiveSupport::TestCase
       1440 * 21
     ].each do |reporting_period|
       ADMIN_OPTIONS['reporting_period_minutes'] = reporting_period
-      [
+      state_params_array = [
         { monitored_address_state: nil, address_state: nil },
         { monitored_address_state: 'california', address_state: nil },
         { monitored_address_state: nil, address_state: 'minnesota' },
         { monitored_address_state: 'montana', address_state: nil },
         { monitored_address_state: nil, address_state: 'florida' }
-      ].each do |state_params|
+      ]
+      state_params_array.each do |state_params|
         patient = create(:patient, state_params)
         # Patient with no reports (latest_report_at is NULL)
         assert_not_nil Patient.reminder_not_sent_recently.find_by(id: patient.id)
@@ -3437,7 +3443,7 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      last_date_of_exposure: 20.days.ago)
     assert_not_nil Patient.close_eligible(:completed_monitoring).find_by(id: patient.id)
   end
@@ -3449,7 +3455,7 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      created_at: 20.days.ago)
     assert_not_nil Patient.close_eligible(:completed_monitoring).find_by(id: patient.id)
     assert_nil Patient.close_eligible(:enrolled_last_day_monitoring_period).find_by(id: patient.id)
@@ -3465,7 +3471,7 @@ class PatientTest < ActiveSupport::TestCase
                      monitoring: true,
                      symptom_onset: nil,
                      public_health_action: 'None',
-                     latest_assessment_at: Time.now,
+                     latest_assessment_at: Time.now.getlocal,
                      created_at: 20.days.ago)
     assert_not_nil Patient.close_eligible(:completed_monitoring).find_by(id: patient.id)
     assert_nil Patient.close_eligible(:enrolled_past_monitioring_period).find_by(id: patient.id)

--- a/test/system/lib/system_test_utils.rb
+++ b/test/system/lib/system_test_utils.rb
@@ -10,7 +10,7 @@ class SystemTestUtils < ApplicationSystemTestCase
 
   SIGN_IN_URL = '/users/sign_in'
   USER_PASSWORD = '1234567ab!'
-  DOWNLOAD_PATH = Rails.root.join('tmp/downloads')
+  DOWNLOAD_PATH = Rails.root.join('tmp', 'downloads')
 
   ENROLLMENT_SUBMISSION_DELAY = 7 # wait for submission alert animation to finish
   ENROLLMENT_PAGE_TRANSITION_DELAY = 1 # wait for carousel animation to finish

--- a/test/system/roles/enroller/enrollment/form.rb
+++ b/test/system/roles/enroller/enrollment/form.rb
@@ -47,7 +47,9 @@ class EnrollmentForm < ApplicationSystemTestCase
         elsif field[:type] == :risk_factor
           page.find('label', text: field[:label].upcase).click
         elsif field[:type] == :react_select
+          # rubocop:disable Rails/DynamicFindBy
           input_element = page.find_by_id("#{field[:id]}_wrapper").first(:xpath, './/div//div//div//div//div//input')
+          # rubocop:enable Rails/DynamicFindBy
           input_element.set data[field[:id]]
           input_element.send_keys :enter
         elsif field[:type] == :recent_date && data[field[:id]]

--- a/test/system/roles/enroller/enrollment/form_validator.rb
+++ b/test/system/roles/enroller/enrollment/form_validator.rb
@@ -124,7 +124,10 @@ class EnrollmentFormValidator < ApplicationSystemTestCase
     @@system_test_utils.wait_for_enrollment_page_transition
     click_on 'edit-identification-btn'
     @@system_test_utils.wait_for_enrollment_page_transition
+    # This is a Capybara/Selenium method so we disable Rubocop.
+    # rubocop:disable Rails/DynamicFindBy
     page.find_by_id('workflow_wrapper').first(:xpath, './/div//div//div//div//div//input').set('Isolation (case)').send_keys(:enter)
+    # rubocop:enable Rails/DynamicFindBy
     click_on 'Next'
     @@system_test_utils.wait_for_enrollment_page_transition
     click_on 'edit-potential_exposure_information-btn'

--- a/test/system/roles/public_health/dashboard/dashboard.rb
+++ b/test/system/roles/public_health/dashboard/dashboard.rb
@@ -235,7 +235,7 @@ class PublicHealthDashboard < ApplicationSystemTestCase
   def bulk_edit_close_records(monitoring_reason, reasoning, apply_to_household)
     click_on 'Actions'
     click_on 'Close Records'
-    select(monitoring_reason, from: 'monitoring_reason') unless monitoring_reason.blank?
+    select(monitoring_reason, from: 'monitoring_reason') if monitoring_reason.present?
     fill_in 'reasoning', with: reasoning
     find_by_id('apply_to_household', { visible: :all }).check({ allow_label_click: true }) if apply_to_household
     click_on 'Submit'

--- a/test/system/roles/public_health/dashboard/dashboard_verifier.rb
+++ b/test/system/roles/public_health/dashboard/dashboard_verifier.rb
@@ -103,7 +103,7 @@ class PublicHealthDashboardVerifier < ApplicationSystemTestCase
     # verify_patient_field('closed at', patient[:closed_at]) if tab == :closed # local timezone
     # verify_patient_field('transferred at', patient[:latest_transfer_at]) if %i[transferred_in transferred_out].include?(tab) # local timezone
     # verify_patient_field('latest report', patient[:latest_assessment_at]) unless %i[transferred_in transferred_out].include?(tab) # local timezone
-    verify_patient_field('status', patient.status.to_s.gsub('_', ' ').sub('exposure ', '')&.sub('isolation ', '')) if tab == :all
+    verify_patient_field('status', patient.status.to_s.tr('_', ' ').sub('exposure ', '')&.sub('isolation ', '')) if tab == :all
   end
 
   def verify_patient_field(field, value)

--- a/test/system/roles/public_health/public_health_custom_export_test.rb
+++ b/test/system/roles/public_health/public_health_custom_export_test.rb
@@ -25,7 +25,7 @@ class PublicHealthCustomExportTest < ApplicationSystemTestCase
     load 'app/jobs/export_job.rb'
 
     # Remove any files downloaded for each test
-    FileUtils.rm_rf(Rails.root.join('tmp/downloads'))
+    FileUtils.rm_rf(Rails.root.join('tmp', 'downloads'))
   end
 
   # Recursively grabs all the "leaf" field options in custom export

--- a/test/system/roles/public_health/public_health_export_test.rb
+++ b/test/system/roles/public_health/public_health_export_test.rb
@@ -22,7 +22,7 @@ class PublicHealthImportExportTest < ApplicationSystemTestCase
     load 'app/jobs/export_job.rb'
 
     # Remove any files downloaded for each test
-    FileUtils.rm_rf(Rails.root.join('tmp/downloads'))
+    FileUtils.rm_rf(Rails.root.join('tmp', 'downloads'))
   end
 
   test 'export line list csv (exposure)' do


### PR DESCRIPTION


# Description
Jira Ticket: [SARAALERT-1470](https://tracker.codev.mitre.org/browse/SARAALERT-1470)

Includes, configures, and makes recommended changes for [Rubocop Rails](https://docs.rubocop.org/rubocop-rails/index.html) and [Rubocop Performance](https://docs.rubocop.org/rubocop-performance/index.html) plugins.

These additional style guides will keep the project up-to-date with best practices from the framework and help us write more performant code.

## Important Changes

**All new cops are disabled** but the changes they would enforce have been made so as not to fail CI.

The main note has to do with Time.now vs. Time.now.getlocal which I have repeated in various places throughout the code so if it becomes an issue the `git blame` and file history will have some nice context in addition to any discussion that takes place in this PR.

## Testing Recommendations

Use the attached [rubocop.txt](https://github.com/SaraAlert/SaraAlert/files/6947510/rubocop.txt) and run rubocop locally on the test and performance directories.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [ ] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ngfreiter :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@sgober :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
