### PR TITLE
SARAALERT-1556: Update lab creation/editing logic

### DIFF
--- a/app/javascript/components/patient/laboratory/LaboratoryModal.js
+++ b/app/javascript/components/patient/laboratory/LaboratoryModal.js
@@ -52,8 +52,8 @@ class LaboratoryModal extends React.Component {
   };
 
   render() {
-    // Data is valid and can be saved if there is either a report or specimen collection date AND a result
-    const isValid = (this.state.report || this.state.specimen_collection) && this.state.result;
+    // Data is valid as long as at least one field has a value
+    const isValid = this.state.lab_type || this.state.specimen_collection || this.state.report || this.state.result;
     return (
       <Modal size="lg" className="laboratory-modal-container" show centered onHide={this.props.cancel}>
         <h1 className="sr-only">{this.props.editMode ? 'Edit' : 'Add New'} Lab Result</h1>
@@ -172,8 +172,8 @@ class LaboratoryModal extends React.Component {
           {/* above, this Tooltip should be placed outside the parent component (to prevent unwanted parent opacity settings from being inherited) */}
           {/* This does not impact component functionality at all. */}
           {!isValid && (
-            <ReactTooltip id="submit-tooltip" multiline={true} place="top" type="dark" effect="solid" className="tooltip-container text-left">
-              Please enter at minimum a result and either a report date or specimen date
+            <ReactTooltip id="submit-tooltip" place="top" type="dark" effect="solid">
+              Please enter at least one field.
             </ReactTooltip>
           )}
         </Modal.Footer>

--- a/app/javascript/components/patient/laboratory/LaboratoryModal.js
+++ b/app/javascript/components/patient/laboratory/LaboratoryModal.js
@@ -66,7 +66,7 @@ class LaboratoryModal extends React.Component {
               <Form.Group as={Col} controlId="lab_type">
                 <Form.Label className="input-label">Lab Test Type</Form.Label>
                 <Form.Control as="select" className="form-control-lg" onChange={this.handleChange} value={this.state.lab_type}>
-                  <option disabled></option>
+                  <option></option>
                   <option>PCR</option>
                   <option>Antigen</option>
                   <option>Total Antibody</option>
@@ -88,6 +88,7 @@ class LaboratoryModal extends React.Component {
                   minDate={'2020-01-01'}
                   maxDate={moment().format('YYYY-MM-DD')}
                   onChange={date => this.handleDateChange('specimen_collection', date)}
+                  isClearable
                   placement="bottom"
                   customClass="form-control-lg"
                   ariaLabel="Specimen Collection Date Input"
@@ -105,6 +106,7 @@ class LaboratoryModal extends React.Component {
                   minDate={'2020-01-01'}
                   maxDate={moment().format('YYYY-MM-DD')}
                   onChange={date => this.handleDateChange('report', date)}
+                  isClearable
                   placement="bottom"
                   isInvalid={this.state.reportInvalid}
                   customClass="form-control-lg"
@@ -123,7 +125,7 @@ class LaboratoryModal extends React.Component {
                     <option>positive</option>
                   ) : (
                     <React.Fragment>
-                      <option disabled></option>
+                      <option></option>
                       <option>positive</option>
                       <option>negative</option>
                       <option>indeterminate</option>

--- a/app/models/laboratory.rb
+++ b/app/models/laboratory.rb
@@ -46,6 +46,7 @@ class Laboratory < ApplicationRecord
   end
 
   validates_with LaboratoryDateValidator, on: %i[api import]
+  validates_with NonEmptyLaboratoryValidator, on: %i[api import]
 
   before_destroy :update_patient_linelist_before_destroy
   after_save :update_patient_linelist_after_save

--- a/app/models/non_empty_laboratory_validator.rb
+++ b/app/models/non_empty_laboratory_validator.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Validates that the laboratory model has at least one field present
+class NonEmptyLaboratoryValidator < ActiveModel::Validator
+  include ValidationHelper
+
+  def validate(record)
+    return if %i[lab_type specimen_collection report result].any? { |field| record[field].present? }
+
+    field_labels = %i[lab_type specimen_collection report result].map { |field| "'#{VALIDATION[field][:label]}'" }.join(', ')
+    record.errors.add(:base, "At least one of #{field_labels} must be present")
+  end
+end

--- a/test/models/laboratory_test.rb
+++ b/test/models/laboratory_test.rb
@@ -22,7 +22,7 @@ class LaboratoryTest < ActiveSupport::TestCase
     assert laboratory.valid?(:api)
     assert laboratory.valid?(:import)
 
-    laboratory = build(:laboratory, report: nil)
+    laboratory = build(:laboratory, report: nil, result: 'positive')
     assert laboratory.valid?(:api)
     assert laboratory.valid?(:import)
 
@@ -46,7 +46,7 @@ class LaboratoryTest < ActiveSupport::TestCase
     assert laboratory.valid?(:api)
     assert laboratory.valid?(:import)
 
-    laboratory = build(:laboratory, specimen_collection: nil)
+    laboratory = build(:laboratory, specimen_collection: nil, result: 'positive')
     assert laboratory.valid?(:api)
     assert laboratory.valid?(:import)
 
@@ -157,7 +157,7 @@ class LaboratoryTest < ActiveSupport::TestCase
   end
 
   test 'validates lab_type inclusion in api and import context' do
-    lab = create(:laboratory)
+    lab = create(:laboratory, result: 'positive')
 
     lab.lab_type = 'PCR'
     assert lab.valid?(:api)
@@ -194,7 +194,7 @@ class LaboratoryTest < ActiveSupport::TestCase
   end
 
   test 'validates specimen_collection is a valid date' do
-    lab = create(:laboratory)
+    lab = create(:laboratory, result: 'positive')
 
     lab.specimen_collection = Time.now.getlocal - 1.day
     assert lab.valid?(:api)
@@ -245,7 +245,7 @@ class LaboratoryTest < ActiveSupport::TestCase
   end
 
   test 'validates report is a valid date' do
-    lab = create(:laboratory)
+    lab = create(:laboratory, result: 'positive')
 
     lab.report = Time.now.getlocal - 1.day
     assert lab.valid?(:api)
@@ -294,5 +294,31 @@ class LaboratoryTest < ActiveSupport::TestCase
     assert_not lab.valid?(:import)
     assert_not lab.valid?(:api)
     assert_equal 'is not a valid date, please use the \'YYYY-MM-DD\' format', lab.errors[:report][0]
+  end
+
+  test 'validates at least one field is present' do
+    lab = create(:laboratory)
+
+    assert_not lab.valid?(:api)
+    assert_not lab.valid?(:import)
+
+    lab.report = Time.now.getlocal - 1.day
+    assert lab.valid?(:api)
+    assert lab.valid?(:import)
+
+    lab.report = nil
+    lab.specimen_collection = Time.now.getlocal - 1.day
+    assert lab.valid?(:api)
+    assert lab.valid?(:import)
+
+    lab.specimen_collection = nil
+    lab.result = 'positive'
+    assert lab.valid?(:api)
+    assert lab.valid?(:import)
+
+    lab.result = nil
+    lab.lab_type = 'PCR'
+    assert lab.valid?(:api)
+    assert lab.valid?(:import)
   end
 end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1556](https://tracker.codev.mitre.org/browse/SARAALERT-1556)

This PR updates the lab validation logic to only require that at least one field is non-empty. The requirement that at least one date field and a result are specified is removed. This requirement is also now enforced in the API. On import, this shouldn't be a problem, since a lab is only created on import when one field is non-empty. This does not affect the validation logic for making a lab when enrolling a monitoree, because in that case we still should require a specimen collection and a positive result.

## Demo/Screenshots
![image](https://user-images.githubusercontent.com/52747882/134404000-eceba17f-45bd-4bac-a398-0125cd43b33a.png)
![image](https://user-images.githubusercontent.com/52747882/134404042-b8e75f14-5aa6-4e92-a5a7-40c948dbf42f.png)

## Important Changes
`LaboratoryModal.js`
- Update the validation to only require at least one field

`laboratory.rb`
- Add a validator on the model to enforce that at least one field is present

`non_empty_laboratory_validator.rb`
- Implement validator used on model

## Testing Recommendations
Test that:
* Validating a model in the UI requires at least one field, and creating a lab with only one of each field works.
* Validating for creating a lab in the UI when enrolling a monitoree is unchanged
* Validation for creating a lab via the API requires at least one field present

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@sgober 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@Bialogs 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
