### PR TITLE
BUGFIX: Status tooltips are not showing up

### DIFF
--- a/app/javascript/components/patient/close_contacts/CloseContactTable.js
+++ b/app/javascript/components/patient/close_contacts/CloseContactTable.js
@@ -435,7 +435,7 @@ class CloseContactTable extends React.Component {
               handlePageUpdate={this.handlePageUpdate}
               entryOptions={this.state.entryOptions}
               entries={this.state.query.entries}
-              tableCustomClass="table-has-dropdown"
+              tableCustomClass="table-has-dropdown-large"
             />
           </Card.Body>
         </Card>

--- a/app/javascript/packs/stylesheets/custom_table.scss
+++ b/app/javascript/packs/stylesheets/custom_table.scss
@@ -43,11 +43,24 @@
   border: none;
 }
 
+.table-responsive {
+  margin-bottom: 1em;
+
+  table {
+    margin-bottom: 0px;
+  }
+}
+
 // This is how we deal with slight vertical overflow from a dropdown in a table that needs to be horizontal scrollable.
 // See this for the core issue: https://stackoverflow.com/a/6433475
 .table-has-dropdown {
-  padding-top: 120px;
-  margin-top: -120px;
+  padding-top: 80px;
+  margin-top: -80px;
+
+  &-large {
+    padding-top: 105px;
+    margin-top: -105px;
+  }
 }
 
 // REMOVE WHEN CLOSE CONTACT AND LAB TABLES ARE CONVERTED


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-###](https://tracker.codev.mitre.org/browse/SARAALERT-###)

Status tooltips are not displaying at certain screen sizes).  I also fixed a bug where the horizontal scrollbar for tables would be detached from the table.

## (Bugfix) How to Replicate
Status tooltips (workflow linelist and notification eligibility) above the reports table are not showing up when the screen size is at a certain width.  This occurs when the screen size is small enough for the reports table to be scrollable, but large enough that the buttons above the table don't wrap.

## (Bugfix) Solution
In `custom_table.scss`, we handle the overflow on the tables that have dropdowns by setting the padding and offsetting the margin.  When the close contacts table was converted to a react component (has a larger dropdown from the others), this value was increased which is what hid the tooltips.  I created two different classes, one for the larger dropdown and one for normal ones that prevents the tooltip from being blocked.

## Testing Recommendations
Please list any recommendations regarding what reviewers should test and if there is any specific guidance on how to test certain aspects of the PR. Be sure to mention edge cases that should be tried, particularly in the UI.

Test that all the dropdowns in monitoree details tables are not cut off and that the status tooltips appear.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA ticket reference.
- [ ] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@tstrass :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.

@ngfreiter :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
