### PR TITLE
SARAALERT-1470: OauthApplication & ApiDownload Model Changes

### DIFF
--- a/app/models/api_download.rb
+++ b/app/models/api_download.rb
@@ -2,5 +2,6 @@
 
 # Generated exports for downloads in the API
 class ApiDownload < ApplicationRecord
+  belongs_to :application, class_name: 'OauthApplication'
   has_many_attached :files
 end

--- a/app/models/oauth_application.rb
+++ b/app/models/oauth_application.rb
@@ -3,8 +3,8 @@
 # OauthApplication: Custom class on top of Doorkeeper Application mixin
 class OauthApplication < ApplicationRecord
   include ::Doorkeeper::Orm::ActiveRecord::Mixins::Application
-  has_many :jwt_identifiers, foreign_key: 'application_id', dependent: :destroy
-  has_many :api_downloads, foreign_key: 'application_id'
+  has_many :api_downloads, foreign_key: 'application_id', dependent: :destroy, inverse_of: 'application'
+  has_many :jwt_identifiers, foreign_key: 'application_id', dependent: :destroy, inverse_of: 'application'
   belongs_to :jurisdiction, optional: true
 
   def exported_recently?


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1470](https://tracker.codev.mitre.org/browse/SARAALERT-1470)

Incorporates Rubocop/Rails and Rubocop/Performance updates into OauthApplication model.

Related #1028

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`OauthApplication.rb`
- Add `inverse_of` letting Rails know about the relationship between JWT and OauthApplication

`ApiDownload.rb`

Since this was now updated with the changes from 1.36 I've added some changes to related to ApiDownload.

    Added the same dependent and inverse_of as JwtIdentifier
    Added a missing belongs_to relationship with OauthApplication


## Testing Recommendations
Use the following [rubocop.txt](https://github.com/SaraAlert/SaraAlert/files/6956507/rubocop.txt) to test similar to last time.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ngfreiter  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@holmesie  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
