### PR TITLE
Re-remove special chars from spa, pr-spa, fra locales

### DIFF
--- a/config/locales/fra.yml
+++ b/config/locales/fra.yml
@@ -49,24 +49,24 @@ fra:
           info2: 'Si vous avez des questions, veuillez contacter le professionnel de santé qui vous a recruté(e).'
     twilio:
       shared:
-        experiencing_symptoms_s: 'Cette personne est-elle y en a-t-il qui présentent un des symptômes suivants: %{symptom_names}.'
-        experiencing_symptoms_p: 'Parmi ces personnes y en a-t-il qui présentent un des symptômes suivants: %{symptom_names}.'
+        experiencing_symptoms_s: 'Cette personne est-elle y en a-t-il qui presentent un des symptomes suivants: %{symptom_names}.'
+        experiencing_symptoms_p: 'Parmi ces personnes y en a-t-il qui presentent un des symptomes suivants: %{symptom_names}.'
         max_retries_message: >-
-          Je suis désolé, vous avez atteint le nombre maximum de tentatives de réponse. Si vous rencontrez une urgence médicale, veuillez appeler le 911.
+          Je suis desole, vous avez atteint le nombre maximum de tentatives de reponse. Si vous rencontrez une urgence medicale, veuillez appeler le 911.
       sms:
         prompt:
           intro: >-
-            Bienvenue sur le système d'Alerte Sara, nous vous enverrons vos rapports quotidiens pour %{name} à ce numéro de téléphone. Pour la confidentialité
+            Bienvenue sur le systeme d'Alerte Sara, nous vous enverrons vos rapports quotidiens pour %{name} a ce numero de telephone. Pour la confidentialite
             et plus d'informations, visitez saraalert.org.
-          reminder: 'Ceci est un rappel du système d''Alerte Sara vous rappelant que vous devez répondre à nos messages de rapport quotidien.'
+          reminder: 'Ceci est un rappel du systeme d''Alerte Sara vous rappelant que vous devez repondre a nos messages de rapport quotidien.'
           name: '%{name}'
-          daily: 'Il s''agit d''un rapport d''alerte Sara quotidien destiné aux: %{names}. %{experiencing_symptoms} Veuillez répondre par "Oui" ou par "Non"'
-          try_again: 'Je suis désolé, je n''ai pas compris. Veuillez répondre par "Oui" ou par "Non"'
+          daily: 'Il s''agit d''un rapport d''alerte Sara quotidien destine aux: %{names}. %{experiencing_symptoms} Veuillez repondre par "Oui" ou par "Non"'
+          try_again: 'Je suis desole, je n''ai pas compris. Veuillez repondre par "Oui" ou par "Non"'
           thanks: 'Merci d''avoir rempli votre rapport quotidien!'
         weblink:
           intro: 'Veuillez remplir le rapport quotidien de Sara Alert pour %{initials_age}: %{url}'
         closed:
-          thank_you: 'La période de surveillance de Sara Alert pour %{initials_age} a été terminée le %{completed_date} ! Merci de votre participation'
+          thank_you: 'La periode de surveillance de Sara Alert pour %{initials_age} a ete terminee le %{completed_date} ! Merci de votre participation'
       voice:
         intro: 'Bonjour, voici Sara, l''assistante de santé publique automatisée qui demande votre rapport quotidien.'
         initials_age: '%{initials}, âge %{age}'
@@ -81,47 +81,47 @@ fra:
       cough:
         name: 'Toux'
       diarrhea:
-        name: 'Diarrhée'
+        name: 'Diarrhee'
       difficulty-breathing:
-        name: 'Difficultés respiratoires'
+        name: 'Difficultes respiratoires'
       fatigue:
         name: 'Fatigue'
       fever:
-        name: 'Fièvre'
-        notes: 'Sensation de fébrilité ou température mesurée supérieure ou égale à 38 °C (100,4 °F)'
+        name: 'Fievre'
+        notes: 'Sensation de febrilite ou temperature mesuree superieure ou egale a 38 °C (100,4 °F)'
       headache:
-        name: 'Maux de tête'
+        name: 'Maux de tete'
       muscle-pain:
         name: 'Douleurs musculaires'
       nausea-or-vomiting:
-        name: 'Nausées ou vomissements'
+        name: 'Nausees ou vomissements'
       new-loss-of-smell:
         name: 'Nouvelle perte de l''odorat'
       new-loss-of-taste:
-        name: 'Nouvelle perte de goût'
+        name: 'Nouvelle perte de gout'
       pulse-ox:
