### PR TITLE
SARAALERT-902 custom welcome message

### DIFF
--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -15,7 +15,7 @@ class PatientMailer < ApplicationMailer
     end
     @lang = patient.select_language(:email)
     @contact_info = patient.jurisdiction.contact_info
-    @custom_enrollment_message = patient&.jurisdiction&.custom_messages_for_hierarchy&.dig('assessments', 'html', 'email', 'info1', @lang&.to_s)
+    @custom_enrollment_message = patient&.jurisdiction&.custom_messages_for_hierarchy&.dig('assessments', 'html', 'email', 'enrollment', 'info1', @lang&.to_s)
 
     mail(to: patient.email&.strip, subject: I18n.t('assessments.html.email.enrollment.subject', locale: @lang)) do |format|
       format.html { render layout: 'main_mailer' }

--- a/app/mailers/patient_mailer.rb
+++ b/app/mailers/patient_mailer.rb
@@ -15,6 +15,8 @@ class PatientMailer < ApplicationMailer
     end
     @lang = patient.select_language(:email)
     @contact_info = patient.jurisdiction.contact_info
+    @custom_enrollment_message = patient&.jurisdiction&.custom_messages_for_hierarchy&.dig('assessments', 'html', 'email', 'info1', @lang&.to_s)
+
     mail(to: patient.email&.strip, subject: I18n.t('assessments.html.email.enrollment.subject', locale: @lang)) do |format|
       format.html { render layout: 'main_mailer' }
     end
@@ -35,7 +37,10 @@ class PatientMailer < ApplicationMailer
     end
 
     lang = patient.select_language(:sms)
-    contents = I18n.t('assessments.twilio.sms.prompt.intro', locale: lang, name: patient&.initials_age('-'))
+    custom_msg = patient&.jurisdiction&.custom_messages_for_hierarchy&.dig('assessments', 'twilio', 'sms', 'prompt', 'intro', lang&.to_s)
+    contents = custom_msg.present? ?
+      "#{patient&.initials_age('-')},\n#{custom_msg}" :
+      I18n.t('assessments.twilio.sms.prompt.intro', locale: lang, name: patient&.initials_age('-'))
     threshold_hash = patient.jurisdiction[:current_threshold_condition_hash]
     message = { prompt: contents, patient_submission_token: patient.submission_token, threshold_hash: threshold_hash }
     success = TwilioSender.send_sms(patient, [message])

--- a/app/models/jurisdiction.rb
+++ b/app/models/jurisdiction.rb
@@ -68,6 +68,13 @@ class Jurisdiction < ApplicationRecord
     contact_info
   end
 
+  def custom_messages_for_hierarchy
+    path&.reverse&.each do |jur|
+      return JSON.parse(jur.custom_messages) unless jur.custom_messages.nil?
+    end
+    nil
+  end
+
   # This calculates the current threshold condition hash which is usually only meant to be called after updating threshold conditions
   # Otherwise, simply reference the :current_threshold_condition_hash field to avoid extra computation and queries
   def calculate_current_threshold_condition_hash

--- a/app/views/patient_mailer/enrollment_email.html.erb
+++ b/app/views/patient_mailer/enrollment_email.html.erb
@@ -7,7 +7,11 @@
     <% @patients.each do |patient| %>
       <p><%= t('assessments.html.email.shared.greeting', locale: @lang, name: patient[:patient]&.initials_age('-')) %></p>
 
