### PR TITLE
SARAALERT-1136: Support unsaved advanced filter stickiness

### DIFF
--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -69,13 +69,17 @@ class AdvancedFilter extends React.Component {
       this.setState({ savedFilters: response.data }, () => {
         // Apply filter if it exists in local storage
         let sessionFilter = this.getLocalStorage(`SaraFilter`);
-        if (this.props.updateStickySettings && parseInt(sessionFilter)) {
-          this.setFilter(
-            this.state.savedFilters.find(filter => {
-              return filter.id === parseInt(sessionFilter);
-            }),
-            true
-          );
+        if (this.props.updateStickySettings) {
+          if (parseInt(sessionFilter)) {
+            this.setFilter(
+              this.state.savedFilters.find(filter => {
+                return filter.id === parseInt(sessionFilter);
+              }),
+              true
+            );
+          } else if (JSON.parse(sessionFilter)) {
+            this.setState({ activeFilterOptions: JSON.parse(sessionFilter) }, this.apply);
+          }
         }
       });
     });
@@ -179,8 +183,8 @@ class AdvancedFilter extends React.Component {
     };
     this.setState({ showAdvancedFilterModal: false, applied: true, lastAppliedFilter: appliedFilter }, () => {
       this.props.advancedFilterUpdate(this.state.activeFilterOptions, keepStickySettings);
-      if (this.props.updateStickySettings && this.state.activeFilter) {
-        this.setLocalStorage(`SaraFilter`, this.state.activeFilter.id);
+      if (this.props.updateStickySettings) {
+        this.setLocalStorage(`SaraFilter`, this.state.activeFilter?.id || JSON.stringify(this.state.activeFilterOptions));
       }
     });
   };


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1136](https://tracker.codev.mitre.org/browse/SARAALERT-1136)

Currently, the dashboard settings and filters are configured to be sticky in Sara Alert as detailed in the chart below (Appendix C in the User Guide). The 'stickiness' for Saved v. Unsaved advanced filters differs. With this ticket, update the stickiness of the Unsaved advanced filters so they behave the same way as the Saved advanced filters as show in this chart.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/javascript/components/public_health/query/AdvancedFilter.js`
- save unsaved adv filters to local storage

## Testing Recommendations
1) Create new advanced filter without saving and apply
2) Refresh page, advanced filter should still be applied

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ngfreiter :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@sgober :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
