### PR TITLE
SARAALERT-1662: Update monitoring and recovery definition periods

### DIFF
--- a/app/helpers/patient_details_helper.rb
+++ b/app/helpers/patient_details_helper.rb
@@ -30,10 +30,11 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
 
     # Time.zone is set by Rails.application.config.time_zone which defaults to UTC.
     # Therefore, Time.zone.today makes UTC explicit and is consistient with previous behavior.
-    return :isolation_asymp_non_test_based if !latest_assessment_at.nil? && !first_positive_lab_at.nil? && first_positive_lab_at < 10.days.ago &&
+    return :isolation_asymp_non_test_based if !latest_assessment_at.nil? && !first_positive_lab_at.nil? &&
+                                              first_positive_lab_at < ADMIN_OPTIONS['recovery_period_days'].days.ago &&
                                               symptom_onset.nil? && (!extended_isolation || extended_isolation < Time.zone.today)
     return :isolation_symp_non_test_based if (latest_fever_or_fever_reducer_at.nil? || latest_fever_or_fever_reducer_at < 24.hours.ago) &&
-                                             !symptom_onset.nil? && symptom_onset <= 10.days.ago &&
+                                             !symptom_onset.nil? && symptom_onset <= ADMIN_OPTIONS['recovery_period_days'].days.ago &&
                                              (!extended_isolation || extended_isolation < Time.zone.today)
     return :isolation_test_based if !latest_assessment_at.nil? && (latest_fever_or_fever_reducer_at.nil? || latest_fever_or_fever_reducer_at < 24.hours.ago) &&
                                     negative_lab_count >= 2 && (!extended_isolation || extended_isolation < Time.zone.today)

