### PR TITLE
SARAALERT-1679: Remove shortened quarantine filters

### DIFF
--- a/app/helpers/patient_query_helper.rb
+++ b/app/helpers/patient_query_helper.rb
@@ -456,8 +456,6 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
                    else
                      patients.where('last_assessment_reminder_sent < ?', 24.hours.ago).or(patients.where(last_assessment_reminder_sent: nil))
                    end
-      when 'seven-day-quarantine'
-        patients = advanced_filter_quarantine_option(patients, filter, :seven_day)
       when 'sms-blocked'
         # rubocop:disable Rails/PluckInWhere
         patients = if filter[:value]
@@ -481,8 +479,6 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
             patients = patients.where('patients.primary_telephone like ?', "%#{filter[:value].delete('^0-9')}%")
           end
         end
-      when 'ten-day-quarantine'
-        patients = advanced_filter_quarantine_option(patients, filter, :ten_day)
       when 'unenrolled-close-contact'
         patients = if filter[:value]
                      patients.where_assoc_exists(:close_contacts, enrolled_id: nil)
@@ -496,20 +492,6 @@ module PatientQueryHelper # rubocop:todo Metrics/ModuleLength
     patients
   end
   # rubocop:enable Metrics/MethodLength
-
-  # Handles a given quarantine option from the advanced filter.
-  def advanced_filter_quarantine_option(patients, filter, option_type)
-    # Get all patients who meet this criteria based on the option type
-    case option_type
-    when :ten_day
-      query = patients.ten_day_quarantine_candidates
-    when :seven_day
-      query = patients.seven_day_quarantine_candidates
-    end
-
-    # Based on if the user selected true/false, return appropriate patients
-    filter[:value].present? ? query : patients.where.not(id: query.pluck(:id))
-  end
 
   def advanced_filter_preferred_contact_time(patients, filter)
     value = %w[0 1 2 3 4 5 6 7] if filter[:value] == 'Early Morning'

