### PR TITLE
SARAALERT-NONE: Fix Advanced Filter Selected Option Scroll

### DIFF
--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -809,7 +809,8 @@ class AdvancedFilter extends React.Component {
    * @param {Number} index - Filter index
    */
   renderOptions = (current, index) => {
-    const selectedValue = this.getFormattedOptions().find(option => {
+    const options = this.getFormattedOptions();
+    const selectedIndex = options.findIndex(option => {
       return option.value === current;
     });
     const Option = props => {
@@ -822,8 +823,8 @@ class AdvancedFilter extends React.Component {
     };
     return (
       <Select
-        options={this.getFormattedOptions()}
-        value={selectedValue || null}
+        options={options}
+        value={options[selectedIndex] || null}
         isOptionDisabled={option => option.disabled}
         components={{ Option }}
         onChange={event => {


### PR DESCRIPTION
# Description
Fix issue where the advanced filter dropdown does not auto scroll to the current selected option

## (Bugfix) How to Replicate
Select an option in the advanced filter dropdown that is further down in the scrollable view.  Close the dropdown and reopen it, the selected option will not be in the current view (but still is selected).

## (Bugfix) Solution
Used the options array to get the value object of the selected value.

## Testing Recommendations
Please list any recommendations regarding what reviewers should test and if there is any specific guidance on how to test certain aspects of the PR. Be sure to mention edge cases that should be tried, particularly in the UI.

Do the steps in the "How to Replicate" section

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [ ] This PR includes the correct JIRA ticket reference.
- [ ] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@timwongj :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@hackrm :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@deastman :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