-        name: 'd''oxymétrie de pouls'
-        notes: 'Saisissez votre mesure d''oxymétrie de pouls la plus faible au cours des dernières 24 heures'
+        name: 'd''oxymetrie de pouls'
+        notes: 'Saisissez votre mesure d''oxymetrie de pouls la plus faible au cours des dernieres 24 heures'
       repeated-shaking-with-chills:
-        name: 'Tremblements répétés accompagnés de frissons'
+        name: 'Tremblements repetes accompagnes de frissons'
       shortness-of-breath:
         name: 'Essoufflement'
       sore-throat:
         name: 'Maux de gorge'
       temperature:
-        name: 'Température'
-        notes: 'Veuillez entrer votre température actuelle en degrés Fahrenheit'
+        name: 'Temperature'
+        notes: 'Veuillez entrer votre temperature actuelle en degres Fahrenheit'
       used-a-fever-reducer:
-        name: 'Utilisation d''un agent pour diminuer la fièvre'
-        notes: 'Avez-vous utilisé un médicament pour diminuer la fièvre au cours des dernières 24 heures?'
+        name: 'Utilisation d''un agent pour diminuer la fievre'
+        notes: 'Avez-vous utilise un medicament pour diminuer la fievre au cours des dernieres 24 heures?'
       other:
         name: 'Other'
-        notes: 'J''aimerais que quelqu''un m''appelle pour faire le suivi d''autres symptômes ou d''autre chose'
-      no-symptoms: 'Aucun symptôme'
+        notes: 'J''aimerais que quelqu''un m''appelle pour faire le suivi d''autres symptomes ou d''autre chose'
+      no-symptoms: 'Aucun symptome'
     threshold-op:
       less-than: 'moins que'
       less-than-or-equal: 'inferieur ou egal a'
       greater-than: 'plus grand que'
-      greater-than-or-equal: 'Plus grand ou égal à'
-      equal: 'égal à'
-      not-equal: 'pas égal à'
+      greater-than-or-equal: 'Plus grand ou egal a'
+      equal: 'egal a'
+      not-equal: 'pas egal a'

--- a/config/locales/spa-pr.yml
+++ b/config/locales/spa-pr.yml
@@ -48,23 +48,23 @@ spa-pr:
           info2: 'Si tiene alguna pregunta, por favor pónganse en contacto con el proveedor de atención médica que le ayudó a inscribirse.'
     twilio:
       shared:
-        experiencing_symptoms_s: '¿Está usted sintiendo uno o más de los siguientes síntomas hoy?: %{symptom_names}.'
-        experiencing_symptoms_p: '¿Esta alguna de estas personas sintiendo uno o más de los siguientes síntomas hoy?: %{symptom_names}.'
-        max_retries_message: 'Lo siento, ha alcanzado el número máximo de intentos de respuesta. Si tiene una emergencia médica, llame al 911.'
+        experiencing_symptoms_s: '¿Esta usted sintiendo uno o mas de los siguientes sintomas hoy?: %{symptom_names}.'
+        experiencing_symptoms_p: '¿Esta alguna de estas personas sintiendo uno o mas de los siguientes sintomas hoy?: %{symptom_names}.'
+        max_retries_message: 'Lo siento, ha alcanzado el numero maximo de intentos de respuesta. Si tiene una emergencia medica, llame al 911.'
       sms:
         prompt:
           intro: >-
-            Bienvenido al sistema Sara Alert, le enviaremos sus reportes diarios para %{name} a este número de teléfono. Para privacidad y más información,
+            Bienvenido al sistema Sara Alert, le enviaremos sus reportes diarios para %{name} a este numero de telefono. Para privacidad y mas informacion,
             visite saraalert.org.
-          reminder: 'Este es el sistema Sara Alert recordándole que por favor responda a nuestros mensajes de reporte diario.'
+          reminder: 'Este es el sistema Sara Alert recordandole que por favor responda a nuestros mensajes de reporte diario.'
           name: '%{name}'
-          daily: 'Este es el informe diario de Sara Alert para: %{names}. %{experiencing_symptoms} Responda con "Sí" o "No"'
-          try_again: 'Lo siento, no entendí. Responda con "Sí" o "No"'
+          daily: 'Este es el informe diario de Sara Alert para: %{names}. %{experiencing_symptoms} Responda con "Si" o "No"'
+          try_again: 'Lo siento, no entendi. Responda con "Si" o "No"'
           thanks: '¡Gracias por completar su informe diario!'
         weblink:
           intro: 'Complete el Informe diario de Sara Alert para %{initials_age}: %{url}'
         closed:
-          thank_you: 'La supervisión de Sara Alert para %{initials_age} se completó el %{completed_date}. Gracias por su participación'
+          thank_you: 'La supervision de Sara Alert para %{initials_age} se completo el %{completed_date}. Gracias por su participacion'
     voice:
       intro: 'Hola, soy Sara, la asistente de salud pública automatizada que solicita su informe diario.'
       initials_age: '%{initials}, años %{age}'
@@ -73,9 +73,9 @@ spa-pr:
       thanks: '¡Gracias por completar su informe diario! Adiós.'
     symptoms:
       chills:
-        name: 'Escalofrío'
+        name: 'Escalofrio'
       congestion-or-runny-nose:
-        name: 'Congestión nasal o un exceso de moco en la nariz'
+        name: 'Congestion nasal o un exceso de moco en la nariz'
       cough:
         name: 'Tos'
       diarrhea:
@@ -92,16 +92,16 @@ spa-pr:
       muscle-pain:
         name: 'Dolor muscular'
       nausea-or-vomiting:
-        name: 'Náuseas o vómitos'
+        name: 'Nauseas o vomitos'
       new-loss-of-smell:
-        name: 'Pérdida reciente el olfato'
+        name: 'Perdida reciente el olfato'
       new-loss-of-taste:
-        name: 'Pérdida reciente del gusto'
+        name: 'Perdida reciente del gusto'
       pulse-ox:
-        name: 'oxímetro de pulso'
-        notes: 'Ingrese la lectura más baja del oxímetro de pulso en las últimas 24 horas'
+        name: 'oximetro de pulso'
+        notes: 'Ingrese la lectura mas baja del oximetro de pulso en las ultimas 24 horas'
       repeated-shaking-with-chills:
-        name: 'Tiembla repetidamente y tiene escalofríos'
+        name: 'Tiembla repetidamente y tiene escalofrios'
       shortness-of-breath:
         name: 'Falta de aire'
       sore-throat:
@@ -110,12 +110,12 @@ spa-pr:
         name: 'Temperatura'
         notes: 'Por favor ingrese su temperatura actual en grados Fahrenheit'
       used-a-fever-reducer:
-        name: 'Tomó medicina para reducir la fiebre'
-        notes: 'En las últimas 24 horas, ¿ha tomado algún medicamento para reducir la fiebre?'
+        name: 'Tomo medicina para reducir la fiebre'
+        notes: 'En las ultimas 24 horas, ¿ha tomado algun medicamento para reducir la fiebre?'
       other:
         name: 'Otro'
-        notes: 'Me gustaría que alguien me llamara para hacer un seguimiento de otros síntomas o necesidades adicionales'
-      no-symptoms: 'No tengo ningún síntoma.'
+        notes: 'Me gustaria que alguien me llamara para hacer un seguimiento de otros sintomas o necesidades adicionales'
+      no-symptoms: 'No tengo ningun sintoma.'
     threshold-op:
       less-than: 'Menos que'
       less-than-or-equal: 'Menor o igual a'

--- a/config/locales/spa.yml
+++ b/config/locales/spa.yml
@@ -47,23 +47,23 @@ spa:
           info2: 'Si tiene alguna pregunta, por favor pónganse en contacto con el proveedor de atención médica que le ayudó a inscribirse.'
     twilio:
       shared:
-        experiencing_symptoms_s: '¿Está usted sintiendo uno o mas de los siguientes síntomas hoy?: %{symptom_names}.'
-        experiencing_symptoms_p: '¿Esta alguna de estas personas sintiendo uno o mas de los siguientes síntomas hoy?: %{symptom_names}.'
-        max_retries_message: 'Lo siento, ha alcanzado el número máximo de intentos de respuesta. Si tiene una emergencia médica, llame al 911.'
+        experiencing_symptoms_s: '¿Esta usted sintiendo uno o mas de los siguientes sintomas hoy?: %{symptom_names}.'
+        experiencing_symptoms_p: '¿Esta alguna de estas personas sintiendo uno o mas de los siguientes sintomas hoy?: %{symptom_names}.'
+        max_retries_message: 'Lo siento, ha alcanzado el numero maximo de intentos de respuesta. Si tiene una emergencia medica, llame al 911.'
       sms:
         prompt:
           intro: >-
-            Bienvenido al sistema Sara Alert, le enviaremos sus reportes diarios para %{name} a este número de teléfono. Para privacidad y más información,
+            Bienvenido al sistema Sara Alert, le enviaremos sus reportes diarios para %{name} a este numero de telefono. Para privacidad y mas informacion,
             visite saraalert.org.
