### PR TITLE
SARAALERT-1649: Column Sort should result in all null and blank values appearing at the bottom

### DIFF
--- a/app/helpers/assessment_query_helper.rb
+++ b/app/helpers/assessment_query_helper.rb
@@ -53,6 +53,9 @@ module AssessmentQueryHelper
       # Reverse if in descending order
       ordered_values = ordered_values.reverse if dir == 'desc'
 
+      # Blank and null values always belong at the end
+      ordered_values = ordered_values.filter { |v| v[:val].present? } + ordered_values.filter { |v| v[:val].blank? }
+
       # Collect just the assessment IDs
       ordered_assessment_ids = ordered_values.pluck(:id)
 

--- a/app/helpers/close_contact_query_helper.rb
+++ b/app/helpers/close_contact_query_helper.rb
@@ -76,23 +76,23 @@ module CloseContactQueryHelper
 
     case order
     when 'first_name'
-      close_contacts = close_contacts.order(Arel.sql('CASE WHEN first_name IS NULL THEN 1 ELSE 0 END, first_name ' + dir))
+      close_contacts = close_contacts.order(Arel.sql('first_name IS NULL OR first_name = "", first_name ' + dir))
     when 'last_name'
-      close_contacts = close_contacts.order(Arel.sql('CASE WHEN last_name IS NULL THEN 1 ELSE 0 END, last_name ' + dir))
+      close_contacts = close_contacts.order(Arel.sql('last_name IS NULL OR last_name = "", last_name ' + dir))
     when 'primary_telephone'
-      close_contacts = close_contacts.order(Arel.sql('CASE WHEN primary_telephone IS NULL THEN 1 ELSE 0 END, primary_telephone ' + dir))
+      close_contacts = close_contacts.order(Arel.sql('primary_telephone IS NULL OR primary_telephone = "", primary_telephone ' + dir))
     when 'email'
-      close_contacts = close_contacts.order(Arel.sql('CASE WHEN email IS NULL THEN 1 ELSE 0 END, email ' + dir))
+      close_contacts = close_contacts.order(Arel.sql('email IS NULL OR email = "", email ' + dir))
     when 'enrolled_id'
-      close_contacts = close_contacts.order(Arel.sql('CASE WHEN enrolled_id IS NULL THEN "no" ELSE "yes" END ' + dir))
+      close_contacts = close_contacts.order(Arel.sql('enrolled_id IS NOT NULL ' + dir))
     when 'last_date_of_exposure'
-      close_contacts = close_contacts.order(Arel.sql('CASE WHEN last_date_of_exposure IS NULL THEN 1 ELSE 0 END, last_date_of_exposure ' + dir))
+      close_contacts = close_contacts.order(Arel.sql('last_date_of_exposure IS NULL, last_date_of_exposure ' + dir))
     when 'assigned_user'
-      close_contacts = close_contacts.order(Arel.sql('CASE WHEN assigned_user IS NULL THEN 1 ELSE 0 END, assigned_user ' + dir))
+      close_contacts = close_contacts.order(Arel.sql('assigned_user IS NULL, assigned_user ' + dir))
     when 'contact_attempts'
-      close_contacts = close_contacts.order(Arel.sql('CASE WHEN contact_attempts IS NULL THEN 1 ELSE 0 END, contact_attempts ' + dir))
+      close_contacts = close_contacts.order(Arel.sql('contact_attempts IS NULL, contact_attempts ' + dir))
     when 'notes'
-      close_contacts = close_contacts.order(Arel.sql("CASE WHEN notes IS NULL THEN 2 WHEN notes = '' THEN 1 ELSE 0 END, notes " + dir))
+      close_contacts = close_contacts.order(Arel.sql('CASE WHEN notes IS NULL THEN 2 WHEN notes = "" THEN 1 ELSE 0 END, notes ' + dir))
     end
     close_contacts
   end

--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -208,43 +208,43 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     when 'transferred_to'
       patients = patients.includes(:jurisdiction).order('jurisdictions.path ' + dir, id: dir)
     when 'assigned_user'
-      patients = patients.order(Arel.sql('CASE WHEN assigned_user IS NULL THEN 1 ELSE 0 END, assigned_user ' + dir), id: dir)
+      patients = patients.order(Arel.sql('assigned_user IS NULL, assigned_user ' + dir), id: dir)
     when 'state_local_id'
