### PR TITLE
SARAALERT-1039: Update History Filters to include "Manual Contact Attempt"

### DIFF
--- a/app/controllers/contact_attempts_controller.rb
+++ b/app/controllers/contact_attempts_controller.rb
@@ -25,6 +25,6 @@ class ContactAttemptsController < ApplicationController
     History.create!(patient_id: patient_id,
                     created_by: current_user.email,
                     comment: "#{successful ? 'Successful' : 'Unsuccessful'} contact attempt. Note: #{note}",
-                    history_type: 'Contact Attempt')
+                    history_type: 'Manual Contact Attempt')
   end
 end

--- a/app/javascript/components/patient/history/HistoryList.js
+++ b/app/javascript/components/patient/history/HistoryList.js
@@ -28,7 +28,7 @@ class HistoryList extends React.Component {
     this.creatorFilterData = [
       {
         label: 'History Creator',
-        options: _.uniq(props.histories.map(h => h[0].created_by)).map(x => {
+        options: _.orderBy(_.uniq(props.histories.map(h => h[0].created_by)), x => x, 'asc').map(x => {
           return { value: x, label: x };
         }),
       },
@@ -47,6 +47,7 @@ class HistoryList extends React.Component {
         label: this.props.history_types[`${historyType}`],
       });
     }
+    this.typeFilterData[0].options = _.orderBy(this.typeFilterData[0].options, x => x.label, 'asc');
   }
 
   handleChange = event => {

--- a/app/javascript/components/patient/history/HistoryList.js
+++ b/app/javascript/components/patient/history/HistoryList.js
@@ -28,7 +28,7 @@ class HistoryList extends React.Component {
     this.creatorFilterData = [
       {
         label: 'History Creator',
-        options: _.orderBy(_.uniq(props.histories.map(h => h[0].created_by)), x => x, 'asc').map(x => {
+        options: _.orderBy(_.uniq(props.histories.map(h => h[0].created_by)), x => _.toLower(x), 'asc').map(x => {
           return { value: x, label: x };
         }),
       },

--- a/app/javascript/tests/patient/history/HistoryList.test.js
+++ b/app/javascript/tests/patient/history/HistoryList.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Button, Card } from 'react-bootstrap';
+import _ from 'lodash';
 import Select from 'react-select';
 import Pagination from 'jw-react-pagination';
 import HistoryList from '../../../components/patient/history/HistoryList';
@@ -11,9 +12,17 @@ import { mockEnrollmentHistory, mockCommentHistory1, mockCommentHistory2, mockCo
 
 const mockToken = 'testMockTokenString12345';
 const histories = [[mockEnrollmentHistory], [mockCommentHistory2, mockCommentHistory2Edit1, mockCommentHistory2Edit2], [mockCommentHistory1]];
-let historyCreators = histories.map(history_group => history_group[0].created_by);
+let historyCreators = _.orderBy(
+  histories.map(history_group => history_group[0].created_by),
+  x => x,
+  'asc'
+);
 historyCreators = historyCreators.filter((creator, index) => historyCreators.includes(creator) && index === historyCreators.indexOf(creator));
-let historyTypes = histories.map(history_group => history_group[0].history_type);
+let historyTypes = _.orderBy(
+  histories.map(history_group => history_group[0].history_type),
+  x => x,
+  'asc'
+);
 historyTypes = historyTypes.filter((type, index) => historyTypes.includes(type) && index === historyTypes.indexOf(type));
 
 function getWrapper() {

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -30,6 +30,7 @@ class History < ApplicationRecord
     close_contact: 'Close Contact',
     close_contact_edit: 'Close Contact Edit',
     contact_attempt: 'Contact Attempt',
+    manual_contact_attempt: 'Manual Contact Attempt',
     welcome_message_sent: 'Welcome Message Sent',
     record_automatically_closed: 'Record Automatically Closed',
     monitoring_complete_message_sent: 'Monitoring Complete Message Sent',

--- a/db/migrate/20210811133939_add_manual_contact_attempt_history_type.rb
+++ b/db/migrate/20210811133939_add_manual_contact_attempt_history_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# This migration was created to change manual contact attempt history items from 'Contact Attempt' to 'Manual Contact Attempt' History type
+class AddManualContactAttemptHistoryType < ActiveRecord::Migration[6.1]
+  def up
+    History.where('history_type = ? AND comment like ?', 'Contact Attempt', '%contact attempt. Note:%').update_all(history_type: 'Manual Contact Attempt')
+  end
+
+  def down
+    History.where(history_type: 'Manual Contact Attempt').update_all(history_type: 'Contact Attempt')
+  end
+end

--- a/db/migrate/20210811133939_add_manual_contact_attempt_history_type.rb
+++ b/db/migrate/20210811133939_add_manual_contact_attempt_history_type.rb
@@ -3,7 +3,7 @@
 # This migration was created to change manual contact attempt history items from 'Contact Attempt' to 'Manual Contact Attempt' History type
 class AddManualContactAttemptHistoryType < ActiveRecord::Migration[6.1]
   def up
-    History.where('history_type = ? AND comment like ?', 'Contact Attempt', '%contact attempt. Note:%').update_all(history_type: 'Manual Contact Attempt')
+    History.where('history_type = ? AND created_by not like ?', 'Contact Attempt', 'Sara Alert System').update_all(history_type: 'Manual Contact Attempt')
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_30_162750) do
+ActiveRecord::Schema.define(version: 2021_08_11_133939) do
 
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false

--- a/lib/tasks/demo.rake
+++ b/lib/tasks/demo.rake
@@ -947,8 +947,8 @@ namespace :demo do
       histories << History.new(
         patient_id: patient_id,
         created_by: manual_attempt ? user[1] : 'Sara Alert System',
-        comment: "#{successful ? 'Successful' : 'Unsuccessful'} contact attempt. Note: #{note}",
-        history_type: 'Contact Attempt',
+        comment: manual_attempt ? "#{successful ? 'Successful' : 'Unsuccessful'} contact attempt. Note: #{note}" : 'The system attempted to make contact with the monitoree.',
+        history_type: manual_attempt ? 'Manual Contact Attempt' : 'Contact Attempt',
         created_at: contact_attempt_ts,
         updated_at: contact_attempt_ts
       )


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1039](https://tracker.codev.mitre.org/browse/SARAALERT-1039)

Currently: Right now, the "Contact Attempt" history tag includes both manual contact attempts and for when the system sent a notification to a monitoree but did not receive a response. Maine is using the "manual contact attempt" button to track monitorees lost to follow up. 

This PR creates an additional history type "Manual Contact Attempt" rather than "Contact Attempt" so we can filter them appropriately in History. It also alphabetically sorts the creator and type history filter options.

## (Feature) Demo/Screenshots
<img width="1136" alt="Screen Shot 2021-08-12 at 20 21 04" src="https://user-images.githubusercontent.com/55925276/129286023-bc922bca-fd07-42a6-b0cb-457419ef88d7.png">

## Important Changes

`history.rb`
- Create 'Manual Contact Attempt' History type

` ccontact_attempts_controller.rb`
- Change contact attempts controller so that it creates a 'Manual Contact Attempt' history item when a user logs a manual contact attempt

`20210811133939_add_manual_contact_attempt_history_type.rb`
- Write database migration to assign new 'Manual Contact Attempt' history type to all existing manual 'Contact Attempt' history items

`schema.rb`
- Update schema version

`demo.rake`
- Change demo to create 'Manual Contact Attempt' history items for manual contact attempts and change history item comment

`HistoryList.js`
- Sort (alphabetically, ascending) creator and type history filter options

`HistoryList.test.js`
- Update tests

## Testing Recommendations
- Log a manual contact attempt
- Filter by History type 'Manual Contact Attempt'

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ngfreiter :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
