### PR TITLE
SARAALERT-1439: Update Placeholder text in Close Contact Notes field

### DIFF
--- a/app/javascript/components/patient/assessment/AssessmentTable.js
+++ b/app/javascript/components/patient/assessment/AssessmentTable.js
@@ -322,60 +322,56 @@ class AssessmentTable extends React.Component {
             Reports
           </Card.Header>
           <Card.Body>
-            <div className="mt-4">
-              <CurrentStatus report_eligibility={this.props.report_eligibility} status={this.props.patient_status} isolation={this.props.patient?.isolation} />
-              <Row className="my-4">
-                <Col>
-                  <Button variant="primary" className="mr-2" onClick={this.handleAddReportClick}>
-                    <i className="fas fa-plus fa-fw"></i>
-                    <span className="ml-2">Add New Report</span>
-                  </Button>
-                  <ClearAssessments authenticity_token={this.props.authenticity_token} patient={this.props.patient} num_pos_labs={this.props.num_pos_labs} />
-                  <PauseNotifications authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
-                  <ContactAttempt
-                    authenticity_token={this.props.authenticity_token}
-                    patient={this.props.patient}
-                    household_members={this.props.household_members}
-                    current_user={this.props.current_user}
-                    jurisdiction_paths={this.props.jurisdiction_paths}
-                    workflow={this.props.workflow}
-                  />
-                </Col>
-                <Col lg={5}>
-                  <InputGroup size="md">
-                    <InputGroup.Prepend>
-                      <OverlayTrigger overlay={<Tooltip>Search by id or reporter.</Tooltip>}>
-                        <InputGroup.Text className="rounded-0">
-                          <i className="fas fa-search"></i>
-                          <label htmlFor="reports-search-input" className="ml-1 mb-0" aria-label="Search Reports Table by ID or reporter.">
-                            Search
-                          </label>
-                        </InputGroup.Text>
-                      </OverlayTrigger>
-                    </InputGroup.Prepend>
-                    <Form.Control id="reports-search-input" autoComplete="off" size="md" name="search" onChange={this.handleSearchChange} aria-label="Search" />
-                  </InputGroup>
-                </Col>
-              </Row>
-              <div className="mb-4">
-                <CustomTable
-                  title="Reports"
-                  dataType="assessments"
-                  columnData={this.state.table.colData}
-                  rowData={this.state.table.rowData}
-                  totalRows={this.state.table.totalRows}
-                  handleTableUpdate={query => this.updateTable({ ...this.state.query, order: query.orderBy, page: query.page, direction: query.sortDirection })}
-                  handleEntriesChange={this.handleEntriesChange}
-                  isLoading={this.state.isLoading}
-                  page={this.state.query.page}
-                  handlePageUpdate={this.handlePageUpdate}
-                  entryOptions={this.state.entryOptions}
-                  entries={this.state.query.entries}
-                  tableCustomClass="table-has-dropdown"
-                  getRowClassName={this.getRowClassName}
+            <CurrentStatus report_eligibility={this.props.report_eligibility} status={this.props.patient_status} isolation={this.props.patient?.isolation} />
+            <Row className="my-4">
+              <Col>
+                <Button variant="primary" className="mr-2" onClick={this.handleAddReportClick}>
+                  <i className="fas fa-plus fa-fw"></i>
+                  <span className="ml-2">Add New Report</span>
+                </Button>
+                <ClearAssessments authenticity_token={this.props.authenticity_token} patient={this.props.patient} num_pos_labs={this.props.num_pos_labs} />
+                <PauseNotifications authenticity_token={this.props.authenticity_token} patient={this.props.patient} />
+                <ContactAttempt
+                  authenticity_token={this.props.authenticity_token}
+                  patient={this.props.patient}
+                  household_members={this.props.household_members}
+                  current_user={this.props.current_user}
+                  jurisdiction_paths={this.props.jurisdiction_paths}
+                  workflow={this.props.workflow}
                 />
-              </div>
-            </div>
+              </Col>
+              <Col lg={5}>
+                <InputGroup size="md">
+                  <InputGroup.Prepend>
+                    <OverlayTrigger overlay={<Tooltip>Search by id or reporter.</Tooltip>}>
+                      <InputGroup.Text className="rounded-0">
+                        <i className="fas fa-search"></i>
+                        <label htmlFor="reports-search-input" className="ml-1 mb-0" aria-label="Search Reports Table by ID or reporter.">
+                          Search
+                        </label>
+                      </InputGroup.Text>
+                    </OverlayTrigger>
+                  </InputGroup.Prepend>
+                  <Form.Control id="reports-search-input" autoComplete="off" size="md" name="search" onChange={this.handleSearchChange} aria-label="Search" />
+                </InputGroup>
+              </Col>
+            </Row>
+            <CustomTable
+              title="Reports"
+              dataType="assessments"
+              columnData={this.state.table.colData}
+              rowData={this.state.table.rowData}
+              totalRows={this.state.table.totalRows}
+              handleTableUpdate={query => this.updateTable({ ...this.state.query, order: query.orderBy, page: query.page, direction: query.sortDirection })}
+              handleEntriesChange={this.handleEntriesChange}
+              isLoading={this.state.isLoading}
+              page={this.state.query.page}
+              handlePageUpdate={this.handlePageUpdate}
+              entryOptions={this.state.entryOptions}
+              entries={this.state.query.entries}
+              tableCustomClass="table-has-dropdown"
+              getRowClassName={this.getRowClassName}
+            />
             <MonitoringPeriod
               authenticity_token={this.props.authenticity_token}
               patient={this.props.patient}

--- a/app/javascript/components/patient/assessment/actions/CurrentStatus.js
+++ b/app/javascript/components/patient/assessment/actions/CurrentStatus.js
@@ -148,7 +148,7 @@ class CurrentStatus extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <h2 className="tertiary-title pb-3">
+        <h2 className="tertiary-title">
           <b>
             {this.props.isolation ? 'Isolation' : 'Exposure'} Workflow: {this.renderStatus(this.props.status)}
           </b>

--- a/app/javascript/components/patient/assessment/actions/MonitoringPeriod.js
+++ b/app/javascript/components/patient/assessment/actions/MonitoringPeriod.js
@@ -44,7 +44,7 @@ class MonitoringPeriod extends React.Component {
 
   render() {
     return (
-      <Row>
+      <Row className="mt-3">
         <Col xl={{ span: this.props.patient.isolation ? 9 : 8, order: 1 }} md={{ span: 12, order: 1 }} xs={{ span: 24, order: 1 }}>
           <SymptomOnset
             authenticity_token={this.props.authenticity_token}

--- a/app/javascript/components/patient/close_contacts/CloseContactModal.js
+++ b/app/javascript/components/patient/close_contacts/CloseContactModal.js
@@ -190,7 +190,7 @@ class CloseContactModal extends React.Component {
                 rows="5"
                 className="form-square"
                 value={this.state.notes || ''}
-                placeholder={this.closeContactNotePlaceholder}
+                placeholder="enter additional information about contact"
                 maxLength={MAX_NOTES_LENGTH}
                 onChange={this.handleNotesChange}
               />

--- a/app/javascript/components/patient/close_contacts/CloseContactTable.js
+++ b/app/javascript/components/patient/close_contacts/CloseContactTable.js
@@ -385,62 +385,58 @@ class CloseContactTable extends React.Component {
   render() {
     return (
       <React.Fragment>
-        <Card className="mx-2 mt-3 mb-4 card-square">
+        <Card className="mx-2 my-4 card-square">
           <Card.Header as="h1" className="patient-card-header">
             Close Contacts <InfoTooltip tooltipTextKey="closeContacts" location="right" />
           </Card.Header>
-          <Card.Body>
-            <div className="mt-4">
-              <Row className="my-4">
-                <Col>
-                  <Button variant="primary" className="mr-2" onClick={() => this.toggleAddModal()}>
-                    <i className="fas fa-plus fa-fw"></i>
-                    <span className="ml-2">Add New Close Contact</span>
-                  </Button>
-                </Col>
-                <Col xl={6} lg={10} md={12}>
-                  <InputGroup size="md" className="mt-3 mt-md-0 ">
-                    <InputGroup.Prepend>
-                      <OverlayTrigger overlay={<Tooltip>Search by First Name, Last Name, Phone Number, Email, Assigned User, or Contact Attempts.</Tooltip>}>
-                        <InputGroup.Text className="rounded-0">
-                          <i className="fas fa-search"></i>
-                          <label
-                            htmlFor="close-contact-search-input"
-                            className="ml-2 mb-0"
-                            aria-label="Search Close Contact Table by First Name, Last Name, Phone Number, Email, Assigned User, or Contact Attempts.">
-                            Search
-                          </label>
-                        </InputGroup.Text>
-                      </OverlayTrigger>
-                    </InputGroup.Prepend>
-                    <Form.Control
-                      id="close-contact-search-input"
-                      autoComplete="off"
-                      size="md"
-                      name="search"
-                      onChange={this.handleSearchChange}
-                      aria-label="Search"
-                    />
-                  </InputGroup>
-                </Col>
-              </Row>
-              <div className="mb-4">
-                <CustomTable
-                  dataType="close-contacts"
-                  columnData={this.state.table.colData}
-                  rowData={this.state.table.rowData}
-                  totalRows={this.state.table.totalRows}
-                  handleTableUpdate={query => this.updateTable({ ...this.state.query, order: query.orderBy, page: query.page, direction: query.sortDirection })}
-                  handleEntriesChange={this.handleEntriesChange}
-                  isLoading={this.state.isLoading}
-                  page={this.state.query.page}
-                  handlePageUpdate={this.handlePageUpdate}
-                  entryOptions={this.state.entryOptions}
-                  entries={this.state.query.entries}
-                  tableCustomClass="table-has-dropdown"
-                />
-              </div>
-            </div>
+          <Card.Body className="my-1">
+            <Row className="mb-4">
+              <Col>
+                <Button variant="primary" className="mr-2" onClick={() => this.toggleAddModal()}>
+                  <i className="fas fa-plus fa-fw"></i>
+                  <span className="ml-2">Add New Close Contact</span>
+                </Button>
+              </Col>
+              <Col xl={6} lg={10} md={12}>
+                <InputGroup size="md" className="mt-3 mt-md-0 ">
+                  <InputGroup.Prepend>
+                    <OverlayTrigger overlay={<Tooltip>Search by First Name, Last Name, Phone Number, Email, Assigned User, or Contact Attempts.</Tooltip>}>
+                      <InputGroup.Text className="rounded-0">
+                        <i className="fas fa-search"></i>
+                        <label
+                          htmlFor="close-contact-search-input"
+                          className="ml-2 mb-0"
+                          aria-label="Search Close Contact Table by First Name, Last Name, Phone Number, Email, Assigned User, or Contact Attempts.">
+                          Search
+                        </label>
+                      </InputGroup.Text>
+                    </OverlayTrigger>
+                  </InputGroup.Prepend>
+                  <Form.Control
+                    id="close-contact-search-input"
+                    autoComplete="off"
+                    size="md"
+                    name="search"
+                    onChange={this.handleSearchChange}
+                    aria-label="Search"
+                  />
+                </InputGroup>
+              </Col>
+            </Row>
+            <CustomTable
+              dataType="close-contacts"
+              columnData={this.state.table.colData}
+              rowData={this.state.table.rowData}
+              totalRows={this.state.table.totalRows}
+              handleTableUpdate={query => this.updateTable({ ...this.state.query, order: query.orderBy, page: query.page, direction: query.sortDirection })}
+              handleEntriesChange={this.handleEntriesChange}
+              isLoading={this.state.isLoading}
+              page={this.state.query.page}
+              handlePageUpdate={this.handlePageUpdate}
+              entryOptions={this.state.entryOptions}
+              entries={this.state.query.entries}
+              tableCustomClass="table-has-dropdown"
+            />
           </Card.Body>
         </Card>
         {this.state.showDeleteModal && (


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1439](https://tracker.codev.mitre.org/browse/SARAALERT-1439)

The language that appears in a blank notes field in the Close Contacts modal says "enter additional information about case" if the monitoree is in isolation, and "enter additional information about monitoree's potential exposure" if monitoree is in exposure. Should say "enter additional information about contact"–regardless of the workflow the monitoree is in.

## (Feature) Demo/Screenshots
<img width="713" alt="Screen Shot 2021-08-30 at 12 47 39 PM" src="https://user-images.githubusercontent.com/35042815/131376059-a7620cbc-ea06-465f-8ada-801ad256abf4.png">

Also updated this spacing issue where not all the tables had the same spacing in monitoree details: 
<img width="1743" alt="Screen Shot 2021-08-30 at 12 50 13 PM" src="https://user-images.githubusercontent.com/35042815/131376127-68d8cf92-7727-44f4-86de-6792dc260edf.png">

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@timwongj :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@hackrm :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] **na/** The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] **n/a** If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] **n/a** Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ngfreiter :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
