### PR TITLE
SARAALERT-1601: Apply Contact Attempt to Household Bug

### DIFF
--- a/app/controllers/contact_attempts_controller.rb
+++ b/app/controllers/contact_attempts_controller.rb
@@ -30,7 +30,7 @@ class ContactAttemptsController < ApplicationController
 
       comment = "#{successful ? 'Successful' : 'Unsuccessful'} contact attempt"
       comment += " logged on a household member’s record (Sara Alert ID: #{patient_id}) and also applied to this monitoree" unless member.id == patient_id
-      comment += "."
+      comment += '.'
       comment += " Note: #{note}" unless note.blank?
 
       History.create!(patient_id: member.id,

--- a/app/controllers/contact_attempts_controller.rb
+++ b/app/controllers/contact_attempts_controller.rb
@@ -30,7 +30,8 @@ class ContactAttemptsController < ApplicationController
 
       comment = "#{successful ? 'Successful' : 'Unsuccessful'} contact attempt"
       comment += " logged on a household member’s record (Sara Alert ID: #{patient_id}) and also applied to this monitoree" unless member.id == patient_id
-      comment += ". Note: #{note}"
+      comment += "."
+      comment += " Note: #{note}" unless note.blank?
 
       History.create!(patient_id: member.id,
                       created_by: current_user.email,

--- a/app/javascript/components/patient/assessment/actions/ContactAttempt.js
+++ b/app/javascript/components/patient/assessment/actions/ContactAttempt.js
@@ -14,7 +14,6 @@ class ContactAttempt extends React.Component {
       note: '',
       attempt: 'Successful',
       loading: false,
-      noMembersSelected: false,
       apply_to_household: false,
       apply_to_household_ids: [],
     };
@@ -26,7 +25,6 @@ class ContactAttempt extends React.Component {
       showContactAttemptModal: !current,
       apply_to_household: false,
       apply_to_household_ids: [],
-      noMembersSelected: false,
     });
   };
 
