### PR TITLE
SARAALERT-NONE: Fix bug with reporting eligibility icon in patient table

### DIFF
--- a/app/javascript/components/util/EligibilityTooltip.js
+++ b/app/javascript/components/util/EligibilityTooltip.js
@@ -17,38 +17,30 @@ const eligibility_options = [
 class EligibilityTooltip extends React.Component {
   constructor(props) {
     super(props);
-    let activeOption = eligibility_options.find(eo => props.report_eligibility[`${eo.conditional}`]) || _.last(eligibility_options);
-    activeOption.messages = activeOption.messageCount === 1 ? [this.props.report_eligibility.messages[0]] : this.props.report_eligibility.messages;
-    this.state = {
-      activeOption,
-    };
-  }
-
-  static getDerivedStateFromProps(nextProps) {
-    let activeOption = eligibility_options.find(eo => nextProps.report_eligibility[`${eo.conditional}`]) || _.last(eligibility_options);
-    activeOption.messages = activeOption.messageCount === 1 ? [nextProps.report_eligibility.messages[0]] : nextProps.report_eligibility.messages;
-    return { activeOption };
   }
 
   render() {
+    let activeOption = eligibility_options.find(eo => this.props.report_eligibility[`${eo.conditional}`]) || _.last(eligibility_options);
+    activeOption.messages = activeOption.messageCount === 1 ? [this.props.report_eligibility.messages[0]] : this.props.report_eligibility.messages;
+
     return (
       <React.Fragment>
         <span key={`re-icon${this.props.id}`} data-for={`re${this.props.id}`} data-tip="">
-          {this.props.inline && <i className={`fa-fw fas ${this.state.activeOption.icon}`}></i>}
+          {this.props.inline && <i className={`fa-fw fas ${activeOption.icon}`}></i>}
           {!this.props.inline && (
             <div className="text-center ml-0">
-              <i className={`fa-fw fas ${this.state.activeOption.icon}`}></i>
+              <i className={`fa-fw fas ${activeOption.icon}`}></i>
             </div>
           )}
         </span>
         <ReactTooltip key={`re-tooltip${this.props.id}`} id={`re${this.props.id}`} multiline={true} type="dark" effect="solid" className="tooltip-container">
           <div>
-            <p className="lead mb-0">{this.state.activeOption.title}</p>
-            {this.state.activeOption.messageCount === 1 ? (
-              <span aria-label={this.state.activeOption.messages[0].message}>{this.state.activeOption.messages[0].message}</span>
+            <p className="lead mb-0">{activeOption.title}</p>
+            {activeOption.messageCount === 1 ? (
+              <span aria-label={activeOption.messages[0].message}>{activeOption.messages[0].message}</span>
             ) : (
               <ul className="pl-3 mb-0">
-                {this.state.activeOption.messages.map((m, index) => {
+                {activeOption.messages.map((m, index) => {
                   const message = m.datetime ? `${m.message} (${formatTimestamp(m.datetime)})` : m.message;
                   return (
                     <li className="mb-0" key={`rei${this.props.id}${index}`} aria-label={message}>

--- a/app/javascript/components/util/EligibilityTooltip.js
+++ b/app/javascript/components/util/EligibilityTooltip.js
@@ -24,6 +24,12 @@ class EligibilityTooltip extends React.Component {
     };
   }
 
+  static getDerivedStateFromProps(nextProps) {
+    let activeOption = eligibility_options.find(eo => nextProps.report_eligibility[`${eo.conditional}`]) || _.last(eligibility_options);
+    activeOption.messages = activeOption.messageCount === 1 ? [nextProps.report_eligibility.messages[0]] : nextProps.report_eligibility.messages;
+    return { activeOption };
+  }
+
   render() {
     return (
       <React.Fragment>


### PR DESCRIPTION
# Description
Jira Ticket: N/A

This fixes a bug which would cause the incorrect notification status to display for patients in the patients table following some sort of filtering that does not refresh the full page, such as applying an advanced filter.

## How to Replicate
1. Navigate to the patients table with no filters applied.
2. Apply the "Household Member" filter as `true`.
3. Note that the notification status column does not update, we would expect that all patients would have the household icon, but the icons remain the same as before the advanced filter was applied.

## Solution
Add a hook to update the state on the `EligibilityTooltip` component when the props update. This ensures that the state of this component is accurate.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`EligibilityTooltip.js`
- Add `getDerivedStateFromProps` hook

## Testing Recommendations
Test that after applying various filters, the notification status icons match the values you see if you actually click on the patient and look at the reports table.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@sgober 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
