### PR TITLE
SARAALERT-1627: make non reporting period configurable

### DIFF
--- a/app/helpers/patient_details_helper.rb
+++ b/app/helpers/patient_details_helper.rb
@@ -22,8 +22,8 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
     unless isolation
       return :exposure_under_investigation if public_health_action != 'None'
       return :exposure_symptomatic unless symptom_onset.nil?
-      return :exposure_asymptomatic if (!latest_assessment_at.nil? && latest_assessment_at >= ADMIN_OPTIONS['reporting_period_minutes'].minutes.ago) ||
-                                       (!created_at.nil? && created_at >= ADMIN_OPTIONS['reporting_period_minutes'].minutes.ago)
+      return :exposure_asymptomatic if (!latest_assessment_at.nil? && latest_assessment_at >= ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago) ||
+                                       (!created_at.nil? && created_at >= ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago)
 
       return :exposure_non_reporting
     end
@@ -38,8 +38,8 @@ module PatientDetailsHelper # rubocop:todo Metrics/ModuleLength
                                              (!extended_isolation || extended_isolation < Time.zone.today)
     return :isolation_test_based if !latest_assessment_at.nil? && (latest_fever_or_fever_reducer_at.nil? || latest_fever_or_fever_reducer_at < 24.hours.ago) &&
                                     negative_lab_count >= 2 && (!extended_isolation || extended_isolation < Time.zone.today)
-    return :isolation_reporting if (!latest_assessment_at.nil? && latest_assessment_at >= ADMIN_OPTIONS['reporting_period_minutes'].minutes.ago) ||
-                                   (!created_at.nil? && created_at >= ADMIN_OPTIONS['reporting_period_minutes'].minutes.ago)
+    return :isolation_reporting if (!latest_assessment_at.nil? && latest_assessment_at >= ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago) ||
+                                   (!created_at.nil? && created_at >= ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago)
 
     :isolation_non_reporting
   end

--- a/config/sara/sara.yml
+++ b/config/sara/sara.yml
@@ -16,7 +16,7 @@ isolation_non_reporting_max_days: <%= ENV["SARA_ALERT_ISOLATION_NON_REPORING_MAX
 # How many minutes in a reporting period (hint: 1440 mins for 24 hours)
 reporting_period_minutes: <%= ENV["SARA_ALERT_REPORTING_PERIOD_MINUTES"] || 1440 %>
 
-# The number of minutes beyond which a monitoree will be considered non-reporting (hint: 1440 mins for 24 hours)
+# The number of minutes since a monitoree's last symptom report to be considered non-reporting (hint: 1440 mins is 24 hours)
 non_reporting_period_minutes: <%= ENV["SARA_ALERT_NON_REPORTING_PERIOD_MINUTES"] || 1440 %>
 
 # How many minutes after a closed record last_update it can be purged

--- a/config/sara/sara.yml
+++ b/config/sara/sara.yml
@@ -16,6 +16,9 @@ isolation_non_reporting_max_days: <%= ENV["SARA_ALERT_ISOLATION_NON_REPORING_MAX
 # How many minutes in a reporting period (hint: 1440 mins for 24 hours)
 reporting_period_minutes: <%= ENV["SARA_ALERT_REPORTING_PERIOD_MINUTES"] || 1440 %>
 
+# The number of minutes beyond which a monitoree will be considered non-reporting (hint: 1440 mins for 24 hours)
+non_reporting_period_minutes: <%= ENV["SARA_ALERT_NON_REPORTING_PERIOD_MINUTES"] || 1440 %>
+
 # How many minutes after a closed record last_update it can be purged
 purgeable_after: <%= ENV["SARA_ALERT_PURGEABLE_AFTER_MINUTES"] || 20160 %>
 

--- a/test/models/patient_notification_eligibility_test.rb
+++ b/test/models/patient_notification_eligibility_test.rb
@@ -8,11 +8,11 @@ class PatientNotificationEligibilityTest < ActiveSupport::TestCase
     # and if it will be non-nil, then the specific test can change the Timecop time.
     # Default timezone is Eastern Time.
     Timecop.freeze(Time.now.in_time_zone('Eastern Time (US & Canada)').noon.utc)
-    @original_reporting_period = ADMIN_OPTIONS['reporting_period_minutes']
+    @original_non_reporting_period = ADMIN_OPTIONS['non_reporting_period_minutes']
   end
 
   def teardown
-    ADMIN_OPTIONS['reporting_period_minutes'] = @original_reporting_period
+    ADMIN_OPTIONS['non_reporting_period_minutes'] = @original_non_reporting_period
     Timecop.return
   end
 
@@ -493,7 +493,7 @@ class PatientNotificationEligibilityTest < ActiveSupport::TestCase
       continuous_exposure: true
     )
     assert_eligible(patient)
-    ADMIN_OPTIONS['reporting_period_minutes'] = 1440 * 7 # 1 week
+    ADMIN_OPTIONS['non_reporting_period_minutes'] = 1440 * 7 # 1 week
 
     create(
       :assessment,

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -1014,12 +1014,12 @@ class PatientTest < ActiveSupport::TestCase
 
   test 'exposure non reporting' do
     patient = create(:patient, monitoring: true, purged: false, public_health_action: 'None',
-                     created_at: ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago - 1.minute)
+                               created_at: ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago - 1.minute)
     verify_patient_status(patient, :exposure_non_reporting)
 
     patient = create(:patient, monitoring: true, purged: false, public_health_action: 'None', created_at: 25.hours.ago)
     create(:assessment, patient: patient, symptomatic: false,
-           created_at: ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago - 1.minute)
+                        created_at: ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago - 1.minute)
     verify_patient_status(patient, :exposure_non_reporting)
   end
 
