### PR TITLE
SARAALERT-1556: Clarify enrollment lab result validation

### DIFF
--- a/app/javascript/components/patient/laboratory/LaboratoryModal.js
+++ b/app/javascript/components/patient/laboratory/LaboratoryModal.js
@@ -53,7 +53,9 @@ class LaboratoryModal extends React.Component {
 
   render() {
     // Data is valid as long as at least one field has a value
-    const isValid = this.state.lab_type || this.state.specimen_collection || this.state.report || this.state.result;
+    const isValid = this.props.onlyPositiveResult
+      ? this.state.result && this.state.specimen_collection
+      : this.state.lab_type || this.state.specimen_collection || this.state.report || this.state.result;
     return (
       <Modal size="lg" className="laboratory-modal-container" show centered onHide={this.props.cancel}>
         <h1 className="sr-only">{this.props.editMode ? 'Edit' : 'Add New'} Lab Result</h1>
@@ -174,8 +176,8 @@ class LaboratoryModal extends React.Component {
           {/* above, this Tooltip should be placed outside the parent component (to prevent unwanted parent opacity settings from being inherited) */}
           {/* This does not impact component functionality at all. */}
           {!isValid && (
-            <ReactTooltip id="submit-tooltip" place="top" type="dark" effect="solid">
-              Please enter at least one field.
+            <ReactTooltip id="submit-tooltip" place="top" type="dark" effect="solid" multiline={this.props.onlyPositiveResult}>
+              {this.props.onlyPositiveResult ? 'Please enter specimen collection date.' : 'Please enter at least one field.'}
             </ReactTooltip>
           )}
         </Modal.Footer>


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1556](https://tracker.codev.mitre.org/browse/SARAALERT-1556)

This is a fix on top of https://github.com/SaraAlert/SaraAlert/pull/1086. In #1086, I updated the lab validation logic on enrollment so that only one field was required by the modal, but once you clicked the "Next" button you would still get an error if you did not include specimen collection date. We'd rather have that validation in the modal itself, so now the modal requires that you enter a specimen collection date. 

## How to Replicate
Enroll a patient into isolation, and enter a lab result with no dates on it, and no symptom onset. You will get an error when you click "Next". On this branch however, you should not be allowed to save the lab at all unless you enter specimen collection.

## Solution
Require specimen collection to be entered.

## Important Changes
`LaboratoryModal.js`
- Require specimen collection when in enrollment.

## Testing Recommendations
Test that you can still create a lab via the patient page with only one field, and the tooltip is correct. Test that in enrollment you must include specimen collection, and the tooltip is correct. 

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
