### PR TITLE
SARAALERT-1666: Admin Panel - Have active/inactive statuses dependent on most recent activity instead of login

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -45,7 +45,7 @@ class AdminController < ApplicationController
                 .joins(:jurisdiction)
                 .select('users.id, users.email, users.api_enabled, users.locked_at, users.authy_id,
                         users.failed_attempts, users.role, users.notes, jurisdictions.path, users.manual_lock_reason,
-                        users.current_sign_in_at, users.force_password_change')
+                        users.last_activity_at, users.force_password_change')
 
     # Filter by search text
     users = filter(users, search)

--- a/app/javascript/components/admin/UserModal.js
+++ b/app/javascript/components/admin/UserModal.js
@@ -188,8 +188,8 @@ class UserModal extends React.Component {
                   <ReactTooltip id="disabled-status-select" multiline={true} type="dark" effect="solid" place="bottom" className="tooltip-container">
                     <div>
                       {this.state.activeState === 'Active'
-                        ? `Logged into the system within the last ${this.props.inactive_user_threshold} days`
-                        : `Has not logged into the system for at least ${this.props.inactive_user_threshold} days`}
+                        ? `Active in the system within the last ${this.props.inactive_user_threshold} days`
+                        : `Has not been active in the system for at least ${this.props.inactive_user_threshold} days`}
                     </div>
                   </ReactTooltip>
                 )}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,7 +46,7 @@ class User < ApplicationRecord
   end
 
   def active_state
-    current_sign_in_at.present? && current_sign_in_at >= Time.zone.today - ADMIN_OPTIONS['inactive_user_threshold'].to_i ? 'Active' : 'Inactive'
+    last_activity_at.present? && last_activity_at >= Time.zone.today - ADMIN_OPTIONS['inactive_user_threshold'].to_i ? 'Active' : 'Inactive'
   end
 
   def auto_lock_reason

--- a/db/migrate/20220126135321_add_last_activity_at_to_user.rb
+++ b/db/migrate/20220126135321_add_last_activity_at_to_user.rb
@@ -3,12 +3,13 @@ class AddLastActivityAtToUser < ActiveRecord::Migration[6.1]
     ActiveRecord::Base.record_timestamps = false
 
     add_column :users, :last_activity_at, :datetime
-    add_index :users, :last_activity_at
 
     up_only do
       execute 'update users set last_activity_at=current_sign_in_at'
     end
 
     ActiveRecord::Base.record_timestamps = true
+
+    add_index :users, :last_activity_at
   end
 end

--- a/db/migrate/20220126135321_add_last_activity_at_to_user.rb
+++ b/db/migrate/20220126135321_add_last_activity_at_to_user.rb
@@ -1,0 +1,14 @@
+class AddLastActivityAtToUser < ActiveRecord::Migration[6.1]
+  def change
+    ActiveRecord::Base.record_timestamps = false
+
+    add_column :users, :last_activity_at, :datetime
+    add_index :users, :last_activity_at
+
+    up_only do
+      execute 'update users set last_activity_at=current_sign_in_at'
+    end
+
+    ActiveRecord::Base.record_timestamps = true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_30_184033) do
+ActiveRecord::Schema.define(version: 2022_01_26_135321) do
 
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -600,9 +600,11 @@ ActiveRecord::Schema.define(version: 2021_12_30_184033) do
     t.boolean "is_api_proxy", default: false
     t.text "notes"
     t.string "manual_lock_reason"
+    t.datetime "last_activity_at"
     t.index ["authy_id"], name: "index_users_on_authy_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["jurisdiction_id"], name: "index_users_on_jurisdiction_id"
+    t.index ["last_activity_at"], name: "index_users_on_last_activity_at"
     t.index ["password_changed_at"], name: "index_users_on_password_changed_at"
   end
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -391,6 +391,7 @@ manual_locked_user:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   current_sign_in_at: "<%= 50.days.ago %>"
+  last_activity_at: "<%= 50.days.ago %>"
   authy_enabled: false
   authy_enforced: false
   api_enabled: false
@@ -408,6 +409,7 @@ auto_locked_user:
   created_at: "<%= 50.days.ago %>"
   updated_at: "<%= 50.days.ago %>"
   current_sign_in_at: "<%= 2.days.ago %>"