-      <p><%= t('assessments.html.email.enrollment.info1', locale: @lang) %></p>
+      <% if @custom_enrollment_message.present? %>
+        <p><%= sanitize @custom_enrollment_message %></p>
+      <% else %>
+        <p><%= t('assessments.html.email.enrollment.info1', locale: @lang) %></p>
+      <% end %>
 
       <%= render partial: 'main_mailer/responsive_button', locals: {
             patient: patient,

--- a/config/sara/jurisdiction_messages.yml
+++ b/config/sara/jurisdiction_messages.yml
@@ -1,0 +1,28 @@
+'USA':
+  children:
+    'State 1':
+      messages:
+        assessments:
+          html:
+            email:
+              info1:
+                eng: |
+                  Welcome to symptom monitoring for <a href="http://example.com">State 1 DOH</a><br><br>
+                  - Lorem<br>
+                  - Ipsum
+                spa: |
+                  Bienvenido a la monitorización de los síntomas para <a href="http://example.com">El State 1 DOH</a><br><br>
+                  - Lorem<br>
+                  - Ipsum
+          twilio:
+            sms:
+              prompt:
+                intro:
+                  eng: |
+                    You've been identified by State 1 DOH to be enrolled in Sara Alert to be monitored for COVID symptoms.
+
+                    For privacy and more info, visit saraalert.org.
+                  spa: |
+                    El State 1 DOH lo identifico para inscribirse en Sara Alert para ser monitoreado por sintomas de COVID.
+
+                    Para privacidad y mas informacion, visite saraalert.org.

--- a/config/sara/jurisdiction_messages.yml
+++ b/config/sara/jurisdiction_messages.yml
@@ -5,15 +5,16 @@
         assessments:
           html:
             email:
-              info1:
-                eng: |
-                  Welcome to symptom monitoring for <a href="http://example.com">State 1 DOH</a><br><br>
-                  - Lorem<br>
-                  - Ipsum
-                spa: |
-                  Bienvenido a la monitorización de los síntomas para <a href="http://example.com">El State 1 DOH</a><br><br>
-                  - Lorem<br>
-                  - Ipsum
+              enrollment:
+                info1:
+                  eng: |
+                    Welcome to symptom monitoring for <a href="http://example.com">State 1 DOH</a>.<br><br>
+                    - Lorem<br>
+                    - Ipsum
+                  spa: |
+                    Bienvenido a la monitorización de los síntomas para <a href="http://example.com">El State 1 DOH</a><br><br>
+                    - Lorem<br>
+                    - Ipsum
           twilio:
             sms:
               prompt:

--- a/db/migrate/20211110160736_add_custom_messages_to_jurisdictions.rb
+++ b/db/migrate/20211110160736_add_custom_messages_to_jurisdictions.rb
@@ -1,0 +1,5 @@
+class AddCustomMessagesToJurisdictions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :jurisdictions, :custom_messages, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_15_013855) do
+ActiveRecord::Schema.define(version: 2021_11_10_160736) do
 
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -195,6 +195,7 @@ ActiveRecord::Schema.define(version: 2021_10_15_013855) do
     t.boolean "send_digest", default: false
     t.boolean "send_close", default: false
     t.string "current_threshold_condition_hash"
+    t.json "custom_messages"
     t.index ["ancestry"], name: "index_jurisdictions_on_ancestry"
   end
 

--- a/lib/tasks/admin.rake
+++ b/lib/tasks/admin.rake
@@ -182,7 +182,10 @@ namespace :admin do
     end
 
     unless jurisdiction.nil? || jur_values.nil?
-      jurisdiction.update(custom_messages: jur_values['messages']&.to_json)
+      if jur_values['messages'].present?
+        puts "Updating custom messages for jurisdiction: #{jurisdiction[:path]}"
+        jurisdiction.update!(custom_messages: jur_values['messages']&.to_json)
+      end
     end
 
     # Parse and recursively create custom messages for child jurisdictions if included

--- a/lib/tasks/mailers.rake
+++ b/lib/tasks/mailers.rake
@@ -17,11 +17,27 @@ namespace :mailers do
     user = User.new(email: 'foobar@foobar.foo', password: 'foobarfoobar2')
     test_patient = Patient.new(creator: user)
     test_patient.responder = test_patient
+    test_patient.first_name = "Test"
+    test_patient.last_name = "McTest"
     test_patient.email = '<test_email>'
     test_patient.submission_token = SecureRandom.urlsafe_base64[0, 10]
     test_patient.jurisdiction = Jurisdiction.where(name: 'County 1').first
+    test_patient.primary_language = 'eng'
     test_patient.save!
     PatientMailer.enrollment_email(test_patient).deliver_now
+  end
+
+  desc "Test making an enrollment sms"
+  task test_enrollment_sms: :environment do
+    # patient = Patient.first.dup
+    # patient.first_name = "Test"
+    # patient.last_name = "McTest"
+    # patient.primary_language = "eng"
+    # patient.age = 27
+    # patient.jurisdiction = Jurisdiction.where(name: 'County 1').first
+    # patient.primary_telephone = <Test Number in E164 format>
+    # patient.save!
+    # PatientMailer.enrollment_sms_text_based(patient).deliver_now
   end
 
   desc "Test making an assessment sms"

--- a/test/fixtures/jurisdictions.yml
+++ b/test/fixtures/jurisdictions.yml
@@ -24,6 +24,7 @@ jurisdiction_3:
   path: 'USA, State 2'
   unique_identifier: <%= Base64::urlsafe_encode64([[Digest::SHA256.hexdigest('USA, State 2')].pack('H*')].pack('m0'))[0, 10] %>
   current_threshold_condition_hash: <%= Digest::SHA256.hexdigest('USA, State 2' + '1') %>
+  custom_messages: "{\"assessments\":{\"html\":{\"email\":{\"enrollment\":{\"info1\":{\"eng\":\"Welcome to symptom monitoring for \\u003ca href=\\\"http://example.com\\\"\\u003eState 1 DOH\\u003c/a\\u003e.\\u003cbr\\u003e\\u003cbr\\u003e\\n- Lorem\\u003cbr\\u003e\\n- Ipsum\\n\",\"spa\":\"Bienvenido a la monitorización de los síntomas para \\u003ca href=\\\"http://example.com\\\"\\u003eEl State 1 DOH\\u003c/a\\u003e\\u003cbr\\u003e\\u003cbr\\u003e\\n- Lorem\\u003cbr\\u003e\\n- Ipsum\\n\"}}}},\"twilio\":{\"sms\":{\"prompt\":{\"intro\":{\"eng\":\"You've been identified by State 1 DOH to be enrolled in Sara Alert to be monitored for COVID symptoms.\\n\\nFor privacy and more info, visit saraalert.org.\\n\",\"spa\":\"El State 1 DOH lo identifico para inscribirse en Sara Alert para ser monitoreado por sintomas de COVID.\\n\\nPara privacidad y mas informacion, visite saraalert.org.\"}}}}}}"
 jurisdiction_4:
   id: 4
   created_at: <%= 50.days.ago %>