--- a/app/javascript/components/patient/assessment/AssessmentTable.js
+++ b/app/javascript/components/patient/assessment/AssessmentTable.js
@@ -324,7 +324,12 @@ class AssessmentTable extends React.Component {
             Reports
           </Card.Header>
           <Card.Body>
-            <CurrentStatus report_eligibility={this.props.report_eligibility} status={this.props.patient_status} isolation={this.props.patient?.isolation} />
+            <CurrentStatus
+              report_eligibility={this.props.report_eligibility}
+              status={this.props.patient_status}
+              isolation={this.props.patient?.isolation}
+              recovery_period_days={this.props.recovery_period_days}
+            />
             <Row className="my-4">
               <Col>
                 <Button variant="primary" className="mr-2" onClick={this.handleAddReportClick}>
@@ -438,6 +443,7 @@ AssessmentTable.propTypes = {
   calculated_age: PropTypes.number,
   patient_initials: PropTypes.string,
   monitoring_period_days: PropTypes.number,
+  recovery_period_days: PropTypes.number,
   current_user: PropTypes.object,
   translations: PropTypes.object,
   authenticity_token: PropTypes.string,

--- a/app/javascript/components/patient/assessment/actions/CurrentStatus.js
+++ b/app/javascript/components/patient/assessment/actions/CurrentStatus.js
@@ -102,9 +102,9 @@ class CurrentStatus extends React.Component {
       return (
         <ReactTooltip id={`symptomatic-non-test-based`} multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
           <span>
-            At least 5 days have passed since the Symptom Onset Date and at least 24 hours have passed since the case last reported “Yes” for fever or use of
-            fever-reducing medicine to the system. The system does not collect information on severity of symptoms. Public health will need to validate if other
-            symptoms have improved.
+            At least {this.props.recovery_period_days} days have passed since the Symptom Onset Date and at least 24 hours have passed since the case last
+            reported “Yes” for fever or use of fever-reducing medicine to the system. The system does not collect information on severity of symptoms. Public
+            health will need to validate if other symptoms have improved.
           </span>
         </ReactTooltip>
       );
@@ -112,7 +112,8 @@ class CurrentStatus extends React.Component {
       return (
         <ReactTooltip id={`asymptomatic-non-test-based`} multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
           <span>
-            At least 5 days have passed since the specimen collection date of a positive laboratory test and the monitoree has never reported symptoms.
+            At least {this.props.recovery_period_days} days have passed since the specimen collection date of a positive laboratory test and the monitoree has
+            never reported symptoms.
           </span>
         </ReactTooltip>
       );
@@ -167,6 +168,7 @@ CurrentStatus.propTypes = {
   report_eligibility: PropTypes.object,
   status: PropTypes.string,
   isolation: PropTypes.bool,
+  recovery_period_days: PropTypes.number,
 };
 
 export default CurrentStatus;

--- a/app/javascript/components/patient/assessment/actions/CurrentStatus.js
+++ b/app/javascript/components/patient/assessment/actions/CurrentStatus.js
@@ -102,7 +102,7 @@ class CurrentStatus extends React.Component {
       return (
         <ReactTooltip id={`symptomatic-non-test-based`} multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
           <span>
-            At least 10 days have passed since the Symptom Onset Date and at least 24 hours have passed since the case last reported “Yes” for fever or use of
+            At least 5 days have passed since the Symptom Onset Date and at least 24 hours have passed since the case last reported “Yes” for fever or use of
             fever-reducing medicine to the system. The system does not collect information on severity of symptoms. Public health will need to validate if other
             symptoms have improved.
           </span>
@@ -112,7 +112,7 @@ class CurrentStatus extends React.Component {
       return (
         <ReactTooltip id={`asymptomatic-non-test-based`} multiline={true} place="top" type="dark" effect="solid" className="tooltip-container">
           <span>
-            At least 10 days have passed since the specimen collection date of a positive laboratory test and the monitoree has never reported symptoms.
+            At least 5 days have passed since the specimen collection date of a positive laboratory test and the monitoree has never reported symptoms.
           </span>
         </ReactTooltip>
       );

--- a/app/javascript/tests/patient/assessment/actions/CurrentStatus.test.js
+++ b/app/javascript/tests/patient/assessment/actions/CurrentStatus.test.js
@@ -88,7 +88,7 @@ describe('CurrentStatus', () => {
     expect(wrapper.find(Badge).text()).toEqual('requires review (symptomatic non test based)');
     expect(wrapper.find(Badge).prop('variant')).toEqual('danger');
     expect(wrapper.find(ReactTooltip).exists()).toBe(true);
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual('At least 10 days have passed since the Symptom Onset Date and at least 24 hours have passed since the case last reported “Yes” for fever or use of fever-reducing medicine to the system. The system does not collect information on severity of symptoms. Public health will need to validate if other symptoms have improved.');
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual('At least 5 days have passed since the Symptom Onset Date and at least 24 hours have passed since the case last reported “Yes” for fever or use of fever-reducing medicine to the system. The system does not collect information on severity of symptoms. Public health will need to validate if other symptoms have improved.');
   });
 
   it('Correctly renders isolation requires review (asymptomatic non test based) status', () => {
@@ -97,7 +97,7 @@ describe('CurrentStatus', () => {
     expect(wrapper.find(Badge).text()).toEqual('requires review (asymptomatic non test based)');
     expect(wrapper.find(Badge).prop('variant')).toEqual('danger');
     expect(wrapper.find(ReactTooltip).exists()).toBe(true);
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual('At least 10 days have passed since the specimen collection date of a positive laboratory test and the monitoree has never reported symptoms.');
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual('At least 5 days have passed since the specimen collection date of a positive laboratory test and the monitoree has never reported symptoms.');
   });
 
   it('Correctly renders isolation requires review (test based) status', () => {

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -520,7 +520,7 @@ class Patient < ApplicationRecord
       .where(isolation: true)
       .where(symptom_onset: nil)
       .where.not(latest_assessment_at: nil)
-      .where('first_positive_lab_at < ?', 10.days.ago)
+      .where('first_positive_lab_at < ?', ADMIN_OPTIONS['recovery_period_days'].days.ago)
       .where('extended_isolation IS NULL OR extended_isolation < ?', Time.zone.today)
   }
 
@@ -529,14 +529,14 @@ class Patient < ApplicationRecord
     where(monitoring: true)
       .where(purged: false)
       .where(isolation: true)
-      .where('symptom_onset <= ?', 10.days.ago)
+      .where('symptom_onset <= ?', ADMIN_OPTIONS['recovery_period_days'].days.ago)
       .where(latest_fever_or_fever_reducer_at: nil)
       .where('extended_isolation IS NULL OR extended_isolation < ?', Time.zone.today)
       .or(
         where(monitoring: true)
         .where(purged: false)
         .where(isolation: true)
-        .where('symptom_onset <= ?', 10.days.ago)
+        .where('symptom_onset <= ?', ADMIN_OPTIONS['recovery_period_days'].days.ago)
         .where('latest_fever_or_fever_reducer_at < ?', 24.hours.ago)
         .where('extended_isolation IS NULL OR extended_isolation < ?', Time.zone.today)
       )

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -54,6 +54,7 @@
                         symptoms: reporting_condition.symptoms,
                         threshold_condition_hash: reporting_condition.threshold_condition_hash,
                         monitoring_period_days: ADMIN_OPTIONS['monitoring_period_days'].to_i,
+                        recovery_period_days: ADMIN_OPTIONS['recovery_period_days'].to_i,
                         current_user: current_user,
                         translations: Assessment.new.translations,
                         authenticity_token: form_authenticity_token,

--- a/config/sara/sara.yml
+++ b/config/sara/sara.yml
@@ -5,7 +5,10 @@ version: v1.41
 base_path: ''
 
 # How many days an enrolled monitoree should be monitored
-monitoring_period_days: <%= ENV["MONITORING_PERIOD_DAYS"] || 14 %>
+monitoring_period_days: <%= ENV["MONITORING_PERIOD_DAYS"] || 10 %>
+
+# How many days an enrolled case should be monitored until recovery
+recovery_period_days: <%= ENV["recovery_period_days"] || 5 %>
 
 # How long a monitoree should be in isolation and considered non-reporting before we halt daily reports
 isolation_non_reporting_max_days: <%= ENV["SARA_ALERT_ISOLATION_NON_REPORING_MAX"] || 7 %>

--- a/config/sara/sara.yml
+++ b/config/sara/sara.yml
@@ -8,7 +8,7 @@ base_path: ''
 monitoring_period_days: <%= ENV["MONITORING_PERIOD_DAYS"] || 10 %>
 
 # How many days an enrolled case should be monitored until recovery
-recovery_period_days: <%= ENV["recovery_period_days"] || 5 %>
+recovery_period_days: <%= ENV["RECOVERY_PERIOD_DAYS"] || 5 %>
 
 # How long a monitoree should be in isolation and considered non-reporting before we halt daily reports
 isolation_non_reporting_max_days: <%= ENV["SARA_ALERT_ISOLATION_NON_REPORING_MAX"] || 7 %>

--- a/test/jobs/close_patients_job_test.rb
+++ b/test/jobs/close_patients_job_test.rb
@@ -42,7 +42,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
                      symptom_onset: nil,
                      public_health_action: 'None',
                      latest_assessment_at: Time.now.getlocal,
-                     last_date_of_exposure: 20.days.ago)
+                     last_date_of_exposure: (ADMIN_OPTIONS['monitoring_period_days'] + 6).days.ago)
 
     ClosePatientsJob.perform_now
 
@@ -60,7 +60,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
                      symptom_onset: nil,
                      public_health_action: 'None',
                      latest_assessment_at: Time.now.getlocal,
-                     last_date_of_exposure: 20.days.ago)
+                     last_date_of_exposure: (ADMIN_OPTIONS['monitoring_period_days'] + 6).days.ago)
 
     ClosePatientsJob.perform_now
     updated_patient = Patient.find_by(id: patient.id)
@@ -76,7 +76,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
                      symptom_onset: nil,
                      public_health_action: 'None',
                      latest_assessment_at: Time.now.getlocal,
-                     last_date_of_exposure: 20.days.ago,
+                     last_date_of_exposure: (ADMIN_OPTIONS['monitoring_period_days'] + 6).days.ago,
                      created_at: 7.days.ago)
 
     ClosePatientsJob.perform_now
@@ -93,7 +93,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
                      symptom_onset: nil,
                      public_health_action: 'None',
                      latest_assessment_at: Time.now.getlocal,
-                     last_date_of_exposure: 20.days.ago,
+                     last_date_of_exposure: (ADMIN_OPTIONS['monitoring_period_days'] + 6).days.ago,
                      created_at: Time.now.getlocal)
 
     ClosePatientsJob.perform_now
@@ -110,9 +110,9 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
                      symptom_onset: nil,
                      public_health_action: 'None',
                      latest_assessment_at: Time.now.getlocal,
-                     last_date_of_exposure: 14.days.ago,
+                     last_date_of_exposure: ADMIN_OPTIONS['monitoring_period_days'].days.ago,
                      created_at: Time.now.getlocal)
-    patient.update(last_date_of_exposure: patient.curr_date_in_timezone.to_date - 14.days)
+    patient.update(last_date_of_exposure: patient.curr_date_in_timezone.to_date - ADMIN_OPTIONS['monitoring_period_days'].days)
     assert_not_nil Patient.enrolled_last_day_monitoring_period.find_by(id: patient.id)
     assert_not_nil Patient.close_eligible(:enrolled_last_day_monitoring_period).find_by(id: patient.id)
     ClosePatientsJob.perform_now
@@ -132,7 +132,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
                      symptom_onset: nil,
                      public_health_action: 'None',
                      latest_assessment_at: Time.now.getlocal,
-                     last_date_of_exposure: 20.days.ago,
+                     last_date_of_exposure: (ADMIN_OPTIONS['monitoring_period_days'] + 6).days.ago,
                      email: 'testpatient@example.com',
                      preferred_contact_method: 'E-mailed Web Link',
                      created_at: 20.days.ago)
@@ -160,7 +160,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
                      symptom_onset: nil,
                      public_health_action: 'None',
                      latest_assessment_at: Time.now.getlocal,
-                     last_date_of_exposure: 20.days.ago,
+                     last_date_of_exposure: (ADMIN_OPTIONS['monitoring_period_days'] + 6).days.ago,
                      email: 'testpatient@example.com',
                      preferred_contact_method: 'E-mailed Web Link')
     patient.jurisdiction.update(send_close: false)
@@ -178,7 +178,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
                        symptom_onset: nil,
                        public_health_action: 'None',
                        latest_assessment_at: Time.now.getlocal,
-                       last_date_of_exposure: 20.days.ago,
+                       last_date_of_exposure: (ADMIN_OPTIONS['monitoring_period_days'] + 6).days.ago,
                        email: 'testpatient@example.com',
                        preferred_contact_method: preferred_contact_method,
                        created_at: 20.days.ago)
