### PR TITLE
SARAALERT-1382: Fix contact time warning message appearing when undefined

### DIFF
--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -370,9 +370,9 @@ class Contact extends React.Component {
                   <Form.Control.Feedback className="d-block" type="invalid">
                     {this.state.errors['preferred_contact_time']}
                   </Form.Control.Feedback>
-                  {![null, undefined, ''].includes(this.state.current.patient.preferred_contact_time) && (
+                  {this.state.current.patient.preferred_contact_time && (
                     <React.Fragment>
-                      {[null, undefined, ''].includes(this.state.current.patient.preferred_contact_method) &&
+                      {!this.state.current.patient.preferred_contact_method &&
                         this.renderWarningBanner(
                           'The monitoree will not be sent reminders while they do not have a Preferred Reporting Method selected.',
                           false,

--- a/app/javascript/components/enrollment/steps/Contact.js
+++ b/app/javascript/components/enrollment/steps/Contact.js
@@ -370,9 +370,9 @@ class Contact extends React.Component {
                   <Form.Control.Feedback className="d-block" type="invalid">
                     {this.state.errors['preferred_contact_time']}
                   </Form.Control.Feedback>
-                  {![null, ''].includes(this.state.current.patient.preferred_contact_time) && (
+                  {![null, undefined, ''].includes(this.state.current.patient.preferred_contact_time) && (
                     <React.Fragment>
-                      {[null, ''].includes(this.state.current.patient.preferred_contact_method) &&
+                      {[null, undefined, ''].includes(this.state.current.patient.preferred_contact_method) &&
                         this.renderWarningBanner(
                           'The monitoree will not be sent reminders while they do not have a Preferred Reporting Method selected.',
                           false,


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1382](https://tracker.codev.mitre.org/browse/SARAALERT-1382)

Fix contact time warning message appearing when undefined

## (Bugfix) How to Replicate
Enroll new monitoree and notice warning message appearing by default

## (Bugfix) Solution
Do not display warning message when contact time is undefined

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`example_file.js`
- Example change (ex: refactored import function)

## Testing Recommendations
Please list any recommendations regarding what reviewers should test and if there is any specific guidance on how to test certain aspects of the PR. Be sure to mention edge cases that should be tried, particularly in the UI.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ngfreiter :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@sgober :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