+  last_activity_at: "<%= 2.days.ago %>"
   authy_enabled: false
   authy_enforced: false
   api_enabled: false

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -794,24 +794,24 @@ class UserTest < ActiveSupport::TestCase
     assert_nil(user.auto_lock_reason)
   end
 
-  test 'user active status has no lock and current_sign_in_at <= 30 days ago' do
-    user = create(:user, current_sign_in_at: 29.days.ago)
+  test 'user active status has no lock and last_activity_at <= 30 days ago' do
+    user = create(:user, last_activity_at: 29.days.ago)
 
     assert_equal(user.status, 'Active')
     assert_nil(user.lock_reason)
     assert_nil(user.auto_lock_reason)
   end
 
-  test 'user inactive status has no lock and current_sign_in_at > 30 days ago' do
-    user = create(:user, current_sign_in_at: 31.days.ago)
+  test 'user inactive status has no lock and last_activity_at > 30 days ago' do
+    user = create(:user, last_activity_at: 31.days.ago)
 
     assert_equal(user.status, 'Inactive')
     assert_nil(user.lock_reason)
     assert_nil(user.auto_lock_reason)
   end
 
-  test 'user inactive status has no current_sign_in_at' do
-    user = create(:user, current_sign_in_at: nil)
+  test 'user inactive status has nil last_activity_at' do
+    user = create(:user, last_activity_at: nil)
 
     assert_equal(user.status, 'Inactive')
     assert_nil(user.lock_reason)


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1666](https://tracker.codev.mitre.org/browse/SARAALERT-1666)

Currently, if a user is unlocked, the system sets that user's status to inactive/active based on whether it's been 30 days since `current_user_sign_in_at`.  (Note: the 30-day value is configurable, which was added in SARAALERT-1375 and is `<%= ENV['INACTIVE_USER_THRESHOLD'] || 30 %>`)

This pull request adds a new timestamp column to the Users table, `last_activity_at`. Specifically, `last_activity_at` is updated at 15 minute intervals, i.e., the `last_activity_at` timestamp is updated on the current_user's request if the `last_activity_at` timestamp is more 15 minutes in the past. (This was discussed with @tstrass in lieu of updating the timestamp on every request and incurring the I/O cost of doing so.) Thus, the user's status will be inactive/active based on whether it's been 30 days since `last_activity_at`.

## Demo/Screenshots
There are no UI changes to the Admin Panel table or Admin Export. But, the Status Column in both should now determine activity/inactivity based on last_activity_at timestamp.

In the User Edit Modal, the Active/Inactive tooltip text should be updated according to the screenshots below. Otherwise there are no UI changes to the User Edit Modal. When the Status field is visible in the User Edit Modal, it should determine activity/inactivity based on last_activity_at timestamp. 

<img width="503" alt="Screen Shot 2022-01-27 at 1 06 30 PM" src="https://user-images.githubusercontent.com/2328582/151418011-d7bd2ed9-77de-4d9e-9cd5-3cb974bcfea0.png">

<img width="506" alt="Screen Shot 2022-01-27 at 1 06 19 PM" src="https://user-images.githubusercontent.com/2328582/151418055-86c03169-75d3-4fa9-ac30-bf28dced763f.png">


## Important Changes

`app/controllers/application_controller.rb`
- Adds `before_action :set_last_activity_at` to set last_activity_at timestamp

`app/javascript/components/admin/UserModal.js`
- Updates Status tooltip text

`app/models/user.rb`
- Updates active_state to use `last_activity_at` timestamp

`db/migrate/20220126135321_add_last_activity_at_to_user.rb`
- Adds migration to add `last_activity_at` timestamp
- Populates `last_activity_at` with `current_sign_in_at`

## Testing Recommendations

- Set `last_activity_at` timestamp to nil, within 30 days from current date, and greater than 30 days from current date. Confirm that within the UI, Status is Inactive, Active, and Inactive, respectively. 
- After making a request, confirm that `last_activity_at` timestamp is updated when `last_activity_at` is nil and when `last_activity_at` occurred more than 15 minutes ago. 
- Confirm that migration populates `last_activity_at` timestamp with `current_sign_in_at` for pre-existing users. 

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@timwongj  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@sgober  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