@@ -199,7 +199,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
                        symptom_onset: nil,
                        public_health_action: 'None',
                        latest_assessment_at: Time.now.getlocal,
-                       last_date_of_exposure: 20.days.ago,
+                       last_date_of_exposure: (ADMIN_OPTIONS['monitoring_period_days'] + 6).days.ago,
                        preferred_contact_method: preferred_contact_method,
                        created_at: 20.days.ago)
 
@@ -218,7 +218,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
                        symptom_onset: nil,
                        public_health_action: 'None',
                        latest_assessment_at: Time.now.getlocal,
-                       last_date_of_exposure: 20.days.ago,
+                       last_date_of_exposure: (ADMIN_OPTIONS['monitoring_period_days'] + 6).days.ago,
                        email: 'testpatient@example.com',
                        primary_telephone: '+12223334444',
                        preferred_contact_method: preferred_contact_method,
@@ -241,7 +241,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
                        symptom_onset: nil,
                        public_health_action: 'None',
                        latest_assessment_at: Time.now.getlocal,
-                       last_date_of_exposure: 20.days.ago,
+                       last_date_of_exposure: (ADMIN_OPTIONS['monitoring_period_days'] + 6).days.ago,
                        preferred_contact_method: preferred_contact_method,
                        primary_telephone: '+12223334444',
                        created_at: 20.days.ago)
