### PR TITLE
SARAALERT-1625: Remove Signs and Symptoms section from PHDC

### DIFF
--- a/app/lib/phdc/serializer.rb
+++ b/app/lib/phdc/serializer.rb
@@ -354,7 +354,7 @@ module PHDC
         sas_tbody << sas_tbody_tr
         sas_tbody_tr << td_helper('Patient Symptomatic')
         sas_tbody_tr << td_helper('Yes')
-        sas_tbody_tr << td_helper(assessment.updated_at.strftime('%FT%T%:z'))
+        sas_tbody_tr << td_helper(assessment.reported_at.strftime('%Y/%m/%d %H:%M %Z'))
       end
 
       # Return XML

--- a/app/lib/phdc/serializer.rb
+++ b/app/lib/phdc/serializer.rb
@@ -336,6 +336,7 @@ module PHDC
       sas_table['border'] = '5'
       sas_text << sas_table
       sas_colgroup = Ox::Element.new(:colgroup)
+      sas_table << sas_colgroup
       sas_colgroup << col_helper('30%')
       sas_colgroup << col_helper('30%')
       sas_colgroup << col_helper('40%')

--- a/app/lib/phdc/serializer.rb
+++ b/app/lib/phdc/serializer.rb
@@ -313,38 +313,47 @@ module PHDC
         qrq_org_notes << comp_obs_helper('OBS', 'EVN', code, value)
       end
 
-      # Signs and Symptoms Information Section
+      # Active Problems Information Section HTML table
 
       sas_component = Ox::Element.new(:component)
       structured_body << sas_component
       sas_section = Ox::Element.new(:section)
       sas_component << sas_section
-      sas_id = Ox::Element.new(:id)
-      sas_id['root'] = '2.16.840.1.113883.19'
-      sas_id['extension'] = patient.id
-      sas_section << sas_id
-      sas_section << code_helper('123-5897', 'Local-codesystem-oid', 'Signs and Symptoms Section', 'LocalSystem')
-      sas_section_title = Ox::Element.new(:title)
-      sas_section_title << 'SIGNS AND SYMPTOMS'
-      sas_section << sas_section_title
+      sas_section << template_id_helper('2.16.840.1.113883.10.20.22.2.5', nil)
+      sas_section << template_id_helper('2.16.840.1.113883.10.20.22.2.5', '2015-08-01')
+      sas_section << template_id_helper('2.16.840.1.113883.10.20.22.2.5.1', nil)
+      sas_section << template_id_helper('2.16.840.1.113883.10.20.22.2.5.1', '2015-08-01')
+      sas_section << code_helper('11450-4', '2.16.840.1.113883.6.1', 'Problem List', 'LOINC')
+      sas_title = Ox::Element.new(:title)
+      sas_title << 'Active Problems'
+      sas_section << sas_title
+      sas_text = Ox::Element.new(:text)
+      sas_section << sas_text
+      sas_paragraph = Ox::Element.new(:paragraph)
+      sas_paragraph << 'Patient Symptomatic Events'
+      sas_text << sas_paragraph
+      sas_table = Ox::Element.new(:table)
+      sas_table['border'] = '5'
+      sas_text << sas_table
+      sas_colgroup = Ox::Element.new(:colgroup)
+      sas_colgroup << col_helper('30%')
+      sas_colgroup << col_helper('30%')
+      sas_colgroup << col_helper('40%')
+      sas_thead = Ox::Element.new(:thead)
+      sas_table << sas_thead
+      sas_thead_tr = Ox::Element.new(:tr)
+      sas_thead << sas_thead_tr
+      sas_thead_tr << th_helper('Problem Type')
+      sas_thead_tr << th_helper('Indicator')
+      sas_thead_tr << th_helper('Date(s)')
+      sas_tbody = Ox::Element.new(:tbody)
+      sas_table << sas_tbody
       symptomatic_assessments.each do |assessment|
-        sas_entry = entry_helper('COMP')
-        sas_section << sas_entry
-        sas_obs = observation_helper('OBS', 'EVN')
-        sas_entry << sas_obs
-        sas_obs << code_helper('INV576', '2.16.840.1.114222.4.5.232', 'Symptomatic', 'PHIN Questions')
-        effective_time = Ox::Element.new(:effectiveTime)
-        effective_time['value'] = assessment.updated_at.strftime('%Y%m%d%H%M%S%z')
-        sas_obs << effective_time
-        sas_val = value_helper_code('CE', 'Y', '2.16.840.1.113883.12.136', 'Yes')
-        sas_val['codeSystemName'] = 'Yes/No Indicator (HL7)'
-        sas_obs << sas_val
-        translation = Ox::Element.new(:translation)
-        translation['codeSystem'] = '2.16.840.1.113883.12.136'
-        translation['codeSystemName'] = 'Yes/No Indicator (HL7)'
-        translation['displayName'] = 'Yes'
-        translation['code'] = 'Y'
-        sas_val << translation
+        sas_tbody_tr = Ox::Element.new(:tr)
+        sas_tbody << sas_tbody_tr
+        sas_tbody_tr << td_helper('Patient Symptomatic')
+        sas_tbody_tr << td_helper('Yes')
+        sas_tbody_tr << td_helper(assessment.updated_at.strftime('%FT%T%:z'))
       end
 
       # Return XML
@@ -451,6 +460,31 @@ module PHDC
       observation_el << code
       observation_el << value
       component_el
+    end
+
+    def template_id_helper(root, extension)
+      template_id = Ox::Element.new(:templateId)
+      template_id['root'] = root
+      template_id['extension'] = extension if extension.present?
+      template_id
+    end
+
+    def col_helper(width)
+      col = Ox::Element.new(:col)
+      col['width'] = width
+      col
+    end
+
+    def th_helper(header)
+      th = Ox::Element.new(:th)
+      th << header
+      th
+    end
+
+    def td_helper(content)
+      td = Ox::Element.new(:td)
+      td << content
+      td
     end
   end
 end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1625](https://tracker.codev.mitre.org/browse/SARAALERT-1625)

This updates the PHDC export to remove the signs and symptoms section, and instead represent this data in an HTML table. See the example linked in the ticket for how this is supposed to look. I made a few style changes, but when exporting the PHDC for a patient with symptomatic reports, the PHDC should contain an HTML table similar to that in the linked example.

## Important Changes
`serializer.rb`
- Update the PHDC export to remove the Signs and Symptoms section and replace it with "Active Problems" HTML table

## Testing Recommendations
- NBS export a Patient with no reports
- NBS export a Patient with reports, but none that are symptomatic
- NBS export a Patient with symptomatic reports

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@tstrass 
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@sgober 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
