### PR TITLE
SARAALERT-1020: Add Assigned User and Jurisdiction to advanced filter

### DIFF
--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -9,14 +9,17 @@ class PublicHealthController < ApplicationController
 
   def exposure
     @title = 'Exposure Dashboard'
+    @possible_jurisdiction_paths = current_user.jurisdiction.subtree.pluck(:id, :path).to_h
   end
 
   def isolation
     @title = 'Isolation Dashboard'
+    @possible_jurisdiction_paths = current_user.jurisdiction.subtree.pluck(:id, :path).to_h
   end
 
   def global
     @title = 'Global Dashboard'
+    @possible_jurisdiction_paths = current_user.jurisdiction.subtree.pluck(:id, :path).to_h
   end
 
   def patients

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -6,20 +6,18 @@ class PublicHealthController < ApplicationController
 
   before_action :authenticate_user!
   before_action :authenticate_user_role
+  before_action :set_jurisdiction_paths, only: %i[exposure isolation global]
 
   def exposure
     @title = 'Exposure Dashboard'
-    @possible_jurisdiction_paths = current_user.jurisdiction.subtree.pluck(:id, :path).to_h
   end
 
   def isolation
     @title = 'Isolation Dashboard'
-    @possible_jurisdiction_paths = current_user.jurisdiction.subtree.pluck(:id, :path).to_h
   end
 
   def global
     @title = 'Global Dashboard'
-    @possible_jurisdiction_paths = current_user.jurisdiction.subtree.pluck(:id, :path).to_h
   end
 
   def patients
@@ -81,5 +79,9 @@ class PublicHealthController < ApplicationController
   def authenticate_user_role
     # Restrict access to public health only
     redirect_to(root_url) && return unless current_user.can_view_public_health_dashboard?
+  end
+
+  def set_jurisdiction_paths
+    @possible_jurisdiction_paths = current_user.jurisdiction.subtree.pluck(:id, :path).to_h
   end
 end

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -6,7 +6,7 @@ class PublicHealthController < ApplicationController
 
   before_action :authenticate_user!
   before_action :authenticate_user_role
-  before_action :set_jurisdiction_paths, only: %i[exposure isolation global]
+  before_action :set_jurisdiction_paths, :set_all_assigned_users, only: %i[exposure isolation global]
 
   def exposure
     @title = 'Exposure Dashboard'
@@ -83,5 +83,11 @@ class PublicHealthController < ApplicationController
 
   def set_jurisdiction_paths
     @possible_jurisdiction_paths = current_user.jurisdiction.subtree.pluck(:id, :path).to_h
+  end
+
+  def set_all_assigned_users
+    # Get all assigned users of current user's jurisdiction
+    patients = current_user.patients&.where(jurisdiction_id: current_user.jurisdiction.subtree_ids)
+    @all_assigned_users = patients.where.not(assigned_user: nil).distinct.pluck(:assigned_user).sort
   end
 end

--- a/app/controllers/public_health_controller.rb
+++ b/app/controllers/public_health_controller.rb
@@ -87,7 +87,6 @@ class PublicHealthController < ApplicationController
 
   def set_all_assigned_users
     # Get all assigned users of current user's jurisdiction
-    patients = current_user.patients&.where(jurisdiction_id: current_user.jurisdiction.subtree_ids)
-    @all_assigned_users = patients.where.not(assigned_user: nil).distinct.pluck(:assigned_user).sort
+    @all_assigned_users = current_user.patients.where.not(assigned_user: nil).pluck(:assigned_user).uniq.sort
   end
 end

--- a/app/controllers/user_filters_controller.rb
+++ b/app/controllers/user_filters_controller.rb
@@ -21,7 +21,8 @@ class UserFiltersController < ApplicationController
       {
         filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, :hasTimestamp, :allowRange, :tooltip,
                                                            options: [], fields: [:name, :title, :type, { options: [] }]),
-        value: filter.permit(:value, value: [])[:value] || filter.require(:value) || false,
+        value: filter[:value].nil? && filter[:filterOption][:type].eql?('multi') ? [] : filter.permit(:value,
+                                                                                                      value: [])[:value] || filter.require(:value) || false,
         numberOption: filter.permit(:numberOption)[:numberOption],
         dateOption: filter.permit(:dateOption)[:dateOption],
         relativeOption: filter.permit(:relativeOption)[:relativeOption],
@@ -37,7 +38,8 @@ class UserFiltersController < ApplicationController
       {
         filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, :hasTimestamp, :allowRange, :tooltip,
                                                            options: [], fields: [:name, :title, :type, { options: [] }]),
-        value: filter.permit(:value, value: [])[:value] || filter.require(:value) || false,
+        value: filter[:value].nil? && filter[:filterOption][:type].eql?('multi') ? [] : filter.permit(:value,
+                                                                                                      value: [])[:value] || filter.require(:value) || false,
         numberOption: filter.permit(:numberOption)[:numberOption],
         dateOption: filter.permit(:dateOption)[:dateOption],
         relativeOption: filter.permit(:relativeOption)[:relativeOption],

--- a/app/controllers/user_filters_controller.rb
+++ b/app/controllers/user_filters_controller.rb
@@ -21,7 +21,7 @@ class UserFiltersController < ApplicationController
       {
         filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, :hasTimestamp, :allowRange, :tooltip,
                                                            options: [], fields: [:name, :title, :type, { options: [] }]),
-        value: filter.permit(:value)[:value] || filter.require(:value) || false,
+        value: filter.permit(:value, value: [])[:value] || filter.require(:value) || false,
         numberOption: filter.permit(:numberOption)[:numberOption],
         dateOption: filter.permit(:dateOption)[:dateOption],
         relativeOption: filter.permit(:relativeOption)[:relativeOption],
@@ -37,7 +37,7 @@ class UserFiltersController < ApplicationController
       {
         filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, :hasTimestamp, :allowRange, :tooltip,
                                                            options: [], fields: [:name, :title, :type, { options: [] }]),
-        value: filter.permit(:value)[:value] || filter.require(:value) || false,
+        value: filter.permit(:value, value: [])[:value] || filter.require(:value) || false,
         numberOption: filter.permit(:numberOption)[:numberOption],
         dateOption: filter.permit(:dateOption)[:dateOption],
         relativeOption: filter.permit(:relativeOption)[:relativeOption],

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -76,11 +76,11 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
 
       query[:filter] = unsanitized_query[:filter].collect do |filter|
         permitted_filter_params = filter.permit(:value, :numberOption, :dateOption, :relativeOption, :additionalFilterOption,
-                                                filterOption: {}, value: filter[:value].is_a?(Array) ? %i[label value] : {})
+                                                filterOption: {}, value: filter[:value].is_a?(Array) ? [] : {})
         {
           filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, :hasTimestamp, :tooltip,
                                                              options: [], fields: [:name, :title, :type, { options: [] }]),
-          value: permitted_filter_params[:value] || false,
+          value: permitted_filter_params[:value] || filter.require(:value) || false,
           numberOption: permitted_filter_params[:numberOption],
           dateOption: permitted_filter_params[:dateOption],
           relativeOption: permitted_filter_params[:relativeOption],

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -502,7 +502,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
           #     [{"label": "USA", "value": "1"}, {"label": "USA, State 1", "value": "2"}],
           #   would map to
           #     Jurisdiction.where([1, 2])
-          filter_jurisdictions = Jurisdiction.where(id: filter[:value].map(&:values).map(&:second).map(&:to_i)&.flatten)
+          filter_jurisdictions = Jurisdiction.where(id: filter[:value].map(&:values).map(&:second).map(&:to_i))
 
           # Get subset of jurisdictions
           subjurisdictions = filter_jurisdictions.map(&:subtree_ids).flatten.uniq

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -80,7 +80,8 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
         {
           filterOption: filter.require(:filterOption).permit(:name, :title, :description, :type, :hasTimestamp, :tooltip,
                                                              options: [], fields: [:name, :title, :type, { options: [] }]),
-          value: permitted_filter_params[:value] || filter.require(:value) || false,
+          value: filter[:value].nil? && filter[:filterOption][:type].eql?('multi') ? [] : filter.permit(:value,
+                                                                                                        value: [])[:value] || filter.require(:value) || false,
           numberOption: permitted_filter_params[:numberOption],
           dateOption: permitted_filter_params[:dateOption],
           relativeOption: permitted_filter_params[:relativeOption],

--- a/app/javascript/components/public_health/CustomExport.js
+++ b/app/javascript/components/public_health/CustomExport.js
@@ -272,7 +272,7 @@ class CustomExport extends React.Component {
                                     : filter.relativeOption}
                                 </span>
                               )}
