### PR TITLE
SARAALERT-1297: Make selectable dates for Arrival Information consistent with system validation

### DIFF
--- a/app/javascript/components/enrollment/steps/Arrival.js
+++ b/app/javascript/components/enrollment/steps/Arrival.js
@@ -91,7 +91,7 @@ class Arrival extends React.Component {
                     id="date_of_departure"
                     date={this.state.current.patient.date_of_departure}
                     minDate={'2020-01-01'}
-                    maxDate={moment().add(30, 'days').format('YYYY-MM-DD')}
+                    maxDate={moment().format('YYYY-MM-DD')}
                     onChange={date => this.handleDateChange('date_of_departure', date)}
                     placement="bottom"
                     isInvalid={!!this.state.errors['date_of_departure']}

--- a/app/models/concerns/patient_date_validator.rb
+++ b/app/models/concerns/patient_date_validator.rb
@@ -17,7 +17,7 @@ class PatientDateValidator < ActiveModel::Validator
     # validate_between_dates(record, :date_of_birth, Date.new(1900, 1, 1), earliest_tz_today) if record.date_of_birth_changed?
     # validate_between_dates(record, :last_date_of_exposure, year_start, month_ahead) if record.last_date_of_exposure_changed?
     # validate_between_dates(record, :extended_isolation, month_behind, month_ahead) if record.extended_isolation_changed?
-    # validate_between_dates(record, :date_of_departure, year_start, month_ahead) if record.date_of_departure_changed?
+    # validate_between_dates(record, :date_of_departure, year_start, earliest_tz_today) if record.date_of_departure_changed?
     # validate_between_dates(record, :date_of_arrival, year_start, month_ahead) if record.date_of_arrival_changed?
     # validate_between_dates(record, :additional_planned_travel_start_date, year_start, month_ahead) if record.additional_planned_travel_start_date_changed?
     # validate_between_dates(record, :additional_planned_travel_end_date, year_start, month_ahead) if record.additional_planned_travel_end_date_changed?


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1297](https://tracker.codev.mitre.org/browse/SARAALERT-1297)

The "Date of Departure" field and calendar modal allows the user to select a date 30 days in the future. However, a future date is not valid and on the next page red validation language appears saying the future dating is not allowed. This PR updates the calendar modal to set the maxDate to today. 

## Demo/Screenshots
Dates beyond the current date are not selectable in the "Date of Departure" calendar modal. 
<img width="584" alt="Screen Shot 2022-01-20 at 5 05 43 PM" src="https://user-images.githubusercontent.com/2328582/150433032-f6a980de-fead-40ce-af56-5ed4e20318dc.png">

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/javascript/components/enrollment/steps/Arrival.js`
- Change maxDate to today

## Testing Recommendations
Ensure that dates beyond the current date are not selectable in the "Date of Departure" calendar modal. 

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@sgober  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@hackrm  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
