### PR TITLE
SARAALERT-1596: Disable retry of failed SMS

### DIFF
--- a/app/jobs/consume_assessments_job.rb
+++ b/app/jobs/consume_assessments_job.rb
@@ -100,8 +100,6 @@ class ConsumeAssessmentsJob < ApplicationJob
           queue.commit
           next
         when 'error_sms'
-          # If there was an error sending an SMS, nil out the last_reminder_sent field so the system will try calling again
-          patient.update(last_assessment_reminder_sent: nil)
           History.contact_attempt(patient: patient, comment: "Sara Alert was unable to send an SMS to this monitoree's \
                                                               primary telephone number #{patient.primary_telephone}.")
           unless dependents.blank?

--- a/test/jobs/consume_assessments_job_test.rb
+++ b/test/jobs/consume_assessments_job_test.rb
@@ -29,7 +29,6 @@ class ConsumeAssessmentsJobTest < ActiveJob::TestCase
         @redis_queue.push @assessment_generator.no_answer_assessment(response_status)
         ConsumeAssessmentsJob.perform_now
         @patient.reload
-        assert_nil @patient.last_assessment_reminder_sent unless response_status == 'no_answer_sms'
         assert_equal 'Contact Attempt', @patient.histories.first.history_type
         assert_includes @patient.histories.first.comment, @patient.primary_telephone
       end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1596](https://tracker.codev.mitre.org/browse/SARAALERT-1596)

Disable retry of failed SMS. Most likely, if SMS messages fail, they are not going to succeed when retried an hour later, so this provided marginal benefit, and results in substantial cost when high numbers of messages fail (e.g. in the case of a carrier filtering all our messages).

## Important Changes
`consume_assessments_job.rb`
- Removed the line that results in retries.