@@ -1221,19 +1221,19 @@ class PatientTest < ActiveSupport::TestCase
     # patient was created more than non_reporting_period_minutes ago with no assessments
     Patient.destroy_all
     patient = create(:patient, monitoring: true, purged: false, isolation: true,
-                     created_at: ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago - 1.minute)
+                               created_at: ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago - 1.minute)
     verify_patient_status(patient, :isolation_non_reporting)
 
     # patient has asymptomatic assessment more than non_reporting_period_minutes ago
     assessment = create(:assessment, patient: patient, symptomatic: false,
-                        created_at: ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago - 1.minute)
+                                     created_at: ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago - 1.minute)
 
     verify_patient_status(patient, :isolation_non_reporting)
     assessment.destroy
 
     # patient has symptomatic assessment more than non_reporting_period_minutes ago
     assessment = create(:assessment, patient: patient, symptomatic: true,
-                        created_at: ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago - 1.minute)
+                                     created_at: ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago - 1.minute)
     verify_patient_status(patient, :isolation_non_reporting)
     assessment.destroy
   end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -1013,11 +1013,13 @@ class PatientTest < ActiveSupport::TestCase
   end
 
   test 'exposure non reporting' do
-    patient = create(:patient, monitoring: true, purged: false, public_health_action: 'None', created_at: 25.hours.ago)
+    patient = create(:patient, monitoring: true, purged: false, public_health_action: 'None',
+                     created_at: ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago - 1.minute)
     verify_patient_status(patient, :exposure_non_reporting)
 
     patient = create(:patient, monitoring: true, purged: false, public_health_action: 'None', created_at: 25.hours.ago)
-    create(:assessment, patient: patient, symptomatic: false, created_at: 25.hours.ago)
+    create(:assessment, patient: patient, symptomatic: false,
+           created_at: ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago - 1.minute)
     verify_patient_status(patient, :exposure_non_reporting)
   end
 
@@ -1216,18 +1218,22 @@ class PatientTest < ActiveSupport::TestCase
   end
 
   test 'isolation non reporting' do
-    # patient was created more than 24 hours ago with no assessments
+    # patient was created more than non_reporting_period_minutes ago with no assessments
     Patient.destroy_all
-    patient = create(:patient, monitoring: true, purged: false, isolation: true, created_at: 2.days.ago)
+    patient = create(:patient, monitoring: true, purged: false, isolation: true,
+                     created_at: ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago - 1.minute)
     verify_patient_status(patient, :isolation_non_reporting)
 
-    # patient has asymptomatic assessment more than 24 hours ago
-    assessment = create(:assessment, patient: patient, symptomatic: false, created_at: 25.hours.ago)
+    # patient has asymptomatic assessment more than non_reporting_period_minutes ago
+    assessment = create(:assessment, patient: patient, symptomatic: false,
+                        created_at: ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago - 1.minute)
+
     verify_patient_status(patient, :isolation_non_reporting)
     assessment.destroy
 
