### PR TITLE
SARAALERT-1682: Change status code in export_controller when same export type created less than 15 minutes ago

### DIFF
--- a/app/controllers/export_controller.rb
+++ b/app/controllers/export_controller.rb
@@ -272,7 +272,7 @@ class ExportController < ApplicationController
     exp_recently = current_user.export_receipts.where(export_type: export_type).where('created_at > ?', 15.minutes.ago).exists?
     if exp_recently
       render json: { message: 'You have already initiated an export of this type in the last 15 minutes. Please try again later.' }.to_json,
-             status: :unauthorized
+             status: :bad_request
     end
     exp_recently
   end


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1682](https://tracker.codev.mitre.org/browse/SARAALERT-1682)

The `exported_recently?` method in the export_controller returns a 401 unauthorized status code if a user attempts to create the same type of report within 15 minutes.

The unauthorized status code erroneously causes a toast to appear with the text, 'Your session expired. Please sign in again to continue.' This is because the unauthorized status code is used to timeout the user's session [here](https://github.com/SaraAlert/SaraAlert/blob/master/app/javascript/components/layout/Header.js#L23) 

## (Bugfix) How to Replicate

- Create a Custom Format Export
- Immediately try to create another Custom Format Export
- Confirm toast appears with text: 'Your session expired. Please sign in again to continue.' 

## (Bugfix) Solution

This PR updates the `exported_recently?` method to return a 400 status code, ensuring that the correct text is shown in the toast. The error message correctly shows as: 'You have already initiated an export of this type in the last 15 minutes. Please try again later.'

![correct_toast](https://user-images.githubusercontent.com/2328582/153419281-a73373d4-acd5-4815-99ae-5147897c35ee.jpg)

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/controllers/export_controller.rb`
- Updates the `exported_recently?` method to return a 400 status code (`:bad_request`)

## Testing Recommendations

- Create a Custom Format Export
- Immediately try to create another Custom Format Export
- Confirm toast appears with text: 'You have already initiated an export of this type in the last 15 minutes. Please try again later.'

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@hackrm  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@tstrass  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