@@ -266,7 +266,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
                      symptom_onset: nil,
                      public_health_action: 'None',
                      latest_assessment_at: Time.now.getlocal,
-                     last_date_of_exposure: 20.days.ago)
+                     last_date_of_exposure: (ADMIN_OPTIONS['monitoring_period_days'] + 6).days.ago)
     email = ClosePatientsJob.perform_now
     email_body = email.parts.first.body.to_s.tr("\n", ' ')
     assert_not ActionMailer::Base.deliveries.empty?
@@ -281,7 +281,7 @@ class ClosePatientsJobTest < ActiveSupport::TestCase
                      symptom_onset: nil,
                      public_health_action: 'None',
                      latest_assessment_at: Time.now.getlocal,
-                     last_date_of_exposure: 20.days.ago)
+                     last_date_of_exposure: (ADMIN_OPTIONS['monitoring_period_days'] + 6).days.ago)
 
     allow_any_instance_of(Patient).to(receive(:save!) do
       raise StandardError, 'Test StandardError'

--- a/test/jobs/send_assessments_job_test.rb
+++ b/test/jobs/send_assessments_job_test.rb
@@ -42,7 +42,7 @@ class SendAssessmentsJobTest < ActiveSupport::TestCase
       { preferred_contact_method: 'SMS Texted Weblink', continuous_exposure: true },
       { preferred_contact_method: 'Telephone call', last_date_of_exposure: nil, created_at: default_days_ago(5) },
       { preferred_contact_method: 'SMS Text-message', last_date_of_exposure: default_days_ago(5), created_at: default_days_ago(5) },
-      { last_date_of_exposure: default_days_ago(11), created_at: default_days_ago(20) }
+      { last_date_of_exposure: default_days_ago(9), created_at: default_days_ago(20) }
     ].map do |eligible_params|
       create(
         :patient_with_submission_token,
@@ -116,7 +116,7 @@ class SendAssessmentsJobTest < ActiveSupport::TestCase
       { preferred_contact_method: 'SMS Texted Weblink', continuous_exposure: true },
       { preferred_contact_method: 'Telephone call', last_date_of_exposure: nil, created_at: default_days_ago(5) },
       { preferred_contact_method: 'SMS Text-message', last_date_of_exposure: default_days_ago(5), created_at: default_days_ago(5) },
-      { last_date_of_exposure: default_days_ago(11), created_at: default_days_ago(20) }
+      { last_date_of_exposure: default_days_ago(9), created_at: default_days_ago(20) }
     ].map do |eligible_params|
       create(
         :patient,

--- a/test/models/patient_notification_eligibility_test.rb
+++ b/test/models/patient_notification_eligibility_test.rb
@@ -86,7 +86,7 @@ class PatientNotificationEligibilityTest < ActiveSupport::TestCase
       { continuous_exposure: true },
       { last_date_of_exposure: nil, created_at: default_days_ago(5) },
       { last_date_of_exposure: default_days_ago(5), created_at: default_days_ago(5) },
-      { last_date_of_exposure: default_days_ago(11), created_at: default_days_ago(20) }
+      { last_date_of_exposure: default_days_ago(9), created_at: default_days_ago(20) }
     ].each do |workflow_params|
       dependent_params = {
         responder: patient,
@@ -106,7 +106,7 @@ class PatientNotificationEligibilityTest < ActiveSupport::TestCase
       { continuous_exposure: true },
       { last_date_of_exposure: nil, created_at: default_days_ago(5) },
       { last_date_of_exposure: default_days_ago(5), created_at: default_days_ago(5) },
-      { last_date_of_exposure: default_days_ago(11), created_at: default_days_ago(20) }
+      { last_date_of_exposure: default_days_ago(9), created_at: default_days_ago(20) }
     ].each do |workflow_params|
       dependent = create(
         :patient,
@@ -257,7 +257,7 @@ class PatientNotificationEligibilityTest < ActiveSupport::TestCase
         { continuous_exposure: true },
         { last_date_of_exposure: nil, created_at: default_days_ago(5) },
         { last_date_of_exposure: default_days_ago(5), created_at: default_days_ago(5) },
-        { last_date_of_exposure: default_days_ago(11), created_at: default_days_ago(20) }
+        { last_date_of_exposure: default_days_ago(9), created_at: default_days_ago(20) }
       ].each do |workflow_params|
         patient = create(
           :patient,
@@ -304,7 +304,7 @@ class PatientNotificationEligibilityTest < ActiveSupport::TestCase
         { continuous_exposure: true },
         { last_date_of_exposure: nil, created_at: default_days_ago(5) },
         { last_date_of_exposure: default_days_ago(5), created_at: default_days_ago(5) },
-        { last_date_of_exposure: default_days_ago(11), created_at: default_days_ago(20) }
+        { last_date_of_exposure: default_days_ago(9), created_at: default_days_ago(20) }
       ].each do |workflow_params|
         [
           { pause_notifications: true },
@@ -393,7 +393,7 @@ class PatientNotificationEligibilityTest < ActiveSupport::TestCase
       purged: false,
       isolation: false,
       created_at: default_days_ago(20),
-      last_date_of_exposure: default_days_ago(14)
+      last_date_of_exposure: default_days_ago(ADMIN_OPTIONS['monitoring_period_days'])
     )
     # patient has asymptomatic assessment more than 1 day ago but less than 7 days ago
     create(:assessment, patient: patient, symptomatic: false, created_at: default_days_ago(2))