-                              {filter.filterOption?.type === 'multi' && (
+                              {filter.filterOption?.type === 'combination' && (
                                 <div style={{ display: 'inline-grid' }}>
                                   {filter.value?.map((f, i) => {
                                     return (

--- a/app/javascript/components/public_health/CustomExport.js
+++ b/app/javascript/components/public_health/CustomExport.js
@@ -253,6 +253,17 @@ class CustomExport extends React.Component {
                               {['search', 'select', 'number'].includes(filter.filterOption?.type) && (
                                 <span>{filter.value === '' ? '<blank>' : filter.value}</span>
                               )}
+                              {filter.filterOption?.type === 'multi' && (
+                                <div style={{ display: 'inline-grid' }}>
+                                  {filter.value?.map((elem, i) => {
+                                    return (
+                                      <span key={`filter-${index}-${i}`} className="mb-0">
+                                        {elem.label}
+                                      </span>
+                                    );
+                                  })}
+                                </div>
+                              )}
                               {filter.filterOption?.type === 'boolean' && <span>{filter.value ? 'True' : 'False'}</span>}
                               {filter.filterOption?.type === 'date' && (
                                 <span>
@@ -333,6 +344,7 @@ class CustomExport extends React.Component {
                     <PatientsFilters
                       authenticity_token={this.props.authenticity_token}
                       jurisdiction_paths={this.props.jurisdiction_paths}
+                      all_assigned_users={this.props.all_assigned_users}
                       jurisdiction={this.props.jurisdiction}
                       query={this.state.custom_patient_query}
                       onQueryChange={(field, value, cb) =>
@@ -577,6 +589,7 @@ class CustomExport extends React.Component {
 CustomExport.propTypes = {
   authenticity_token: PropTypes.string,
   jurisdiction_paths: PropTypes.object,
+  all_assigned_users: PropTypes.array,
   jurisdiction: PropTypes.object,
   tabs: PropTypes.object,
   preset: PropTypes.object,

--- a/app/javascript/components/public_health/Export.js
+++ b/app/javascript/components/public_health/Export.js
@@ -123,6 +123,7 @@ class Export extends React.Component {
           <CustomExport
             authenticity_token={this.props.authenticity_token}
             jurisdiction_paths={this.props.jurisdiction_paths}
+            all_assigned_users={this.props.all_assigned_users}
             jurisdiction={this.props.jurisdiction}
             tabs={this.props.tabs}
             preset={this.state.savedPreset}
@@ -145,6 +146,7 @@ class Export extends React.Component {
 Export.propTypes = {
   authenticity_token: PropTypes.string,
   jurisdiction_paths: PropTypes.object,
+  all_assigned_users: PropTypes.array,
   jurisdiction: PropTypes.object,
   tabs: PropTypes.object,
   query: PropTypes.object,

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -696,7 +696,7 @@ class PatientsTable extends React.Component {
                     authenticity_token={this.props.authenticity_token}
                     updateStickySettings={true}
                     jurisdiction_paths={this.props.jurisdiction_paths}
-                    assigned_users={this.state.assigned_users}
+                    all_assigned_users={this.props.all_assigned_users}
                   />
                   {this.state.query.tab !== 'transferred_out' && (
                     <DropdownButton
@@ -809,6 +809,7 @@ class PatientsTable extends React.Component {
 PatientsTable.propTypes = {
   authenticity_token: PropTypes.string,
   jurisdiction_paths: PropTypes.object,
+  all_assigned_users: PropTypes.array,
   workflow: PropTypes.oneOf(['global', 'exposure', 'isolation']),
   jurisdiction: PropTypes.exact({
     id: PropTypes.number,

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -695,6 +695,8 @@ class PatientsTable extends React.Component {
                     advancedFilterUpdate={this.advancedFilterUpdate}
                     authenticity_token={this.props.authenticity_token}
                     updateStickySettings={true}
+                    jurisdiction_paths={this.props.jurisdiction_paths}
+                    assigned_users={this.state.assigned_users}
                   />
                   {this.state.query.tab !== 'transferred_out' && (
                     <DropdownButton

--- a/app/javascript/components/public_health/PublicHealthHeader.js
+++ b/app/javascript/components/public_health/PublicHealthHeader.js
@@ -175,6 +175,7 @@ class PublicHealthHeader extends React.Component {
                 <Export
                   authenticity_token={this.props.authenticity_token}
                   jurisdiction_paths={this.props.jurisdiction_paths}
+                  all_assigned_users={this.props.all_assigned_users}
                   jurisdiction={this.props.jurisdiction}
                   tabs={this.props.tabs}
                   workflow={this.props.workflow}
@@ -227,6 +228,7 @@ class PublicHealthHeader extends React.Component {
 PublicHealthHeader.propTypes = {
   authenticity_token: PropTypes.string,
   jurisdiction_paths: PropTypes.object,
+  all_assigned_users: PropTypes.array,
   workflow: PropTypes.oneOf(['global', 'exposure', 'isolation']),
   jurisdiction: PropTypes.object,
   tabs: PropTypes.object,

--- a/app/javascript/components/public_health/Workflow.js
+++ b/app/javascript/components/public_health/Workflow.js
@@ -27,7 +27,8 @@ class Workflow extends React.Component {
       <React.Fragment>
         <PublicHealthHeader
           authenticity_token={this.props.authenticity_token}
-          jurisdiction_paths={this.state.jurisdiction_paths}
+          all_assigned_users={this.props.all_assigned_users}
+          jurisdiction_paths={this.props.jurisdiction_paths}
           workflow={this.props.workflow}
           jurisdiction={this.props.jurisdiction}
           tabs={this.props.tabs}
@@ -39,6 +40,7 @@ class Workflow extends React.Component {
         <PatientsTable
           authenticity_token={this.props.authenticity_token}
           jurisdiction_paths={this.props.jurisdiction_paths}
+          all_assigned_users={this.props.all_assigned_users}
           workflow={this.props.workflow}
           jurisdiction={this.props.jurisdiction}
           tabs={this.props.tabs}
@@ -60,6 +62,7 @@ Workflow.propTypes = {
   tabs: PropTypes.object,
   default_tab: PropTypes.string,
   jurisdiction_paths: PropTypes.object,
+  all_assigned_users: PropTypes.array,
   custom_export_options: PropTypes.object,
   monitoring_reasons: PropTypes.array,
 };

--- a/app/javascript/components/public_health/Workflow.js
+++ b/app/javascript/components/public_health/Workflow.js
@@ -38,7 +38,7 @@ class Workflow extends React.Component {
         />
         <PatientsTable
           authenticity_token={this.props.authenticity_token}
-          jurisdiction_paths={this.state.jurisdiction_paths}
+          jurisdiction_paths={this.props.jurisdiction_paths}
           workflow={this.props.workflow}
           jurisdiction={this.props.jurisdiction}
           tabs={this.props.tabs}
@@ -59,6 +59,7 @@ Workflow.propTypes = {
   workflow: PropTypes.string,
   tabs: PropTypes.object,
   default_tab: PropTypes.string,
+  jurisdiction_paths: PropTypes.object,
   custom_export_options: PropTypes.object,
   monitoring_reasons: PropTypes.array,
 };

--- a/app/javascript/components/public_health/custom_export/PatientsFilters.js
+++ b/app/javascript/components/public_health/custom_export/PatientsFilters.js
@@ -173,6 +173,8 @@ class PatientsFilters extends React.Component {
                 }
                 authenticity_token={this.props.authenticity_token}
                 updateStickySettings={false}
+                jurisdiction_paths={this.props.jurisdiction_paths}
+                all_assigned_users={this.props.all_assigned_users}
               />
             </InputGroup>
           </Col>
@@ -185,6 +187,7 @@ class PatientsFilters extends React.Component {
 PatientsFilters.propTypes = {
   authenticity_token: PropTypes.string,
   jurisdiction_paths: PropTypes.object,
+  all_assigned_users: PropTypes.array,
   jurisdiction: PropTypes.object,
   query: PropTypes.object,
   onQueryChange: PropTypes.func,

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -292,36 +292,36 @@ class AdvancedFilter extends React.Component {
   };
 
   /**
-   * Adds another multi filter statement at certain index
+   * Adds another combination filter statement at certain index
    * Ensures no field is repeated when a new statement is added
-   * @param {Object} filter - Current multi filter object containing all the possible fields
+   * @param {Object} filter - Current combination filter object containing all the possible fields
    * @param {Number} statementIndex - Current overall statement filter index
    */
-  addMultiStatement = (filter, statementIndex) => {
-    const currentMultiFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
-    let possibleFields = currentMultiFilter.filterOption.fields;
-    currentMultiFilter.value.forEach(value => {
+  addCombinationStatement = (filter, statementIndex) => {
+    const currentCombinationFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
+    let possibleFields = currentCombinationFilter.filterOption.fields;
+    currentCombinationFilter.value.forEach(value => {
       possibleFields = possibleFields.filter(field => field.name !== value.name);
     });
-    const newValue = [...currentMultiFilter.value, this.getDefaultMultiValue(filter, possibleFields[0].name)];
+    const newValue = [...currentCombinationFilter.value, this.getDefaultCombinationValue(filter, possibleFields[0].name)];
     this.changeValue(statementIndex, newValue);
   };
 
   /**
-   * Removes one of the multi filter statements at certain index
+   * Removes one of the combination filter statements at certain index
    * @param {Number} statementIndex - Current overall statement filter index
-   * @param {Number} multiIndex - Index of the statement within the multi filter that will be removed
+   * @param {Number} combinationIndex - Index of the statement within the combination filter that will be removed
    */
-  removeMultiStatement = (statementIndex, multiIndex) => {
-    const currentMultiFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
-    let value = [...currentMultiFilter.value];
+  removeCombinationStatement = (statementIndex, combinationIndex) => {
+    const currentCombinationFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
+    let value = [...currentCombinationFilter.value];
 
-    // if removing the last multi statement, remove the whole filter
-    // otherwise just remove that multi statement
+    // if removing the last combination statement, remove the whole filter
+    // otherwise just remove that combination statement
     if (value.length === 1) {
       this.removeStatement(statementIndex);
     } else {
-      value.splice(multiIndex, 1);
+      value.splice(combinationIndex, 1);
       this.changeValue(statementIndex, value);
     }
   };
@@ -355,8 +355,8 @@ class AdvancedFilter extends React.Component {
       value = 'today';
     } else if (filterOption.type === 'search') {
       value = '';
-    } else if (filterOption.type === 'multi') {
-      value = [this.getDefaultMultiValue(filterOption, filterOption.fields[0].name)];
+    } else if (filterOption.type === 'combination') {
+      value = [this.getDefaultCombinationValue(filterOption, filterOption.fields[0].name)];
     }
 
     activeFilterOptions[parseInt(index)] = {
@@ -479,51 +479,51 @@ class AdvancedFilter extends React.Component {
   };
 
   /**
-   * Change value of a filter statement of type multi
+   * Change value of a filter statement of type combination
    * @param {Number} statementIndex - Current overall statement filter index
-   * @param {Number} multiIndex - Index of the statement within the multi filter that needs to be updated
-   * @param {*} value - New value for the statement at the multi index
+   * @param {Number} combinationIndex - Index of the statement within the combination filter that needs to be updated
+   * @param {*} value - New value for the statement at the combination index
    */
-  changeMultiValue = (statementIndex, multiIndex, value) => {
-    const currentMultiFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
-    const newValue = [...currentMultiFilter.value];
-    newValue[parseInt(multiIndex)] = value;
+  changeCombinationValue = (statementIndex, combinationIndex, value) => {
+    const currentCombinationFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
+    const newValue = [...currentCombinationFilter.value];
+    newValue[parseInt(combinationIndex)] = value;
     this.changeValue(statementIndex, newValue);
   };
 
   /**
-   * Determines if a field within a multi statement should be disabled
-   * A field is disabled if it already exists in a different multi statement, but not the one it is selected in
+   * Determines if a field within a combination statement should be disabled
+   * A field is disabled if it already exists in a different combination statement, but not the one it is selected in
    * @param {String} name - Field name attribute of the dropdown option
    * @param {Number} statementIndex - Current overall statement filter index
-   * @param {Number} multiIndex - Index of the statement within the multi filter
+   * @param {Number} combinationIndex - Index of the statement within the combination filter
    */
-  multiFieldDisabled = (name, multiIndex, statementIndex) => {
-    const currentMultiFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
-    return currentMultiFilter.value.some((value, index) => value.name === name && index !== multiIndex);
+  combinationFieldDisabled = (name, combinationIndex, statementIndex) => {
+    const currentCombinationFilter = this.state.activeFilterOptions[parseInt(statementIndex)];
+    return currentCombinationFilter.value.some((value, index) => value.name === name && index !== combinationIndex);
   };
 
   /**
    * Returns the field of a filter when given the name of that filter
-   * @param {Object} filter - Multi filter object containing all the possible fields
+   * @param {Object} filter - Combination filter object containing all the possible fields
    * @param {String} name - Field name attribute
    */
-  getMultiFilter = (filter, name) => {
+  getCombinationFilter = (filter, name) => {
     return filter.fields.find(field => field.name === name);
   };
 
   /**
-   * Given the name on of a field for a certain multi filter, returns the default value
+   * Given the name on of a field for a certain combination filter, returns the default value
    * The default value is determined by the type of the field
-   * @param {Object} filter - Multi filter object containing all the possible fields
+   * @param {Object} filter - combination filter object containing all the possible fields
    * @param {String} name - Field name attribute
    */
-  getDefaultMultiValue = (filter, name) => {
-    const multiFilter = this.getMultiFilter(filter, name);
+  getDefaultCombinationValue = (filter, name) => {
+    const combinationFilter = this.getCombinationFilter(filter, name);
     let value = null;
-    if (multiFilter.type === 'select') {
-      value = { name: name, value: multiFilter.options[0] };
-    } else if (multiFilter.type === 'date') {
+    if (combinationFilter.type === 'select') {
+      value = { name: name, value: combinationFilter.options[0] };
+    } else if (combinationFilter.type === 'date') {
       value = {
         name: name,
         value: { when: 'before', date: moment().format('YYYY-MM-DD') },
@@ -1052,79 +1052,82 @@ class AdvancedFilter extends React.Component {
   };
 
   /**
-   * Renders multi-select type line "statement"
-   * @param {Object} filter - Multi filter object containing all the possible fields
+   * Renders combination type line "statement"
+   * @param {Object} filter - Combination filter object containing all the possible fields
    * @param {Number} statementIndex - Current overall statement filter index
-   * @param {Number} multiIndex - Index of the statement within the multi filter
-   * @param {Number} total - Total number of statments within the multi filter
-   * @param {*} multiValue - Value of this statement within the multi filter (name/value pair)
+   * @param {Number} combinationIndex - Index of the statement within the combination filter
+   * @param {Number} total - Total number of statments within the combination filter
+   * @param {*} combinationValue - Value of this statement within the combination filter (name/value pair)
    */
-  renderMultiStatement = (filter, statementIndex, multiIndex, total, multiValue) => {
+  renderCombinationStatement = (filter, statementIndex, combinationIndex, total, combinationValue) => {
     return (
-      <React.Fragment key={'rowkey-filter-m' + multiIndex}>
-        {multiIndex > 0 && multiIndex < total && (
+      <React.Fragment key={'rowkey-filter-m' + combinationIndex}>
+        {combinationIndex > 0 && combinationIndex < total && (
           <Row className="and-row py-2">
             <Col className="py-0">
               <b>AND</b>
             </Col>
           </Row>
         )}
-        <Row className="advanced-filter-multi-type-statement m-0">
+        <Row className="advanced-filter-combination-type-statement m-0">
           <Col className="p-0">
             <Form.Group className="form-group-inline py-0 my-0">
               <Form.Control
                 as="select"
-                value={multiValue.name}
-                className="advanced-filter-multi-options advanced-filter-select py-0 my-0"
-                aria-label="Advanced Filter Multi Select Options"
+                value={combinationValue.name}
+                className="advanced-filter-combination-options advanced-filter-select py-0 my-0"
+                aria-label="Advanced Filter Combination Options"
                 onChange={event => {
-                  this.changeMultiValue(statementIndex, multiIndex, this.getDefaultMultiValue(filter, event.target.value));
+                  this.changeCombinationValue(statementIndex, combinationIndex, this.getDefaultCombinationValue(filter, event.target.value));
                 }}>
                 {filter.fields?.map((field, f_index) => {
                   return (
-                    <option key={f_index} value={field.name} disabled={this.multiFieldDisabled(field.name, multiIndex, statementIndex)}>
+                    <option key={f_index} value={field.name} disabled={this.combinationFieldDisabled(field.name, combinationIndex, statementIndex)}>
                       {field.title}
                     </option>
                   );
                 })}
               </Form.Control>
-              {this.getMultiFilter(filter, multiValue.name).type === 'select' && (
+              {this.getCombinationFilter(filter, combinationValue.name).type === 'select' && (
                 <Form.Control
                   as="select"
-                  value={multiValue.value}
-                  className="advanced-filter-multi-select-options advanced-filter-select my-0 mx-3 py-0"
-                  aria-label="Advanced Filter Multi Select Options"
+                  value={combinationValue.value}
+                  className="advanced-filter-combination-select-options advanced-filter-select my-0 mx-3 py-0"
+                  aria-label="Advanced Filter Combination Select Options"
                   onChange={event => {
-                    this.changeMultiValue(statementIndex, multiIndex, { name: multiValue.name, value: event.target.value });
+                    this.changeCombinationValue(statementIndex, combinationIndex, { name: combinationValue.name, value: event.target.value });
                   }}>
-                  {this.getMultiFilter(filter, multiValue.name).options.map((option, o_index) => {
+                  {this.getCombinationFilter(filter, combinationValue.name).options.map((option, o_index) => {
                     return <option key={o_index}>{option}</option>;
                   })}
                 </Form.Control>
               )}
-              {this.getMultiFilter(filter, multiValue.name).type === 'date' && (
+              {this.getCombinationFilter(filter, combinationValue.name).type === 'date' && (
                 <React.Fragment>
                   <Form.Control
                     as="select"
-                    value={multiValue.value.when}
+                    value={combinationValue.value.when}
                     className="advanced-filter-date-options py-0 my-0 mx-3"
                     aria-label="Advanced Filter Date Select Options"
                     onChange={event => {
-                      this.changeMultiValue(statementIndex, multiIndex, {
-                        name: multiValue.name,
-                        value: { when: event.target.value, date: multiValue.value.date },
+                      this.changeCombinationValue(statementIndex, combinationIndex, {
+                        name: combinationValue.name,
+                        value: { when: event.target.value, date: combinationValue.value.date },
                       });
                     }}>
                     <option value="before">before</option>
                     <option value="after">after</option>
                     <option></option>
                   </Form.Control>
-                  {(multiValue.value.when === 'before' || multiValue.value.when === 'after') && (
+                  {(combinationValue.value.when === 'before' || combinationValue.value.when === 'after') && (
                     <div className="advanced-filter-date-input mr-3">
                       <DateInput
-                        date={multiValue.value.date}
+                        date={combinationValue.value.date}
                         onChange={date => {
-                          this.changeMultiValue(statementIndex, multiIndex, { name: multiValue.name, value: { when: multiValue.value.when, date: date } });
+                          this.changeCombinationValue(statementIndex, combinationIndex, {
+                            name: combinationValue.name,
+                            value: { when: combinationValue.value.when, date: date },
+                          });
                         }}
                         placement="bottom"
                         customClass="form-control-md"
@@ -1137,36 +1140,36 @@ class AdvancedFilter extends React.Component {
                   )}
                 </React.Fragment>
               )}
-              {multiIndex + 1 === total && multiIndex + 1 < filter.fields.length && (
+              {combinationIndex + 1 === total && combinationIndex + 1 < filter.fields.length && (
                 <React.Fragment>
-                  <div className="my-auto" data-for={`${filter.name}-${statementIndex}-multi-add`} data-tip="">
+                  <div className="my-auto" data-for={`${filter.name}-${statementIndex}-combination-add`} data-tip="">
                     <Button
                       className="btn-circle"
                       variant="secondary"
                       onClick={() => {
-                        this.addMultiStatement(filter, statementIndex);
+                        this.addCombinationStatement(filter, statementIndex);
                       }}
-                      aria-label="Add Advanced Filter Multi Option">
+                      aria-label="Add Advanced Filter Combination Option">
                       <i className="fas fa-plus"></i>
                     </Button>
                   </div>
                   <ReactTooltip
-                    id={`${filter.name}-${statementIndex}-multi-add`}
+                    id={`${filter.name}-${statementIndex}-combination-add`}
                     multiline={true}
                     place="top"
                     type="dark"
                     effect="solid"
                     className="tooltip-container">
-                    <span>Select to add multiple {filter.title.replace(' (Multi-select)', '')} search criteria.</span>
+                    <span>Select to add multiple {filter.title.replace(' (Combination)', '')} search criteria.</span>
                   </ReactTooltip>
                 </React.Fragment>
               )}
             </Form.Group>
           </Col>
           <Col className="p-0" md="auto">
-            {multiIndex === 0 && filter.tooltip && this.renderStatementTooltip(filter.name, statementIndex, filter.tooltip)}
+            {combinationIndex === 0 && filter.tooltip && this.renderStatementTooltip(filter.name, statementIndex, filter.tooltip)}
           </Col>
-          <Col md="auto">{this.renderRemoveStatementButton(statementIndex, multiIndex, this.removeMultiStatement)}</Col>
+          <Col md="auto">{this.renderRemoveStatementButton(statementIndex, combinationIndex, this.removeCombinationStatement)}</Col>
         </Row>
       </React.Fragment>
     );
@@ -1210,15 +1213,15 @@ class AdvancedFilter extends React.Component {
             {filterOption?.type === 'number' && this.renderNumberStatement(filterOption, index, value, numberOption, additionalFilterOption)}
             {filterOption?.type === 'date' && this.renderDateStatement(filterOption, index, value, dateOption)}
             {filterOption?.type === 'relative' && this.renderRelativeDateStatement(filterOption, index, value, relativeOption)}
-            {filterOption?.type === 'multi' && (
+            {filterOption?.type === 'combination' && (
               <React.Fragment>
                 {value.map((m_value, m_index) => {
-                  return this.renderMultiStatement(filterOption, index, m_index, value.length, m_value);
+                  return this.renderCombinationStatement(filterOption, index, m_index, value.length, m_value);
                 })}
               </React.Fragment>
             )}
           </Col>
-          {filterOption?.type !== 'multi' && (
+          {filterOption?.type !== 'combination' && (
             <Col className="py-0" md="auto">
               {this.renderRemoveStatementButton(index, null, this.removeStatement)}
             </Col>

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -50,6 +50,15 @@ class AdvancedFilter extends React.Component {
       advancedFilterOptions[Number(index)].options = paths;
     }
 
+    // Get all assigned user options for assigned user multi-select advanced filter
+    if (this.props.all_assigned_users) {
+      let index = advancedFilterOptions.findIndex(x => x.name === 'assigned-user');
+      let all_assigned_users = _.values(this.props.all_assigned_users).map(assigned_user => {
+        return { value: assigned_user, label: assigned_user };
+      });
+      advancedFilterOptions[Number(index)].options = all_assigned_users;
+    }
+
     if (this.state.activeFilterOptions?.length === 0) {
       // Start with empty default
       this.addStatement();
@@ -74,18 +83,6 @@ class AdvancedFilter extends React.Component {
         }
       });
     });
-  }
-
-  componentDidUpdate(prevProps) {
-    // Get list of assigned users for assigned users multi-select advanced filter
-    if (this.props.assigned_users !== prevProps.assigned_users) {
-      let index = advancedFilterOptions.findIndex(x => x.name === 'assigned-user');
-      let assigned_users = _.values(this.props.assigned_users).map(assigned_user => {
-        return { value: assigned_user, label: assigned_user };
-      });
-
-      advancedFilterOptions[Number(index)].options = assigned_users;
-    }
   }
 
   /**
@@ -1491,7 +1488,7 @@ AdvancedFilter.propTypes = {
   advancedFilterUpdate: PropTypes.func,
   updateStickySettings: PropTypes.bool,
   jurisdiction_paths: PropTypes.object,
-  assigned_users: PropTypes.array,
+  all_assigned_users: PropTypes.array,
 };
 
 export default AdvancedFilter;

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -45,7 +45,7 @@ class AdvancedFilter extends React.Component {
     if (this.props.jurisdiction_paths) {
       let index = advancedFilterOptions.findIndex(x => x.name === 'jurisdiction');
       let paths = Object.entries(this.props.jurisdiction_paths).map(([id, path]) => {
-        return { value: id, label: path };
+        return { label: path, value: id };
       });
       advancedFilterOptions[Number(index)].options = paths;
     }
@@ -854,6 +854,37 @@ class AdvancedFilter extends React.Component {
   };
 
   /**
+   * Renders multi-select type line "statement"
+   * @param {Object} filter - Filter currently selected
+   * @param {Number} index - Filter index
+   * @param {Array} value - Current values selected
+   */
+  renderMultiStatement = (filter, index, value) => {
+    // Tooltip for Multi-select type
+    let tooltip = 'Leaving this field blank will not filter out any monitorees.';
+
+    return (
+      <React.Fragment>
+        <div className="d-flex justify-content-between py-0 my-0">
+          <Select
+            closeMenuOnSelect={false}
+            isMulti
+            value={value}
+            options={filter.options}
+            className="advanced-filter-multi-select w-100"
+            placeholder=""
+            aria-label="Advanced Filter Multi-select Options"
+            onChange={event => {
+              this.changeValue(index, event);
+            }}
+          />
+          {tooltip && this.renderStatementTooltip(filter.name, index, tooltip)}
+        </div>
+      </React.Fragment>
+    );
+  };
+
+  /**
    * Renders number type line "statement"
    * @param {Object} filterOption - Filter currently selected
    * @param {Number} index - Filter index
@@ -1199,37 +1230,6 @@ class AdvancedFilter extends React.Component {
   };
 
   /**
-   * Renders multi-select type line "statement"
-   * @param {Object} filter - Filter currently selected
-   * @param {Number} index - Filter index
-   * @param {Array} value - Current values selected
-   * @param {Function} handleChange - Function to handle onChange
-   */
-  renderMultiStatement = (filter, index, value, handleChange) => {
-    // Function here to pass in selected options and index
-    function handleMultiStatementChange(selectedOptions) {
-      handleChange(index, selectedOptions);
-    }
-
-    return (
-      <React.Fragment>
-        <div className="d-flex justify-content-between py-0 my-0">
-          <Select
-            closeMenuOnSelect={false}
-            isMulti
-            value={value}
-            options={filter.options}
-            className="advanced-filter-multi-select w-50 mr-3"
-            placeholder=""
-            aria-label="Advanced Filter Multi-select Options"
-            onChange={handleMultiStatementChange}
-          />
-        </div>
-      </React.Fragment>
-    );
-  };
-
-  /**
    * Renders a single line "statement"
    * @param {Object} filterOption - Filter currently selected
    * @param {*} value - Current value for this statement (could be a string, bool, date or object)
@@ -1264,6 +1264,7 @@ class AdvancedFilter extends React.Component {
             {filterOption?.type === 'boolean' && this.renderBooleanStatement(filterOption, index, value)}
             {filterOption?.type === 'search' && this.renderSearchStatement(filterOption, index, value, additionalFilterOption)}
             {filterOption?.type === 'select' && this.renderSelectStatement(filterOption, index, value)}
+            {filterOption?.type === 'multi' && this.renderMultiStatement(filterOption, index, value)}
             {filterOption?.type === 'number' && this.renderNumberStatement(filterOption, index, value, numberOption, additionalFilterOption)}
             {filterOption?.type === 'date' && this.renderDateStatement(filterOption, index, value, dateOption)}
             {filterOption?.type === 'relative' && this.renderRelativeDateStatement(filterOption, index, value, relativeOption)}
@@ -1274,7 +1275,6 @@ class AdvancedFilter extends React.Component {
                 })}
               </React.Fragment>
             )}
-            {filterOption?.type === 'multi' && this.renderMultiStatement(filterOption, index, value, this.changeValue)}
           </Col>
           {filterOption?.type !== 'combination' && (
             <Col className="py-0" md="auto">

--- a/app/javascript/data/advancedFilterOptions.js
+++ b/app/javascript/data/advancedFilterOptions.js
@@ -275,12 +275,12 @@ export const advancedFilterOptions = [
     hasTimestamp: false,
   },
 
-  /* MULTI FILTER OPTIONS */
+  /* COMBINATION OPTIONS */
   {
     name: 'lab-result',
-    title: 'Lab Result (Multi-select)',
+    title: 'Lab Result (Combination)',
     description: 'Monitorees with specified Lab Result criteria',
-    type: 'multi',
+    type: 'combination',
     tooltip:
       'Returns records that contain at least one Lab Result entry that meets all user-specified criteria (e.g., searching for a specific Lab Test Type and Report Date will only return records containing at least one Lab Result entry with matching values in both fields).',
     fields: [
@@ -310,9 +310,9 @@ export const advancedFilterOptions = [
   },
   {
     name: 'vaccination',
-    title: 'Vaccination (Multi-select)',
+    title: 'Vaccination (Combination)',
     description: 'Monitorees with specified Vaccination criteria',
-    type: 'multi',
+    type: 'combination',
     tooltip:
       'Returns records that contain at least one Vaccination entry that meets all user-specified criteria (e.g., searching for a specific Vaccination Product Name and Administration Date will only return records containing at least one Vaccination entry with matching values in both fields).',
     fields: [

--- a/app/javascript/data/advancedFilterOptions.js
+++ b/app/javascript/data/advancedFilterOptions.js
@@ -341,4 +341,20 @@ export const advancedFilterOptions = [
       },
     ],
   },
+
+  /* MULTI-SELECT OPTIONS */
+  {
+    name: 'assigned-user',
+    title: 'Assigned User (Multi-select)',
+    description: 'Monitorees who have a specific assigned user',
+    type: 'multi',
+    options: [], // Populated asynchronously in the AdvancedFilter component
+  },
+  {
+    name: 'jurisdiction',
+    title: 'Jurisdiction (Multi-select)',
+    description: 'Monitorees of a specific jurisdiction',
+    type: 'multi',
+    options: [], // Populated in the AdvancedFilter component
+  },
 ];

--- a/app/javascript/data/advancedFilterOptions.js
+++ b/app/javascript/data/advancedFilterOptions.js
@@ -203,6 +203,22 @@ export const advancedFilterOptions = [
     tooltip: 'This will return monitorees that are flagged for follow-up for the selected reason. To return all montitorees flagged for follow-up, select the “Any Reason” option.'
   },
 
+  /* MULTI-SELECT OPTIONS */
+  {
+    name: 'assigned-user',
+    title: 'Assigned User (Multi-select)',
+    description: 'Monitorees who have a specific assigned user',
+    type: 'multi',
+    options: [], // Populated asynchronously in the AdvancedFilter component
+  },
+  {
+    name: 'jurisdiction',
+    title: 'Jurisdiction (Multi-select)',
+    description: 'Monitorees of a specific jurisdiction',
+    type: 'multi',
+    options: [], // Populated in the AdvancedFilter component
+  },
+
   /* NUMBER FILTER OPTIONS */
   {
     name: 'age',
@@ -340,21 +356,5 @@ export const advancedFilterOptions = [
         options: ['', '1', '2', 'Unknown'],
       },
     ],
-  },
-
-  /* MULTI-SELECT OPTIONS */
-  {
-    name: 'assigned-user',
-    title: 'Assigned User (Multi-select)',
-    description: 'Monitorees who have a specific assigned user',
-    type: 'multi',
-    options: [], // Populated asynchronously in the AdvancedFilter component
-  },
-  {
-    name: 'jurisdiction',
-    title: 'Jurisdiction (Multi-select)',
-    description: 'Monitorees of a specific jurisdiction',
-    type: 'multi',
-    options: [], // Populated in the AdvancedFilter component
   },
 ];

--- a/app/javascript/tests/mocks/mockFilters.js
+++ b/app/javascript/tests/mocks/mockFilters.js
@@ -196,7 +196,7 @@ const mockFilterAddressForeign = {
   value: '42 Wallaby Way',
 };
 
-/* MULTI TYPE MOCK FILTERS */
+/* COMBINATION TYPE MOCK FILTERS */
 const mockFilterLabResults = {
   additionalFilterOption: null,
   dateOption: null,

--- a/app/javascript/tests/mocks/mockFilters.js
+++ b/app/javascript/tests/mocks/mockFilters.js
@@ -39,6 +39,25 @@ const mockFilterPreferredContactTime = {
   value: 'Morning',
 };
 
+/* MULTI-SELECT TYPE MOCK FILTERS */
+const mockFilterAssignedUser = {
+  additionalFilterOption: null,
+  dateOption: null,
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'assigned-user'),
+  numberOption: null,
+  relativeOption: null,
+  value: [],
+};
+
+const mockFilterJurisdiction = {
+  additionalFilterOption: null,
+  dateOption: null,
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'jurisdiction'),
+  numberOption: null,
+  relativeOption: null,
+  value: [],
+};
+
 /* NUMBER TYPE MOCK FILTERS */
 const mockFilterAgeEqual = {
   additionalFilterOption: null,
@@ -204,25 +223,6 @@ const mockFilterLabResults = {
   numberOption: null,
   relativeOption: null,
   value: [{ name: 'result', value: 'positive' }],
-};
-
-/* MULTI-SELECT TYPE MOCK FILTERS */
-const mockFilterAssignedUser = {
-  additionalFilterOption: null,
-  dateOption: null,
-  filterOption: advancedFilterOptions.find(filter => filter.name === 'assigned-user'),
-  numberOption: null,
-  relativeOption: null,
-  value: [],
-};
-
-const mockFilterJurisdiction = {
-  additionalFilterOption: null,
-  dateOption: null,
-  filterOption: advancedFilterOptions.find(filter => filter.name === 'jurisdiction'),
-  numberOption: null,
-  relativeOption: null,
-  value: [],
 };
 
 /* MOCK SAVED FILTERS */

--- a/app/javascript/tests/mocks/mockFilters.js
+++ b/app/javascript/tests/mocks/mockFilters.js
@@ -206,6 +206,25 @@ const mockFilterLabResults = {
   value: [{ name: 'result', value: 'positive' }],
 };
 
+/* MULTI-SELECT TYPE MOCK FILTERS */
+const mockFilterAssignedUser = {
+  additionalFilterOption: null,
+  dateOption: null,
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'assigned-user'),
+  numberOption: null,
+  relativeOption: null,
+  value: [],
+};
+
+const mockFilterJurisdiction = {
+  additionalFilterOption: null,
+  dateOption: null,
+  filterOption: advancedFilterOptions.find(filter => filter.name === 'jurisdiction'),
+  numberOption: null,
+  relativeOption: null,
+  value: [],
+};
+
 /* MOCK SAVED FILTERS */
 const mockFilter1 = {
   contents: [mockFilterAddressForeign],
@@ -248,6 +267,8 @@ export {
   mockFilterAddressForeignEmpty,
   mockFilterAddressForeign,
   mockFilterLabResults,
+  mockFilterAssignedUser,
+  mockFilterJurisdiction,
   mockFilter1,
   mockFilter2,
   mockSavedFilters,

--- a/app/javascript/tests/public_health/query/AdvancedFilter.test.js
+++ b/app/javascript/tests/public_health/query/AdvancedFilter.test.js
@@ -807,14 +807,15 @@ describe('AdvancedFilter', () => {
     wrapper.find(Button).simulate('click');
     wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterAssignedUser.filterOption.name });
     expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterAssignedUser.filterOption.name);
-    expect(wrapper.find('.advanced-filter-multi-select').exists()).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-multi-select').exists()).toBe(true);
     expect(wrapper.find('.advanced-filter-multi-select').length).toEqual(1);
     expect(wrapper.find('.advanced-filter-multi-select').prop('value')).toEqual([]);
     mockFilterAssignedUser.filterOption.options.forEach((value, index) => {
       expect(wrapper.find('.advanced-filter-multi-select').find('options').at(index).prop('value')).toEqual(value.value);
       expect(wrapper.find('.advanced-filter-multi-select').find('options').at(index).prop('label')).toEqual(value.label);
     });
-    expect(wrapper.find(ReactTooltip).exists()).toBeFalsy();
+    expect(wrapper.find(ReactTooltip).exists()).toBe(true);
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(`Leaving this field blank will not filter out any monitorees.`);
   });
 
   it('Toggling boolean buttons properly updates state and value', () => {
@@ -1166,13 +1167,11 @@ describe('AdvancedFilter', () => {
 
   it('Changing advanced filter multi-select filter to another multi-select resets selected', () => {
     const wrapper = getWrapper();
-
     wrapper.find(Button).simulate('click');
     wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterAssignedUser.filterOption.name });
     expect(wrapper.find('.advanced-filter-multi-select').prop('value')).toEqual([]);
     wrapper.find('.advanced-filter-multi-select').simulate('change', { value: [{ value: 1, label: 1 }] });
     expect(wrapper.find('.advanced-filter-multi-select').prop('value').value).toEqual([{ value: 1, label: 1 }]);
-
     wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterJurisdiction.filterOption.name });
     expect(wrapper.find('.advanced-filter-multi-select').prop('value')).toEqual([]);
   });

--- a/app/javascript/tests/public_health/query/AdvancedFilter.test.js
+++ b/app/javascript/tests/public_health/query/AdvancedFilter.test.js
@@ -38,7 +38,7 @@ const mockToken = 'testMockTokenString12345';
 const numberOptionValues = ['less-than', 'less-than-equal', 'equal', 'greater-than-equal', 'greater-than', 'between'];
 const numberOptionValuesText = ['less than', 'less than or equal to', 'equal to', 'greater than or equal to', 'greater than', 'between'];
 const dateOptionValues = ['within', 'before', 'after'];
-const multiDateOptionValues = ['before', 'after', ''];
+const combinationDateOptionValues = ['before', 'after', ''];
 const relativeOptionValues = ['today', 'tomorrow', 'yesterday', 'custom'];
 const relativeOptionOperatorValues = ['less-than', 'greater-than'];
 const relativeOptionUnitValues = ['day(s)', 'week(s)', 'month(s)'];
@@ -539,24 +539,24 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(mockFilterSevenDayQuarantine.filterOption.tooltip);
   });
 
-  it('Properly renders main components of advanced filter multi type statement', () => {
+  it('Properly renders main components of advanced filter combination type statement', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
     wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
     expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterLabResults.filterOption.name);
-    expect(wrapper.find('.advanced-filter-multi-type-statement').exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(1);
-    expect(wrapper.find('.advanced-filter-multi-options').exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-multi-options').prop('value')).toEqual(mockFilterLabResults.filterOption.fields[0].name);
-    expect(wrapper.find('.advanced-filter-multi-options').find('option').length).toEqual(mockFilterLabResults.filterOption.fields.length);
+    expect(wrapper.find('.advanced-filter-combination-type-statement').exists()).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-combination-type-statement').length).toEqual(1);
+    expect(wrapper.find('.advanced-filter-combination-options').exists()).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-combination-options').prop('value')).toEqual(mockFilterLabResults.filterOption.fields[0].name);
+    expect(wrapper.find('.advanced-filter-combination-options').find('option').length).toEqual(mockFilterLabResults.filterOption.fields.length);
     mockFilterLabResults.filterOption.fields.forEach((field, index) => {
-      expect(wrapper.find('.advanced-filter-multi-options').find('option').at(index).text()).toEqual(field.title);
-      expect(wrapper.find('.advanced-filter-multi-options').find('option').at(index).prop('value')).toEqual(field.name);
-      expect(wrapper.find('.advanced-filter-multi-options').find('option').at(index).prop('disabled')).toBeFalsy();
+      expect(wrapper.find('.advanced-filter-combination-options').find('option').at(index).text()).toEqual(field.title);
+      expect(wrapper.find('.advanced-filter-combination-options').find('option').at(index).prop('value')).toEqual(field.name);
+      expect(wrapper.find('.advanced-filter-combination-options').find('option').at(index).prop('disabled')).toBeFalsy();
     });
-    expect(wrapper.find('.advanced-filter-multi-type-statement').find(Button).length).toEqual(2);
-    expect(wrapper.find('.advanced-filter-multi-type-statement').find(Button).at(0).find('i').hasClass('fa-plus')).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-multi-type-statement').find(Button).at(1).find('i').hasClass('fa-minus')).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-combination-type-statement').find(Button).length).toEqual(2);
+    expect(wrapper.find('.advanced-filter-combination-type-statement').find(Button).at(0).find('i').hasClass('fa-plus')).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-combination-type-statement').find(Button).at(1).find('i').hasClass('fa-minus')).toBeTruthy();
     expect(wrapper.find('.advanced-filter-additional-filter-options').exists()).toBeFalsy();
     expect(wrapper.find(ReactTooltip).exists()).toBeTruthy();
     expect(wrapper.find(ReactTooltip).length).toEqual(2);
@@ -564,74 +564,74 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find(ReactTooltip).at(1).find('span').text()).toEqual(mockFilterLabResults.filterOption.tooltip);
   });
 
-  it('Properly renders select option of advanced filter multi type statement', () => {
+  it('Properly renders select option of advanced filter combination type statement', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
     wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
-    expect(wrapper.find('.advanced-filter-multi-type-statement').find(Form.Control).length).toEqual(2);
-    expect(wrapper.find('.advanced-filter-multi-options').exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-multi-select-options').exists()).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-combination-type-statement').find(Form.Control).length).toEqual(2);
+    expect(wrapper.find('.advanced-filter-combination-options').exists()).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-combination-select-options').exists()).toBeTruthy();
     expect(wrapper.find('.advanced-filter-date-options').exists()).toBeFalsy();
     expect(wrapper.find(DateInput).exists()).toBeFalsy();
-    expect(wrapper.find('.advanced-filter-multi-select-options').prop('value')).toEqual(mockFilterLabResults.filterOption.fields[0].options[0]);
-    expect(wrapper.find('.advanced-filter-multi-select-options').find('option').length).toEqual(mockFilterLabResults.filterOption.fields[0].options.length);
+    expect(wrapper.find('.advanced-filter-combination-select-options').prop('value')).toEqual(mockFilterLabResults.filterOption.fields[0].options[0]);
+    expect(wrapper.find('.advanced-filter-combination-select-options').find('option').length).toEqual(mockFilterLabResults.filterOption.fields[0].options.length);
     mockFilterLabResults.filterOption.fields[0].options.forEach((option, index) => {
-      expect(wrapper.find('.advanced-filter-multi-select-options').find('option').at(index).text()).toEqual(option);
-      expect(wrapper.find('.advanced-filter-multi-select-options').find('option').at(index).prop('disabled')).toBeFalsy();
+      expect(wrapper.find('.advanced-filter-combination-select-options').find('option').at(index).text()).toEqual(option);
+      expect(wrapper.find('.advanced-filter-combination-select-options').find('option').at(index).prop('disabled')).toBeFalsy();
     });
   });
 
-  it('Properly renders date option of advanced filter multi type statement', () => {
+  it('Properly renders date option of advanced filter combination type statement', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
     wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
-    wrapper.find('.advanced-filter-multi-options').simulate('change', { target: { value: 'report' } });
-    expect(wrapper.find('.advanced-filter-multi-type-statement').find(Form.Control).length).toEqual(2);
-    expect(wrapper.find('.advanced-filter-multi-options').exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-multi-select-options').exists()).toBeFalsy();
+    wrapper.find('.advanced-filter-combination-options').simulate('change', { target: { value: 'report' } });
+    expect(wrapper.find('.advanced-filter-combination-type-statement').find(Form.Control).length).toEqual(2);
+    expect(wrapper.find('.advanced-filter-combination-options').exists()).toBeTruthy();
+    expect(wrapper.find('.advanced-filter-combination-select-options').exists()).toBeFalsy();
     expect(wrapper.find('.advanced-filter-date-options').exists()).toBeTruthy();
     expect(wrapper.find(DateInput).exists()).toBeTruthy();
-    expect(wrapper.find('.advanced-filter-date-options').prop('value')).toEqual(multiDateOptionValues[0]);
-    expect(wrapper.find('.advanced-filter-date-options').find('option').length).toEqual(multiDateOptionValues.length);
-    multiDateOptionValues.forEach((value, index) => {
+    expect(wrapper.find('.advanced-filter-date-options').prop('value')).toEqual(combinationDateOptionValues[0]);
+    expect(wrapper.find('.advanced-filter-date-options').find('option').length).toEqual(combinationDateOptionValues.length);
+    combinationDateOptionValues.forEach((value, index) => {
       expect(wrapper.find('.advanced-filter-date-options').find('option').at(index).text()).toEqual(value);
       expect(wrapper.find('.advanced-filter-date-options').find('option').at(index).prop('disabled')).toBeFalsy();
     });
-    expect(wrapper.find('.advanced-filter-multi-type-statement').find(DateInput).prop('date')).toEqual(moment().format('YYYY-MM-DD'));
+    expect(wrapper.find('.advanced-filter-combination-type-statement').find(DateInput).prop('date')).toEqual(moment().format('YYYY-MM-DD'));
   });
 
-  it('Clicking the multi type "+" button adds another multi statement and displays "AND" row', () => {
+  it('Clicking the combination type "+" button adds another combination statement and displays "AND" row', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
     wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
     _.times(mockFilterLabResults.filterOption.fields.length - 1, i => {
-      expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(i + 1);
+      expect(wrapper.find('.advanced-filter-combination-type-statement').length).toEqual(i + 1);
       expect(wrapper.find('.and-row').length).toEqual(i);
-      expect(wrapper.find('#lab-result-0-multi-add').exists()).toBeTruthy();
+      expect(wrapper.find('#lab-result-0-combination-add').exists()).toBeTruthy();
       wrapper.find('.btn-circle').simulate('click');
     });
-    expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(mockFilterLabResults.filterOption.fields.length);
+    expect(wrapper.find('.advanced-filter-combination-type-statement').length).toEqual(mockFilterLabResults.filterOption.fields.length);
     expect(wrapper.find('.and-row').length).toEqual(mockFilterLabResults.filterOption.fields.length - 1);
-    expect(wrapper.find('#lab-result-0-multi-add').exists()).toBeFalsy();
+    expect(wrapper.find('#lab-result-0-combination-add').exists()).toBeFalsy();
   });
 
-  it('Adding additional fields to multi filter does not allow for repeats', () => {
+  it('Adding additional fields to combination filter does not allow for repeats', () => {
     const wrapper = getWrapper();
-    let activeMultiValues = [];
+    let activeCombinationValues = [];
     wrapper.find(Button).simulate('click');
     wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
     _.times(mockFilterLabResults.filterOption.fields.length, i => {
-      activeMultiValues.push(mockFilterLabResults.filterOption.fields[Number(i)].name);
-      expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(i + 1);
-      wrapper.find('.advanced-filter-multi-type-statement').forEach(statement => {
-        let statementValue = statement.find('.advanced-filter-multi-options').prop('value');
-        expect(activeMultiValues.filter(value => value === statementValue).length).toEqual(1);
+      activeCombinationValues.push(mockFilterLabResults.filterOption.fields[Number(i)].name);
+      expect(wrapper.find('.advanced-filter-combination-type-statement').length).toEqual(i + 1);
+      wrapper.find('.advanced-filter-combination-type-statement').forEach(statement => {
+        let statementValue = statement.find('.advanced-filter-combination-options').prop('value');
+        expect(activeCombinationValues.filter(value => value === statementValue).length).toEqual(1);
         statement
-          .find('.advanced-filter-multi-options')
+          .find('.advanced-filter-combination-options')
           .find('option')
           .forEach(option => {
             let optionValue = option.prop('value');
-            expect(option.prop('disabled')).toEqual(activeMultiValues.includes(optionValue) && optionValue !== statementValue);
+            expect(option.prop('disabled')).toEqual(activeCombinationValues.includes(optionValue) && optionValue !== statementValue);
           });
       });
       if (i < mockFilterLabResults.filterOption.fields.length - 1) {
@@ -640,35 +640,35 @@ describe('AdvancedFilter', () => {
     });
     _.times(mockFilterLabResults.filterOption.fields.length - 1, i => {
       let random = _.random(0, wrapper.find('.remove-filter-row').length - 1);
-      activeMultiValues = activeMultiValues.slice(0, random).concat(activeMultiValues.slice(random + 1, activeMultiValues.length));
+      activeCombinationValues = activeCombinationValues.slice(0, random).concat(activeCombinationValues.slice(random + 1, activeCombinationValues.length));
       wrapper.find('.remove-filter-row').at(random).simulate('click');
-      expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(mockFilterLabResults.filterOption.fields.length - 1 - i);
-      wrapper.find('.advanced-filter-multi-type-statement').forEach(statement => {
-        let statementValue = statement.find('.advanced-filter-multi-options').prop('value');
-        expect(activeMultiValues.filter(value => value === statementValue).length).toEqual(1);
+      expect(wrapper.find('.advanced-filter-combination-type-statement').length).toEqual(mockFilterLabResults.filterOption.fields.length - 1 - i);
+      wrapper.find('.advanced-filter-combination-type-statement').forEach(statement => {
+        let statementValue = statement.find('.advanced-filter-combination-options').prop('value');
+        expect(activeCombinationValues.filter(value => value === statementValue).length).toEqual(1);
         statement
-          .find('.advanced-filter-multi-options')
+          .find('.advanced-filter-combination-options')
           .find('option')
           .forEach(option => {
             let optionValue = option.prop('value');
-            expect(option.prop('disabled')).toEqual(activeMultiValues.includes(optionValue) && optionValue !== statementValue);
+            expect(option.prop('disabled')).toEqual(activeCombinationValues.includes(optionValue) && optionValue !== statementValue);
           });
       });
     });
   });
 
-  it('Removes the multi type "+" button when all the filter option fields are displayed', () => {
+  it('Removes the combination type "+" button when all the filter option fields are displayed', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
     wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
     _.times(mockFilterLabResults.filterOption.fields.length - 1, () => {
-      expect(wrapper.find('.advanced-filter-multi-type-statement').find('.btn-circle').exists()).toBeTruthy();
+      expect(wrapper.find('.advanced-filter-combination-type-statement').find('.btn-circle').exists()).toBeTruthy();
       wrapper.find('.btn-circle').simulate('click');
     });
-    expect(wrapper.find('.advanced-filter-multi-type-statement').find('.btn-circle').exists()).toBeFalsy();
+    expect(wrapper.find('.advanced-filter-combination-type-statement').find('.btn-circle').exists()).toBeFalsy();
   });
 
-  it('Clicking the multi type "-" removes multi statements until there is one left, then removed the entire filter statement', () => {
+  it('Clicking the combination type "-" removes combination statements until there is one left, then removed the entire filter statement', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
     wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
@@ -678,32 +678,32 @@ describe('AdvancedFilter', () => {
     _.times(mockFilterLabResults.filterOption.fields.length, i => {
       let random = _.random(0, wrapper.find('.remove-filter-row').length - 1);
       expect(wrapper.find('.advanced-filter-statement').length).toEqual(1);
-      expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(mockFilterLabResults.filterOption.fields.length - i);
+      expect(wrapper.find('.advanced-filter-combination-type-statement').length).toEqual(mockFilterLabResults.filterOption.fields.length - i);
       wrapper.find('.remove-filter-row').at(random).simulate('click');
     });
     expect(wrapper.find('.advanced-filter-statement').exists()).toBeFalsy();
-    expect(wrapper.find('.advanced-filter-multi-type-statement').exists()).toBeFalsy();
+    expect(wrapper.find('.advanced-filter-combination-type-statement').exists()).toBeFalsy();
   });
 
-  it('Clicking the multi type "+" and "-" properly updates state and value', () => {
+  it('Clicking the combination type "+" and "-" properly updates state and value', () => {
     const wrapper = getWrapper();
-    let activeMultiValues = [];
+    let activeCombinationValues = [];
     wrapper.find(Button).simulate('click');
     wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
     _.times(mockFilterLabResults.filterOption.fields.length, i => {
       let newField = mockFilterLabResults.filterOption.fields[Number(i)];
       let newValue = newField.type === 'select' ? newField.options[0] : { when: 'before', date: moment().format('YYYY-MM-DD') };
-      activeMultiValues.push({ name: newField.name, value: newValue });
-      expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(i + 1);
+      activeCombinationValues.push({ name: newField.name, value: newValue });
+      expect(wrapper.find('.advanced-filter-combination-type-statement').length).toEqual(i + 1);
       expect(wrapper.state('activeFilterOptions')[0].value.length).toEqual(i + 1);
-      expect(wrapper.state('activeFilterOptions')[0].value).toEqual(activeMultiValues);
-      wrapper.find('.advanced-filter-multi-type-statement').forEach((statement, index) => {
-        expect(statement.find('.advanced-filter-multi-options').prop('value')).toEqual(activeMultiValues[Number(index)].name);
-        if (mockFilterLabResults.filterOption.fields.filter(field => field.name === activeMultiValues[Number(index)].name).type === 'select') {
-          expect(statement.find('.advanced-filter-multi-select-options').prop('value')).toEqual(activeMultiValues[Number(index)].value);
-        } else if (mockFilterLabResults.filterOption.fields.filter(field => field.name === activeMultiValues[Number(index)].name).type === 'date') {
-          expect(statement.find('.advanced-filter-date-options').prop('value')).toEqual(activeMultiValues[Number(index)].value.when);
-          expect(statement.find(DateInput).prop('date')).toEqual(activeMultiValues[Number(index)].value.date);
+      expect(wrapper.state('activeFilterOptions')[0].value).toEqual(activeCombinationValues);
+      wrapper.find('.advanced-filter-combination-type-statement').forEach((statement, index) => {
+        expect(statement.find('.advanced-filter-combination-options').prop('value')).toEqual(activeCombinationValues[Number(index)].name);
+        if (mockFilterLabResults.filterOption.fields.filter(field => field.name === activeCombinationValues[Number(index)].name).type === 'select') {
+          expect(statement.find('.advanced-filter-combination-select-options').prop('value')).toEqual(activeCombinationValues[Number(index)].value);
+        } else if (mockFilterLabResults.filterOption.fields.filter(field => field.name === activeCombinationValues[Number(index)].name).type === 'date') {
+          expect(statement.find('.advanced-filter-date-options').prop('value')).toEqual(activeCombinationValues[Number(index)].value.when);
+          expect(statement.find(DateInput).prop('date')).toEqual(activeCombinationValues[Number(index)].value.date);
         }
       });
       if (i < mockFilterLabResults.filterOption.fields.length - 1) {
@@ -712,24 +712,24 @@ describe('AdvancedFilter', () => {
     });
     _.times(mockFilterLabResults.filterOption.fields.length - 1, i => {
       let random = _.random(0, wrapper.find('.remove-filter-row').length - 1);
-      activeMultiValues = activeMultiValues.slice(0, random).concat(activeMultiValues.slice(random + 1, activeMultiValues.length));
+      activeCombinationValues = activeCombinationValues.slice(0, random).concat(activeCombinationValues.slice(random + 1, activeCombinationValues.length));
       wrapper.find('.remove-filter-row').at(random).simulate('click');
-      expect(wrapper.find('.advanced-filter-multi-type-statement').length).toEqual(mockFilterLabResults.filterOption.fields.length - 1 - i);
+      expect(wrapper.find('.advanced-filter-combination-type-statement').length).toEqual(mockFilterLabResults.filterOption.fields.length - 1 - i);
       expect(wrapper.state('activeFilterOptions')[0].value.length).toEqual(mockFilterLabResults.filterOption.fields.length - 1 - i);
-      expect(wrapper.state('activeFilterOptions')[0].value).toEqual(activeMultiValues);
-      wrapper.find('.advanced-filter-multi-type-statement').forEach((statement, index) => {
-        expect(statement.find('.advanced-filter-multi-options').prop('value')).toEqual(activeMultiValues[Number(index)].name);
-        if (mockFilterLabResults.filterOption.fields.filter(field => field.name === activeMultiValues[Number(index)].name).type === 'select') {
-          expect(statement.find('.advanced-filter-multi-select-options').prop('value')).toEqual(activeMultiValues[Number(index)].value);
-        } else if (mockFilterLabResults.filterOption.fields.filter(field => field.name === activeMultiValues[Number(index)].name).type === 'date') {
-          expect(statement.find('.advanced-filter-date-options').prop('value')).toEqual(activeMultiValues[Number(index)].value.when);
-          expect(statement.find(DateInput).prop('date')).toEqual(activeMultiValues[Number(index)].value.date);
+      expect(wrapper.state('activeFilterOptions')[0].value).toEqual(activeCombinationValues);
+      wrapper.find('.advanced-filter-combination-type-statement').forEach((statement, index) => {
+        expect(statement.find('.advanced-filter-combination-options').prop('value')).toEqual(activeCombinationValues[Number(index)].name);
+        if (mockFilterLabResults.filterOption.fields.filter(field => field.name === activeCombinationValues[Number(index)].name).type === 'select') {
+          expect(statement.find('.advanced-filter-combination-select-options').prop('value')).toEqual(activeCombinationValues[Number(index)].value);
+        } else if (mockFilterLabResults.filterOption.fields.filter(field => field.name === activeCombinationValues[Number(index)].name).type === 'date') {
+          expect(statement.find('.advanced-filter-date-options').prop('value')).toEqual(activeCombinationValues[Number(index)].value.when);
+          expect(statement.find(DateInput).prop('date')).toEqual(activeCombinationValues[Number(index)].value.date);
         }
       });
     });
   });
 
-  it('Changing the multi type dropdowns and date inputs properly updates ', () => {
+  it('Changing the combinati type dropdowns and date inputs properly updates ', () => {
     const wrapper = getWrapper();
     const selectField = mockFilterLabResults.filterOption.fields.filter(field => field.type === 'select')[0];
     const dateField = mockFilterLabResults.filterOption.fields.filter(field => field.type === 'date')[0];
@@ -739,44 +739,44 @@ describe('AdvancedFilter', () => {
 
     wrapper.find(Button).simulate('click');
     wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterLabResults.filterOption.name });
-    wrapper.find('.advanced-filter-multi-options').simulate('change', { target: { value: selectField.name } });
+    wrapper.find('.advanced-filter-combination-options').simulate('change', { target: { value: selectField.name } });
     expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: selectField.name, value: selectField.options[0] }]);
-    expect(wrapper.find('.advanced-filter-multi-options').prop('value')).toEqual(selectField.name);
-    expect(wrapper.find('.advanced-filter-multi-select-options').prop('value')).toEqual(selectField.options[0]);
+    expect(wrapper.find('.advanced-filter-combination-options').prop('value')).toEqual(selectField.name);
+    expect(wrapper.find('.advanced-filter-combination-select-options').prop('value')).toEqual(selectField.options[0]);
 
-    wrapper.find('.advanced-filter-multi-select-options').simulate('change', { target: { value: selectField.options[`${random}`] } });
+    wrapper.find('.advanced-filter-combination-select-options').simulate('change', { target: { value: selectField.options[`${random}`] } });
     expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: selectField.name, value: selectField.options[`${random}`] }]);
-    expect(wrapper.find('.advanced-filter-multi-options').prop('value')).toEqual(selectField.name);
-    expect(wrapper.find('.advanced-filter-multi-select-options').prop('value')).toEqual(selectField.options[`${random}`]);
+    expect(wrapper.find('.advanced-filter-combination-options').prop('value')).toEqual(selectField.name);
+    expect(wrapper.find('.advanced-filter-combination-select-options').prop('value')).toEqual(selectField.options[`${random}`]);
 
-    wrapper.find('.advanced-filter-multi-options').simulate('change', { target: { value: dateField.name } });
-    expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: dateField.name, value: { when: multiDateOptionValues[0], date: initialDate } }]);
-    expect(wrapper.find('.advanced-filter-multi-options').prop('value')).toEqual(dateField.name);
-    expect(wrapper.find('.advanced-filter-date-options').prop('value')).toEqual(multiDateOptionValues[0]);
+    wrapper.find('.advanced-filter-combination-options').simulate('change', { target: { value: dateField.name } });
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: dateField.name, value: { when: combinationDateOptionValues[0], date: initialDate } }]);
+    expect(wrapper.find('.advanced-filter-combination-options').prop('value')).toEqual(dateField.name);
+    expect(wrapper.find('.advanced-filter-date-options').prop('value')).toEqual(combinationDateOptionValues[0]);
     expect(wrapper.find(DateInput).prop('date')).toEqual(initialDate);
 
-    wrapper.find('.advanced-filter-date-options').simulate('change', { target: { value: multiDateOptionValues[1] } });
-    expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: dateField.name, value: { when: multiDateOptionValues[1], date: initialDate } }]);
-    expect(wrapper.find('.advanced-filter-multi-options').prop('value')).toEqual(dateField.name);
-    expect(wrapper.find('.advanced-filter-date-options').prop('value')).toEqual(multiDateOptionValues[1]);
+    wrapper.find('.advanced-filter-date-options').simulate('change', { target: { value: combinationDateOptionValues[1] } });
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: dateField.name, value: { when: combinationDateOptionValues[1], date: initialDate } }]);
+    expect(wrapper.find('.advanced-filter-combination-options').prop('value')).toEqual(dateField.name);
+    expect(wrapper.find('.advanced-filter-date-options').prop('value')).toEqual(combinationDateOptionValues[1]);
     expect(wrapper.find(DateInput).prop('date')).toEqual(initialDate);
 
     wrapper.find(DateInput).simulate('change', newDate);
-    expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: dateField.name, value: { when: multiDateOptionValues[1], date: newDate } }]);
-    expect(wrapper.find('.advanced-filter-multi-options').prop('value')).toEqual(dateField.name);
-    expect(wrapper.find('.advanced-filter-date-options').prop('value')).toEqual(multiDateOptionValues[1]);
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: dateField.name, value: { when: combinationDateOptionValues[1], date: newDate } }]);
+    expect(wrapper.find('.advanced-filter-combination-options').prop('value')).toEqual(dateField.name);
+    expect(wrapper.find('.advanced-filter-date-options').prop('value')).toEqual(combinationDateOptionValues[1]);
     expect(wrapper.find(DateInput).prop('date')).toEqual(newDate);
 
-    wrapper.find('.advanced-filter-date-options').simulate('change', { target: { value: multiDateOptionValues[0] } });
-    expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: dateField.name, value: { when: multiDateOptionValues[0], date: newDate } }]);
-    expect(wrapper.find('.advanced-filter-multi-options').prop('value')).toEqual(dateField.name);
-    expect(wrapper.find('.advanced-filter-date-options').prop('value')).toEqual(multiDateOptionValues[0]);
+    wrapper.find('.advanced-filter-date-options').simulate('change', { target: { value: combinationDateOptionValues[0] } });
+    expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: dateField.name, value: { when: combinationDateOptionValues[0], date: newDate } }]);
+    expect(wrapper.find('.advanced-filter-combination-options').prop('value')).toEqual(dateField.name);
+    expect(wrapper.find('.advanced-filter-date-options').prop('value')).toEqual(combinationDateOptionValues[0]);
     expect(wrapper.find(DateInput).prop('date')).toEqual(newDate);
 
-    wrapper.find('.advanced-filter-multi-options').simulate('change', { target: { value: selectField.name } });
+    wrapper.find('.advanced-filter-combination-options').simulate('change', { target: { value: selectField.name } });
     expect(wrapper.state('activeFilterOptions')[0].value).toEqual([{ name: selectField.name, value: selectField.options[0] }]);
-    expect(wrapper.find('.advanced-filter-multi-options').prop('value')).toEqual(selectField.name);
-    expect(wrapper.find('.advanced-filter-multi-select-options').prop('value')).toEqual(selectField.options[0]);
+    expect(wrapper.find('.advanced-filter-combination-options').prop('value')).toEqual(selectField.name);
+    expect(wrapper.find('.advanced-filter-combination-select-options').prop('value')).toEqual(selectField.options[0]);
   });
 
   it('Toggling boolean buttons properly updates state and value', () => {

--- a/app/views/public_health/exposure.html.erb
+++ b/app/views/public_health/exposure.html.erb
@@ -65,6 +65,7 @@
                         }
                       },
                       default_tab: 'symptomatic',
+                      jurisdiction_paths: @possible_jurisdiction_paths,
                       custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS,
                       monitoring_reasons: ValidationHelper::USER_SELECTABLE_MONITORING_REASONS
                     }) %>

--- a/app/views/public_health/exposure.html.erb
+++ b/app/views/public_health/exposure.html.erb
@@ -66,6 +66,7 @@
                       },
                       default_tab: 'symptomatic',
                       jurisdiction_paths: @possible_jurisdiction_paths,
+                      all_assigned_users: @all_assigned_users,
                       custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS,
                       monitoring_reasons: ValidationHelper::USER_SELECTABLE_MONITORING_REASONS
                     }) %>

--- a/app/views/public_health/global.html.erb
+++ b/app/views/public_health/global.html.erb
@@ -46,6 +46,7 @@
                       },
                       default_tab: 'all',
                       jurisdiction_paths: @possible_jurisdiction_paths,
+                      all_assigned_users: @all_assigned_users,
                       custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS,
                       monitoring_reasons: ValidationHelper::USER_SELECTABLE_MONITORING_REASONS
                     }) %>

--- a/app/views/public_health/global.html.erb
+++ b/app/views/public_health/global.html.erb
@@ -45,6 +45,7 @@
                         }
                       },
                       default_tab: 'all',
+                      jurisdiction_paths: @possible_jurisdiction_paths,
                       custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS,
                       monitoring_reasons: ValidationHelper::USER_SELECTABLE_MONITORING_REASONS
                     }) %>

--- a/app/views/public_health/isolation.html.erb
+++ b/app/views/public_health/isolation.html.erb
@@ -60,6 +60,7 @@
                         }
                       },
                       default_tab: 'requiring_review',
+                      jurisdiction_paths: @possible_jurisdiction_paths,
                       custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS,
                       monitoring_reasons: ValidationHelper::USER_SELECTABLE_MONITORING_REASONS
                     }) %>

--- a/app/views/public_health/isolation.html.erb
+++ b/app/views/public_health/isolation.html.erb
@@ -61,6 +61,7 @@
                       },
                       default_tab: 'requiring_review',
                       jurisdiction_paths: @possible_jurisdiction_paths,
+                      all_assigned_users: @all_assigned_users,
                       custom_export_options: ImportExport::CUSTOM_EXPORT_OPTIONS,
                       monitoring_reasons: ValidationHelper::USER_SELECTABLE_MONITORING_REASONS
                     }) %>

--- a/test/controllers/user_filters_controller_test.rb
+++ b/test/controllers/user_filters_controller_test.rb
@@ -1,30 +1,13 @@
 # frozen_string_literal: true
 
 require 'test_case'
+require_relative '../test_helpers/user_filters_test_helper'
 
 class UserFiltersControllerTest < ActionController::TestCase
   def setup
     @original_max_filters = ADMIN_OPTIONS['max_user_filters']
-    @params = {
-      'activeFilterOptions' => [{
-        'filterOption' => {
-          'name' => 'assigned-user',
-          'title' => 'Assigned User (Multi-select)',
-          'description' => 'Monitorees who have a specific assigned user',
-          'type' => 'multi',
-          # rubocop:disable Layout/LineLength
-          'options' => [{ 'value' => 57, 'label' => 57 }, { 'value' => 134_095, 'label' => 134_095 }, { 'value' => 144_444, 'label' => 144_444 },
-                        { 'value' => 242_947, 'label' => 242_947 }, { 'value' => 251_048, 'label' => 251_048 }, { 'value' => 265_024, 'label' => 265_024 }, { 'value' => 266_800, 'label' => 266_800 }, { 'value' => 326_480, 'label' => 326_480 }, { 'value' => 386_822, 'label' => 386_822 }, { 'value' => 485_594, 'label' => 485_594 }, { 'value' => 497_452, 'label' => 497_452 }, { 'value' => 538_127, 'label' => 538_127 }, { 'value' => 678_295, 'label' => 678_295 }, { 'value' => 825_208, 'label' => 825_208 }, { 'value' => 832_541, 'label' => 832_541 }, { 'value' => 885_015, 'label' => 885_015 }, { 'value' => 894_558, 'label' => 894_558 }, { 'value' => 895_323, 'label' => 895_323 }, { 'value' => 946_448, 'label' => 946_448 }]
-          # rubocop:enable Layout/LineLength
-        },
-        'value' => [],
-        'numberOption' => nil,
-        'dateOption' => nil,
-        'relativeOption' => nil,
-        'additionalFilterOption' => nil
-      }],
-      'name' => 'Test'
-    }
+    @user = create(:user)
+    sign_in @user
   end
 
   def teardown
@@ -34,22 +17,32 @@ class UserFiltersControllerTest < ActionController::TestCase
   test 'cannot create if the user has too many filters' do
     # Allow only 1 filter to be created
     ADMIN_OPTIONS['max_user_filters'] = 1
-    user = create(:user)
-    create(:user_filter, user: user)
+    create(:user_filter, user: @user)
     # Allowed to create another filter here, only enforcement is in the controller.
-    create(:user_filter, user: user)
-    sign_in user
+    create(:user_filter, user: @user)
     get :create
     assert_response :bad_request
     assert(JSON.parse(response.body).key?('error'))
   end
 
-  test 'create a multi-select advanced filter with no options selected' do
-    user = create(:user)
-    sign_in user
-    post :create, params: @params
+  test 'index properly returns a multi-select advanced filter with no options selected' do
+    create(:user_filter, user: @user, contents: [UserFiltersTestHelper.multi_select_filter_params(options_selected: false)].to_json)
+    get :index
     assert_response :success
-    user.reload
-    assert_equal(1, user.user_filters.count)
+    assert_equal(UserFiltersTestHelper.multi_select_filter_params(options_selected: false).to_s, JSON.parse(response.body)[0]['contents'][0].to_s)
+  end
+
+  test 'create a multi-select advanced filter with no options selected' do
+    post :create, params: UserFiltersTestHelper.multi_select_filter_params(options_selected: false)
+    assert_response :success
+    assert_equal(1, @user.user_filters.count)
+    parsed_filter = JSON.parse(@user.user_filters.first.contents)
+    assert_equal([], parsed_filter[0]['value'])
+  end
+
+  test 'create a combination advanced filter' do
+    post :create, params: UserFiltersTestHelper.combination_filter_params
+    assert_response :success
+    assert_equal(1, @user.user_filters.count)
   end
 end

--- a/test/controllers/user_filters_controller_test.rb
+++ b/test/controllers/user_filters_controller_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'test_case'
+
+class UserFiltersControllerTest < ActionController::TestCase
+  def setup
+    @original_max_filters = ADMIN_OPTIONS['max_user_filters']
+    @params = {
+      'activeFilterOptions' => [{
+        'filterOption' => {
+          'name' => 'assigned-user',
+          'title' => 'Assigned User (Multi-select)',
+          'description' => 'Monitorees who have a specific assigned user',
+          'type' => 'multi',
+          # rubocop:disable Layout/LineLength
+          'options' => [{ 'value' => 57, 'label' => 57 }, { 'value' => 134_095, 'label' => 134_095 }, { 'value' => 144_444, 'label' => 144_444 },
+                        { 'value' => 242_947, 'label' => 242_947 }, { 'value' => 251_048, 'label' => 251_048 }, { 'value' => 265_024, 'label' => 265_024 }, { 'value' => 266_800, 'label' => 266_800 }, { 'value' => 326_480, 'label' => 326_480 }, { 'value' => 386_822, 'label' => 386_822 }, { 'value' => 485_594, 'label' => 485_594 }, { 'value' => 497_452, 'label' => 497_452 }, { 'value' => 538_127, 'label' => 538_127 }, { 'value' => 678_295, 'label' => 678_295 }, { 'value' => 825_208, 'label' => 825_208 }, { 'value' => 832_541, 'label' => 832_541 }, { 'value' => 885_015, 'label' => 885_015 }, { 'value' => 894_558, 'label' => 894_558 }, { 'value' => 895_323, 'label' => 895_323 }, { 'value' => 946_448, 'label' => 946_448 }]
+          # rubocop:enable Layout/LineLength
+        },
+        'value' => [],
+        'numberOption' => nil,
+        'dateOption' => nil,
+        'relativeOption' => nil,
+        'additionalFilterOption' => nil
+      }],
+      'name' => 'Test'
+    }
+  end
+
+  def teardown
+    ADMIN_OPTIONS['max_user_filters'] = @original_max_filters
+  end
+
+  test 'cannot create if the user has too many filters' do
+    # Allow only 1 filter to be created
+    ADMIN_OPTIONS['max_user_filters'] = 1
+    user = create(:user)
+    create(:user_filter, user: user)
+    # Allowed to create another filter here, only enforcement is in the controller.
+    create(:user_filter, user: user)
+    sign_in user
+    get :create
+    assert_response :bad_request
+    assert(JSON.parse(response.body).key?('error'))
+  end
+
+  test 'create a multi-select advanced filter with no options selected' do
+    user = create(:user)
+    sign_in user
+    post :create, params: @params
+    assert_response :success
+    user.reload
+    assert_equal(1, user.user_filters.count)
+  end
+end

--- a/test/factories/user_filter.rb
+++ b/test/factories/user_filter.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user_filter do
+    user { create(:user) }
+    # rubocop:disable Layout/LineLength
+    contents do
+      [
+        {
+          'filterOption' => {
+            'name' => 'vaccination',
+            'title' => 'Vaccination (Combination)',
+            'description' => 'Monitorees with specified Vaccination criteria',
+            'type' => 'combination',
+            'tooltip' => 'Returns records that contain at least one Vaccination entry that meets all user-specified criteria (e.g., searching for a specific Vaccination Product Name and Administration Date will only return records containing at least one Vaccination entry with matching values in both fields).',
+            'fields' => [{
+              'name' => 'vaccine-group',
+              'title' => 'vaccine group',
+              'type' => 'select',
+              'options' => ['COVID-19']
+            }, {
+              'name' => 'product-name',
+              'title' => 'product name',
+              'type' => 'select',
+              'options' => [
+                'Moderna COVID-19 Vaccine',
+                'Pfizer-BioNTech COVID-19 Vaccine',
+                'Janssen (J&J) COVID-19 Vaccine',
+                'Unknown'
+              ]
+            }, {
+              'name' => 'administration-date',
+              'title' => 'administration date',
+              'type' => 'date'
+            }, {
+              'name' => 'dose-number',
+              'title' => 'dose number',
+              'type' => 'select',
+              'options' => ['', '1', '2', 'Unknown']
+            }]
+          },
+          'value' => [{
+            'name' => 'vaccine-group',
+            'value' => 'COVID-19'
+          }, {
+            'name' => 'product-name',
+            'value' => 'Janssen (J&J) COVID-19 Vaccine'
+          }],
+          'numberOption' => nil,
+          'dateOption' => nil,
+          'relativeOption' => nil,
+          'additionalFilterOption' => nil
+        }
+      ].to_json
+    end
+    # rubocop:enable Layout/LineLength
+    name { Faker::Alphanumeric.alphanumeric(number: 5) }
+  end
+end

--- a/test/helpers/patient_query_helper_test.rb
+++ b/test/helpers/patient_query_helper_test.rb
@@ -890,35 +890,56 @@ class PatientQueryHelperTest < ActionView::TestCase
 
     tz_offset = 240
 
+    # Check for monitorees with assigned user user_1
     filters = [{ filterOption: {}, additionalFilterOption: nil,
-                 value: [{ value: user_1[:id], label: user_1[:id] }] }]
+                 value: [{ label: user_1[:id], value: user_1[:id] }] }]
     filters[0][:filterOption]['name'] = 'assigned-user'
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_2]
     assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
 
+    # Check for monitorees with assigned user user_1 or user_2 or user_3
     filters = [{ filterOption: {}, additionalFilterOption: nil,
-                 value: [{ value: user_1[:id], label: user_1[:id] },
-                         { value: user_2[:id], label: user_2[:id] }] }]
-    filters[0][:filterOption]['name'] = 'assigned-user'
-    filtered_patients = advanced_filter(patients, filters, tz_offset)
-    filtered_patients_array = [patient_1, patient_2, patient_3]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
-
-    filters = [{ filterOption: {}, additionalFilterOption: nil,
-                 value: [{ value: user_1[:id], label: user_1[:id] },
-                         { value: user_2[:id], label: user_2[:id] },
-                         { value: user_3[:id], label: user_3[:id] }] }]
+                 value: [{ label: user_1[:id], value: user_1[:id] },
+                         { label: user_2[:id], value: user_2[:id] },
+                         { label: user_3[:id], value: user_3[:id] }] }]
     filters[0][:filterOption]['name'] = 'assigned-user'
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_2, patient_3, patient_4]
     assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
 
-    # filters = [{ filterOption: {}, additionalFilterOption: nil, value: []}]
-    # filters[0][:filterOption]['name'] = 'assigned-user'
-    # filtered_patients = advanced_filter(patients, filters, tz_offset)
-    # filtered_patients_array = []
-    # assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    # Check for monitorees with assigned user user_1 or user_2
+    filters = [{ filterOption: {}, additionalFilterOption: nil,
+                 value: [{ label: user_1[:id], value: user_1[:id] },
+                         { label: user_2[:id], value: user_2[:id] }] }]
+    filters[0][:filterOption]['name'] = 'assigned-user'
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2, patient_3]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+
+    # No selected assigned user should not filter out any monitorees
+    filters = [{ filterOption: {}, additionalFilterOption: nil, value: [] }]
+    filters[0][:filterOption]['name'] = 'assigned-user'
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2, patient_3, patient_4]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+
+    # Invalid assigned user should not return any monitorees
+    filters = [{ filterOption: {}, additionalFilterOption: nil,
+                 value: [{ label: -1, value: -1 }] }]
+    filters[0][:filterOption]['name'] = 'assigned-user'
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = []
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+
+    # Check for monitorees with assigned user user_1 or invalid assigned user
+    filters = [{ filterOption: {}, additionalFilterOption: nil,
+                 value: [{ label: user_1[:id], value: user_1[:id] },
+                         { label: -1, value: -1 }] }]
+    filters[0][:filterOption]['name'] = 'assigned-user'
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
   end
 
   test 'advanced filter jurisdiction filters by jurisdiction' do
@@ -927,43 +948,68 @@ class PatientQueryHelperTest < ActionView::TestCase
     user_2 = create(:public_health_enroller_user)
     user_3 = create(:public_health_enroller_user)
     patient_1 = create(:patient, creator: user_1)
+    patient_1.update!(jurisdiction_id: user_1[:jurisdiction_id])
     patient_2 = create(:patient, creator: user_1)
+    patient_2.update!(jurisdiction_id: user_1[:jurisdiction_id])
     patient_3 = create(:patient, creator: user_2)
+    patient_3.update!(jurisdiction_id: user_2[:jurisdiction_id])
     patient_4 = create(:patient, creator: user_3)
+    patient_4.update!(jurisdiction_id: user_3[:jurisdiction_id])
 
     patients = Patient.all
 
     tz_offset = 240
 
+    # Check for monitorees with jurisdiction of user_1
     filters = [{ filterOption: {}, additionalFilterOption: nil,
-                 value: [{ value: user_1[:jurisdiction_id], label: user_1[:jurisdiction_id] }] }]
+                 value: [{ label: user_1[:jurisdiction_path], value: user_1[:jurisdiction_id] }] }]
     filters[0][:filterOption]['name'] = 'jurisdiction'
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_2]
     assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
 
+    # Check for monitorees with jurisdiction of user_1 or user_2 or user_3
     filters = [{ filterOption: {}, additionalFilterOption: nil,
-                 value: [{ value: user_1[:jurisdiction_id], label: user_1[:jurisdiction_id] },
-                         { value: user_2[:jurisdiction_id], label: user_2[:jurisdiction_id] }] }]
-    filters[0][:filterOption]['name'] = 'jurisdiction'
-    filtered_patients = advanced_filter(patients, filters, tz_offset)
-    filtered_patients_array = [patient_1, patient_2, patient_3]
-    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
-
-    filters = [{ filterOption: {}, additionalFilterOption: nil,
-                 value: [{ value: user_1[:jurisdiction_id], label: user_1[:jurisdiction_id] },
-                         { value: user_2[:jurisdiction_id], label: user_2[:jurisdiction_id] },
-                         { value: user_3[:jurisdiction_id], label: user_3[:jurisdiction_id] }] }]
+                 value: [{ label: user_1[:jurisdiction_path], value: user_1[:jurisdiction_id] },
+                         { label: user_2[:jurisdiction_path], value: user_2[:jurisdiction_id] },
+                         { label: user_3[:jurisdiction_path], value: user_3[:jurisdiction_id] }] }]
     filters[0][:filterOption]['name'] = 'jurisdiction'
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_2, patient_3, patient_4]
     assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
 
-    # filters = [{ filterOption: {}, additionalFilterOption: nil, value: []}]
-    # filters[0][:filterOption]['name'] = 'jurisdiction'
-    # filtered_patients = advanced_filter(patients, filters, tz_offset)
-    # filtered_patients_array = []
-    # assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+    # Check for monitorees with jurisdiction of user_1 or user_2
+    filters = [{ filterOption: {}, additionalFilterOption: nil,
+                 value: [{ label: user_1[:jurisdiction_path], value: user_1[:jurisdiction_id] },
+                         { label: user_2[:jurisdiction_path], value: user_2[:jurisdiction_id] }] }]
+    filters[0][:filterOption]['name'] = 'jurisdiction'
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2, patient_3]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+
+    # No selected jurisdiction should not filter out any monitorees
+    filters = [{ filterOption: {}, additionalFilterOption: nil, value: [] }]
+    filters[0][:filterOption]['name'] = 'jurisdiction'
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2, patient_3, patient_4]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+
+    # Invalid jurisdiction should not return any monitorees
+    filters = [{ filterOption: {}, additionalFilterOption: nil,
+                 value: [{ label: 'Not real jurisdiction', value: -1 }] }]
+    filters[0][:filterOption]['name'] = 'jurisdiction'
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = []
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+
+    # Check for monitorees with jurisdiction of user_2 or invalid jurisdiction
+    filters = [{ filterOption: {}, additionalFilterOption: nil,
+                 value: [{ label: user_2[:jurisdiction_path], value: user_2[:jurisdiction_id] },
+                         { label: 'Not real jurisdiction', value: -1 }] }]
+    filters[0][:filterOption]['name'] = 'jurisdiction'
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_3]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
   end
 
   # --- SELECT ADVANCED FILTER QUERIES --- #
@@ -1072,6 +1118,118 @@ class PatientQueryHelperTest < ActionView::TestCase
 
     # Check bad_request error is thrown
     assert_raises(InvalidQueryError) { patients_table_data(params, user) }
+  end
+
+  test 'patients table data filters by assigned user multi-select advanced filter' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    user_1 = create(:public_health_enroller_user)
+    user_2 = create(:public_health_enroller_user)
+    user_3 = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    patient_1.update_attribute('assigned_user', user_1[:id])
+    patient_2 = create(:patient, creator: user)
+    patient_2.update_attribute('assigned_user', user_1[:id])
+    patient_3 = create(:patient, creator: user)
+    patient_3.update_attribute('assigned_user', user_2[:id])
+    patient_4 = create(:patient, creator: user)
+    patient_4.update_attribute('assigned_user', user_3[:id])
+
+    params = ActionController::Parameters.new({
+                                                query: {
+                                                  workflow: 'global',
+                                                  tab: 'all',
+                                                  scope: 'all',
+                                                  search: '',
+                                                  entries: 25,
+                                                  tz_offset: 240,
+                                                  filter: [{
+                                                    filterOption: {
+                                                      name: 'assigned-user',
+                                                      title: 'Assigned User (Multi-select)',
+                                                      description: 'Monitorees who have a specific assigned user',
+                                                      type: 'multi'
+                                                    },
+                                                    value: [
+                                                      { label: user_1[:id], value: user_1[:id] },
+                                                      { label: user_2[:id], value: user_2[:id] }
+                                                    ]
+                                                  }]
+                                                }
+                                              })
+    filtered_patients = patients_table_data(params, user)
+    filtered_patients_array = [patient_1, patient_2, patient_3]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients[:linelist]&.pluck(:id)
+  end
+
+  test 'patients table data does not filter when nothing selected in multi-select advanced filter' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient = create(:patient, creator: user)
+    patient.update_attribute('assigned_user', user[:id])
+
+    params = ActionController::Parameters.new({
+                                                query: {
+                                                  workflow: 'global',
+                                                  tab: 'all',
+                                                  scope: 'all',
+                                                  search: '',
+                                                  entries: 25,
+                                                  tz_offset: 240,
+                                                  filter: [{
+                                                    filterOption: {
+                                                      name: 'assigned-user',
+                                                      title: 'Assigned User (Multi-select)',
+                                                      description: 'Monitorees who have a specific assigned user',
+                                                      type: 'multi'
+                                                    },
+                                                    value: []
+                                                  }]
+                                                }
+                                              })
+    filtered_patients = patients_table_data(params, user)
+    filtered_patients_array = [patient]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients[:linelist]&.pluck(:id)
+  end
+
+  test 'patients table data filters by jurisdiction multi-select advanced filter' do
+    Patient.destroy_all
+    user_1 = create(:public_health_enroller_user)
+    user_2 = create(:public_health_enroller_user)
+    user_3 = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user_1)
+    patient_1.update!(jurisdiction_id: user_1[:jurisdiction_id])
+    patient_2 = create(:patient, creator: user_1)
+    patient_2.update!(jurisdiction_id: user_1[:jurisdiction_id])
+    patient_3 = create(:patient, creator: user_2)
+    patient_3.update!(jurisdiction_id: user_2[:jurisdiction_id])
+    patient_4 = create(:patient, creator: user_3)
+    patient_4.update!(jurisdiction_id: user_3[:jurisdiction_id])
+
+    params = ActionController::Parameters.new({
+                                                query: {
+                                                  workflow: 'global',
+                                                  tab: 'all',
+                                                  scope: 'all',
+                                                  search: '',
+                                                  entries: 25,
+                                                  tz_offset: 240,
+                                                  filter: [{
+                                                    filterOption: {
+                                                      name: 'jurisdiction',
+                                                      title: 'Jurisdiction (Multi-select)',
+                                                      description: 'Monitorees of a specific jurisdiction',
+                                                      type: 'multi'
+                                                    },
+                                                    value: [
+                                                      { label: user_1[:jurisdiction_id], value: user_1[:jurisdiction_id] }
+                                                    ]
+                                                  }]
+                                                }
+                                              })
+    filtered_patients = patients_table_data(params, user_1)
+    filtered_patients_array = [patient_1, patient_2]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients[:linelist]&.pluck(:id)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/test/helpers/patient_query_helper_test.rb
+++ b/test/helpers/patient_query_helper_test.rb
@@ -184,7 +184,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 
-  # --- MULTI ADVANCED FILTER QUERIES --- #
+  # --- COMBINATION ADVANCED FILTER QUERIES --- #
 
   test 'advanced filter laboratory single filter option results' do
     Patient.destroy_all
@@ -869,6 +869,104 @@ class PatientQueryHelperTest < ActionView::TestCase
     filtered_patients_array = [patient_4, patient_7]
     assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
+
+  # --- MULTI-SELECT ADVANCED FILTER QUERIES --- #
+
+  test 'advanced filter assigned user filters by assigned user' do
+    Patient.destroy_all
+    user_1 = create(:public_health_enroller_user)
+    user_2 = create(:public_health_enroller_user)
+    user_3 = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user_1)
+    patient_1.update_attribute('assigned_user', user_1[:id])
+    patient_2 = create(:patient, creator: user_1)
+    patient_2.update_attribute('assigned_user', user_1[:id])
+    patient_3 = create(:patient, creator: user_2)
+    patient_3.update_attribute('assigned_user', user_2[:id])
+    patient_4 = create(:patient, creator: user_3)
+    patient_4.update_attribute('assigned_user', user_3[:id])
+
+    patients = Patient.all
+
+    tz_offset = 240
+
+    filters = [{ filterOption: {}, additionalFilterOption: nil,
+                 value: [{ value: user_1[:id], label: user_1[:id] }] }]
+    filters[0][:filterOption]['name'] = 'assigned-user'
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+
+    filters = [{ filterOption: {}, additionalFilterOption: nil,
+                 value: [{ value: user_1[:id], label: user_1[:id] },
+                         { value: user_2[:id], label: user_2[:id] }] }]
+    filters[0][:filterOption]['name'] = 'assigned-user'
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2, patient_3]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+
+    filters = [{ filterOption: {}, additionalFilterOption: nil,
+                 value: [{ value: user_1[:id], label: user_1[:id] },
+                         { value: user_2[:id], label: user_2[:id] },
+                         { value: user_3[:id], label: user_3[:id] }] }]
+    filters[0][:filterOption]['name'] = 'assigned-user'
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2, patient_3, patient_4]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+
+    # filters = [{ filterOption: {}, additionalFilterOption: nil, value: []}]
+    # filters[0][:filterOption]['name'] = 'assigned-user'
+    # filtered_patients = advanced_filter(patients, filters, tz_offset)
+    # filtered_patients_array = []
+    # assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter jurisdiction filters by jurisdiction' do
+    Patient.destroy_all
+    user_1 = create(:public_health_enroller_user)
+    user_2 = create(:public_health_enroller_user)
+    user_3 = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user_1)
+    patient_2 = create(:patient, creator: user_1)
+    patient_3 = create(:patient, creator: user_2)
+    patient_4 = create(:patient, creator: user_3)
+
+    patients = Patient.all
+
+    tz_offset = 240
+
+    filters = [{ filterOption: {}, additionalFilterOption: nil,
+                 value: [{ value: user_1[:jurisdiction_id], label: user_1[:jurisdiction_id] }] }]
+    filters[0][:filterOption]['name'] = 'jurisdiction'
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+
+    filters = [{ filterOption: {}, additionalFilterOption: nil,
+                 value: [{ value: user_1[:jurisdiction_id], label: user_1[:jurisdiction_id] },
+                         { value: user_2[:jurisdiction_id], label: user_2[:jurisdiction_id] }] }]
+    filters[0][:filterOption]['name'] = 'jurisdiction'
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2, patient_3]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+
+    filters = [{ filterOption: {}, additionalFilterOption: nil,
+                 value: [{ value: user_1[:jurisdiction_id], label: user_1[:jurisdiction_id] },
+                         { value: user_2[:jurisdiction_id], label: user_2[:jurisdiction_id] },
+                         { value: user_3[:jurisdiction_id], label: user_3[:jurisdiction_id] }] }]
+    filters[0][:filterOption]['name'] = 'jurisdiction'
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2, patient_3, patient_4]
+    assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+
+    # filters = [{ filterOption: {}, additionalFilterOption: nil, value: []}]
+    # filters[0][:filterOption]['name'] = 'jurisdiction'
+    # filtered_patients = advanced_filter(patients, filters, tz_offset)
+    # filtered_patients_array = []
+    # assert_equal filtered_patients_array.map { |p| p[:id] }, filtered_patients.pluck(:id)
+  end
+
+  # --- SELECT ADVANCED FILTER QUERIES --- #
 
   test 'advanced filter flagged for follow up filters those marked as flagged for follow up' do
     Patient.destroy_all

--- a/test/test_helpers/user_filters_test_helper.rb
+++ b/test/test_helpers/user_filters_test_helper.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module UserFiltersTestHelper
+  def self.combination_filter_params
+    {
+      'activeFilterOptions' => [{
+        'filterOption' => {
+          'name' => 'lab-result',
+          'title' => 'Lab Result (Combination)',
+          'description' => 'Monitorees with specified Lab Result criteria',
+          'type' => 'combination',
+          'tooltip' => 'short tooltip',
+          'fields' => [{
+            'name' => 'result',
+            'title' => 'result',
+            'type' => 'select',
+            'options' => ['positive', 'negative', 'indeterminate', 'other', '']
+          }]
+        },
+        'value' => [{
+          'name' => 'result',
+          'value' => 'positive'
+        }],
+        'numberOption' => nil,
+        'dateOption' => nil,
+        'relativeOption' => nil,
+        'additionalFilterOption' => nil
+      }],
+      'name' => 'Test'
+    }
+  end
+
+  def self.multi_select_filter_params(options_selected:)
+    raise(ArgumentError, 'options_selected must be false, alternative is not implemented') if options_selected
+
+    # Value and all options are nil.
+    {
+      'activeFilterOptions' => [{
+        'filterOption' => {
+          'name' => 'assigned-user',
+          'title' => 'Assigned User (Multi-select)',
+          'description' => 'Monitorees who have a specific assigned user',
+          'type' => 'multi',
+          'options' => [{ 'value' => 57, 'label' => 57 }]
+        },
+        'value' => [],
+        'numberOption' => nil,
+        'dateOption' => nil,
+        'relativeOption' => nil,
+        'additionalFilterOption' => nil
+      }],
+      'name' => 'Test'
+    }
+  end
+end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1020](https://tracker.codev.mitre.org/browse/SARAALERT-1020)

Currently, Sara Alert users are able to filter the dashboard view based on Assigned User & Jurisdiction through the standard dashboard filters. This ticket entails adding the ability to search by multiple users/jurisdictions, or addition of the "OR" operator to support ability to filter by multiple users/jurisdictions. This will require implementing a new "type" of multi-select advanced filter.

## (Feature) Demo/Screenshots

<img width="1111" alt="SARAALERT-1020_AssignedUser" src="https://user-images.githubusercontent.com/55925276/128554956-cfc13779-64a6-455f-8c3b-4522c3213bd5.png">
<img width="1112" alt="SARAALERT-1020_Jurisdiction" src="https://user-images.githubusercontent.com/55925276/128554969-854a4ff1-9852-485d-b01c-2bca9d9831d4.png">

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`AdvancedFilter.js`
- Implement new "Multi-select" advanced filter type
- Add jurisdiction paths and assigned users to propTypes and get those options
- Add function to get options for saved filters (multi-select options are not saved to the db)
- Rename former "multi" advanced filters to "combination"

`AdvancedFilter.test.js`
- Add tests for multi-select advanced filter type
- Rename former "multi" advanced filters to "combination"

`advancedFilterOptions.js`
- Add assigned user and jurisdiction multi-select filters
- Rename former "multi" advanced filters to "combination"

`mockFilters.js`
- Add mock filters for assigned user and jurisdiction filters
- Rename former "multi" advanced filters to "combination"

`public_health_controller.rb`
- Set jurisdiction paths and all assigned users before exposure, isolation, and global run

`exposure.html.erb`, `isolation.html.erb`, `global.html.erb`
- Pass jurisdiction paths and all assigned users to Workflow

`Workflow.js`
- Add jurisdiction paths to Workflow propTypes
- Pass `this.props.jurisdiction_paths` (instead of `this.state.jurisdiction_paths`) to `PatientsTable` and `PublicHealthHeader`
- Pass all assigned users to `PatientsTable` and `PublicHealthHeader`

`PatientsTable.js`
- Pass jurisdiction paths and assigned users to `AdvancedFilter`

`PublicHealthHeader.js`
- Pass all assigned users to `Export`

`Export.js`
- Pass all assigned users to `CustomExport`

`CustomExport.js`
- Render currently selected options for multi-select on custom export
- Pass all assigned users to `PatientsFilters`
- Rename former "multi" advanced filters to "combination"

`PatientsFilters.js`
- Pass jurisdiction paths and all assigned users to AdvancedFilter

`patient_query_helper.rb`
- Add value as an array as a valid param for query and handle `nil` case
- Add cases for `assigned-user` and `jurisdiction` filters to `advanced_filter`

`patient_query_helper_test.rb`
- Add tests for `advanced_filter` for assigned user and jurisdiction multi-select advanced filter
- Add tests for `patients_table_data` for assigned user and jurisdiction multi-select advanced filter

`user_filters_controller.rb`
- Add values as an array to pass values from multi-select filter and handle `nil` case


## Testing Recommendations
- Test adding multiple rows of different filters with multi-select as one (or more) of the rows, and then deleting some rows.
- Test changing the filter option from one multi-select type to the other. Should reset selected values.
- Test not selecting any assigned user or jurisdiction and applying the filter. Should not filter out any monitorees.
- Test saving a multi-select filter
- Test displaying advanced filters when selecting custom export

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@timwongj  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@holmesie  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
