### PR TITLE
SARAALERT-1665: Saved export preset advanced filter is not displayed

### DIFF
--- a/app/javascript/components/public_health/custom_export/PatientsFilters.js
+++ b/app/javascript/components/public_health/custom_export/PatientsFilters.js
@@ -179,6 +179,7 @@ class PatientsFilters extends React.Component {
                 jurisdiction_id={this.props.jurisdiction.id}
                 jurisdiction_paths={this.props.jurisdiction_paths}
                 all_assigned_users={this.props.all_assigned_users}
+                activeFilter={{ contents: this.props.query.filter }}
               />
             </InputGroup>
           </Col>

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -158,8 +158,13 @@ class AdvancedFilter extends React.Component {
           }
           // Apply filter from user export preset if present
         } else if (this.props.activeFilter?.contents) {
+          const comparedAttributes = ['filterOption.name', 'value', 'additiionalFilterOption', 'dateOption', 'numberOption', 'relativeOption'];
+          const activeFilter = this.props.activeFilter.contents.map(c => _.pick(c, comparedAttributes));
           const savedFilter = this.state.savedFilters.find(filter => {
-            return _.isEqual(filter.contents, this.props.activeFilter.contents);
+            return _.isEqual(
+              filter.contents.map(c => _.pick(c, comparedAttributes)),
+              activeFilter
+            );
           });
           this.setFilter(savedFilter?.name ? { ...this.props.activeFilter, name: savedFilter.name } : this.props.activeFilter, true);
         }

--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -144,6 +144,7 @@ class AdvancedFilter extends React.Component {
         // Apply filter if it exists in local storage
         let sessionFilter = this.getLocalStorage(`SaraFilter`);
         if (this.props.updateStickySettings) {
+          // Apply saved filter from localStorage if present
           if (parseInt(sessionFilter)) {
             this.setFilter(
               this.state.savedFilters.find(filter => {
@@ -151,9 +152,16 @@ class AdvancedFilter extends React.Component {
               }),
               true
             );
+            // Apply unsaved filter from localStorage if present
           } else if (JSON.parse(sessionFilter)) {
             this.setState({ activeFilterOptions: JSON.parse(sessionFilter) }, this.apply);
           }
+          // Apply filter from user export preset if present
+        } else if (this.props.activeFilter?.contents) {
+          const savedFilter = this.state.savedFilters.find(filter => {
+            return _.isEqual(filter.contents, this.props.activeFilter.contents);
+          });
+          this.setFilter(savedFilter?.name ? { ...this.props.activeFilter, name: savedFilter.name } : this.props.activeFilter, true);
         }
       });
     });
@@ -1622,6 +1630,7 @@ AdvancedFilter.propTypes = {
   jurisdiction_id: PropTypes.number,
   jurisdiction_paths: PropTypes.object,
   all_assigned_users: PropTypes.array,
+  activeFilter: PropTypes.object,
 };
 
 export default AdvancedFilter;


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1665](https://tracker.codev.mitre.org/browse/SARAALERT-1665)

After saving an export preset with an advanced filter and opening it up again, the advanced filter is applied to the query but not displayed in the modal.

## (Bugfix) How to Replicate
1. Create and save a user export preset with a saved advanced filter
2. Refresh and reload the saved user export preset and notice that the advanced filter is not displayed, but is applied (based on the number of patients filtered)

## (Bugfix) Solution
Insert description for the solution this PR implements to address the bug.

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`example_file.js`
- Example change (ex: refactored import function)

## Testing Recommendations
Please list any recommendations regarding what reviewers should test and if there is any specific guidance on how to test certain aspects of the PR. Be sure to mention edge cases that should be tried, particularly in the UI.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@tstrass :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@sgober :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@deastman :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
