### PR TITLE
SARAALERT-1574: For cases in the Global Dashboard, display <blank> for End of Monitoring value

### DIFF
--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -491,8 +491,8 @@ class PatientsTable extends React.Component {
 
   formatEndOfMonitoring = data => {
     const endOfMonitoring = data.value;
-    if (endOfMonitoring === 'Continuous Exposure') {
-      return 'Continuous Exposure';
+    if (endOfMonitoring === 'Continuous Exposure' || endOfMonitoring === '') {
+      return endOfMonitoring;
     }
     return moment(endOfMonitoring, 'YYYY-MM-DD').format('MM/DD/YYYY');
   };

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1054,7 +1054,7 @@ class Patient < ApplicationRecord
 
   # Single place for calculating the end of monitoring date for this subject.
   def end_of_monitoring
-    return '' if isolation
+    return nil if isolation
     return 'Continuous Exposure' if continuous_exposure
     return (last_date_of_exposure + ADMIN_OPTIONS['monitoring_period_days'].days)&.to_s if last_date_of_exposure.present?
 

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1054,6 +1054,7 @@ class Patient < ApplicationRecord
 
   # Single place for calculating the end of monitoring date for this subject.
   def end_of_monitoring
+    return '' if isolation
     return 'Continuous Exposure' if continuous_exposure
     return (last_date_of_exposure + ADMIN_OPTIONS['monitoring_period_days'].days)&.to_s if last_date_of_exposure.present?
 


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1574](https://tracker.codev.mitre.org/browse/SARAALERT-1574)

Since End of Monitoring date is only relevant for monitorees in the Exposure workflow, show End of Monitoring as blank for monitorees in the Isolation workflow within the Global Dashboard and the CSV Line List export.  

**Note**: This PR does not remove the End of Monitoring date column from the CSV Line List export in the Isolation dashboard (with this PR, all values in the column are blank). Per @hackrm there is a [ticket in the backlog](https://tracker.codev.mitre.org/browse/SARAALERT-1108) to completely deactivate CE for the Isolation workflow in the future since CE has no impact on the Isolation workflow.

## Demo/Screenshots
End of Monitoring is blank for monitorees in the Isolation Workflow within the Global Dashboard.
<img width="1710" alt="Screen Shot 2022-01-20 at 5 09 30 PM" src="https://user-images.githubusercontent.com/2328582/150430434-1c9ceac2-db86-4a69-a6a1-5aefac32ffed.png">

End of Monitoring is blank for monitorees in the Isolation Workflow within the CSV Line List export (note: several columns were hidden in the screenshot of the CSV)
<img width="933" alt="Screen Shot 2022-01-20 at 5 10 21 PM" src="https://user-images.githubusercontent.com/2328582/150430528-6c560ee9-b2c9-4c1b-8698-a475b32c54c6.png">

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/models/patient.rb`
- Update end_of_monitoring to return blank if isolation is TRUE

`app/javascript/components/public_health/PatientsTable.js`
- Return endOfMonitoring if endOfMonitoring is "Continuous Exposure" or blank, else format endOfMonitoring as date and return 

## Testing Recommendations
- Ensure all monitorees in the Isolation workflow have blank values for End of Monitoring column in the global dashboard
- Ensure all monitorees in the Isolation workflow have blank values for End of Monitoring column in the CSV line list export formats (both from Global Dashboard and Isolation Dashboard)

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@timwongj  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@sgober  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