@@ -35,13 +33,11 @@ class ContactAttempt extends React.Component {
   };
 
   handleApplyHouseholdChange = apply_to_household => {
-    const noMembersSelected = apply_to_household && this.state.apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household, noMembersSelected });
+    this.setState({ apply_to_household, apply_to_household_ids: [] });
   };
 
   handleApplyHouseholdIdsChange = apply_to_household_ids => {
-    const noMembersSelected = this.state.apply_to_household && apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household_ids, noMembersSelected });
+    this.setState({ apply_to_household_ids });
   };
 
   submit = () => {
@@ -98,7 +94,10 @@ class ContactAttempt extends React.Component {
           <Button variant="secondary btn-square" onClick={toggle}>
             Cancel
           </Button>
-          <Button variant="primary btn-square" onClick={submit} disabled={this.state.loading || this.state.noMembersSelected}>
+          <Button
+            variant="primary btn-square"
+            onClick={submit}
+            disabled={this.state.loading || (this.state.apply_to_household && this.state.apply_to_household_ids.length === 0)}>
             {this.state.loading && (
               <React.Fragment>
                 <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
@@ -107,7 +106,7 @@ class ContactAttempt extends React.Component {
             <span data-for="contact-attempt-submit" data-tip="">
               Submit
             </span>
-            {this.state.noMembersSelected && (
+            {this.state.apply_to_household && this.state.apply_to_household_ids.length === 0 && (
               <ReactTooltip id="contact-attempt-submit" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
                 <div>Please select at least one household member or change your selection to apply to this monitoree only</div>
               </ReactTooltip>

--- a/app/javascript/components/patient/assessment/actions/LastDateExposure.js
+++ b/app/javascript/components/patient/assessment/actions/LastDateExposure.js
@@ -18,7 +18,6 @@ class LastDateExposure extends React.Component {
       last_date_of_exposure: this.props.patient.last_date_of_exposure,
       continuous_exposure: !!this.props.patient.continuous_exposure,
       loading: false,
-      noMembersSelected: false,
       apply_to_household: false,
       apply_to_household_ids: [],
       showLastDateOfExposureModal: false,
@@ -26,6 +25,47 @@ class LastDateExposure extends React.Component {
     };
     this.origState = Object.assign({}, this.state);
   }
+
+  openContinuousExposureModal = () => {
+    this.setState({
+      showContinuousExposureModal: true,
+      last_date_of_exposure: null,
+      continuous_exposure: !this.props.patient.continuous_exposure,
+      apply_to_household: false,
+      apply_to_household_ids: [],
+    });
+  };
+
+  openLastDateOfExposureModal = date => {
+    if (date !== this.props.patient.last_date_of_exposure) {
+      this.setState({
+        showLastDateOfExposureModal: true,
+        last_date_of_exposure: date,
+        continuous_exposure: date === null,
+        apply_to_household: false,
+        apply_to_household_ids: [],
+      });
+    }
+  };
+
+  handleApplyHouseholdChange = apply_to_household => {
+    this.setState({ apply_to_household, apply_to_household_ids: [] });
+  };
+
+  handleApplyHouseholdIdsChange = apply_to_household_ids => {
+    this.setState({ apply_to_household_ids });
+  };
+
+  closeModal = () => {
+    this.setState({
+      last_date_of_exposure: this.props.patient.last_date_of_exposure,
+      continuous_exposure: !!this.props.patient.continuous_exposure,
+      showLastDateOfExposureModal: false,
+      showContinuousExposureModal: false,
+      apply_to_household: false,
+      apply_to_household_ids: [],
+    });
+  };
 
   submit = () => {
     let diffState = Object.keys(this.state).filter(k => _.get(this.state, k) !== _.get(this.origState, k));
@@ -46,52 +86,6 @@ class LastDateExposure extends React.Component {
         .catch(err => {
           reportError(err?.response?.data?.error ? err.response.data.error : err, false);
         });
-    });
-  };
-
-  handleApplyHouseholdChange = apply_to_household => {
-    const noMembersSelected = apply_to_household && this.state.apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household, noMembersSelected });
-  };
-
-  handleApplyHouseholdIdsChange = apply_to_household_ids => {
-    const noMembersSelected = this.state.apply_to_household && apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household_ids, noMembersSelected });
-  };
-
-  openContinuousExposureModal = () => {
-    this.setState({
-      showContinuousExposureModal: true,
-      last_date_of_exposure: null,
-      continuous_exposure: !this.props.patient.continuous_exposure,
-      apply_to_household: false,
-      apply_to_household_ids: [],
-      noMembersSelected: false,
-    });
-  };
-
-  openLastDateOfExposureModal = date => {
-    if (date !== this.props.patient.last_date_of_exposure) {
-      this.setState({
-        showLastDateOfExposureModal: true,
-        last_date_of_exposure: date,
-        continuous_exposure: date === null,
-        apply_to_household: false,
-        apply_to_household_ids: [],
-        noMembersSelected: false,
-      });
-    }
-  };
-
-  closeModal = () => {
-    this.setState({
-      last_date_of_exposure: this.props.patient.last_date_of_exposure,
-      continuous_exposure: !!this.props.patient.continuous_exposure,
-      showLastDateOfExposureModal: false,
-      showContinuousExposureModal: false,
-      apply_to_household: false,
-      apply_to_household_ids: [],
-      noMembersSelected: false,
     });
   };
 
@@ -135,7 +129,11 @@ class LastDateExposure extends React.Component {
           <Button
             variant="primary btn-square"
             onClick={submit}
-            disabled={this.state.loading || this.state.noMembersSelected || (!this.state.last_date_of_exposure && !this.state.continuous_exposure)}>
+            disabled={
+              this.state.loading ||
+              (this.state.apply_to_household && this.state.apply_to_household_ids.length === 0) ||
+              (!this.state.last_date_of_exposure && !this.state.continuous_exposure)
+            }>
             {this.state.loading && (
               <React.Fragment>
                 <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
@@ -144,7 +142,7 @@ class LastDateExposure extends React.Component {
             <span data-for="lde-submit" data-tip="">
               Submit
             </span>
-            {this.state.noMembersSelected && (
+            {this.state.apply_to_household && this.state.apply_to_household_ids.length === 0 && (
               <ReactTooltip id="lde-submit" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
                 <div>Please select at least one household member or change your selection to apply to this monitoree only</div>
               </ReactTooltip>

--- a/app/javascript/components/patient/follow_up_flag/FollowUpFlag.js
+++ b/app/javascript/components/patient/follow_up_flag/FollowUpFlag.js
@@ -15,7 +15,6 @@ class FollowUpFlag extends React.Component {
     this.state = {
       apply_to_household: false,
       apply_to_household_ids: [],
-      noMembersSelected: false,
       bulk_action_apply_to_household: false,
       cancelToken: axios.CancelToken.source(),
       clear_flag_disabled: true,
@@ -72,13 +71,11 @@ class FollowUpFlag extends React.Component {
   };
 
   handleApplyHouseholdChange = apply_to_household => {
-    const noMembersSelected = apply_to_household && this.state.apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household, noMembersSelected });
+    this.setState({ apply_to_household, apply_to_household_ids: [] });
   };
 
   handleApplyHouseholdIdsChange = apply_to_household_ids => {
-    const noMembersSelected = this.state.apply_to_household && apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household_ids, noMembersSelected });
+    this.setState({ apply_to_household_ids });
   };
 
   /**
@@ -242,7 +239,11 @@ class FollowUpFlag extends React.Component {
             id="follow_up_flag_submit_button"
             variant="primary btn-square"
             onClick={this.submit}
-            disabled={(!this.state.clear_flag && this.state.follow_up_reason === '') || this.state.loading || this.state.noMembersSelected}>
+            disabled={
+              (!this.state.clear_flag && this.state.follow_up_reason === '') ||
+              this.state.loading ||
+              (this.state.apply_to_household && this.state.apply_to_household_ids.length === 0)
+            }>
             {this.state.loading && (
               <React.Fragment>
                 <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
@@ -253,16 +254,18 @@ class FollowUpFlag extends React.Component {
               {!this.props.bulkAction && this.state.initial_follow_up_reason !== '' && !this.state.clear_flag && 'Update'}
               {!this.props.bulkAction && this.state.clear_flag && 'Clear'}
             </span>
-            {this.state.noMembersSelected && (
+            {this.state.apply_to_household && this.state.apply_to_household_ids.length === 0 && (
               <ReactTooltip id="follow-up-submit" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
                 <div>Please select at least one household member or change your selection to apply to this monitoree only</div>
               </ReactTooltip>
             )}
-            {!this.state.noMembersSelected && !this.state.clear_flag && this.state.follow_up_reason === '' && (
-              <ReactTooltip id="follow-up-submit" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
-                <div>Please select a reason for follow-up</div>
-              </ReactTooltip>
-            )}
+            {!(this.state.apply_to_household && this.state.apply_to_household_ids.length === 0) &&
+              !this.state.clear_flag &&
+              this.state.follow_up_reason === '' && (
+                <ReactTooltip id="follow-up-submit" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
+                  <div>Please select a reason for follow-up</div>
+                </ReactTooltip>
+              )}
           </Button>
         </Modal.Footer>
       </React.Fragment>

--- a/app/javascript/components/patient/household/HouseholdMemberTable.js
+++ b/app/javascript/components/patient/household/HouseholdMemberTable.js
@@ -313,7 +313,6 @@ HouseholdMemberTable.propTypes = {
   current_user: PropTypes.object,
   jurisdiction_paths: PropTypes.object,
   isSelectable: PropTypes.bool,
-  handleApplyHouseholdChange: PropTypes.func,
   handleApplyHouseholdIdsChange: PropTypes.func,
   workflow: PropTypes.string,
 };

--- a/app/javascript/components/patient/household/actions/ApplyToHousehold.js
+++ b/app/javascript/components/patient/household/actions/ApplyToHousehold.js
@@ -50,7 +50,6 @@ class ApplyToHousehold extends React.Component {
             current_user={this.props.current_user}
             jurisdiction_paths={this.props.jurisdiction_paths}
             isSelectable={true}
-            handleApplyHouseholdChange={this.props.handleApplyHouseholdChange}
             handleApplyHouseholdIdsChange={this.props.handleApplyHouseholdIdsChange}
             workflow={this.props.workflow}
           />

--- a/app/javascript/components/patient/monitoring_actions/AssignedUser.js
+++ b/app/javascript/components/patient/monitoring_actions/AssignedUser.js
@@ -20,7 +20,6 @@ class AssignedUser extends React.Component {
       apply_to_household_ids: [],
       reasoning: '',
       loading: false,
-      noMembersSelected: false,
     };
     this.origState = Object.assign({}, this.state);
   }
@@ -40,13 +39,11 @@ class AssignedUser extends React.Component {
   };
 
   handleApplyHouseholdChange = apply_to_household => {
-    const noMembersSelected = apply_to_household && this.state.apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household, noMembersSelected });
+    this.setState({ apply_to_household, apply_to_household_ids: [] });
   };
 
   handleApplyHouseholdIdsChange = apply_to_household_ids => {
-    const noMembersSelected = this.state.apply_to_household && apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household_ids, noMembersSelected });
+    this.setState({ apply_to_household_ids });
   };
 
   // if user hits the Enter key after changing the Assigned User value, shows the modal (in leu of clicking the button)
@@ -65,7 +62,6 @@ class AssignedUser extends React.Component {
       apply_to_household: false,
       apply_to_household_ids: [],
       reasoning: '',
-      noMembersSelected: false,
     });
   };
 
@@ -119,7 +115,10 @@ class AssignedUser extends React.Component {
           <Button variant="secondary btn-square" onClick={toggle}>
             Cancel
           </Button>
-          <Button variant="primary btn-square" onClick={submit} disabled={this.state.loading || this.state.noMembersSelected}>
+          <Button
+            variant="primary btn-square"
+            onClick={submit}
+            disabled={this.state.loading || (this.state.apply_to_household && this.state.apply_to_household_ids.length === 0)}>
             {this.state.loading && (
               <React.Fragment>
                 <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
@@ -128,7 +127,7 @@ class AssignedUser extends React.Component {
             <span data-for="assigned-user-submit" data-tip="">
               Submit
             </span>
-            {this.state.noMembersSelected && (
+            {this.state.apply_to_household && this.state.apply_to_household_ids.length === 0 && (
               <ReactTooltip id="assigned-user-submit" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
                 <div>Please select at least one household member or change your selection to apply to this monitoree only</div>
               </ReactTooltip>

--- a/app/javascript/components/patient/monitoring_actions/CaseStatus.js
+++ b/app/javascript/components/patient/monitoring_actions/CaseStatus.js
@@ -29,7 +29,6 @@ class CaseStatus extends React.Component {
       reasoning: '',
       loading: false,
       disabled: false,
-      noMembersSelected: false,
     };
     this.origState = Object.assign({}, this.state);
   }
@@ -133,13 +132,11 @@ class CaseStatus extends React.Component {
   };
 
   handleApplyHouseholdChange = apply_to_household => {
-    const noMembersSelected = apply_to_household && this.state.apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household, noMembersSelected });
+    this.setState({ apply_to_household, apply_to_household_ids: [] });
   };
 
   handleApplyHouseholdIdsChange = apply_to_household_ids => {
-    const noMembersSelected = this.state.apply_to_household && apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household_ids, noMembersSelected });
+    this.setState({ apply_to_household_ids });
   };
 
   toggleCaseStatusModal = () => {
@@ -254,7 +251,10 @@ class CaseStatus extends React.Component {
           <Button variant="secondary btn-square" onClick={toggle}>
             Cancel
           </Button>
-          <Button variant="primary btn-square" onClick={submit} disabled={this.state.disabled || this.state.loading || this.state.noMembersSelected}>
+          <Button
+            variant="primary btn-square"
+            onClick={submit}
+            disabled={this.state.disabled || this.state.loading || (this.state.apply_to_household && this.state.apply_to_household_ids.length === 0)}>
             {this.state.loading && (
               <React.Fragment>
                 <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
@@ -263,7 +263,7 @@ class CaseStatus extends React.Component {
             <span data-for="case-status-submit" data-tip="">
               Submit
             </span>
-            {this.state.noMembersSelected && (
+            {this.state.apply_to_household && this.state.apply_to_household_ids.length === 0 && (
               <ReactTooltip id="case-status-submit" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
                 <div>Please select at least one household member or change your selection to apply to this monitoree only</div>
               </ReactTooltip>

--- a/app/javascript/components/patient/monitoring_actions/ExposureRiskAssessment.js
+++ b/app/javascript/components/patient/monitoring_actions/ExposureRiskAssessment.js
@@ -20,7 +20,6 @@ class ExposureRiskAssessment extends React.Component {
       apply_to_household: false,
       apply_to_household_ids: [],
       loading: false,
-      noMembersSelected: false,
     };
     this.origState = Object.assign({}, this.state);
   }
@@ -38,13 +37,11 @@ class ExposureRiskAssessment extends React.Component {
   };
 
   handleApplyHouseholdChange = apply_to_household => {
-    const noMembersSelected = apply_to_household && this.state.apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household, noMembersSelected });
+    this.setState({ apply_to_household, apply_to_household_ids: [] });
   };
 
   handleApplyHouseholdIdsChange = apply_to_household_ids => {
-    const noMembersSelected = this.state.apply_to_household && apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household_ids, noMembersSelected });
+    this.setState({ apply_to_household_ids });
   };
 
   toggleExposureRiskAssessmentModal = () => {
@@ -55,7 +52,6 @@ class ExposureRiskAssessment extends React.Component {
       apply_to_household: false,
       apply_to_household_ids: [],
       reasoning: '',
-      noMembersSelected: false,
     });
   };
 
@@ -110,7 +106,10 @@ class ExposureRiskAssessment extends React.Component {
           <Button variant="secondary btn-square" onClick={toggle}>
             Cancel
           </Button>
-          <Button variant="primary btn-square" onClick={submit} disabled={this.state.loading || this.state.noMembersSelected}>
+          <Button
+            variant="primary btn-square"
+            onClick={submit}
+            disabled={this.state.loading || (this.state.apply_to_household && this.state.apply_to_household_ids.length === 0)}>
             {this.state.loading && (
               <React.Fragment>
                 <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
@@ -119,7 +118,7 @@ class ExposureRiskAssessment extends React.Component {
             <span data-for="exposure-risk-assessment-submit" data-tip="">
               Submit
             </span>
-            {this.state.noMembersSelected && (
+            {this.state.apply_to_household && this.state.apply_to_household_ids.length === 0 && (
               <ReactTooltip id="exposure-risk-assessment-submit" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
                 <div>Please select at least one household member or change your selection to apply to this monitoree only</div>
               </ReactTooltip>

--- a/app/javascript/components/patient/monitoring_actions/Jurisdiction.js
+++ b/app/javascript/components/patient/monitoring_actions/Jurisdiction.js
@@ -22,7 +22,6 @@ class Jurisdiction extends React.Component {
       apply_to_household_ids: [],
       reasoning: '',
       loading: false,
-      noMembersSelected: false,
     };
     this.origState = Object.assign({}, this.state);
   }
@@ -40,13 +39,11 @@ class Jurisdiction extends React.Component {
   };
 
   handleApplyHouseholdChange = apply_to_household => {
-    const noMembersSelected = apply_to_household && this.state.apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household, noMembersSelected });
+    this.setState({ apply_to_household, apply_to_household_ids: [] });
   };
 
   handleApplyHouseholdIdsChange = apply_to_household_ids => {
-    const noMembersSelected = this.state.apply_to_household && apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household_ids, noMembersSelected });
+    this.setState({ apply_to_household_ids });
   };
 
   // if user hits the Enter key after changing the jurisdiction value, shows the modal (in leu of clicking the button)
@@ -69,7 +66,6 @@ class Jurisdiction extends React.Component {
       apply_to_household: false,
       apply_to_household_ids: [],
       reasoning: '',
-      noMembersSelected: false,
     });
   };
 
@@ -136,7 +132,10 @@ class Jurisdiction extends React.Component {
           <Button variant="secondary btn-square" onClick={toggle}>
             Cancel
           </Button>
-          <Button variant="primary btn-square" onClick={submit} disabled={this.state.loading || this.state.noMembersSelected}>
+          <Button
+            variant="primary btn-square"
+            onClick={submit}
+            disabled={this.state.loading || (this.state.apply_to_household && this.state.apply_to_household_ids.length === 0)}>
             {this.state.loading && (
               <React.Fragment>
                 <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
@@ -145,7 +144,7 @@ class Jurisdiction extends React.Component {
             <span data-for="jurisdiction-submit" data-tip="">
               Submit
             </span>
-            {this.state.noMembersSelected && (
+            {this.state.apply_to_household && this.state.apply_to_household_ids.length === 0 && (
               <ReactTooltip id="jurisdiction-submit" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
                 <div>Please select at least one household member or change your selection to apply to this monitoree only</div>
               </ReactTooltip>

--- a/app/javascript/components/patient/monitoring_actions/MonitoringPlan.js
+++ b/app/javascript/components/patient/monitoring_actions/MonitoringPlan.js
@@ -20,7 +20,6 @@ class MonitoringPlan extends React.Component {
       apply_to_household: false,
       apply_to_household_ids: [],
       loading: false,
-      noMembersSelected: false,
     };
     this.origState = Object.assign({}, this.state);
   }
@@ -38,13 +37,11 @@ class MonitoringPlan extends React.Component {
   };
 
   handleApplyHouseholdChange = apply_to_household => {
-    const noMembersSelected = apply_to_household && this.state.apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household, noMembersSelected });
+    this.setState({ apply_to_household, apply_to_household_ids: [] });
   };
 
   handleApplyHouseholdIdsChange = apply_to_household_ids => {
-    const noMembersSelected = this.state.apply_to_household && apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household_ids, noMembersSelected });
+    this.setState({ apply_to_household_ids });
   };
 
   toggleMonitoringPlanModal = () => {
@@ -55,7 +52,6 @@ class MonitoringPlan extends React.Component {
       apply_to_household: false,
       apply_to_household_ids: [],
       reasoning: '',
-      noMembersSelected: false,
     });
   };
 
@@ -107,7 +103,10 @@ class MonitoringPlan extends React.Component {
           <Button variant="secondary btn-square" onClick={toggle}>
             Cancel
           </Button>
-          <Button variant="primary btn-square" onClick={submit} disabled={this.state.loading || this.state.noMembersSelected}>
+          <Button
+            variant="primary btn-square"
+            onClick={submit}
+            disabled={this.state.loading || (this.state.apply_to_household && this.state.apply_to_household_ids.length === 0)}>
             {this.state.loading && (
               <React.Fragment>
                 <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
@@ -116,7 +115,7 @@ class MonitoringPlan extends React.Component {
             <span data-for="monitoring-plan-submit" data-tip="">
               Submit
             </span>
-            {this.state.noMembersSelected && (
+            {this.state.apply_to_household && this.state.apply_to_household_ids.length === 0 && (
               <ReactTooltip id="monitoring-plan-submit" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
                 <div>Please select at least one household member or change your selection to apply to this monitoree only</div>
               </ReactTooltip>

--- a/app/javascript/components/patient/monitoring_actions/MonitoringStatus.js
+++ b/app/javascript/components/patient/monitoring_actions/MonitoringStatus.js
@@ -21,7 +21,6 @@ class MonitoringStatus extends React.Component {
       monitoring_reason: '',
       reasoning: '',
       loading: false,
-      noMembersSelected: false,
       apply_to_household: false,
       apply_to_household_ids: [],
       apply_to_household_cm_exp_only: false,
@@ -38,13 +37,11 @@ class MonitoringStatus extends React.Component {
   };
 
   handleApplyHouseholdChange = apply_to_household => {
-    const noMembersSelected = apply_to_household && this.state.apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household, apply_to_household_cm_exp_only: false, noMembersSelected });
+    this.setState({ apply_to_household, apply_to_household_ids: [] });
   };
 
   handleApplyHouseholdIdsChange = apply_to_household_ids => {
-    const noMembersSelected = this.state.apply_to_household && apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household_ids, noMembersSelected });
+    this.setState({ apply_to_household_ids });
   };
 
   handleApplyLdeChange = event => {
@@ -69,7 +66,6 @@ class MonitoringStatus extends React.Component {
       apply_to_household_ids: [],
       apply_to_household_cm_exp_only: false,
       apply_to_household_cm_exp_only_date: moment(new Date()).format('YYYY-MM-DD'),
-      noMembersSelected: false,
     });
   };
 
@@ -196,7 +192,10 @@ class MonitoringStatus extends React.Component {
           <Button variant="secondary btn-square" onClick={toggle}>
             Cancel
           </Button>
-          <Button variant="primary btn-square" onClick={submit} disabled={this.state.loading || this.state.noMembersSelected}>
+          <Button
+            variant="primary btn-square"
+            onClick={submit}
+            disabled={this.state.loading || (this.state.apply_to_household && this.state.apply_to_household_ids.length === 0)}>
             {this.state.loading && (
               <React.Fragment>
                 <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
@@ -205,7 +204,7 @@ class MonitoringStatus extends React.Component {
             <span data-for="monitoring-status-submit" data-tip="">
               Submit
             </span>
-            {this.state.noMembersSelected && (
+            {this.state.apply_to_household && this.state.apply_to_household_ids.length === 0 && (
               <ReactTooltip id="monitoring-status-submit" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
                 <div>Please select at least one household member or change your selection to apply to this monitoree only</div>
               </ReactTooltip>

--- a/app/javascript/components/patient/monitoring_actions/PublicHealthAction.js
+++ b/app/javascript/components/patient/monitoring_actions/PublicHealthAction.js
@@ -20,7 +20,6 @@ class PublicHealthAction extends React.Component {
       apply_to_household: false,
       apply_to_household_ids: [],
       loading: false,
-      noMembersSelected: false,
     };
     this.origState = Object.assign({}, this.state);
   }
@@ -38,13 +37,11 @@ class PublicHealthAction extends React.Component {
   };
 
   handleApplyHouseholdChange = apply_to_household => {
-    const noMembersSelected = apply_to_household && this.state.apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household, noMembersSelected });
+    this.setState({ apply_to_household, apply_to_household_ids: [] });
   };
 
   handleApplyHouseholdIdsChange = apply_to_household_ids => {
-    const noMembersSelected = this.state.apply_to_household && apply_to_household_ids.length === 0;
-    this.setState({ apply_to_household_ids, noMembersSelected });
+    this.setState({ apply_to_household_ids });
   };
 
   togglePublicHealthAction = () => {
@@ -55,7 +52,6 @@ class PublicHealthAction extends React.Component {
       apply_to_household: false,
       apply_to_household_ids: [],
       reasoning: '',
-      noMembersSelected: false,
     });
   };
 
@@ -134,7 +130,10 @@ class PublicHealthAction extends React.Component {
           <Button variant="secondary btn-square" onClick={toggle}>
             Cancel
           </Button>
-          <Button variant="primary btn-square" onClick={submit} disabled={this.state.loading || this.state.noMembersSelected}>
+          <Button
+            variant="primary btn-square"
+            onClick={submit}
+            disabled={this.state.loading || (this.state.apply_to_household && this.state.apply_to_household_ids.length === 0)}>
             {this.state.loading && (
               <React.Fragment>
                 <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>&nbsp;
@@ -143,7 +142,7 @@ class PublicHealthAction extends React.Component {
             <span data-for="public-health-action-submit" data-tip="">
               Submit
             </span>
-            {this.state.noMembersSelected && (
+            {this.state.apply_to_household && this.state.apply_to_household_ids.length === 0 && (
               <ReactTooltip id="public-health-action-submit" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
                 <div>Please select at least one household member or change your selection to apply to this monitoree only</div>
               </ReactTooltip>


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1601](https://tracker.codev.mitre.org/browse/SARAALERT-1601)

Household members don't clear when toggling in Contact Attempt modal, see How to Replicate section for recreation steps.

## (Bugfix) How to Replicate
1. Go to the details page for a monitoree with household members
2. Click the Log Manual Contact Attempt button
3. Select radio button for "This monitoree and selected household members"
4. Select checkboxes for one or more household members
5. Select radio button for "This monitoree only"
6. Click submit

## (Bugfix) Solution
The implementations for the `ApplyToHousehold` component are the same across the board, however, this bug only occurred for contact attempts.  In all cases, the ids were NOT cleared on when toggling the radio buttons.  For consistencies sake, I made this change to every instance of the `ApplyToHousehold`.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`ContactAttempt.js`, `LastDateExposure.js`, `FollowUpFlag.js`, `AssignedUser.js`,  `CaseStatus.js`, `ExposureRiskAssessment.js`, `Jurisdiction.js`, `MonitoringPlan.js`, `MonitoringStatus.js`, `PublicHealthAction.js`
- Clear `apply_to_household_ids` when changing the apply to household radio buttons
- Removed `noMembersSelected` flag to reduce the amount of variables changed

`HouseholdMemberTable.js`, `ApplyToHousehold.js`
- Removed unused prop

## Testing Recommendations
Please list any recommendations regarding what reviewers should test and if there is any specific guidance on how to test certain aspects of the PR. Be sure to mention edge cases that should be tried, particularly in the UI.

Test clearing of the selected checkboxed in the apply to household table in all instances (see components listed above)

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@tstrass :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@hackrm :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
