### PR TITLE
SARAALERT-1053: Hide "Last Date of Exposure" and "Continous Exposure" in monitoree's profile when in Isolation Workflow

### DIFF
--- a/app/javascript/components/patient/assessment/actions/MonitoringPeriod.js
+++ b/app/javascript/components/patient/assessment/actions/MonitoringPeriod.js
@@ -45,7 +45,7 @@ class MonitoringPeriod extends React.Component {
   render() {
     return (
       <Row>
-        <Col xl={{ span: 8, order: 1 }} md={{ span: this.props.patient.isolation ? 12 : 8, order: 1 }} xs={{ span: 24, order: 1 }}>
+        <Col xl={{ span: this.props.patient.isolation ? 9 : 8, order: 1 }} md={{ span: 12, order: 1 }} xs={{ span: 24, order: 1 }}>
           <SymptomOnset
             authenticity_token={this.props.authenticity_token}
             patient={this.props.patient}
@@ -55,7 +55,7 @@ class MonitoringPeriod extends React.Component {
           />
         </Col>
         {!this.props.patient.isolation && (
-          <Col md={{ span: 8, order: 2 }} xs={{ span: 24, order: 3 }}>
+          <Col xl={{ span: 8, order: 2 }} md={{ span: 12, order: 2 }} xs={{ span: 24, order: 3 }}>
             <LastDateExposure
               household_members={this.props.household_members}
               authenticity_token={this.props.authenticity_token}
@@ -65,7 +65,7 @@ class MonitoringPeriod extends React.Component {
             />
           </Col>
         )}
-        <Col xl={{ span: 8, order: 3 }} md={{ span: this.props.patient.isolation ? 12 : 8, order: 3 }} xs={{ span: 24, order: 4 }}>
+        <Col xl={{ span: this.props.patient.isolation ? 9 : 8, order: 3 }} md={{ span: 12, order: 3 }} xs={{ span: 24, order: 4 }}>
           {this.props.patient.isolation ? (
             <ExtendedIsolation authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
           ) : (
@@ -73,7 +73,7 @@ class MonitoringPeriod extends React.Component {
           )}
         </Col>
         {this.props.patient.isolation && !this.props.patient.symptom_onset && !this.props.symptomatic_assessments_exist && this.props.num_pos_labs === 0 && (
-          <Col md={{ span: 24, order: 4 }} xs={{ span: 24, order: 2 }}>
+          <Col xl={{ span: 9, order: 4 }} md={{ span: 12, order: 4 }} xs={{ span: 24, order: 2 }}>
             <Alert variant="warning" className="alert-warning-text">
               <b>Warning: </b>This case does not have a Symptom Onset Date or positive lab result and may never become eligible to end monitoring
             </Alert>

--- a/app/javascript/components/patient/assessment/actions/MonitoringPeriod.js
+++ b/app/javascript/components/patient/assessment/actions/MonitoringPeriod.js
@@ -45,7 +45,7 @@ class MonitoringPeriod extends React.Component {
   render() {
     return (
       <Row>
-        <Col md={{ span: 8, order: 1 }} xs={{ span: 24, order: 1 }}>
+        <Col xl={{ span: 8, order: 1 }} md={{ span: this.props.patient.isolation ? 12 : 8, order: 1 }} xs={{ span: 24, order: 1 }}>
           <SymptomOnset
             authenticity_token={this.props.authenticity_token}
             patient={this.props.patient}
@@ -54,16 +54,18 @@ class MonitoringPeriod extends React.Component {
             calculated_symptom_onset={this.props.calculated_symptom_onset}
           />
         </Col>
-        <Col md={{ span: 8, order: 2 }} xs={{ span: 24, order: 3 }}>
-          <LastDateExposure
-            household_members={this.props.household_members}
-            authenticity_token={this.props.authenticity_token}
-            patient={this.props.patient}
-            current_user={this.props.current_user}
-            jurisdiction_paths={this.props.jurisdiction_paths}
-          />
-        </Col>
-        <Col md={{ span: 8, order: 3 }} xs={{ span: 24, order: 4 }}>
+        {!this.props.patient.isolation && (
+          <Col md={{ span: 8, order: 2 }} xs={{ span: 24, order: 3 }}>
+            <LastDateExposure
+              household_members={this.props.household_members}
+              authenticity_token={this.props.authenticity_token}
+              patient={this.props.patient}
+              current_user={this.props.current_user}
+              jurisdiction_paths={this.props.jurisdiction_paths}
+            />
+          </Col>
+        )}
+        <Col xl={{ span: 8, order: 1 }} md={{ span: this.props.patient.isolation ? 12 : 8, order: 3 }} xs={{ span: 24, order: 4 }}>
           {this.props.patient.isolation ? (
             <ExtendedIsolation authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
           ) : (

--- a/app/javascript/components/patient/assessment/actions/MonitoringPeriod.js
+++ b/app/javascript/components/patient/assessment/actions/MonitoringPeriod.js
@@ -65,7 +65,7 @@ class MonitoringPeriod extends React.Component {
             />
           </Col>
         )}
-        <Col xl={{ span: 8, order: 1 }} md={{ span: this.props.patient.isolation ? 12 : 8, order: 3 }} xs={{ span: 24, order: 4 }}>
+        <Col xl={{ span: 8, order: 3 }} md={{ span: this.props.patient.isolation ? 12 : 8, order: 3 }} xs={{ span: 24, order: 4 }}>
           {this.props.patient.isolation ? (
             <ExtendedIsolation authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
           ) : (

--- a/app/javascript/tests/patient/assessment/actions/MonitoringPeriod.test.js
+++ b/app/javascript/tests/patient/assessment/actions/MonitoringPeriod.test.js
@@ -17,20 +17,20 @@ function getWrapper(patient) {
 describe('MonitoringPeriod', () => {
   it('Properly renders symptom onset and extended isolation when patient is in isolation workflow', () => {
     const wrapper = getWrapper(mockPatient1);
-    expect(wrapper.find(SymptomOnset).exists()).toBeTruthy();
-    expect(wrapper.find(LastDateExposure).exists()).toBeTruthy();
-    expect(wrapper.find(ExtendedIsolation).exists()).toBeTruthy();
-    expect(wrapper.find(InfoTooltip).exists()).toBeFalsy();
-    expect(wrapper.find('#end_of_monitoring_date').exists()).toBeFalsy();
+    expect(wrapper.find(SymptomOnset).exists()).toBe(true);
+    expect(wrapper.find(LastDateExposure).exists()).toBe(false);
+    expect(wrapper.find(ExtendedIsolation).exists()).toBe(true);
+    expect(wrapper.find(InfoTooltip).exists()).toBe(false);
+    expect(wrapper.find('#end_of_monitoring_date').exists()).toBe(false);
   });
 
   it('Properly renders symptom onset, last date of exposure, and end of monitoring when patient is in exposure workflow', () => {
     const wrapper = getWrapper(mockPatient2);
-    expect(wrapper.find(SymptomOnset).exists()).toBeTruthy();
-    expect(wrapper.find(LastDateExposure).exists()).toBeTruthy();
-    expect(wrapper.find(ExtendedIsolation).exists()).toBeFalsy();
+    expect(wrapper.find(SymptomOnset).exists()).toBe(true);
+    expect(wrapper.find(LastDateExposure).exists()).toBe(true);
+    expect(wrapper.find(ExtendedIsolation).exists()).toBe(false);
     expect(wrapper.find('.input-label').text()).toEqual('END OF MONITORING');
-    expect(wrapper.find(InfoTooltip).exists()).toBeTruthy();
+    expect(wrapper.find(InfoTooltip).exists()).toBe(true);
     expect(wrapper.find('#end_of_monitoring_date').text()).toEqual(moment(mockPatient2.linelist.end_of_monitoring).format('MM/DD/YYYY'));
   });
 });


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1053](https://tracker.codev.mitre.org/browse/SARAALERT-1053)

Since the LDE and Continuous Exposure fields have not real relevance for the Isolation workflow, they should be hidden in the moniotree's main profile view as shown below, but they should still be available in the monitoree's Exposure Information Details.

## (Feature) Demo/Screenshots
<img width="1160" alt="Screen Shot 2021-08-04 at 6 54 42 PM" src="https://user-images.githubusercontent.com/35042815/128266010-a1a4a8a0-af2a-4f54-924f-aea7e95f1880.png">

<img width="835" alt="Screen Shot 2021-08-04 at 6 54 49 PM" src="https://user-images.githubusercontent.com/35042815/128266012-5111408e-a57c-4356-863a-21384e417835.png">

<img width="523" alt="Screen Shot 2021-08-04 at 6 54 58 PM" src="https://user-images.githubusercontent.com/35042815/128266013-38ed26db-f08a-4b6e-9256-bc8de0e8ca7a.png">

## Testing Recommendations
Test resizing the screen for monitorees in both workflows, both should be dynamic

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@annmarieb1 :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
