### PR TITLE
SARAALERT-1587: Fix bug where updating case status cleared reason for closure

### DIFF
--- a/app/javascript/components/patient/monitoring_actions/CaseStatus.js
+++ b/app/javascript/components/patient/monitoring_actions/CaseStatus.js
@@ -37,7 +37,7 @@ class CaseStatus extends React.Component {
   handleCaseStatusChange = event => {
     const value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
     const confirmedOrProbable = value === 'Confirmed' || value === 'Probable';
-    if (!confirmedOrProbable) {
+    if (this.state.monitoring && !confirmedOrProbable) {
       this.setState({ monitoring_reason: '', reasoning: '' });
     }
 
@@ -164,7 +164,8 @@ class CaseStatus extends React.Component {
     const diffState = Object.keys(this.state).filter(k => _.get(this.state, k) !== _.get(this.origState, k));
     this.setState({ loading: true }, () => {
       // Per feedback, include the monitoring_reason in the reasoning text, as the user might not inlude any text
-      let reasoning = this.state.isolation ? '' : [this.state.monitoring_reason, this.state.reasoning].filter(x => x).join(', ');
+      let alreadyClosed = !this.props.patient.monitoring && !this.state.monitoring;
+      let reasoning = this.state.isolation || alreadyClosed ? '' : [this.state.monitoring_reason, this.state.reasoning].filter(x => x).join(', ');
       // Add a period at the end of the Reasoning (if it's not already included)
       if (reasoning && !['.', '!', '?'].includes(_.last(reasoning))) {
         reasoning += '.';


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1587](https://tracker.codev.mitre.org/browse/SARAALERT-1587)

This fixes a bug introduced in 1.31 where changing the case status of a closed monitoree caused the reason for closure to be cleared. [Slack context](https://mitrecorp.slack.com/archives/G01792S9Z5M/p1627395768001300).

## How to Replicate
- Enroll a monitoree with Case Status unknown
- Change their Case Status to Probable or Confirmed, and choose to end monitoring with a reason
- Open another tab with the Exposure Dashboard and go to the Closed linelist, confirm your monitoree is there with the Reason For Closure
- Go back to the monitoree and update the Case Status to Unknown
- Go back to the Exposure Dashboard and see that the Reason For Closure has been cleared

## Solution
Don't clear the monitoring reason if the patient is closed.

## Testing Recommendations
Confirm you can replicate the bug on `1.36.0` and then switch to this branch and confirm you cannot replicate. Also, perform various combinations of changing Monitoring Status and Case Status and confirm that it works correctly and that the History items generated are correct.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@ngfreiter:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@holmesie:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