--- a/test/mailers/patient_mailer_test.rb
+++ b/test/mailers/patient_mailer_test.rb
@@ -248,6 +248,36 @@ class PatientMailerTest < ActionMailer::TestCase
       assert_includes email_body, I18n.t('assessments.html.email.shared.footer', locale: lang)
     end
 
+    test "enrollment email custom messages in #{language}" do
+      @patient.update(primary_language: language.to_s, jurisdiction: Jurisdiction.find(3))
+      email = PatientMailer.enrollment_email(@patient).deliver_now
+      email_body = email.parts.first.body.to_s.tr("\n", ' ').tr("\r", '')
+      lang = Languages.supported_language?(@patient.primary_language, :email) ? @patient.primary_language : 'eng'
+      case lang
+      when 'eng'
+        assert_includes email_body, 'Welcome to symptom monitoring for'
+      when 'spa'
+        assert_includes email_body, 'Bienvenido a la monitorización de los síntomas para'
+      else
+        assert_includes email_body, I18n.t('assessments.html.email.enrollment.info1', locale: lang)
+      end
+    end
+
+    test "enrollment email custom messages for descendent jurisdiction in #{language}" do
+      @patient.update(primary_language: language.to_s, jurisdiction: Jurisdiction.find(6))
+      email = PatientMailer.enrollment_email(@patient).deliver_now
+      email_body = email.parts.first.body.to_s.tr("\n", ' ').tr("\r", '')
+      lang = Languages.supported_language?(@patient.primary_language, :email) ? @patient.primary_language : 'eng'
+      case lang
+      when 'eng'
+        assert_includes email_body, 'Welcome to symptom monitoring for'
+      when 'spa'
+        assert_includes email_body, 'Bienvenido a la monitorización de los síntomas para'
+      else
+        assert_includes email_body, I18n.t('assessments.html.email.enrollment.info1', locale: lang)
+      end
+    end
+
     test "enrollment sms weblink message contents not using messaging service in #{language}" do
       ENV['TWILLIO_MESSAGING_SERVICE_SID'] = nil
       @patient.update(primary_language: language.to_s)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-902](https://tracker.codev.mitre.org/browse/SARAALERT-902)

This adds the ability for jurisdictions to specify a custom welcome messages (and their translations) for SMS and email.

## Demo/Screenshots
![image](https://user-images.githubusercontent.com/8235974/142210646-62632f10-8773-4d4c-b5ff-c855697a9ffa.png)

<img width="323" alt="image" src="https://user-images.githubusercontent.com/8235974/142226207-5fa9b555-d0bd-469f-855f-cdab8b2d1d85.png">


## Important Changes
`20211110160736_add_custom_messages_to_jurisdictions.rb`
- Add a column in Jurisdiction table to hold the custom messages

`admin.rake `
- Add a task to read in and save the custom messages
- See `jurisdiction_messages.yml` for a sample to the expected structure of this file
- Structure was designed to mimic both the jurisdictions.yml file and the translations files that hold the default messages
- Ideally the translations would be registered with Rails in the same way the translations of the default messages are, but like the actual jurisdiction hierarchy, the jurisdictions' custom messages cannot be checked into the repo.
- The custom email is to be interpreted as HTML. For simplicity for now, we are limiting what we allow to hyperlinked text (`<a>` tags) and newlines (`<br>`). We might allow `<ul>` and `<li>` as well. But that limiting will occur as a part of an external human review process where jurs submit their custom messages to the adoption team (they will not submit HTML, but they're told they're allowed hyperlinks and lists, so we will translate it to HTML where necessary).

`enrollment_email.html.erb `
- Display the custom welcome message in the welcome email

`patient_mailer.rb`
- Use custom welcome messages for SMS and email if one exists for the jurisdiction

`jurisdiction.rb`
- Method to grab the custom messages for a jurisdiction, going up the hierarchy if needed.

## Testing Recommendations
- Run the new rake task on the sample messages file
- Use the tasks in `mailers.rake` to generate sample enrollment emails and SMS messages.
  - Test with jurs with custom welcome messages
  - Test with jurs that inherit custom welcome messages from an ancestor jur
  - Test with jurs that _don't_ have custom messages
  - The SMS testing requires certain environment variables to be set. Let me know offline if you need help.
- Make a variety changes to the sample file, and repeat the above

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@ngfreiter:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@deastman:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
