### PR TITLE
Update sidekiq due to redis issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -398,7 +398,7 @@ GEM
       rubyzip (>= 1.2.2)
     sentry-raven (3.1.2)
       faraday (>= 1.0)
-    sidekiq (6.4.0)
+    sidekiq (6.4.1)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)


### PR DESCRIPTION
This update is necessary due to an [issue](https://github.com/mperham/sidekiq/issues/5178) with the previous version