-          reminder: 'Este es el sistema Sara Alert recordándole que por favor responda a nuestros mensajes de reporte diario.'
+          reminder: 'Este es el sistema Sara Alert recordandole que por favor responda a nuestros mensajes de reporte diario.'
           name: '%{name}'
-          daily: 'Este es el informe diario de Sara Alert para: %{names}. %{experiencing_symptoms} Responda con "Sí" o "No"'
-          try_again: 'Lo siento, no entendí. Responda con "Sí" o "No"'
+          daily: 'Este es el informe diario de Sara Alert para: %{names}. %{experiencing_symptoms} Responda con "Si" o "No"'
+          try_again: 'Lo siento, no entendi. Responda con "Si" o "No"'
           thanks: '¡Gracias por completar su informe diario!'
         weblink:
           intro: 'Complete el Informe diario de Sara Alert para %{initials_age}: %{url}'
         closed:
-          thank_you: 'La supervisión de Sara Alert para %{initials_age} se completó el %{completed_date}. Gracias por su participación'
+          thank_you: 'La supervision de Sara Alert para %{initials_age} se completo el %{completed_date}. Gracias por su participacion'
       voice:
         intro: 'Hola, soy Sara, la asistente de salud pública automatizada que solicita su informe diario.'
         initials_age: '%{initials}, años %{age}'
@@ -72,9 +72,9 @@ spa:
         thanks: '¡Gracias por completar su informe diario! Adiós.'
     symptoms:
       chills:
-        name: 'Escalofrío'
+        name: 'Escalofrio'
       congestion-or-runny-nose:
-        name: 'Congestión nasal o un exceso de moco en la nariz'
+        name: 'Congestion nasal o un exceso de moco en la nariz'
       cough:
         name: 'Tos'
       diarrhea:
@@ -91,16 +91,16 @@ spa:
       muscle-pain:
         name: 'Dolor muscular'
       nausea-or-vomiting:
-        name: 'Náuseas o vómitos'
+        name: 'Nauseas o vomitos'
       new-loss-of-smell:
-        name: 'Pérdida reciente el olfato'
+        name: 'Perdida reciente el olfato'
       new-loss-of-taste:
-        name: 'Pérdida reciente del gusto'
+        name: 'Perdida reciente del gusto'
       pulse-ox:
         name: 'oximetro de pulso'
-        notes: 'Ingrese la lectura más baja del oximetro de pulso en las últimas 24 horas'
+        notes: 'Ingrese la lectura mas baja del oximetro de pulso en las ultimas 24 horas'
       repeated-shaking-with-chills:
-        name: 'Tiembla repetidamente y tiene escalofríos'
+        name: 'Tiembla repetidamente y tiene escalofrios'
       shortness-of-breath:
         name: 'Falta de aire'
       sore-throat:
@@ -109,12 +109,12 @@ spa:
         name: 'Temperatura'
         notes: 'Por favor ingrese su temperatura actual en grados Fahrenheit'
       used-a-fever-reducer:
-        name: 'Tomó medicina para reducir la fiebre'
-        notes: 'En las últimas 24 horas, ¿ha tomado algún medicamento para reducir la fiebre?'
+        name: 'Tomo medicina para reducir la fiebre'
+        notes: 'En las ultimas 24 horas, ¿ha tomado algun medicamento para reducir la fiebre?'
       other:
         name: 'Otro'
-        notes: 'Me gustaría que alguien me llamara para hacer un seguimiento de otros síntomas o necesidades adicionales'
-      no-symptoms: 'No tengo ningún síntoma.'
+        notes: 'Me gustaria que alguien me llamara para hacer un seguimiento de otros sintomas o necesidades adicionales'
+      no-symptoms: 'No tengo ningun sintoma.'
     threshold-op:
       less-than: 'Menos que'
       less-than-or-equal: 'Menor o igual a'


### PR DESCRIPTION
# Description
Remove special characters from Spanish, Puerto Rican Spanish, and French locales.

They were previously removed here: https://github.com/SaraAlert/SaraAlert/pull/1042
And mistakenly reintroduced here: https://github.com/SaraAlert/SaraAlert/pull/1041

It's crucial that we remove them in order to get a more efficient encoding for SMS messaging.

I am aware that some of the affected parts of the locale file are shared by voice and web mediums. It's not ideal, but that is how it must be for now. Note that the initial removal of the characters was deployed in 1.35.2 and has been live in prod for a couple weeks now without issue.