### PR TITLE
SARAALERT-1480: Resolve ActiveJob::DeserializationError Download not found error

### DIFF
--- a/app/controllers/active_storage/blobs/proxy_controller.rb
+++ b/app/controllers/active_storage/blobs/proxy_controller.rb
@@ -45,7 +45,7 @@ class ActiveStorage::Blobs::ProxyController < ActiveStorage::BaseController
   end
 
   def queue_destroy_download(download)
-    DestroyDownloadsJob.set(wait_until: ADMIN_OPTIONS['download_destroy_wait_time'].to_i.minute.from_now).perform_later(download)
+    DestroyDownloadsJob.set(wait_until: ADMIN_OPTIONS['download_destroy_wait_time'].to_i.minute.from_now).perform_later(download.id)
     download.update(marked_for_deletion: true)
   end
 end

--- a/app/jobs/destroy_downloads_job.rb
+++ b/app/jobs/destroy_downloads_job.rb
@@ -4,7 +4,7 @@
 class DestroyDownloadsJob < ApplicationJob
   queue_as :exports
 
-  def perform(download)
-    download.destroy
+  def perform(download_id)
+    Download.find(download_id).destroy if Download.exists?(download_id)
   end
 end

--- a/test/jobs/destroy_downloads_job_test.rb
+++ b/test/jobs/destroy_downloads_job_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'test_case'
+
+class DestroyDownloadsJobTest < ActiveSupport::TestCase
+  test 'download exists' do
+    assert(DestroyDownloadsJob.perform_now(create(:download).id))
+  end
+
+  # When performing another export of the same type, all existing downloads of that type
+  # will be deleted before the job runs. It should not raise in this case.
+  test 'download does not exist' do
+    assert_nothing_raised do
+      DestroyDownloadsJob.perform_now(0)
+    end
+  end
+end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1480](https://tracker.codev.mitre.org/browse/SARAALERT-1480)

This error appears when the Export Retry time is set lower than the Download Destroy Wait time. This configuration allows a User to perform another export before the DownloadsDestroyJob is run, causing the DeserializationError. When the User performs another export, the previous exports of the same type are destroyed. This causes the DeserializationError at most 45 minutes later.

As before, even if the Download is not found for a different reason, it will be destroyed by the PurgeJob and not lingering in object storage.

## (Bugfix) How to Replicate
1. Set the admin setting for exports lower than the download destroy wait time
2. Perform an export and download the results 
3. Perform another export of the same type once the export timer has passed
4. Wait for the destroy downloads job to be performed (this should error)

## (Bugfix) Solution
* Convert the Worker's perform call to use the Download ID instead of object so that exists can be called before destroy.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`proxy_controller.rb`
- Pass ID instead of Model 

`destroy_downloads_job.rb`
- Check if Download exists before continuing

## Testing Recommendations
Please list any recommendations regarding what reviewers should test and if there is any specific guidance on how to test certain aspects of the PR. Be sure to mention edge cases that should be tried, particularly in the UI.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@timwongj  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ngfreiter  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