-    # patient has symptomatic assessment more than 24 hours ago
-    assessment = create(:assessment, patient: patient, symptomatic: true, created_at: 28.hours.ago)
+    # patient has symptomatic assessment more than non_reporting_period_minutes ago
+    assessment = create(:assessment, patient: patient, symptomatic: true,
+                        created_at: ADMIN_OPTIONS['non_reporting_period_minutes'].minutes.ago - 1.minute)
     verify_patient_status(patient, :isolation_non_reporting)
     assessment.destroy
   end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -3375,17 +3375,17 @@ class PatientTest < ActiveSupport::TestCase
   end
 
   test 'has_not_reported_recently scope' do
-    # Example: 1 day reporting period => was patient last assessment before midnight today?
-    # Example: 2 day reporting period => was patient last assessment before midnight yesterday?
-    # Example: 7 day reporting period => was patient last assessment before midnight 6 days ago?
-    original_reporting_period = ADMIN_OPTIONS['reporting_period_minutes']
+    # Example: 1 day non_reporting_period => was patient last assessment before midnight today?
+    # Example: 2 day non_reporting_period => was patient last assessment before midnight yesterday?
+    # Example: 7 day non_reporting_period => was patient last assessment before midnight 6 days ago?
+    original_non_reporting_period = ADMIN_OPTIONS['non_reporting_period_minutes']
     [
       1440,
       1440 * 2,
       1440 * 7,
       1440 * 21
-    ].each do |reporting_period|
-      ADMIN_OPTIONS['reporting_period_minutes'] = reporting_period
+    ].each do |non_reporting_period|
+      ADMIN_OPTIONS['non_reporting_period_minutes'] = non_reporting_period
       state_params_array = [
         { monitored_address_state: nil, address_state: nil },
         { monitored_address_state: 'california', address_state: nil },
@@ -3409,7 +3409,7 @@ class PatientTest < ActiveSupport::TestCase
           patient: patient,
           created_at: correct_dst_edge(
             patient,
-            Time.now.getlocal(patient.address_timezone_offset).end_of_day - ADMIN_OPTIONS['reporting_period_minutes'].minutes
+            Time.now.getlocal(patient.address_timezone_offset).end_of_day - ADMIN_OPTIONS['non_reporting_period_minutes'].minutes
           )
         )
         patient.reload
@@ -3419,7 +3419,7 @@ class PatientTest < ActiveSupport::TestCase
         assessment_2.update(
           created_at: correct_dst_edge(
             patient,
-            Time.now.getlocal(patient.address_timezone_offset).end_of_day - ADMIN_OPTIONS['reporting_period_minutes'].minutes + 1.second
+            Time.now.getlocal(patient.address_timezone_offset).end_of_day - ADMIN_OPTIONS['non_reporting_period_minutes'].minutes + 1.second
           )
         )
         assessment_2.reload
@@ -3433,7 +3433,7 @@ class PatientTest < ActiveSupport::TestCase
         assert_nil Patient.has_not_reported_recently.find_by(id: patient.id)
       end
     end
-    ADMIN_OPTIONS['reporting_period_minutes'] = original_reporting_period
+    ADMIN_OPTIONS['non_reporting_period_minutes'] = original_non_reporting_period
   end
 
   test 'is_being_monitored scope' do


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1627](https://tracker.codev.mitre.org/browse/SARAALERT-1627)

Adds a config value to sara.yml to make the non-reporting interval configurable independent of the reporting interval.

## Demo/Screenshots
N/A

## Important Changes
`app/models/patient.rb`
- Updates scopes in `patient.rb` to use `non_reporting_period_minutes` instead of `reporting_period_minutes`

`app/helpers/patient_details_helper.rb`
- Updates status to use `non_reporting_period_minutes` instead of `reporting_period_minutes`

`config/sara/sara.yml`
- Adds `non_reporting_period_minutes` as config to to make the non-reporting interval configurable independent of the reporting interval (defaults to 1440 minutes or 1 day) 


## Testing Recommendations
One possible testing avenue is to `rails c `, change `ADMIN_OPTIONS['non_reporting_period_minutes']` and confirm that the affected scopes in patient.rb return the right patients.

Example:
```
ADMIN_OPTIONS['non_reporting_period_minutes'] = 4320
patient = Patient.global_non_reporting.first
patient.latest_assessment_at = 2.days.ago
# Patient's latest_assessment_at now does not cross non_reporting_period_minutes threshold 
patient.save!
# Confirm ActiveRecord::RecordNotFound when finding patient.id 
Patient.global_non_reporting.find(patient.id) 
```

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@tstrass  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@hackrm  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