--- a/app/javascript/data/advancedFilterOptions.js
+++ b/app/javascript/data/advancedFilterOptions.js
@@ -68,22 +68,6 @@ export const advancedFilterOptions = [
       'This filter will return monitorees that have texted “STOP” in response to a Sara Alert text message and cannot receive messages through SMS Preferred Reporting Methods until they text "START".',
   },
   {
-    name: 'seven-day-quarantine',
-    title: 'Candidate to Reduce Quarantine after 7 Days (Boolean)',
-    description: 'All asymptomatic records that meet CDC criteria to end quarantine after Day 7 (based on last date of exposure and most recent lab result)',
-    type: 'boolean',
-    tooltip:
-      'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.',
-  },
-  {
-    name: 'ten-day-quarantine',
-    title: 'Candidate to Reduce Quarantine after 10 Days (Boolean)',
-    description: 'All asymptomatic records that meet CDC criteria to end quarantine after Day 10 (based on last date of exposure)',
-    type: 'boolean',
-    tooltip:
-      'This filter is based on "Options to Reduce Quarantine for Contacts of Persons with SARS-COV-2 Infection Using Symptom Monitoring and Diagnostic Testing" released by the CDC on December 2, 2020. For more specific information, see Appendix A in the User Guide.',
-  },
-  {
     name: 'unenrolled-close-contact',
     title: 'Unenrolled Close Contact (Boolean)',
     description: 'All records with at least one unenrolled Close Contact',

--- a/app/javascript/tests/mocks/mockFilters.js
+++ b/app/javascript/tests/mocks/mockFilters.js
@@ -20,15 +20,6 @@ const mockFilterMonitoringStatusFalse = {
   value: false,
 };
 
-const mockFilterSevenDayQuarantine = {
-  additionalFilterOption: null,
-  dateOption: null,
-  filterOption: advancedFilterOptions.find(filter => filter.name === 'seven-day-quarantine'),
-  numberOption: null,
-  relativeOption: null,
-  value: false,
-};
-
 /* SELECT TYPE MOCK FILTERS */
 const mockFilterPreferredContactTime = {
   additionalFilterOption: null,
@@ -258,7 +249,6 @@ const mockSavedFilters = [mockFilter1, mockFilter2];
 export {
   mockFilterMonitoringStatusTrue,
   mockFilterMonitoringStatusFalse,
-  mockFilterSevenDayQuarantine,
   mockFilterPreferredContactTime,
   mockFilterAgeEqual,
   mockFilterAgeBetween,

--- a/app/javascript/tests/public_health/query/AdvancedFilter.test.js
+++ b/app/javascript/tests/public_health/query/AdvancedFilter.test.js
@@ -558,10 +558,10 @@ describe('AdvancedFilter', () => {
   it('Properly renders tooltip when defined with advanced filter option', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterPreferredContactTime.filterOption.name });
-    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterPreferredContactTime.filterOption.name);
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterContactType.filterOption.name });
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterContactType.filterOption.name);
     expect(wrapper.find(ReactTooltip).exists()).toBe(true);
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(mockFilterPreferredContactTime.filterOption.tooltip);
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(mockFilterContactType.filterOption.tooltip);
   });
 
   it('Properly renders main components of advanced filter combination type statement', () => {

--- a/app/javascript/tests/public_health/query/AdvancedFilter.test.js
+++ b/app/javascript/tests/public_health/query/AdvancedFilter.test.js
@@ -13,7 +13,6 @@ import {
   mockFilter2,
   mockFilterMonitoringStatusTrue,
   mockFilterMonitoringStatusFalse,
-  mockFilterSevenDayQuarantine,
   mockFilterPreferredContactTime,
   mockFilterAgeEqual,
   mockFilterAgeBetween,
@@ -559,10 +558,10 @@ describe('AdvancedFilter', () => {
   it('Properly renders tooltip when defined with advanced filter option', () => {
     const wrapper = getWrapper();
     wrapper.find(Button).simulate('click');
-    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterSevenDayQuarantine.filterOption.name });
-    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterSevenDayQuarantine.filterOption.name);
+    wrapper.find('.advanced-filter-options-dropdown').simulate('change', { value: mockFilterPreferredContactTime.filterOption.name });
+    expect(wrapper.find('.advanced-filter-options-dropdown').prop('value').value).toEqual(mockFilterPreferredContactTime.filterOption.name);
     expect(wrapper.find(ReactTooltip).exists()).toBe(true);
-    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(mockFilterSevenDayQuarantine.filterOption.tooltip);
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual(mockFilterPreferredContactTime.filterOption.tooltip);
   });
 
   it('Properly renders main components of advanced filter combination type statement', () => {

--- a/db/migrate/20220203164307_remove_shortened_quarantine_filters.rb
+++ b/db/migrate/20220203164307_remove_shortened_quarantine_filters.rb
@@ -5,7 +5,11 @@ class RemoveShortenedQuarantineFilters < ActiveRecord::Migration[6.1]
       relevant_filters.each do |uf|
         contents = JSON.parse(uf[:contents])
         contents = migrate_advanced_filter_contents(contents)
-        uf.update!(contents: contents.to_json)
+        if contents.empty?
+          uf.destroy
+        else
+          uf.update!(contents: contents.to_json)
+        end
       end
 
       # Migrate advanced filters in saved export presets
@@ -13,7 +17,7 @@ class RemoveShortenedQuarantineFilters < ActiveRecord::Migration[6.1]
         config = JSON.parse(uep[:config])
         contents = config.dig('data', 'patients', 'query', 'filter')
         contents = migrate_advanced_filter_contents(contents)
-        config['data']['patients']['query']['filter'] = contents
+        config['data']['patients']['query']['filter'] = contents.empty? ? nil : contents
         uep.update!(config: config.to_json)
       end
     end

--- a/db/migrate/20220203164307_remove_shortened_quarantine_filters.rb
+++ b/db/migrate/20220203164307_remove_shortened_quarantine_filters.rb
@@ -1,0 +1,41 @@
+class RemoveShortenedQuarantineFilters < ActiveRecord::Migration[6.1]
+  def up
+    ActiveRecord::Base.transaction do
+      # Migrate saved advanced filters
+      relevant_filters.each do |uf|
+        contents = JSON.parse(uf[:contents])
+        contents = migrate_advanced_filter_contents(contents)
+        uf.update!(contents: contents.to_json)
+      end
+
+      # Migrate advanced filters in saved export presets
+      relevant_export_presets.each do |uep|
+        config = JSON.parse(uep[:config])
+        contents = config.dig('data', 'patients', 'query', 'filter')
+        contents = migrate_advanced_filter_contents(contents)
+        config['data']['patients']['query']['filter'] = contents
+        uep.update!(config: config.to_json)
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  def migrate_advanced_filter_contents(contents)
+    contents.select { |content| %w[seven-day-quarantine ten-day-quarantine].exclude?(content['filterOption']['name']) }
+  end
+
+  def relevant_filters
+    UserFilter.where('contents LIKE "%seven-day-quarantine%"').or(
+      UserFilter.where('contents LIKE "%ten-day-quarantine%"')
+    )
+  end
+
+  def relevant_export_presets
+    UserExportPreset.where('config LIKE "%seven-day-quarantine%"').or(
+      UserExportPreset.where('config LIKE "%ten-day-quarantine%"')
+    )
+  end
+end

--- a/db/migrate/20220203164307_remove_shortened_quarantine_filters.rb
+++ b/db/migrate/20220203164307_remove_shortened_quarantine_filters.rb
@@ -17,7 +17,7 @@ class RemoveShortenedQuarantineFilters < ActiveRecord::Migration[6.1]
         config = JSON.parse(uep[:config])
         contents = config.dig('data', 'patients', 'query', 'filter')
         contents = migrate_advanced_filter_contents(contents)
-        config['data']['patients']['query']['filter'] = contents.empty? ? nil : contents
+        config['data']['patients']['query']['filter'] = contents
         uep.update!(config: config.to_json)
       end
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_26_135321) do
+ActiveRecord::Schema.define(version: 2022_02_03_164307) do
 
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false

--- a/test/controllers/public_health_controller_test.rb
+++ b/test/controllers/public_health_controller_test.rb
@@ -495,33 +495,4 @@ class PublicHealthControllerTest < ActionController::TestCase
       end
     end
   end
-
-  test 'advanced filter quarantine option ten_day contains patient when querying from different timezones' do
-    user = create(:public_health_enroller_user)
-    patient = create(:patient, creator: user, monitoring: true, last_date_of_exposure: 15.days.ago)
-    assessment = create(:assessment, patient: patient, symptomatic: false)
-    (10..15).to_a.each do |lde|
-      patient.update(last_date_of_exposure: Time.now.getlocal(patient.address_timezone_offset) - lde.days)
-      assessment.update(created_at: 1.day.ago) if lde == 14
-      assessment.update(created_at: 2.days.ago) if lde == 15
-      patients = @controller.send(:advanced_filter_quarantine_option, user.viewable_patients, { value: true }, :ten_day)
-      assert_equal(patients.count, 1)
-    end
-  end
-
-  test 'advanced filter quarantine option seven_day contains patient when querying from different timezones' do
-    user = create(:public_health_enroller_user)
-    patient = create(:patient, creator: user, monitoring: true, last_date_of_exposure: 15.days.ago)
-    assessment = create(:assessment, patient: patient, symptomatic: false)
-    laboratory = create(:laboratory, patient: patient, result: 'negative', lab_type: 'Antigen', specimen_collection: DateTime.now)
-    (7..12).to_a.each do |lde|
-      patient.update(last_date_of_exposure: Time.now.getlocal(patient.address_timezone_offset) - lde.days)
-      if lde > 9
-        assessment.update(created_at: lde.days.ago + 8.days)
-        laboratory.update(specimen_collection: lde.days.ago + 7.days)
-      end
-      patients = @controller.send(:advanced_filter_quarantine_option, user.viewable_patients, { value: true }, :seven_day)
-      assert_equal(1, patients.count)
-    end
-  end
 end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1679](https://tracker.codev.mitre.org/browse/SARAALERT-1679)

As a result of [SARAALERT-1662](https://tracker.codev.mitre.org/browse/SARAALERT-1662), the 2 candidate for shortened quarantine filters are no longer relevant and need to be removed. 

Do not remove the scopes used for these filters in the patient model. But remove usage of these scopes and remove the 2 candidate for shortened quarantine filters from the Advanced Filter drop down
Create a migration that removes both of these filter options from any saved Advanced Filters that contain them.

Note: User export preset advanced filters are now shown properly until https://github.com/SaraAlert/SaraAlert/pull/1196 is merged

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`example_file.js`
- Example change (ex: refactored import function)

## Testing Recommendations
- Before checking out this branch, create advanced filters and user export presets with seven and ten day quarantine filter options
- Check out this branch and perform the migration
- Verify that the advanced filters and user export presets previously created no longer include the seven and ten day quarantine filter options
- Verify that the removed filters no longer show up as options when creating/editing filters

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@sgober :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@deastman :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
