### PR TITLE
SARAALERT-1591: Update PHDC Serialization

### DIFF
--- a/app/lib/phdc/serializer.rb
+++ b/app/lib/phdc/serializer.rb
@@ -196,13 +196,11 @@ module PHDC
       auth_id = Ox::Element.new(:id)
       auth_id['root'] = '2.16.840.1.113883.19.5'
       assigned_author << auth_id
-      assigned_person = Ox::Element.new(:assignedPerson)
-      assigned_author << assigned_person
-      auth_name = Ox::Element.new(:name)
-      assigned_person << auth_name
-      jur_name = Ox::Element.new(:family)
-      jur_name << "Sara Alert NBS Export: #{jurisdiction_path_string}"
-      auth_name << jur_name
+      assigned_authoring_device = Ox::Element.new(:assignedAuthoringDevice)
+      assigned_author << assigned_authoring_device
+      auth_name = Ox::Element.new(:softwareName)
+      auth_name << "Sara Alert NBS Export: #{jurisdiction_path_string}"
+      assigned_authoring_device << auth_name
 
       # Custodian
       custodian = Ox::Element.new(:custodian)
@@ -264,9 +262,11 @@ module PHDC
       clin_section_title << 'CLINICAL INFORMATION'
       clin_section << clin_section_title
       unless patient.user_defined_id_statelocal.blank?
-        clin_section << entry_helper_text('INV168', 'Investigation Local ID', 'ST', patient.user_defined_id_statelocal, nil)
         clin_section << entry_helper_text('INV173', 'Investigation State Local ID', 'ST', patient.user_defined_id_statelocal, nil)
       end
+      clin_section << clinical_entry_helper_code('INV169', '2.16.840.1.114222.4.5.232', 'Condition', 'PHIN Questions',
+                                                 '11065', '2.16.840.1.114222.4.5.277', 'Coronavirus Disease 2019 (COVID-19)',
+                                                 'Notifiable Event (Disease/Condition) Code List')
 
       # Generic Repeating Questions Information Section
 
@@ -383,6 +383,18 @@ module PHDC
       value_el['xsi:type'] = type
       value_el << text
       value_el
+    end
+
+    # Clinical Information entry helper for coded values
+    def clinical_entry_helper_code(code, code_system, display, code_system_name, value_code, value_code_system, value_display, value_code_system_name)
+      s_entry = entry_helper
+      s_obs = observation_helper('OBS', 'EVN')
+      s_entry << s_obs
+      s_obs << code_helper(code, code_system, display, code_system_name)
+      val = value_helper_code('CE', value_code, value_code_system, value_display)
+      val['codeSystemName'] = value_code_system_name
+      s_obs << val
+      s_entry
     end
 
     # Social History entry helper for coded values


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1591](https://tracker.codev.mitre.org/browse/SARAALERT-1591)

This PR makes some minor updates to the PHDC serialization after some feedback we got back from folks with NBS. The updates are:

* Remove the repetitive `Investigation Local ID` element. This element contains the same info as the `Investigation State Local ID` element, so no need to have both.
* Add an entry to the "Clinical Information" section of the PHDC for the condition, in this case COVID-19. 
* Change `assignedPerson` to the more accurate `assignedAuthoringDevice`, since the Sara Alert jurisdiction which authored is not a specific person.

## Important Changes
`serializer.rb`
- Made the changes described above.

## Testing Recommendations
* Test that the PHDC is serialized without error
* If you want, you can test that the resulting XML is valid using the XSD files found [here](https://mitre.sharepoint.com/sites/CoVDT/Shared%20Documents/Forms/AllItems.aspx?viewid=007c8287%2D600b%2D472a%2D80b6%2Ddb5d29f94763&id=%2Fsites%2FCoVDT%2FShared%20Documents%2FEngineering%20Team%2FNBS). When you download a file, you will need to point it towards the schemas, so do do that set the `xsi:schemaLocation` like `xsi:schemaLocation="urn:hl7-org:v3 file:///path/to/PHDC_XSD/CDA_SDTC.xsd"`

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@Bialogs 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
