### PR TITLE
1660: Remove ability to delete an already existing positive lab result in the Edit Case Status page

### DIFF
--- a/app/javascript/components/enrollment/steps/CaseInformation.js
+++ b/app/javascript/components/enrollment/steps/CaseInformation.js
@@ -241,7 +241,7 @@ class CaseInformation extends React.Component {
           <Form.Group as={Col} md={12} xs={24} controlId="first_positive_lab" className="mb-2">
             <FirstPositiveLaboratory
               lab={this.state.current.first_positive_lab}
-              disableDelete={this.props.first_positive_lab != null}
+              preventDelete={this.props.first_positive_lab != null}
               onChange={this.handleLabChange}
               size="lg"
               displayedLabClass="mx-1 mb-2"

--- a/app/javascript/components/enrollment/steps/CaseInformation.js
+++ b/app/javascript/components/enrollment/steps/CaseInformation.js
@@ -239,7 +239,13 @@ class CaseInformation extends React.Component {
             </Form.Control.Feedback>
           </Form.Group>
           <Form.Group as={Col} md={12} xs={24} controlId="first_positive_lab" className="mb-2">
-            <FirstPositiveLaboratory lab={this.state.current.first_positive_lab} onChange={this.handleLabChange} size="lg" displayedLabClass="mx-1 mb-2" />
+            <FirstPositiveLaboratory
+              lab={this.state.current.first_positive_lab}
+              disableDelete={this.props.first_positive_lab != null}
+              onChange={this.handleLabChange}
+              size="lg"
+              displayedLabClass="mx-1 mb-2"
+            />
           </Form.Group>
           <Form.Group as={Col} md={12} xs={24} controlId="case_status" className="mb-2">
             <Form.Label className="input-label">CASE STATUS{schema?.fields?.case_status?._exclusive?.required && ' *'}</Form.Label>

--- a/app/javascript/components/patient/laboratory/FirstPositiveLaboratory.js
+++ b/app/javascript/components/patient/laboratory/FirstPositiveLaboratory.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
 import { Button } from 'react-bootstrap';
+import ReactTooltip from 'react-tooltip';
 import moment from 'moment';
 
 import confirmDialog from '../../util/ConfirmDialog';
@@ -33,16 +34,22 @@ class FirstPositiveLaboratory extends React.Component {
           <div className={this.props.displayedLabClass || 'my-2'}>
             <div className="first-positive-lab-result-header pb-1">
               <span className="input-label">FIRST POSITIVE LAB RESULT</span>
-              <div className="edit-link">
+              <span data-for="delete-first_positive_lab_tooltip" data-tip="" className="edit-link">
                 <Button
                   variant="link"
                   id="delete-first_positive_lab"
                   className="py-0 px-1 icon-btn-dark"
                   onClick={this.handleDelete}
+                  disabled={this.props.disableDelete}
                   aria-label="Delete Positive Lab Result">
-                  <i className="fas fa-times fa-fw"></i>
+                  <i className="fas fa-trash"></i>
                 </Button>
-              </div>
+              </span>
+              {this.props.disableDelete && (
+                <ReactTooltip id="delete-first_positive_lab_tooltip" multiline={true} place="left" type="dark" effect="solid" className="tooltip-container">
+                  Existing lab results must be deleted from the Lab Results table in the monitoree&apos;s record
+                </ReactTooltip>
+              )}
               <div className="edit-link">
                 <Button
                   variant="link"
@@ -105,6 +112,7 @@ class FirstPositiveLaboratory extends React.Component {
 
 FirstPositiveLaboratory.propTypes = {
   lab: PropTypes.object,
+  disableDelete: PropTypes.bool,
   onChange: PropTypes.func,
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
   displayedLabClass: PropTypes.string,

--- a/app/javascript/components/patient/laboratory/FirstPositiveLaboratory.js
+++ b/app/javascript/components/patient/laboratory/FirstPositiveLaboratory.js
@@ -34,26 +34,26 @@ class FirstPositiveLaboratory extends React.Component {
           <div className={this.props.displayedLabClass || 'my-2'}>
             <div className="first-positive-lab-result-header pb-1">
               <span className="input-label">FIRST POSITIVE LAB RESULT</span>
-              <span data-for="delete-first_positive_lab_tooltip" data-tip="" className="edit-link">
+              <span data-for="delete-first-positive-lab-tooltip" data-tip="" className="edit-link">
                 <Button
                   variant="link"
-                  id="delete-first_positive_lab"
+                  id="delete-first-positive-lab"
                   className="py-0 px-1 icon-btn-dark"
                   onClick={this.handleDelete}
-                  disabled={this.props.disableDelete}
+                  disabled={this.props.preventDelete}
                   aria-label="Delete Positive Lab Result">
                   <i className="fas fa-trash"></i>
                 </Button>
               </span>
-              {this.props.disableDelete && (
-                <ReactTooltip id="delete-first_positive_lab_tooltip" multiline={true} place="left" type="dark" effect="solid" className="tooltip-container">
+              {this.props.preventDelete && (
+                <ReactTooltip id="delete-first-positive-lab-tooltip" multiline={true} place="left" type="dark" effect="solid" className="tooltip-container">
                   <span>Existing lab results must be deleted from the Lab Results table in the monitoree&apos;s record</span>
                 </ReactTooltip>
               )}
               <div className="edit-link">
                 <Button
                   variant="link"
-                  id="edit-first_positive_lab"
+                  id="edit-first-positive-lab"
                   className="py-0 px-1 icon-btn-dark"
                   onClick={() => this.setState({ showModal: true })}
                   aria-label="Edit Positive Lab Result">
@@ -112,7 +112,7 @@ class FirstPositiveLaboratory extends React.Component {
 
 FirstPositiveLaboratory.propTypes = {
   lab: PropTypes.object,
-  disableDelete: PropTypes.bool,
+  preventDelete: PropTypes.bool,
   onChange: PropTypes.func,
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
   displayedLabClass: PropTypes.string,

--- a/app/javascript/components/patient/laboratory/FirstPositiveLaboratory.js
+++ b/app/javascript/components/patient/laboratory/FirstPositiveLaboratory.js
@@ -47,7 +47,7 @@ class FirstPositiveLaboratory extends React.Component {
               </span>
               {this.props.disableDelete && (
                 <ReactTooltip id="delete-first_positive_lab_tooltip" multiline={true} place="left" type="dark" effect="solid" className="tooltip-container">
-                  Existing lab results must be deleted from the Lab Results table in the monitoree&apos;s record
+                  <span>Existing lab results must be deleted from the Lab Results table in the monitoree&apos;s record</span>
                 </ReactTooltip>
               )}
               <div className="edit-link">

--- a/app/javascript/tests/patient/laboratory/FirstPositiveLaboratory.test.js
+++ b/app/javascript/tests/patient/laboratory/FirstPositiveLaboratory.test.js
@@ -9,31 +9,31 @@ import { mockLaboratory1 } from '../../mocks/mockLaboratories';
 
 import LaboratoryModal from '../../../components/patient/laboratory/LaboratoryModal';
 
-function getWrapper(lab, disableDelete) {
-  return shallow(<FirstPositiveLaboratory lab={lab} disableDelete={disableDelete} />);
+function getWrapper(additionalProps) {
+  return shallow(<FirstPositiveLaboratory lab={mockLaboratory1} {...additionalProps} />);
 }
 
 describe('FirstPositiveLaboratory', () => {
   it('Properly renders a button to enter a lab result if lab is null', () => {
-    const wrapper = getWrapper(null, false);
+    const wrapper = getWrapper({ lab: null });
     expect(wrapper.find(Button).text()).toEqual('Enter Lab Result');
-    expect(wrapper.find('#edit-first_positive_lab').exists()).toBe(false);
-    expect(wrapper.find('#delete-first_positive_lab').exists()).toBe(false);
+    expect(wrapper.find('#edit-first-positive-lab').exists()).toBe(false);
+    expect(wrapper.find('#delete-first-positive-lab').exists()).toBe(false);
     expect(wrapper.find('.first-positive-lab-result-field-name').exists()).toBe(false);
   });
 
   it('Properly opens the laboratory modal when user clicks on the enter lab result button', () => {
-    const wrapper = getWrapper(null, false);
+    const wrapper = getWrapper({ lab: null });
     wrapper.find(Button).simulate('click');
     expect(wrapper.find(LaboratoryModal).exists()).toBe(true);
   });
 
   it('Properly renders lab result details when lab is present', () => {
-    const wrapper = getWrapper(mockLaboratory1, false);
+    const wrapper = getWrapper();
     expect(wrapper.find(LaboratoryModal).exists()).toBe(false);
-    expect(wrapper.find('#edit-first_positive_lab').exists()).toBe(true);
-    expect(wrapper.find('#delete-first_positive_lab').exists()).toBe(true);
-    expect(wrapper.find('#delete-first_positive_lab').prop('disabled')).toBe(false);
+    expect(wrapper.find('#edit-first-positive-lab').exists()).toBe(true);
+    expect(wrapper.find('#delete-first-positive-lab').exists()).toBe(true);
+    expect(wrapper.find('#delete-first-positive-lab').prop('disabled')).toBe(false);
     expect(wrapper.find(ReactTooltip).exists()).toBe(false);
     expect(wrapper.find('.first-positive-lab-result-field-name').length).toEqual(4);
     expect(wrapper.find('.first-positive-lab-result-field-value').length).toEqual(4);
@@ -48,22 +48,22 @@ describe('FirstPositiveLaboratory', () => {
   });
 
   it('Properly opens LaboratoryModal when the edit button is clicked', () => {
-    const wrapper = getWrapper(mockLaboratory1, false);
-    wrapper.find('#edit-first_positive_lab').simulate('click');
+    const wrapper = getWrapper();
+    wrapper.find('#edit-first-positive-lab').simulate('click');
     expect(wrapper.find(LaboratoryModal).exists()).toBe(true);
   });
 
   it('Properly calls onChange with a null lab when the delete button is clicked', () => {
-    const wrapper = getWrapper(mockLaboratory1, false);
+    const wrapper = getWrapper();
     const handleDeleteSpy = jest.spyOn(wrapper.instance(), 'handleDelete');
     wrapper.instance().forceUpdate();
-    wrapper.find('#delete-first_positive_lab').simulate('click');
+    wrapper.find('#delete-first-positive-lab').simulate('click');
     expect(handleDeleteSpy).toHaveBeenCalled();
   });
 
-  it('Disables the delete button when the disableDelete flag is set', () => {
-    const wrapper = getWrapper(mockLaboratory1, true);
-    expect(wrapper.find('#delete-first_positive_lab').prop('disabled')).toBe(true);
+  it('Disables the delete button when the preventDelete flag is set', () => {
+    const wrapper = getWrapper({ preventDelete: true });
+    expect(wrapper.find('#delete-first-positive-lab').prop('disabled')).toBe(true);
     expect(wrapper.find(ReactTooltip).exists()).toBe(true);
     expect(wrapper.find(ReactTooltip).find('span').text()).toEqual("Existing lab results must be deleted from the Lab Results table in the monitoree's record");
   });

--- a/app/javascript/tests/patient/laboratory/FirstPositiveLaboratory.test.js
+++ b/app/javascript/tests/patient/laboratory/FirstPositiveLaboratory.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Button } from 'react-bootstrap';
+import ReactTooltip from 'react-tooltip';
 import moment from 'moment';
 
 import FirstPositiveLaboratory from '../../../components/patient/laboratory/FirstPositiveLaboratory';
@@ -8,13 +9,13 @@ import { mockLaboratory1 } from '../../mocks/mockLaboratories';
 
 import LaboratoryModal from '../../../components/patient/laboratory/LaboratoryModal';
 
-function getWrapper(lab) {
-  return shallow(<FirstPositiveLaboratory lab={lab} />);
+function getWrapper(lab, disableDelete) {
+  return shallow(<FirstPositiveLaboratory lab={lab} disableDelete={disableDelete} />);
 }
 
 describe('FirstPositiveLaboratory', () => {
   it('Properly renders a button to enter a lab result if lab is null', () => {
-    const wrapper = getWrapper(null);
+    const wrapper = getWrapper(null, false);
     expect(wrapper.find(Button).text()).toEqual('Enter Lab Result');
     expect(wrapper.find('#edit-first_positive_lab').exists()).toBe(false);
     expect(wrapper.find('#delete-first_positive_lab').exists()).toBe(false);
@@ -22,16 +23,18 @@ describe('FirstPositiveLaboratory', () => {
   });
 
   it('Properly opens the laboratory modal when user clicks on the enter lab result button', () => {
-    const wrapper = getWrapper(null);
+    const wrapper = getWrapper(null, false);
     wrapper.find(Button).simulate('click');
     expect(wrapper.find(LaboratoryModal).exists()).toBe(true);
   });
 
   it('Properly renders lab result details when lab is present', () => {
-    const wrapper = getWrapper(mockLaboratory1);
+    const wrapper = getWrapper(mockLaboratory1, false);
     expect(wrapper.find(LaboratoryModal).exists()).toBe(false);
     expect(wrapper.find('#edit-first_positive_lab').exists()).toBe(true);
     expect(wrapper.find('#delete-first_positive_lab').exists()).toBe(true);
+    expect(wrapper.find('#delete-first_positive_lab').prop('disabled')).toBe(false);
+    expect(wrapper.find(ReactTooltip).exists()).toBe(false);
     expect(wrapper.find('.first-positive-lab-result-field-name').length).toEqual(4);
     expect(wrapper.find('.first-positive-lab-result-field-value').length).toEqual(4);
     expect(wrapper.find('.first-positive-lab-result-field-name').at(0).text()).toEqual('Type: ');
@@ -45,16 +48,23 @@ describe('FirstPositiveLaboratory', () => {
   });
 
   it('Properly opens LaboratoryModal when the edit button is clicked', () => {
-    const wrapper = getWrapper(mockLaboratory1);
+    const wrapper = getWrapper(mockLaboratory1, false);
     wrapper.find('#edit-first_positive_lab').simulate('click');
     expect(wrapper.find(LaboratoryModal).exists()).toBe(true);
   });
 
   it('Properly calls onChange with a null lab when the delete button is clicked', () => {
-    const wrapper = getWrapper(mockLaboratory1);
+    const wrapper = getWrapper(mockLaboratory1, false);
     const handleDeleteSpy = jest.spyOn(wrapper.instance(), 'handleDelete');
     wrapper.instance().forceUpdate();
     wrapper.find('#delete-first_positive_lab').simulate('click');
     expect(handleDeleteSpy).toHaveBeenCalled();
+  });
+
+  it('Disables the delete button when the disableDelete flag is set', () => {
+    const wrapper = getWrapper(mockLaboratory1, true);
+    expect(wrapper.find('#delete-first_positive_lab').prop('disabled')).toBe(true);
+    expect(wrapper.find(ReactTooltip).exists()).toBe(true);
+    expect(wrapper.find(ReactTooltip).find('span').text()).toEqual("Existing lab results must be deleted from the Lab Results table in the monitoree's record");
   });
 });


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1660](https://tracker.codev.mitre.org/browse/SARAALERT-1660)

Currently, if a user tries to delete a lab result that already exists via the Edit Case Status page, the lab result will not be deleted. To address this situation, this PR prevents the user from being able to delete an already existing lab result via the Edit Case Status page and directs them to delete it from the Lab Results Table.

## Screenshots
![image](https://user-images.githubusercontent.com/42656458/152597787-fbed0051-1abe-4fb1-9ad4-751afbdfa614.png)


## Bugfix - How to Replicate the Bug
While on the `1.42.0` branch ...

- Find a existing monitoree in the Isolation workflow that has at least one positive lab result and go to their Edit Case Status page
- Remember the details of the Lab Result currently displayed.
- Delete the lab result, go to the review screen and save the monitoree
- Go to the Lab Results table and see that the lab result you attempted to delete still exists
- Similarly, go back to the Edit Case Status page and see that the lab result you attempted to delete still appears. 

## Bugfix - Solution
The user is now prevented from being able to delete an existing lab result in the Edit Case Status Info page.

## Important Changes
`app/javascript/components/enrollment/steps/CaseInformation.js`
- Included new prop to send to the `FirstPositiveLaboratory` component so it can determine if the Lab Result already exists  for the monitoree

`app/javascript/components/patient/laboratory/FirstPositiveLaboratory.js`
- Included logic so that is the monitoree already has a lab result, the user is not allowed to delete it.

`app/javascript/tests/patient/laboratory/FirstPositiveLaboratory.test.js`
- Revised tests for the `FirstPositiveLaboratory`  component to validate this new behavior

## Testing Recommendations
Go to the Edit Case Information page in the following situations and validate the expected behavior:
- When initially enrolling a monitoree --> A user should be able to create and delete a lab result from the Case Info page
- When accessing the Case Info page for an existing monitoree who does NOT have a postitive lab result --> A user should be able to create and delete a lab result from the Case Info page
- When accessing the Case Info page for an existing monitoree who does have a postitive lab result --> A user should NOT be able to delete the existing lab result and a tooltip should display alerting the user to delete it from the Lab Results table instead. 

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@deastman  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@sgober  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
