### PR TITLE
SARAALERT-1622: Fix bug with enrollment carousel going to blank page

### DIFF
--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -186,11 +186,11 @@ class Enrollment extends React.Component {
     let maxIndex = this.state.enrollmentState.patient.isolation ? 7 : 6; // max number of enrollment steps in the carosel (6 for exposure and 7 for isolation)
 
     // If we are reviewing, then workflow must have changed
-    const changedWorkflow = this.state.review_mode && lastIndex !== maxIndex;
+    const workflowChange = this.state.review_mode && lastIndex !== maxIndex;
 
     if (lastIndex) {
       // If workflow has changed, route to the respective workflow specific page before review
-      this.setState({ index: changedWorkflow ? maxIndex - 1 : lastIndex, lastIndex: null });
+      this.setState({ index: workflowChange ? maxIndex - 1 : lastIndex, lastIndex: null });
     } else {
       this.setState({
         direction: 'next',

--- a/app/javascript/components/enrollment/steps/Identification.js
+++ b/app/javascript/components/enrollment/steps/Identification.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Alert, Button, Card, Col, Form } from 'react-bootstrap';
 import Select from 'react-select';
+import ReactTooltip from 'react-tooltip';
 import { bootstrapSelectTheme, cursorPointerStyleLg } from '../../../packs/stylesheets/ReactSelectStyling';
 
 import _ from 'lodash';
@@ -304,17 +305,26 @@ class Identification extends React.Component {
                   <Form.Label htmlFor="workflow-select" className="input-label">
                     WORKFLOW *
                   </Form.Label>
-                  {this.props.edit_mode && <InfoTooltip tooltipTextKey="editingWorkflow" location="right"></InfoTooltip>}
-                  <Select
-                    inputId="workflow-select"
-                    styles={cursorPointerStyleLg}
-                    value={this.getWorkflowValue()}
-                    options={WORKFLOW_OPTIONS}
-                    onChange={e => this.handleWorkflowChange(e)}
-                    placeholder=""
-                    theme={theme => bootstrapSelectTheme(theme, 'lg')}
-                    isDisabled={this.props.edit_mode}
-                  />
+                  <span data-for="disabled-workflow-select" data-tip="">
+                    <Select
+                      inputId="workflow-select"
+                      styles={cursorPointerStyleLg}
+                      value={this.getWorkflowValue()}
+                      options={WORKFLOW_OPTIONS}
+                      onChange={e => this.handleWorkflowChange(e)}
+                      placeholder=""
+                      theme={theme => bootstrapSelectTheme(theme, 'lg')}
+                      isDisabled={this.props.edit_mode}
+                    />
+                  </span>
+                  {this.props.edit_mode && (
+                    <ReactTooltip id="disabled-workflow-select" multiline={true} type="dark" effect="solid" place="top" className="tooltip-container">
+                      <div>
+                        <i>Workflow</i> cannot be directly edited. To change workflow, return to the <i>Monitoree Details</i> page and update the{' '}
+                        <i>Case Status</i> of the monitoree in the <i>Monitoring Actions</i> section.
+                      </div>
+                    </ReactTooltip>
+                  )}
                 </Form.Group>
               </Form.Row>
               <Form.Row>

--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -21,13 +21,6 @@ const TOOLTIP_TEXT = {
     </div>
   ),
 
-  editingWorkflow: (
-    <div>
-      <i>Workflow</i> cannot be directly edited. To change workflow, return to the <i>Monitoree Details</i> page and update the <i>Case Status</i> of the
-      monitoree in the <i>Monitoring Actions</i> section.
-    </div>
-  ),
-
   primaryLanguage: (
     <div>
       <i>Primary Language</i> is used to determine the translations for what the monitoree sees/hears. If a language is not fully supported, a warning to users


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1622](https://tracker.codev.mitre.org/browse/SARAALERT-1622)

This fixes a big which would cause the enrollment carousel to go to a blank page when an existing patient was editing from the isolation flow to the exposure flow.

## How to Replicate
On an existing patient in the "Isolation" workflow, edit the "Identification" tab, and change "Workflow" to "Exposure". Then click "Next". This should result in a blank page. 
https://user-images.githubusercontent.com/52747882/137555323-0a024aa5-1500-406f-a619-d23a0c05146d.mov

## Solution
Limit the `lastIndex` to not be bigger than the `maxIndex`.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`Enrollment.js`
- Limit the index so it is never bigger than the `maxIndex`

## Testing Recommendations
Test that the bug above is no longer happening. Also test that switching from exposure to isolation also still works, and that normal enrollment progression through the carousel works.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@sgober 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
