### PR TITLE
SARAALERT-NONE: Alternate Contact Bugfix

### DIFF
--- a/app/javascript/components/enrollment/Enrollment.js
+++ b/app/javascript/components/enrollment/Enrollment.js
@@ -89,13 +89,26 @@ class Enrollment extends React.Component {
     }
   };
 
+  fieldUpdated = field => {
+    const oldValue = _.get(this.props.patient, field);
+    const newValue = _.get(this.state.enrollmentState.patient, field);
+    let diff = false;
+    if (newValue !== oldValue) {
+      diff = true;
+      if (_.isNil(newValue) && _.isNil(oldValue)) {
+        diff = false;
+      }
+    }
+    return diff;
+  };
+
   submit = (_event, groupMember, reenableButtons) => {
     window.onbeforeunload = null;
 
     axios.defaults.headers.common['X-CSRF-Token'] = this.props.authenticity_token;
     // If enrolling, include ALL fields in diff keys. If editing, only include the ones that have changed
     let diffKeys = this.props.edit_mode
-      ? Object.keys(this.state.enrollmentState.patient).filter(k => _.get(this.state.enrollmentState.patient, k) !== _.get(this.props.patient, k) || k === 'id')
+      ? Object.keys(this.state.enrollmentState.patient).filter(k => this.fieldUpdated(k) || k === 'id')
       : Object.keys(this.state.enrollmentState.patient);
 
     let data = new Object({


### PR DESCRIPTION
# Description
When editing a monitoree, email and alternate email fields are listed as changed when they are not actually changed ('' versus undefined).

![image](https://user-images.githubusercontent.com/35042815/138964080-5e9f2bb4-048b-4cf1-bd46-30ec6c740eae.png)

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA ticket reference.
- [ ] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@tstrass :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
