### PR TITLE
SARAALERT-1631: Add Ability to Search by Phone Number and Email

### DIFF
--- a/app/helpers/close_contact_query_helper.rb
+++ b/app/helpers/close_contact_query_helper.rb
@@ -53,10 +53,10 @@ module CloseContactQueryHelper
   def search(close_contact, search)
     return close_contact if search.blank?
 
-    close_contact.where('lower(first_name) like ?', "#{search&.downcase}%").or(
-      close_contact.where('lower(last_name) like ?', "#{search&.downcase}%").or(
+    close_contact.where('first_name like ?', "#{search&.downcase}%").or(
+      close_contact.where('last_name like ?', "#{search&.downcase}%").or(
         close_contact.where('primary_telephone like ?', "%#{search}%").or(
-          close_contact.where('lower(email) like ?', "#{search&.downcase}%").or(
+          close_contact.where('email like ?', "#{search&.downcase}%").or(
             close_contact.where('assigned_user like ?', "#{search&.downcase}%").or(
               close_contact.where('contact_attempts like ?', "#{search&.downcase}%")
             )

--- a/app/helpers/patient_details_helper.rb
+++ b/app/helpers/patient_details_helper.rb
@@ -65,7 +65,6 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
       user_defined_id_statelocal: user_defined_id_statelocal || '',
       sex: sex || '',
       date_of_birth: date_of_birth&.strftime('%F') || '',
-      primary_telephone: primary_telephone || '',
       end_of_monitoring: (continuous_exposure ? 'Continuous Exposure' : end_of_monitoring) || '',
       exposure_risk_assessment: exposure_risk_assessment || '',
       monitoring_plan: monitoring_plan || '',
@@ -84,7 +83,8 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
       workflow: isolation ? 'Isolation' : 'Exposure',
       first_positive_lab_at: first_positive_lab_at || '',
       follow_up_reason: follow_up_reason || '',
-      follow_up_note: follow_up_note || ''
+      follow_up_note: follow_up_note || '',
+      primary_telephone: primary_telephone || ''
     }
   end
 

--- a/app/helpers/patient_details_helper.rb
+++ b/app/helpers/patient_details_helper.rb
@@ -65,6 +65,7 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
       user_defined_id_statelocal: user_defined_id_statelocal || '',
       sex: sex || '',
       date_of_birth: date_of_birth&.strftime('%F') || '',
+      primary_telephone: primary_telephone || '',
       end_of_monitoring: (continuous_exposure ? 'Continuous Exposure' : end_of_monitoring) || '',
       exposure_risk_assessment: exposure_risk_assessment || '',
       monitoring_plan: monitoring_plan || '',

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -176,8 +176,8 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
           patients.where('lower(user_defined_id_cdc) like ?', "#{search&.downcase}%").or(
             patients.where('lower(user_defined_id_nndss) like ?', "#{search&.downcase}%").or(
               patients.where('date_of_birth like ?', "#{search&.downcase}%").or(
-                patients.where('primary_telephone like ?', "%#{search.delete('^0-9')}%").or(
-                  patients.where('lower(patients.email) like ?', "%#{search&.downcase}%")
+                patients.where('lower(patients.email) like ?', "#{search&.downcase}%").or(
+                  patients.where('primary_telephone like ?', "%#{search.delete('^0-9')}%")
                 )
               )
             )

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -747,7 +747,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
                                'patients.last_assessment_reminder_sent, patients.preferred_contact_time, patients.extended_isolation, '\
                                'patients.latest_fever_or_fever_reducer_at, patients.first_positive_lab_at, patients.negative_lab_count, '\
                                'patients.head_of_household, patients.follow_up_reason, patients.follow_up_note, jurisdictions.name AS jurisdiction_name, '\
-                               'jurisdictions.path AS jurisdiction_path, jurisdictions.id AS jurisdiction_id')
+                               'jurisdictions.path AS jurisdiction_path, jurisdictions.id AS jurisdiction_id, patients.primary_telephone')
 
     # execute query and get total count
     total = patients.total_entries
@@ -759,7 +759,8 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
         id: patient[:id],
         name: patient.displayed_name,
         state_local_id: patient[:user_defined_id_statelocal] || '',
-        dob: patient[:date_of_birth]&.strftime('%F') || ''
+        dob: patient[:date_of_birth]&.strftime('%F') || '',
+        primary_telephone: patient[:primary_telephone] || '', 
       }
 
       # populate fields specific to this linelist only if relevant

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -176,7 +176,9 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
           patients.where('lower(user_defined_id_cdc) like ?', "#{search&.downcase}%").or(
             patients.where('lower(user_defined_id_nndss) like ?', "#{search&.downcase}%").or(
               patients.where('date_of_birth like ?', "#{search&.downcase}%").or(
-                patients.where('primary_telephone like ?', "%#{search.delete('^0-9')}%")
+                patients.where('primary_telephone like ?', "%#{search.delete('^0-9')}%").or(
+                  patients.where('lower(patients.email) like ?', "%#{search&.downcase}%")
+                )
               )
             )
           )

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -764,7 +764,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
         name: patient.displayed_name,
         state_local_id: patient[:user_defined_id_statelocal] || '',
         dob: patient[:date_of_birth]&.strftime('%F') || '',
-        primary_telephone: patient[:primary_telephone] || '', 
+        primary_telephone: patient[:primary_telephone] || ''
       }
 
       # populate fields specific to this linelist only if relevant

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -175,7 +175,9 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
         patients.where('lower(user_defined_id_statelocal) like ?', "#{search&.downcase}%").or(
           patients.where('lower(user_defined_id_cdc) like ?', "#{search&.downcase}%").or(
             patients.where('lower(user_defined_id_nndss) like ?', "#{search&.downcase}%").or(
-              patients.where('date_of_birth like ?', "#{search&.downcase}%")
+              patients.where('date_of_birth like ?', "#{search&.downcase}%").or(
+                patients.where('primary_telephone like ?', "%#{search.delete('^0-9')}%")
+              )
             )
           )
         )
@@ -794,7 +796,7 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
       linelist << details
     end
 
-    { linelist: linelist, fields: %i[name state_local_id dob].concat(fields), total: total }
+    { linelist: linelist, fields: %i[name state_local_id dob primary_telephone].concat(fields), total: total }
   end
 
   def linelist_specific_fields(workflow, tab)

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -170,13 +170,13 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
   def filter_by_text(patients, search)
     return patients if search.nil? || search.blank?
 
-    patients.where('lower(first_name) like ?', "#{search&.downcase}%").or(
-      patients.where('lower(last_name) like ?', "#{search&.downcase}%").or(
-        patients.where('lower(user_defined_id_statelocal) like ?', "#{search&.downcase}%").or(
-          patients.where('lower(user_defined_id_cdc) like ?', "#{search&.downcase}%").or(
-            patients.where('lower(user_defined_id_nndss) like ?', "#{search&.downcase}%").or(
+    patients.where('first_name like ?', "#{search&.downcase}%").or(
+      patients.where('last_name like ?', "#{search&.downcase}%").or(
+        patients.where('user_defined_id_statelocal like ?', "#{search&.downcase}%").or(
+          patients.where('user_defined_id_cdc like ?', "#{search&.downcase}%").or(
+            patients.where('user_defined_id_nndss like ?', "#{search&.downcase}%").or(
               patients.where('date_of_birth like ?', "#{search&.downcase}%").or(
-                patients.where('lower(patients.email) like ?', "#{search&.downcase}%").or(
+                patients.where('patients.email like ?', "#{search&.downcase}%").or(
                   patients.where('primary_telephone like ?', "%#{search.delete('^0-9')}%")
                 )
               )

--- a/app/javascript/components/patient/household/actions/MoveToHousehold.js
+++ b/app/javascript/components/patient/household/actions/MoveToHousehold.js
@@ -298,7 +298,7 @@ class MoveToHousehold extends React.Component {
                 <InputGroup size="md">
                   <InputGroup.Prepend>
                     <OverlayTrigger
-                      overlay={<Tooltip>Search by Monitoree Name, Date of Birth, Phone Number, State/Local ID, CDC ID, or NNDSS/Case ID</Tooltip>}>
+                      overlay={<Tooltip>Search by Monitoree Name, Date of Birth, Email, Phone Number, State/Local ID, CDC ID, or NNDSS/Case ID</Tooltip>}>
                       <InputGroup.Text className="rounded-0">
                         <i className="fas fa-search"></i>
                         <label htmlFor="search-input" className="ml-1 mb-0">

--- a/app/javascript/components/patient/household/actions/MoveToHousehold.js
+++ b/app/javascript/components/patient/household/actions/MoveToHousehold.js
@@ -298,7 +298,9 @@ class MoveToHousehold extends React.Component {
                 <InputGroup size="md">
                   <InputGroup.Prepend>
                     <OverlayTrigger
-                      overlay={<Tooltip>Search by Monitoree Name, Date of Birth, Email, Phone Number, State/Local ID, CDC ID, or NNDSS/Case ID</Tooltip>}>
+                      overlay={
+                        <Tooltip>Search by Monitoree Name, Date of Birth, Email, Primary Telephone Number, State/Local ID, CDC ID, or NNDSS/Case ID</Tooltip>
+                      }>
                       <InputGroup.Text className="rounded-0">
                         <i className="fas fa-search"></i>
                         <label htmlFor="search-input" className="ml-1 mb-0">

--- a/app/javascript/components/patient/household/actions/MoveToHousehold.js
+++ b/app/javascript/components/patient/household/actions/MoveToHousehold.js
@@ -4,7 +4,7 @@ import { Form, Row, Col, Button, Modal, InputGroup, OverlayTrigger, Tooltip } fr
 import axios from 'axios';
 import _ from 'lodash';
 import { formatDate } from '../../../../utils/DateTime';
-import { formatNameAlt } from '../../../../utils/PatientFormatters';
+import { formatNameAlt, formatPhoneNumberVisually } from '../../../../utils/PatientFormatters';
 
 import BadgeHoH from '../../icons/BadgeHoH';
 import CustomTable from '../../../layout/CustomTable';
@@ -21,6 +21,7 @@ class MoveToHousehold extends React.Component {
           { field: 'state_local_id', label: 'State/Local ID', isSortable: true, tooltip: null },
           { field: 'jurisdiction', label: 'Jurisdiction', isSortable: true, tooltip: null },
           { field: 'dob', label: 'Date of Birth', isSortable: true, tooltip: null, filter: formatDate },
+          { field: 'primary_telephone', label: 'Phone Number', isSortable: false, tooltip: null, filter: this.renderPhoneNumber },
           { field: 'select', label: '', isSortable: false, tooltip: null, filter: this.createSelectButton, className: 'text-center', onClick: this.submit },
         ],
         rowData: [],
@@ -73,6 +74,14 @@ class MoveToHousehold extends React.Component {
       );
     }
     return <a href={patientHref(rowData.id, this.props.workflow)}>{name}</a>;
+  };
+
+  /**
+   * Uses custom phone number formatter for the phone number in the table
+   * @param {Object} data - provided by CustomTable about each cell in the column this filter is called in.
+   */
+  renderPhoneNumber = data => {
+    return formatPhoneNumberVisually(data.value);
   };
 
   /**
@@ -288,7 +297,8 @@ class MoveToHousehold extends React.Component {
                 </p>
                 <InputGroup size="md">
                   <InputGroup.Prepend>
-                    <OverlayTrigger overlay={<Tooltip>Search by monitoree name, date of birth, state/local id, cdc id, or nndss/case id</Tooltip>}>
+                    <OverlayTrigger
+                      overlay={<Tooltip>Search by Monitoree Name, Date of Birth, Phone Number, State/Local ID, CDC ID, or NNDSS/Case ID</Tooltip>}>
                       <InputGroup.Text className="rounded-0">
                         <i className="fas fa-search"></i>
                         <label htmlFor="search-input" className="ml-1 mb-0">

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -679,7 +679,7 @@ class PatientsTable extends React.Component {
                 <InputGroup size="sm" className="d-flex justify-content-between">
                   <InputGroup.Prepend>
                     <OverlayTrigger
-                      overlay={<Tooltip>Search by Monitoree Name, Date of Birth, Phone Number, State/Local ID, CDC ID, or NNDSS/Case ID</Tooltip>}>
+                      overlay={<Tooltip>Search by Monitoree Name, Date of Birth, Email, Phone Number, State/Local ID, CDC ID, or NNDSS/Case ID</Tooltip>}>
                       <InputGroup.Text className="rounded-0">
                         <i className="fas fa-search"></i>
                         <label htmlFor="search" className="ml-1 mb-0">

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -679,7 +679,9 @@ class PatientsTable extends React.Component {
                 <InputGroup size="sm" className="d-flex justify-content-between">
                   <InputGroup.Prepend>
                     <OverlayTrigger
-                      overlay={<Tooltip>Search by Monitoree Name, Date of Birth, Email, Phone Number, State/Local ID, CDC ID, or NNDSS/Case ID</Tooltip>}>
+                      overlay={
+                        <Tooltip>Search by Monitoree Name, Date of Birth, Email, Primary Telephone Number, State/Local ID, CDC ID, or NNDSS/Case ID</Tooltip>
+                      }>
                       <InputGroup.Text className="rounded-0">
                         <i className="fas fa-search"></i>
                         <label htmlFor="search" className="ml-1 mb-0">

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -37,7 +37,7 @@ import EligibilityTooltip from '../util/EligibilityTooltip';
 import confirmDialog from '../util/ConfirmDialog';
 import { patientHref } from '../../utils/Navigation';
 import { formatDate, formatTimestamp } from '../../utils/DateTime';
-import { formatDateOfBirthTableCell } from '../../utils/PatientFormatters';
+import { formatDateOfBirthTableCell, formatPhoneNumberVisually } from '../../utils/PatientFormatters';
 
 class PatientsTable extends React.Component {
   constructor(props) {
@@ -53,6 +53,7 @@ class PatientsTable extends React.Component {
           { field: 'assigned_user', label: 'Assigned User', isSortable: true, tooltip: null },
           { field: 'state_local_id', label: 'State/Local ID', isSortable: true, tooltip: null },
           { field: 'dob', label: 'Date of Birth', isSortable: true, tooltip: null, filter: this.formatDOB },
+          { field: 'primary_telephone', label: 'Phone Number', isSortable: false, tooltip: null, filter: this.formatPhoneNumber },
           { field: 'end_of_monitoring', label: 'End of Monitoring', isSortable: true, tooltip: null, filter: this.formatEndOfMonitoring },
           { field: 'extended_isolation', label: 'Extended Isolation To', isSortable: true, tooltip: 'extendedIsolation', filter: formatDate },
           { field: 'first_positive_lab_at', label: 'First Positive Lab', isSortable: true, filter: formatDate },
@@ -519,6 +520,10 @@ class PatientsTable extends React.Component {
     );
   };
 
+  formatPhoneNumber = data => {
+    return formatPhoneNumberVisually(data.value);
+  };
+
   getRowCheckboxAriaLabel = rowData => {
     return `Monitoree ${rowData.name}`;
   };
@@ -673,7 +678,8 @@ class PatientsTable extends React.Component {
                 </Form.Row>
                 <InputGroup size="sm" className="d-flex justify-content-between">
                   <InputGroup.Prepend>
-                    <OverlayTrigger overlay={<Tooltip>Search by monitoree name, date of birth, state/local id, cdc id, or nndss/case id</Tooltip>}>
+                    <OverlayTrigger
+                      overlay={<Tooltip>Search by Monitoree Name, Date of Birth, Phone Number, State/Local ID, CDC ID, or NNDSS/Case ID</Tooltip>}>
                       <InputGroup.Text className="rounded-0">
                         <i className="fas fa-search"></i>
                         <label htmlFor="search" className="ml-1 mb-0">

--- a/app/javascript/components/public_health/custom_export/PatientsFilters.js
+++ b/app/javascript/components/public_health/custom_export/PatientsFilters.js
@@ -143,7 +143,8 @@ class PatientsFilters extends React.Component {
           <Col md={24} className="my-1 px-1">
             <InputGroup size="sm" className="d-flex justify-content-between">
               <InputGroup.Prepend>
-                <OverlayTrigger overlay={<Tooltip>Search by Monitoree Name, Date of Birth, State/Local ID, CDC ID, or NNDSS/Case ID</Tooltip>}>
+                <OverlayTrigger
+                  overlay={<Tooltip>Search by Monitoree Name, Date of Birth, Email, Phone Number, State/Local ID, CDC ID, or NNDSS/Case ID</Tooltip>}>
                   <InputGroup.Text className="rounded-0">
                     <FontAwesomeIcon icon="search" />
                     <label htmlFor="search" className="ml-1 mb-0">

--- a/app/javascript/components/public_health/custom_export/PatientsFilters.js
+++ b/app/javascript/components/public_health/custom_export/PatientsFilters.js
@@ -144,7 +144,9 @@ class PatientsFilters extends React.Component {
             <InputGroup size="sm" className="d-flex justify-content-between">
               <InputGroup.Prepend>
                 <OverlayTrigger
-                  overlay={<Tooltip>Search by Monitoree Name, Date of Birth, Email, Phone Number, State/Local ID, CDC ID, or NNDSS/Case ID</Tooltip>}>
+                  overlay={
+                    <Tooltip>Search by Monitoree Name, Date of Birth, Email, Primary Telephone Number, State/Local ID, CDC ID, or NNDSS/Case ID</Tooltip>
+                  }>
                   <InputGroup.Text className="rounded-0">
                     <FontAwesomeIcon icon="search" />
                     <label htmlFor="search" className="ml-1 mb-0">

--- a/app/javascript/components/public_health/custom_export/PatientsFilters.js
+++ b/app/javascript/components/public_health/custom_export/PatientsFilters.js
@@ -143,7 +143,7 @@ class PatientsFilters extends React.Component {
           <Col md={24} className="my-1 px-1">
             <InputGroup size="sm" className="d-flex justify-content-between">
               <InputGroup.Prepend>
-                <OverlayTrigger overlay={<Tooltip>Search by monitoree name, date of birth, state/local id, cdc id, or nndss/case id</Tooltip>}>
+                <OverlayTrigger overlay={<Tooltip>Search by Monitoree Name, Date of Birth, State/Local ID, CDC ID, or NNDSS/Case ID</Tooltip>}>
                   <InputGroup.Text className="rounded-0">
                     <FontAwesomeIcon icon="search" />
                     <label htmlFor="search" className="ml-1 mb-0">

--- a/app/javascript/utils/PatientFormatters.js
+++ b/app/javascript/utils/PatientFormatters.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import moment from 'moment-timezone';
+import _ from 'lodash';
 import libphonenumber from 'google-libphonenumber';
 import IconMinor from '../components/patient/icons/IconMinor';
 import { formatDate } from './DateTime';
@@ -52,7 +53,7 @@ function phoneSchemaValidator() {
  * @param {String} phone_number - phone number in e164 format
  */
 function formatPhoneNumberVisually(phone_number) {
-  if (phone_number === null || phone_number === undefined) return '';
+  if (_.isNil(phone_number)) return '';
 
   const match = phone_number
     .replace('+1', '')

--- a/app/lib/import_export_constants.rb
+++ b/app/lib/import_export_constants.rb
@@ -31,12 +31,12 @@ module ImportExportConstants # rubocop:todo Metrics/ModuleLength
   LINELIST_FIELDS = %i[id name jurisdiction_name assigned_user user_defined_id_statelocal sex date_of_birth end_of_monitoring exposure_risk_assessment
                        monitoring_plan latest_assessment_at latest_transfer_at monitoring_reason public_health_action status closed_at transferred_from
                        transferred_to expected_purge_ts symptom_onset extended_isolation responder_id workflow first_positive_lab_at follow_up_reason
-                       follow_up_note].freeze
+                       follow_up_note primary_telephone].freeze
 
   LINELIST_HEADERS = ['Patient ID', 'Monitoree', 'Jurisdiction', 'Assigned User', 'State/Local ID', 'Sex', 'Date of Birth', 'End of Monitoring', 'Risk Level',
                       'Monitoring Plan', 'Latest Report', 'Transferred At', 'Reason For Closure', 'Latest Public Health Action', 'Status', 'Closed At',
                       'Transferred From', 'Transferred To', 'Expected Purge Date', 'Symptom Onset', 'Extended Isolation', 'Reporter ID', 'Workflow',
-                      'First Positive Lab', 'Follow-Up Reason', 'Follow-Up Note'].freeze
+                      'First Positive Lab', 'Follow-Up Reason', 'Follow-Up Note', 'Primary Telephone'].freeze
 
   SARA_ALERT_FORMAT_FIELDS = [:first_name, :middle_name, :last_name, :date_of_birth, :sex, :white, :black_or_african_american,
                               :american_indian_or_alaska_native, :asian, :native_hawaiian_or_other_pacific_islander, :ethnicity, :primary_language,

--- a/test/controllers/public_health_controller_test.rb
+++ b/test/controllers/public_health_controller_test.rb
@@ -110,7 +110,7 @@ class PublicHealthControllerTest < ActionController::TestCase
       user = create(:public_health_user, jurisdiction: user_jur)
       sign_in user
 
-      common_fields = %w[name state_local_id dob]
+      common_fields = %w[name state_local_id dob primary_telephone]
 
       post :patients, params: { query: { workflow: 'exposure', tab: 'symptomatic' } }, as: :json
       json_response = JSON.parse(response.body)

--- a/test/fixtures/patients.yml
+++ b/test/fixtures/patients.yml
@@ -8,7 +8,7 @@ patient_1:
   submission_token: 'agu4DLdHRW'
   monitoring: true
   user_defined_id_statelocal: 'EX-349212'
-  first_name: 'Domingo54'
+  first_name: 'Domingo49'
   middle_name: 'Simonis31'
   last_name: 'Boehm62'
   date_of_birth: <%= 25.years.ago %>

--- a/test/system/roles/public_health/dashboard/dashboard_verifier.rb
+++ b/test/system/roles/public_health/dashboard/dashboard_verifier.rb
@@ -6,6 +6,7 @@ require_relative 'dashboard'
 require_relative '../../../lib/system_test_utils'
 
 class PublicHealthDashboardVerifier < ApplicationSystemTestCase
+  include Utils
   @@public_health_dashboard = PublicHealthDashboard.new(nil)
   @@system_test_utils = SystemTestUtils.new(nil)
 
@@ -94,7 +95,7 @@ class PublicHealthDashboardVerifier < ApplicationSystemTestCase
     verify_patient_field('assigned user', patient[:assigned_user]) unless %i[transferred_in transferred_out].include?(tab)
     verify_patient_field('state/local id', patient[:user_defined_id_statelocal])
     verify_patient_field('date of birth', patient[:date_of_birth].strftime('%m/%d/%Y'))
-    verify_patient_field('phone number', patient[:primary_telephone])
+    verify_patient_field('phone number', format_phone_number(patient[:primary_telephone]))
     verify_patient_field('end of monitoring', Date.parse(patient.end_of_monitoring).strftime('%m/%d/%Y')) unless workflow == :isolation || tab == :closed
     verify_patient_field('risk level', patient[:exposure_risk_assessment]) unless workflow == :isolation || tab == :closed
     verify_patient_field('monitoring plan', patient[:monitoring_plan]) unless %i[closed pui].include?(tab)

--- a/test/system/roles/public_health/dashboard/dashboard_verifier.rb
+++ b/test/system/roles/public_health/dashboard/dashboard_verifier.rb
@@ -94,6 +94,7 @@ class PublicHealthDashboardVerifier < ApplicationSystemTestCase
     verify_patient_field('assigned user', patient[:assigned_user]) unless %i[transferred_in transferred_out].include?(tab)
     verify_patient_field('state/local id', patient[:user_defined_id_statelocal])
     verify_patient_field('date of birth', patient[:date_of_birth].strftime('%m/%d/%Y'))
+    verify_patient_field('phone number', patient[:primary_telephone])
     verify_patient_field('end of monitoring', Date.parse(patient.end_of_monitoring).strftime('%m/%d/%Y')) unless workflow == :isolation || tab == :closed
     verify_patient_field('risk level', patient[:exposure_risk_assessment]) unless workflow == :isolation || tab == :closed
     verify_patient_field('monitoring plan', patient[:monitoring_plan]) unless %i[closed pui].include?(tab)

--- a/test/system/roles/public_health/dashboard/export_verifier.rb
+++ b/test/system/roles/public_health/dashboard/export_verifier.rb
@@ -101,6 +101,8 @@ class PublicHealthMonitoringExportVerifier < ApplicationSystemTestCase
             sleep(4)
             assert_in_delta(details[field].to_datetime, csv[row][col].to_datetime, 1, "For field: #{field}")
           end
+        elsif %i[primary_telephone].include?(field)
+          assert_equal(format_phone_number(details[field]).to_s, csv[row][col].to_s || '', "For field: #{field}")
         else
           assert_equal(details[field].to_s, csv[row][col].to_s, "For field: #{field}")
         end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1631](https://tracker.codev.mitre.org/browse/SARAALERT-1631)

Add Ability to Search by Phone Number and Email to all patient searches (Patients Table, Move to Household modal, export search).  Also add a phone number column to the patients and move to household tables (this column is not sortable)

## (Feature) Demo/Screenshots
<img width="2002" alt="Screen Shot 2021-11-24 at 9 51 02 AM" src="https://user-images.githubusercontent.com/35042815/143260698-1cc830a9-b062-4547-a877-6d4fb10a5b96.png">

<img width="1261" alt="Screen Shot 2021-11-24 at 9 50 36 AM" src="https://user-images.githubusercontent.com/35042815/143260706-34680f2d-1ade-492b-aa4f-afeb91e4f25b.png">

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`patient_query_helper.rb`
- Add support for searching by email and phone number to the `filter_by_text` method

`MoveToHousehold.js`, `PatientsTable.js`, `PatientsFilters.js`
- Added column for phone number to the table (n/a for `PatientsFilters.js`)
- Updated search tooltip to include phone number and email

`PatientFormatters.js`
- Cleaned up phone number formatter method

`patient_details_helper.rb`, `import_export_constants.rb`
- Add phone number to linelist export

`public_health_controller_test.rb`, `export_verifier.rb`, `patients.yml`
- Fix system/controller tests

## Testing Recommendations
Please list any recommendations regarding what reviewers should test and if there is any specific guidance on how to test certain aspects of the PR. Be sure to mention edge cases that should be tried, particularly in the UI.

Test searching for phone numbers and emails in the patients table, move to household modal, and in the custom export dashboard search terms input.  Also, test that phone numbers are now included in the linelist export

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@tstrass :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@ngfreiter :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [x] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
