### PR TITLE
SARAALERT-NONE: Contact Type Reset Bugfix

### DIFF
--- a/app/javascript/components/enrollment/steps/ExposureInformation.js
+++ b/app/javascript/components/enrollment/steps/ExposureInformation.js
@@ -179,7 +179,7 @@ class ExposureInformation extends React.Component {
     this.setState(
       {
         current: { ...current, common_exposure_cohorts, patient: { ...current.patient, member_of_a_common_exposure_cohort: toggle } },
-        modified: { ...modified, common_exposure_cohorts, patient: { ...current.patient, member_of_a_common_exposure_cohort: toggle } },
+        modified: { ...modified, common_exposure_cohorts, patient: { ...modified.patient, member_of_a_common_exposure_cohort: toggle } },
         showCommonExposureCohortModal: false,
         common_exposure_cohort: null,
         common_exposure_cohort_index: null,


### PR DESCRIPTION
# Description
Bugfix to prevent overwriting the Contact Relationship when adding a Common Exposure Cohort

## (Bugfix) How to Replicate

1. Enroll a new monitoree in exposure filling out only the required fields
2. When on the contact step, be sure to swap the primary contact relationship and add a contact name
3. For the Exposure Information (last) step, add a common exposure cohort
4. Click next and the contact type has been reset to self

## (Bugfix) Solution
When updating the `enrollmentState` in the `ExposureInformation` component, `modified` was being updated with the values in `current`, instead of using `modified`.  This then is what is used to set the state in the `Enrollment` component, which is why the value is overwritten


# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA ticket reference.
- [ ] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@tstrass :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@deastman :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
