### PR TITLE
SARAALERT-1018: Ability to search for monitorees with an unenrolled close contact in advanced search

### DIFF
--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -511,6 +511,12 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
           # Get patients where jurisdiction is any of the jurisdictions or subjurisdictions of the filter
           patients = patients.where(jurisdiction_id: subjurisdictions)
         end
+      when 'unenrolled-close-contact'
+        patients = if filter[:value]
+                     patients.where_assoc_exists(:close_contacts, enrolled_id: nil)
+                   else
+                     patients.where_assoc_not_exists(:close_contacts, enrolled_id: nil)
+                   end
       end
     end
     patients

--- a/app/javascript/data/advancedFilterOptions.js
+++ b/app/javascript/data/advancedFilterOptions.js
@@ -21,6 +21,14 @@ export const advancedFilterOptions = [
     type: 'boolean',
   },
   {
+    name: 'ineligible-for-recovery-definition',
+    title: 'Ineligible for any recovery definition (Boolean)',
+    description: 'All isolation records ineligible to ever appear on Records Requiring Review line list',
+    type: 'boolean',
+    tooltip:
+      'This filter will return all records in the Isolation workflow that both do not have a Symptom Onset Date and do not have a positive lab result with a Specimen Collection Date',
+  },
+  {
     name: 'monitoring-status',
     title: 'Active Monitoring (Boolean)',
     description: 'Monitorees who are currently under active monitoring',
@@ -76,12 +84,10 @@ export const advancedFilterOptions = [
       'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.',
   },
   {
-    name: 'ineligible-for-recovery-definition',
-    title: 'Ineligible for any recovery definition (Boolean)',
-    description: 'All isolation records ineligible to ever appear on Records Requiring Review line list',
+    name: 'unenrolled-close-contact',
+    title: 'Unenrolled Close Contact (Boolean)',
+    description: 'All records with at least one unenrolled Close Contact',
     type: 'boolean',
-    tooltip:
-      'This filter will return all records in the Isolation workflow that both do not have a Symptom Onset Date and do not have a positive lab result with a Specimen Collection Date',
   },
 
   /* SEARCH FILTER OPTIONS */

--- a/test/helpers/patient_query_helper_test.rb
+++ b/test/helpers/patient_query_helper_test.rb
@@ -106,7 +106,7 @@ class PatientQueryHelperTest < ActionView::TestCase
     filtered_patients_array = [patient_1, patient_2]
     assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
 
-    # Check for monitorees who have NOT blocked the system
+    # Check for monitorees who have no close contacts or only enrolled close contacts
     filters[0][:value] = false
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_3, patient_4]

--- a/test/helpers/patient_query_helper_test.rb
+++ b/test/helpers/patient_query_helper_test.rb
@@ -6,7 +6,7 @@ require 'test_case'
 class PatientQueryHelperTest < ActionView::TestCase
   # --- BOOLEAN ADVANCED FILTER QUERIES --- #
 
-  test 'advanced filter blocked sms properly filters those with blocked numbers' do
+  test 'advanced filter blocked sms' do
     Patient.destroy_all
     user = create(:public_health_enroller_user)
     patient_1 = create(:patient, creator: user, primary_telephone: '1111111111')
@@ -76,6 +76,40 @@ class PatientQueryHelperTest < ActionView::TestCase
     filters[0][:value] = false
     filtered_patients = advanced_filter(patients, filters, tz_offset)
     filtered_patients_array = [patient_1, patient_2, patient_3]
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
+  end
+
+  test 'advanced filter unenrolled close contact' do
+    Patient.destroy_all
+    user = create(:public_health_enroller_user)
+    patient_1 = create(:patient, creator: user)
+    create(:close_contact, patient: patient_1)
+    create(:close_contact, patient: patient_1, enrolled_id: 111)
+    patient_2 = create(:patient, creator: user)
+    create(:close_contact, patient: patient_2)
+    create(:close_contact, patient: patient_2)
+    patient_3 = create(:patient, creator: user)
+    create(:close_contact, patient: patient_3, enrolled_id: 333)
+    create(:close_contact, patient: patient_3, enrolled_id: 334)
+    create(:close_contact, patient: patient_3, enrolled_id: 335)
+    patient_4 = create(:patient, creator: user)
+
+    patients = Patient.all
+
+    filters = [{ filterOption: {}, additionalFilterOption: nil, value: nil }]
+    filters[0][:filterOption]['name'] = 'unenrolled-close-contact'
+    tz_offset = 300
+
+    # Check for monitorees who have at least one unenrolled close contact
+    filters[0][:value] = true
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_1, patient_2]
+    assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
+
+    # Check for monitorees who have NOT blocked the system
+    filters[0][:value] = false
+    filtered_patients = advanced_filter(patients, filters, tz_offset)
+    filtered_patients_array = [patient_3, patient_4]
     assert_equal filtered_patients_array.pluck(:id), filtered_patients.pluck(:id)
   end
 


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1018](https://tracker.codev.mitre.org/browse/SARAALERT-1018)

Create a Boolean advanced filter for Monitorees who have at least one Close Contact that has not been enrolled yet.

## (Feature) Demo/Screenshots
<img width="944" alt="Screen Shot 2021-08-30 at 3 22 54 PM" src="https://user-images.githubusercontent.com/35042815/131393499-6d5dc5da-2572-4a4d-b3f9-f6c147ce43ad.png">

<img width="937" alt="Screen Shot 2021-08-30 at 3 22 59 PM" src="https://user-images.githubusercontent.com/35042815/131393500-929a16b7-ab09-4cc9-86c9-82568010dac8.png">

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`advancedFilterOptions.js`
- Added boolean unenrolled close contact option to advanced filter list

`patient_query_helper.rb`
- Added support for the unenrolled close contact filter.  True returns monitorees with one or more unenrolled close contact, while false returns monitorees with only enrolled close contacts or no close contacts

`patient_query_helper_test.rb`
- Added test for new advanced filter query

## Testing Recommendations
Please list any recommendations regarding what reviewers should test and if there is any specific guidance on how to test certain aspects of the PR. Be sure to mention edge cases that should be tried, particularly in the UI.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@timwongj :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@hackrm :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] **n/a** If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] **n/a** Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
