### PR TITLE
fix cohorts adv filter

### DIFF
--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -628,6 +628,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     filter[:value].each do |field|
       # Map multi-select type filter from { label, value } to values
       value = field[:value].pluck(:value)
+      next unless value.present?
 
       # Get patients where cohort value is any of the cohort values specified in the filter
       case field[:name]

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -624,6 +624,9 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
   end
 
   def advanced_filter_common_exposure_cohorts(patients, filter)
+    # Do not filter any patients if all values are blank since these are multi-select filters
+    return patients unless filter[:value].any? { |field| field[:value].pluck(:value).present? }
+
     common_exposure_cohorts = patients.joins(:common_exposure_cohorts)
     filter[:value].each do |field|
       # Map multi-select type filter from { label, value } to values


### PR DESCRIPTION
# Description

From Alex: Right now it looks like if you set a Common Exposure Cohort advanced filter and leave the field blank, it'll filter out all monitorees. I think the way we were thinking it would work is that it will filter out no monitorees (that's what the tooltip currently says)

https://mitrecorp.slack.com/archives/C029JM3PFC4/p1637699389134800

## (Bugfix) How to Replicate

![image](https://user-images.githubusercontent.com/9956561/143113818-41a556e1-dec0-4cfd-a6d7-9ff004341957.png)

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`example_file.js`
- Example change (ex: refactored import function)

## Testing Recommendations
Please list any recommendations regarding what reviewers should test and if there is any specific guidance on how to test certain aspects of the PR. Be sure to mention edge cases that should be tried, particularly in the UI.

# Checklists

**Submitter:**
- [ ] This PR describes why these changes were made.
- [ ] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA ticket reference.
- [ ] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [ ] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