@@ -409,7 +409,7 @@ class PatientNotificationEligibilityTest < ActiveSupport::TestCase
       purged: false,
       isolation: false,
       created_at: default_days_ago(2),
-      last_date_of_exposure: default_days_ago(14)
+      last_date_of_exposure: default_days_ago(ADMIN_OPTIONS['monitoring_period_days'])
     )
     assert_eligible(patient)
   end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1662](https://tracker.codev.mitre.org/browse/SARAALERT-1662)

- Shorten the period for when a case is eligible for the Records Requiring Review line list to: at least 5 days (down from 10 days) from Symptom Onset/First Positive Lab AND at least 1 day without a fever/use of a fever reducer.
- Change the default monitoring period from 14 days to 10 days (from Last Date of Exposure).

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/helpers/patient_details_helper.rb`, `app/models/patient.rb`
- replace hard-coded 10 day recovery definition period with admin options variable

`config/sara/sara.yml`
- update `monitoring_period_days` from `14` to `10`
- create new `recovery_period_days` variable

`lib/tasks/demo.rake`
- update demo script to use new admin options variables

`test/jobs/close_patients_job_test.rb`, `test/jobs/send_assessments_job_test.rb`, `test/models/patient_notification_eligibility_test.rb`, `test/models/patient_test.rb`
- fix tests and use new admin options variables

## Testing Recommendations
Please list any recommendations regarding what reviewers should test and if there is any specific guidance on how to test certain aspects of the PR. Be sure to mention edge cases that should be tried, particularly in the UI.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@sgober :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@hackrm :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