-      patients = patients.order(Arel.sql('CASE WHEN user_defined_id_statelocal IS NULL THEN 1 ELSE 0 END, user_defined_id_statelocal ' + dir), id: dir)
+      patients = patients.order(Arel.sql('user_defined_id_statelocal IS NULL OR user_defined_id_statelocal = "", user_defined_id_statelocal ' + dir), id: dir)
     when 'dob'
-      patients = patients.order(Arel.sql('CASE WHEN date_of_birth IS NULL THEN 1 ELSE 0 END, date_of_birth ' + dir), id: dir)
+      patients = patients.order(Arel.sql('date_of_birth IS NULL, date_of_birth ' + dir), id: dir)
     when 'end_of_monitoring'
-      patients = patients.order(Arel.sql('CASE WHEN continuous_exposure = 1 THEN 1 ELSE 0 END,
+      patients = patients.order(Arel.sql('continuous_exposure,
                                  CASE WHEN last_date_of_exposure IS NULL THEN patients.created_at ELSE last_date_of_exposure END ' + dir), id: dir)
     when 'extended_isolation'
-      patients = patients.order(Arel.sql('CASE WHEN extended_isolation IS NULL THEN 1 ELSE 0 END, extended_isolation ' + dir), id: dir)
+      patients = patients.order(Arel.sql('extended_isolation IS NULL, extended_isolation ' + dir), id: dir)
     when 'first_positive_lab_at'
-      patients = patients.order(Arel.sql('CASE WHEN first_positive_lab_at IS NULL THEN 1 ELSE 0 END, first_positive_lab_at ' + dir), id: dir)
+      patients = patients.order(Arel.sql('first_positive_lab_at IS NULL, first_positive_lab_at ' + dir), id: dir)
     when 'symptom_onset'
-      patients = patients.order(Arel.sql('CASE WHEN symptom_onset IS NULL THEN 1 ELSE 0 END, symptom_onset ' + dir), id: dir)
+      patients = patients.order(Arel.sql('symptom_onset IS NULL, symptom_onset ' + dir), id: dir)
     when 'risk_level'
       patients = patients.order_by_risk(asc: dir == 'asc').order(id: dir)
     when 'monitoring_plan'
-      patients = patients.order(Arel.sql('monitoring_plan IS NULL, monitoring_plan ' + dir), id: dir)
+      patients = patients.order(Arel.sql('monitoring_plan IS NULL OR monitoring_plan = "", monitoring_plan ' + dir), id: dir)
     when 'reporter'
       patients = patients.order('responder_id ' + dir, id: dir)
     when 'public_health_action'
-      patients = patients.order(Arel.sql('CASE WHEN public_health_action IS NULL THEN 1 ELSE 0 END, public_health_action ' + dir), id: dir)
+      patients = patients.order(Arel.sql('public_health_action IS NULL, public_health_action ' + dir), id: dir)
     when 'expected_purge_date'
-      patients = patients.order(Arel.sql('CASE WHEN closed_at IS NULL THEN 1 ELSE 0 END, updated_at ' + dir), id: dir)
+      patients = patients.order(Arel.sql('closed_at IS NULL, updated_at ' + dir), id: dir)
       # Eligible purge date is a derivative field from `updated_at`
     when 'reason_for_closure'
-      patients = patients.order(Arel.sql('CASE WHEN monitoring_reason IS NULL THEN 1 ELSE 0 END, monitoring_reason ' + dir), id: dir)
+      patients = patients.order(Arel.sql('monitoring_reason IS NULL, monitoring_reason ' + dir), id: dir)
     when 'closed_at'
-      patients = patients.order(Arel.sql('CASE WHEN closed_at IS NULL THEN 1 ELSE 0 END, closed_at ' + dir), id: dir)
+      patients = patients.order(Arel.sql('closed_at IS NULL, closed_at ' + dir), id: dir)
     when 'transferred_at'
-      patients = patients.order(Arel.sql('CASE WHEN latest_transfer_at IS NULL THEN 1 ELSE 0 END, latest_transfer_at ' + dir), id: dir)
+      patients = patients.order(Arel.sql('latest_transfer_at IS NULL, latest_transfer_at ' + dir), id: dir)
     when 'latest_report'
-      patients = patients.order(Arel.sql('CASE WHEN latest_assessment_at IS NULL THEN 1 ELSE 0 END, latest_assessment_at ' + dir), id: dir)
+      patients = patients.order(Arel.sql('latest_assessment_at IS NULL, latest_assessment_at ' + dir), id: dir)
     when 'workflow'
-      patients = patients.order(Arel.sql('CASE WHEN isolation THEN 1 ELSE 0 END ' + dir), id: dir)
+      patients = patients.order(isolation: dir, id: dir)
     when 'primary_telephone'
-      patients = patients.order(Arel.sql('CASE WHEN primary_telephone IS NULL THEN 1 ELSE 0 END, primary_telephone ' + dir), id: dir)
+      patients = patients.order(Arel.sql('primary_telephone IS NULL OR primary_telephone = "", primary_telephone ' + dir), id: dir)
     end
 
     patients

--- a/app/helpers/vaccine_query_helper.rb
+++ b/app/helpers/vaccine_query_helper.rb
@@ -76,13 +76,13 @@ module VaccineQueryHelper
     when 'product_name'
       vaccines = vaccines.order(product_name: dir)
     when 'administration_date'
-      vaccines = vaccines.order(Arel.sql('CASE WHEN administration_date IS NULL THEN 1 ELSE 0 END, administration_date ' + dir))
+      vaccines = vaccines.order(Arel.sql('administration_date IS NULL, administration_date ' + dir))
     when 'dose_number'
       # nil or empty string values are always sorted at the bottom
-      vaccines = vaccines.order(Arel.sql("CASE WHEN dose_number IS NULL THEN 2 WHEN dose_number = '' THEN 1 ELSE 0 END, dose_number " + dir))
+      vaccines = vaccines.order(Arel.sql('CASE WHEN dose_number IS NULL THEN 2 WHEN dose_number = "" THEN 1 ELSE 0 END, dose_number ' + dir))
     when 'notes'
       # nil or empty string values are always sorted at the bottom
-      vaccines = vaccines.order(Arel.sql("CASE WHEN notes IS NULL THEN 2 WHEN notes = '' THEN 1 ELSE 0 END, notes " + dir))
+      vaccines = vaccines.order(Arel.sql('CASE WHEN notes IS NULL THEN 2 WHEN notes = "" THEN 1 ELSE 0 END, notes ' + dir))
     end
     vaccines
   end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -888,13 +888,13 @@ class Patient < ApplicationRecord
       WHEN exposure_risk_assessment='Medium' THEN 1
       WHEN exposure_risk_assessment='Low' THEN 2
       WHEN exposure_risk_assessment='No Identified Risk' THEN 3
-      WHEN exposure_risk_assessment IS NULL THEN 4
+      WHEN exposure_risk_assessment IS NULL OR exposure_risk_assessment = '' THEN 4
       END
     SQL
 
     order_by_rev = <<~SQL.squish
       CASE
-      WHEN exposure_risk_assessment IS NULL THEN 4
+      WHEN exposure_risk_assessment IS NULL OR exposure_risk_assessment = '' THEN 4
       WHEN exposure_risk_assessment='High' THEN 3
       WHEN exposure_risk_assessment='Medium' THEN 2
       WHEN exposure_risk_assessment='Low' THEN 1


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-###](https://tracker.codev.mitre.org/browse/SARAALERT-###)

Write out a concise summary of this pull request and what it addresses.

For column sorts within Sara Alert, Null values are always sorted to be at the bottom of the list regardless of sort direction. But for blank values (values that held a value at one point that were then cleared out by the monitoree) currently are not sorted the same way. Revise the column sorting logic for all applicable columns to ensure that blank values are sorted to the end of the list regardless of sort direction where Null values are also sorted.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`example_file.js`
- Example change (ex: refactored import function)

## Testing Recommendations
Please list any recommendations regarding what reviewers should test and if there is any specific guidance on how to test certain aspects of the PR. Be sure to mention edge cases that should be tried, particularly in the UI.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@sgober :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@deastman :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
