### PR TITLE
BUGFIX: Monitoring Actions Aria-Labels Fix

### DIFF
--- a/app/javascript/components/patient/monitoring_actions/AssignedUser.js
+++ b/app/javascript/components/patient/monitoring_actions/AssignedUser.js
@@ -151,6 +151,7 @@ class AssignedUser extends React.Component {
             <Form.Control
               as="input"
               id="assigned_user"
+              aria-label="Assigned User Select"
               list="assigned_users"
               autoComplete="off"
               className="form-control-lg"

--- a/app/javascript/components/patient/monitoring_actions/ExposureRiskAssessment.js
+++ b/app/javascript/components/patient/monitoring_actions/ExposureRiskAssessment.js
@@ -142,6 +142,7 @@ class ExposureRiskAssessment extends React.Component {
             as="select"
             className="form-control-lg"
             id="exposure_risk_assessment"
+            aria-label="Exposure Risk Assessment Select"
             onChange={this.handleExposureRiskAssessmentChange}
             value={this.state.exposure_risk_assessment}>
             <option></option>

--- a/app/javascript/components/patient/monitoring_actions/Jurisdiction.js
+++ b/app/javascript/components/patient/monitoring_actions/Jurisdiction.js
@@ -170,6 +170,7 @@ class Jurisdiction extends React.Component {
             <Form.Control
               as="input"
               id="jurisdiction_id"
+              aria-label="Assigned Jurisdiction Select"
               list="jurisdiction_paths"
               autoComplete="off"
               className="form-control-lg"

--- a/app/javascript/components/patient/monitoring_actions/MonitoringPlan.js
+++ b/app/javascript/components/patient/monitoring_actions/MonitoringPlan.js
@@ -139,6 +139,7 @@ class MonitoringPlan extends React.Component {
             as="select"
             className="form-control-lg"
             id="monitoring_plan"
+            aria-label="Monitoring Plan Select"
             onChange={this.handleMonitoringPlanChange}
             value={this.state.monitoring_plan}>
             <option></option>

--- a/app/javascript/components/patient/monitoring_actions/MonitoringStatus.js
+++ b/app/javascript/components/patient/monitoring_actions/MonitoringStatus.js
@@ -228,6 +228,7 @@ class MonitoringStatus extends React.Component {
             as="select"
             className="form-control-lg"
             id="monitoring_status"
+            aria-label="Monitoring Status Select"
             onChange={this.handleMonitoringStatusChange}
             value={this.state.monitoring_status}>
             <option>Actively Monitoring</option>

--- a/app/javascript/components/patient/monitoring_actions/PublicHealthAction.js
+++ b/app/javascript/components/patient/monitoring_actions/PublicHealthAction.js
@@ -168,6 +168,7 @@ class PublicHealthAction extends React.Component {
             as="select"
             className="form-control-lg"
             id="public_health_action"
+            aria-label="Latest Public Health Action Select"
             onChange={this.handlePublicHealthActionChange}
             value={this.state.public_health_action}>
             <option>None</option>


### PR DESCRIPTION
# Description
This PR comes after user feedback saying that the Dropdowns within the Monitoring Actions section of the Patient Detail Page are very "noisy" when using a screen reader. Currently, a screen reader will read the label and the tooltip associated with it for each dropdown.

This PR overrides the `aria-label` for each dropdown in the Monitoring Actions area so that the tooltip is not also read by the screen-readers.

## (Bugfix) How to Replicate
> Open up VoiceOver and attempt to change the dropdown of the Monitoring Actions.
> Notice that screen reader reads a LOT of information for each change.

## (Bugfix) Solution
> Try the same behavior on this branch and notice that it only reads the header.

## Important Changes

`app/javascript/components/patient/monitoring_actions/AssignedUser.js`
`app/javascript/components/patient/monitoring_actions/ExposureRiskAssessment.js`
`app/javascript/components/patient/monitoring_actions/Jurisdiction.js`
`app/javascript/components/patient/monitoring_actions/MonitoringPlan.js`
`app/javascript/components/patient/monitoring_actions/MonitoringStatus.js`
`app/javascript/components/patient/monitoring_actions/PublicHealthAction.js`
- Updated the Aria-Labels for the dropdowns

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@sgober  
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
