### PR TITLE
SARAALERT-NONE: Add a default value for public_health_action in the API

### DIFF
--- a/app/helpers/fhir_helper.rb
+++ b/app/helpers/fhir_helper.rb
@@ -219,7 +219,7 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
       secondary_telephone_type: from_secondary_phone_type_extension(patient, 'Patient'),
       continuous_exposure: from_bool_extension_false_default(patient, 'Patient', 'continuous-exposure'),
       exposure_risk_assessment: from_string_extension(patient, 'Patient', 'exposure-risk-assessment'),
-      public_health_action: from_string_extension(patient, 'Patient', 'public-health-action'),
+      public_health_action: from_string_extension(patient, 'Patient', 'public-health-action', 'None'),
       contact_of_known_case: from_bool_extension_nil_default(patient, 'Patient', 'contact-of-known-case'),
       contact_of_known_case_id: from_string_extension(patient, 'Patient', 'contact-of-known-case-id'),
       member_of_a_common_exposure_cohort_type: from_string_extension(patient, 'Patient', 'common-exposure-cohort-name'),
@@ -648,8 +648,8 @@ module FhirHelper # rubocop:todo Metrics/ModuleLength
     )
   end
 
-  def from_string_extension(element, base_path, extension_id)
-    { value: element&.extension&.find { |e| e.url.include?(extension_id) }&.valueString, path: str_ext_path(base_path, extension_id) }
+  def from_string_extension(element, base_path, extension_id, default_value = nil)
+    { value: element&.extension&.find { |e| e.url.include?(extension_id) }&.valueString || default_value, path: str_ext_path(base_path, extension_id) }
   end
 
   def to_reference_extension(id, resource_type, extension_id)


### PR DESCRIPTION
# Description
Jira Ticket: SARAALERT-NONE

When I added support for `public_health_action` via the API, I didn't account for the default value of `None` that should be used. So via the API, if no `public-health-action` extension is specified, a `public_health_action` is added to the db with the value `nil`. However, in other spots of the app, we assume that `public_health_action` will have a value of `None` by default, see [here](https://github.com/SaraAlert/SaraAlert/blob/f0898dea30e33ef1d0fa7f0e61b7d784ceed6c76/app/helpers/patient_details_helper.rb#L22) for an example.

This result in us assuming that a `public_health_action` has been set, because the value is not `None`, so the patient goes on the PUI line list, but in fact the value is just `nil`, so the patient should not be on the PUI line list.

## How to Replicate
On `master`, create a patient via the API with no `public-health-action` extension. They will be given the PUI status incorrectly.

## Solution
Set `public_health_action` by default to `None` via the API.

## Important Changes
`fhir_helper.rb`
- Default `public_health_action` to `None` via the API.

## Testing Recommendations
Test that on this brach, if you create a Patient via the API with no `public_health_action`, that Patient does _not_ go on the PUI line list, and if you check the value via a rails console for their `public_health_action`, it should be `None` (note that via the UI, even if a Patients `public_health_action` is `nil`, it will show up as `None`, so you have to check via the console).

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)


@holmesie 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@Bialogs 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
