### PR TITLE
SARAALERT-1635 : Change "Telephone Number (Contains)" Filter to ignore special characters

### DIFF
--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -516,7 +516,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
         patients = if filter[:value].blank?
                      patients.where(primary_telephone: [nil, ''])
                    else
-                     patients.where('patients.primary_telephone like ?', "%#{filter[:value]}%")
+                     patients.where('patients.primary_telephone like ?', "%#{filter[:value].delete('^0-9')}%")
                    end
       when 'ten-day-quarantine'
         patients = advanced_filter_quarantine_option(patients, filter, :ten_day)

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -821,7 +821,7 @@ class AdvancedFilter extends React.Component {
    */
   renderSearchStatement = (filter, index, value, additionalFilterOption) => {
     // compute tooltip for specific search cases
-    let tooltip = filter.tooltip !== undefined ? filter.tooltip : '';
+    let tooltip = filter.tooltip || '';
     if (filter.name === 'close-contact-with-known-case-id') {
       if (additionalFilterOption === 'Exact Match') {
         tooltip =

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -821,7 +821,7 @@ class AdvancedFilter extends React.Component {
    */
   renderSearchStatement = (filter, index, value, additionalFilterOption) => {
     // compute tooltip for specific search cases
-    let tooltip = '';
+    let tooltip = filter.tooltip !== undefined ? filter.tooltip : '';
     if (filter.name === 'close-contact-with-known-case-id') {
       if (additionalFilterOption === 'Exact Match') {
         tooltip =
@@ -830,9 +830,6 @@ class AdvancedFilter extends React.Component {
         tooltip =
           'Returns records that contain a user-entered search value when the known Case ID is specified for monitorees with “Close Contact with a Known Case”. Use commas to separate multiple values (ex: “12, 45” will return records where known Case ID is “123, 90” or “12” or “1451). ';
       }
-    }
-
-    if (filter.name === 'close-contact-with-known-case-id' || filter.name === 'cohort') {
       tooltip += 'Leaving this field blank will return monitorees with missing and null values.';
     }
 

--- a/app/javascript/data/advancedFilterOptions.js
+++ b/app/javascript/data/advancedFilterOptions.js
@@ -115,6 +115,7 @@ export const advancedFilterOptions = [
     title: 'Common Exposure Cohort Name (Text)',
     description: 'Monitoree common exposure cohort name or description',
     type: 'search',
+    tooltip: 'Leaving this field blank will return monitorees with missing and null values.',
   },
   {
     name: 'email',
@@ -151,12 +152,14 @@ export const advancedFilterOptions = [
     title: 'Primary Contact Telephone Number (Exact Match) (Text)',
     description: 'Monitorees with a specified 10 digit primary contact telephone number',
     type: 'search',
+    tooltip: 'This will ignore any special characters in the phone number, such as - and ()',
   },
   {
     name: 'telephone-number-partial',
     title: 'Primary Contact Telephone Number (Contains) (Text)',
     description: 'Monitorees with a primary contact telephone number that contains specified digits',
     type: 'search',
+    tooltip: 'This will ignore any special characters in the phone number, such as - and ()',
   },
 
   /* SELECT FILTER OPTIONS */

--- a/app/javascript/data/advancedFilterOptions.js
+++ b/app/javascript/data/advancedFilterOptions.js
@@ -152,14 +152,12 @@ export const advancedFilterOptions = [
     title: 'Primary Contact Telephone Number (Exact Match) (Text)',
     description: 'Monitorees with a specified 10 digit primary contact telephone number',
     type: 'search',
-    tooltip: 'This will ignore any special characters in the phone number, such as - and ()',
   },
   {
     name: 'telephone-number-partial',
     title: 'Primary Contact Telephone Number (Contains) (Text)',
     description: 'Monitorees with a primary contact telephone number that contains specified digits',
     type: 'search',
-    tooltip: 'This will ignore any special characters in the phone number, such as - and ()',
   },
 
   /* SELECT FILTER OPTIONS */


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1635](https://tracker.codev.mitre.org/browse/SARAALERT-1635)

This ticket makes the behavior of the Telephone Number (Contains) advanced filter match the behavior of the Telephone Number (Exact Match) advanced filter. Specifically, the Telephone Number (Contains) filter did not previously strip out special characters, while the Telephone Number (Exact Match) filter uses the Phonelib gem to parse the number and remove special characters before querying the database. 

This ticket also makes a tiny change to the logic in  renderSearchStatement as discussed in Slack [here](https://mitrecorp.slack.com/archives/C029CLK0X2P/p1637171821013600?thread_ts=1637170608.013100&cid=C029CLK0X2P) (Note: This logic was initially introduced because a tooltip was to be added for the Telephone Number (Contains) filter and it seemed worthwhile to keep it even though the PO team has decided a tooltip will not be added for this particular filter.)

## (Feature) Demo/Screenshots
<img width="400" alt="Screen Shot 2021-11-18 at 12 31 55 PM" src="https://user-images.githubusercontent.com/2328582/142466768-a77e62da-6201-457e-be07-7fde68985ef3.png">

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/helpers/patient_query_helper.rb`
- Strips non-numeric characters from the advanced filter input before querying the database. See Slack discussion [here](https://mitrecorp.slack.com/archives/C029CLK0X2P/p1637079777009400)

`app/javascript/components/public_health/query/AdvancedFilter.js` 
- Sets the tooltip to filter.tooltip if defined and '' when undefined within renderSearchStatement

`app/javascript/data/advancedFilterOptions.js`
- Moves tooltip text from AdvancedFilter.js for cohort here (as per above, originally made this change because I was setting the tooltip text to default to filter.tooltip as part of this story and it seemed worthwhile to keep)

`test/helpers/patient_query_helper_test.rb`
- Adds tests to ensure the characters are stripped appropriately from the advanced filter input

## Testing Recommendations

- Select Telephone Number (Contains) from the Advanced Filter on the Dashboard (Exposure, Isolation, or Global). 
- Enter in a phone number that will match a monitoree phone number, but that contains special characters, e.g., dashes, parentheses. Confirm that the monitoree appears in the results after applying the filter. 

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@sgober 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ngfreiter 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
