### PR TITLE
SARAALERT-946: Add Risk Assessment and Monitoring Plan tooltips to last Enrollment wizard screen

### DIFF
--- a/app/javascript/components/enrollment/steps/PublicHealthManagement.js
+++ b/app/javascript/components/enrollment/steps/PublicHealthManagement.js
@@ -156,7 +156,10 @@ class PublicHealthManagement extends React.Component {
               )}
           </Form.Group>
           <Form.Group as={Col} md="8" controlId="exposure_risk_assessment" className="mb-2 pt-2">
-            <Form.Label className="input-label">RISK ASSESSMENT{this.props.schema?.fields?.exposure_risk_assessment?._exclusive?.required && ' *'}</Form.Label>
+            <Form.Label className="input-label">
+              RISK ASSESSMENT{this.props.schema?.fields?.exposure_risk_assessment?._exclusive?.required && ' *'}
+              <InfoTooltip tooltipTextKey={'exposureRiskAssessment'} location="right"></InfoTooltip>
+            </Form.Label>
             <Form.Control
               isInvalid={this.props.errors['exposure_risk_assessment']}
               as="select"
@@ -175,7 +178,10 @@ class PublicHealthManagement extends React.Component {
             </Form.Control.Feedback>
           </Form.Group>
           <Form.Group as={Col} md="16" controlId="monitoring_plan" className="mb-2 pt-2">
-            <Form.Label className="input-label">MONITORING PLAN{this.props.schema?.fields?.monitoring_plan?._exclusive?.required && ' *'}</Form.Label>
+            <Form.Label className="input-label">
+              MONITORING PLAN{this.props.schema?.fields?.monitoring_plan?._exclusive?.required && ' *'}
+              <InfoTooltip tooltipTextKey={'monitoringPlan'} location="right"></InfoTooltip>
+            </Form.Label>
             <Form.Control
               isInvalid={this.props.errors['monitoring_plan']}
               as="select"

--- a/app/javascript/tests/enrollment/steps/PublicHealthManagement.test.js
+++ b/app/javascript/tests/enrollment/steps/PublicHealthManagement.test.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import PublicHealthManagement from '../../../components/enrollment/steps/PublicHealthManagement';
 import { blankIsolationMockPatient, mockPatient1 } from '../../mocks/mockPatients';
 import { mockJurisdictionPaths } from '../../mocks/mockJurisdiction';
+import InfoTooltip from '../../../components/util/InfoTooltip';
 
 const onChangeMock = jest.fn();
 const onPropagatedFieldChangeMock = jest.fn();
@@ -59,12 +60,16 @@ describe('PublicHealthManagement', () => {
 
     expect(wrapper.find('#exposure_risk_assessment').exists()).toBe(true);
     expect(wrapper.find('#exposure_risk_assessment').prop('value')).toEqual('');
+    expect(wrapper.find('[htmlFor="exposure_risk_assessment"]').find(InfoTooltip).exists()).toBe(true);
+    expect(wrapper.find('[htmlFor="exposure_risk_assessment"]').find(InfoTooltip).prop('tooltipTextKey')).toEqual('exposureRiskAssessment');
     exposureRiskAssessmentOptions.forEach((option, index) => {
       expect(wrapper.find('#exposure_risk_assessment').find('option').at(index).text()).toContain(option);
     });
 
     expect(wrapper.find('#monitoring_plan').exists()).toBe(true);
     expect(wrapper.find('#monitoring_plan').prop('value')).toEqual('');
+    expect(wrapper.find('[htmlFor="monitoring_plan"]').find(InfoTooltip).exists()).toBe(true);
+    expect(wrapper.find('[htmlFor="monitoring_plan"]').find(InfoTooltip).prop('tooltipTextKey')).toEqual('monitoringPlan');
     monitoringPlanOptions.forEach((option, index) => {
       expect(wrapper.find('#monitoring_plan').find('option').at(index).text()).toContain(option);
     });

--- a/app/javascript/tests/enrollment/steps/PublicHealthManagement.test.js
+++ b/app/javascript/tests/enrollment/steps/PublicHealthManagement.test.js
@@ -60,16 +60,16 @@ describe('PublicHealthManagement', () => {
 
     expect(wrapper.find('#exposure_risk_assessment').exists()).toBe(true);
     expect(wrapper.find('#exposure_risk_assessment').prop('value')).toEqual('');
-    expect(wrapper.find('[htmlFor="exposure_risk_assessment"]').find(InfoTooltip).exists()).toBe(true);
-    expect(wrapper.find('[htmlFor="exposure_risk_assessment"]').find(InfoTooltip).prop('tooltipTextKey')).toEqual('exposureRiskAssessment');
+    expect(wrapper.find({ controlId: 'exposure_risk_assessment' }).find(InfoTooltip).exists()).toBe(true);
+    expect(wrapper.find({ controlId: 'exposure_risk_assessment' }).find(InfoTooltip).prop('tooltipTextKey')).toEqual('exposureRiskAssessment');
     exposureRiskAssessmentOptions.forEach((option, index) => {
       expect(wrapper.find('#exposure_risk_assessment').find('option').at(index).text()).toContain(option);
     });
 
     expect(wrapper.find('#monitoring_plan').exists()).toBe(true);
     expect(wrapper.find('#monitoring_plan').prop('value')).toEqual('');
-    expect(wrapper.find('[htmlFor="monitoring_plan"]').find(InfoTooltip).exists()).toBe(true);
-    expect(wrapper.find('[htmlFor="monitoring_plan"]').find(InfoTooltip).prop('tooltipTextKey')).toEqual('monitoringPlan');
+    expect(wrapper.find({ controlId: 'monitoring_plan' }).find(InfoTooltip).exists()).toBe(true);
+    expect(wrapper.find({ controlId: 'monitoring_plan' }).find(InfoTooltip).prop('tooltipTextKey')).toEqual('monitoringPlan');
     monitoringPlanOptions.forEach((option, index) => {
       expect(wrapper.find('#monitoring_plan').find('option').at(index).text()).toContain(option);
     });


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-946](https://tracker.codev.mitre.org/browse/SARAALERT-946)

Adds tooltips to Risk Assessment and Monitoring Plan fields within the Enrollment wizard to align with the monitoree's profile view. 

## Demo/Screenshots
<img width="955" alt="Screen Shot 2022-02-15 at 8 26 31 PM" src="https://user-images.githubusercontent.com/2328582/154179054-95be0ea0-46b5-4247-abf3-d208503af636.png">

<img width="1168" alt="Screen Shot 2022-02-15 at 8 26 24 PM" src="https://user-images.githubusercontent.com/2328582/154179086-ce087d89-ba3b-4b6a-9f99-a78fca37cc9a.png">

## Important Changes
`app/javascript/components/enrollment/steps/PublicHealthManagement.js`
- Adds appropriate InfoTooltip to MONITORING PLAN and RISK ASSESSMENT fields. 

## Testing Recommendations
- Confirm that tooltips are present in the Enrollment wizard within the PUBLIC HEALTH RISK ASSESSMENT AND MANAGEMENT SECTION. 

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@sgober  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@hackrm  :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
