### PR TITLE
SARAALERT-1678: Including manual Status changes in Audit log

### DIFF
--- a/app/javascript/components/admin/AuditModal.js
+++ b/app/javascript/components/admin/AuditModal.js
@@ -219,7 +219,7 @@ class AuditModal extends React.Component {
       case 'manual_lock_reason':
         return (
           <span>
-            <b>Manually Set Status</b>
+            <b>Manual Status Update</b>
             <InfoTooltip tooltipTextKey={'manualLockReasonAudit'} location="right"></InfoTooltip>
             <br />
             {!change.details || !Array.isArray(change.details) || change.details.length < 2

--- a/app/javascript/components/admin/AuditModal.js
+++ b/app/javascript/components/admin/AuditModal.js
@@ -7,6 +7,7 @@ import axios from 'axios';
 import _ from 'lodash';
 
 import CustomTable from '../layout/CustomTable';
+import InfoTooltip from '../util/InfoTooltip';
 import reportError from '../util/ReportError';
 
 class AuditModal extends React.Component {
@@ -257,6 +258,25 @@ class AuditModal extends React.Component {
             <b>User Signed In</b>
           </span>
         );
+      case 'manual_lock_reason':
+        // Generic audit message in case before & after values not provided
+        if (!change.details || !Array.isArray(change.details) || !change.details.length) {
+          return (
+            <span>
+              <b>Manually set Status</b>
+              <InfoTooltip tooltipTextKey={'manualLockReasonAudit'} location="right"></InfoTooltip>: Updated
+            </span>
+          );
+          // More detailed audit message when before & after values provided
+        } else {
+          return (
+            <span>
+              <b>Manually set Status</b>
+              <InfoTooltip tooltipTextKey={'manualLockReasonAudit'} location="right"></InfoTooltip>: Changed from &quot;{change.details[0]}&quot; to &quot;
+              {change.details[1]}&quot;
+            </span>
+          );
+        }
     }
   };
 

--- a/app/javascript/components/admin/AuditModal.js
+++ b/app/javascript/components/admin/AuditModal.js
@@ -130,7 +130,7 @@ class AuditModal extends React.Component {
         return (
           <span>
             <b>Account Status</b>
-            <br></br>
+            <br />
             {!change.details || !Array.isArray(change.details) || !change.details.length ? ' Updated' : change.details[0] ? 'Unlocked' : 'Locked'}
           </span>
         );
@@ -138,7 +138,7 @@ class AuditModal extends React.Component {
         return (
           <span>
             <b>Notes</b>
-            <br></br>
+            <br />
             {!change.details || !Array.isArray(change.details) || !change.details.length
               ? ' Updated'
               : ' Changed from "' +
@@ -152,7 +152,7 @@ class AuditModal extends React.Component {
         return (
           <span>
             <b>Jurisdiction</b>
-            <br></br>
+            <br />
             {!change.details || !Array.isArray(change.details) || change.details.length < 2
               ? ' Updated'
               : ' Changed from "' +
@@ -172,7 +172,7 @@ class AuditModal extends React.Component {
         return (
           <span>
             <b>API Access</b>
-            <br></br>
+            <br />
             {!change.details || !Array.isArray(change.details) || !change.details.length ? ' Updated' : change.details[0] ? 'Disabled' : 'Enabled'}
           </span>
         );
@@ -180,7 +180,7 @@ class AuditModal extends React.Component {
         return (
           <span>
             <b>Role</b>
-            <br></br>
+            <br />
             {!change.details || !Array.isArray(change.details) || change.details.length < 2
               ? ' Updated'
               : ' Changed from "' + _.startCase(change.details[0]) + '" to "' + _.startCase(change.details[1]) + '"'}
@@ -190,7 +190,7 @@ class AuditModal extends React.Component {
         return (
           <span>
             <b>Email</b>
-            <br></br>
+            <br />
             {!change.details || !Array.isArray(change.details) || change.details.length < 2
               ? ' Updated'
               : ' Changed from "' + change.details[0] + '" to "' + change.details[1] + '"'}
@@ -200,7 +200,7 @@ class AuditModal extends React.Component {
         return (
           <span>
             <b>2FA</b>
-            <br></br>
+            <br />
             {!change.details || !Array.isArray(change.details) || !change.details.length ? ' Updated' : change.details[0] ? 'Disabled' : 'Enabled'}
           </span>
         );
@@ -221,7 +221,7 @@ class AuditModal extends React.Component {
           <span>
             <b>Manually Set Status</b>
             <InfoTooltip tooltipTextKey={'manualLockReasonAudit'} location="right"></InfoTooltip>
-            <br></br>
+            <br />
             {!change.details || !Array.isArray(change.details) || change.details.length < 2
               ? ' Updated'
               : ' Changed from "' +

--- a/app/javascript/components/admin/AuditModal.js
+++ b/app/javascript/components/admin/AuditModal.js
@@ -127,54 +127,41 @@ class AuditModal extends React.Component {
     const change = data.value;
     switch (change.name) {
       case 'locked_at':
-        // Generic audit message in case before & after values not provided
-        if (!change.details || !Array.isArray(change.details) || !change.details.length) {
-          return (
-            <span>
-              <b>Account Status</b>: Updated
-            </span>
-          );
-          // More detailed audit message when before & after values provided
-        } else {
-          return (
-            <span>
-              <b>Account Status</b>: {change.details[0] ? 'Unlocked' : 'Locked'}
-            </span>
-          );
-        }
+        return (
+          <span>
+            <b>Account Status</b>
+            <br></br>
+            {!change.details || !Array.isArray(change.details) || !change.details.length ? ' Updated' : change.details[0] ? 'Unlocked' : 'Locked'}
+          </span>
+        );
       case 'notes':
-        // Generic audit message in case before & after values not provided
-        if (!change.details || !Array.isArray(change.details) || !change.details.length) {
-          return (
-            <span>
-              <b>Notes</b>: Updated
-            </span>
-          );
-          // More detailed audit message when before & after values provided
-        } else {
-          return (
-            <span>
-              <b>Notes</b>: Changed from &quot;{change.details[0]}&quot; to &quot;{change.details[1]}&quot;
-            </span>
-          );
-        }
+        return (
+          <span>
+            <b>Notes</b>
+            <br></br>
+            {!change.details || !Array.isArray(change.details) || !change.details.length
+              ? ' Updated'
+              : ' Changed from "' +
+                (change.details[0] == null ? '' : change.details[0]) +
+                '" to "' +
+                (change.details[1] == null ? '' : change.details[1]) +
+                '"'}
+          </span>
+        );
       case 'jurisdiction_id':
-        // Generic audit message in case before & after values not provided
-        if (!change.details || !Array.isArray(change.details) || change.details.length < 2) {
-          return (
-            <span>
-              <b>Jurisdiction</b>: Updated
-            </span>
-          );
-          // More detailed audit message when before & after values provided
-        } else {
-          return (
-            <span>
-              <b>Jurisdiction</b>: Changed from &quot;{_.invert(this.state.all_jurisdiction_paths)[change.details[0]]}&quot; to &quot;
-              {_.invert(this.state.all_jurisdiction_paths)[change.details[1]]}&quot;
-            </span>
-          );
-        }
+        return (
+          <span>
+            <b>Jurisdiction</b>
+            <br></br>
+            {!change.details || !Array.isArray(change.details) || change.details.length < 2
+              ? ' Updated'
+              : ' Changed from "' +
+                _.invert(this.state.all_jurisdiction_paths)[change.details[0]] +
+                '" to "' +
+                _.invert(this.state.all_jurisdiction_paths)[change.details[1]] +
+                '"'}
+          </span>
+        );
       case 'created_at':
         return (
           <span>
@@ -182,70 +169,41 @@ class AuditModal extends React.Component {
           </span>
         );
       case 'api_enabled':
-        // Generic audit message in case before & after values not provided
-        if (!change.details || !Array.isArray(change.details) || !change.details.length) {
-          return (
-            <span>
-              <b>API Access</b>: Updated
-            </span>
-          );
-          // More detailed audit message when before & after values provided
-        } else {
-          return (
-            <span>
-              <b>API Access</b>: {change.details[0] ? 'Disabled' : 'Enabled'}
-            </span>
-          );
-        }
+        return (
+          <span>
+            <b>API Access</b>
+            <br></br>
+            {!change.details || !Array.isArray(change.details) || !change.details.length ? ' Updated' : change.details[0] ? 'Disabled' : 'Enabled'}
+          </span>
+        );
       case 'role':
-        // Generic audit message in case before & after values not provided
-        if (!change.details || !Array.isArray(change.details) || change.details.length < 2) {
-          return (
-            <span>
-              <b>Role</b>: Updated
-            </span>
-          );
-          // More detailed audit message when before & after values provided
-        } else {
-          return (
-            <span>
-              <b>Role</b>: Changed from &quot;{_.startCase(change.details[0])}&quot; to &quot;
-              {_.startCase(change.details[1])}&quot;
-            </span>
-          );
-        }
+        return (
+          <span>
+            <b>Role</b>
+            <br></br>
+            {!change.details || !Array.isArray(change.details) || change.details.length < 2
+              ? ' Updated'
+              : ' Changed from "' + _.startCase(change.details[0]) + '" to "' + _.startCase(change.details[1]) + '"'}
+          </span>
+        );
       case 'email':
-        // Generic audit message in case before & after values not provided
-        if (!change.details || !Array.isArray(change.details) || change.details.length < 2) {
-          return (
-            <span>
-              <b>Email</b>: Updated
-            </span>
-          );
-          // More detailed audit message when before & after values provided
-        } else {
-          return (
-            <span>
-              <b>Email</b>: Changed from &quot;{change.details[0]}&quot; to &quot;{change.details[1]}&quot;
-            </span>
-          );
-        }
+        return (
+          <span>
+            <b>Email</b>
+            <br></br>
+            {!change.details || !Array.isArray(change.details) || change.details.length < 2
+              ? ' Updated'
+              : ' Changed from "' + change.details[0] + '" to "' + change.details[1] + '"'}
+          </span>
+        );
       case 'authy_enabled':
-        // Generic audit message in case before & after values not provided
-        if (!change.details || !Array.isArray(change.details) || !change.details.length) {
-          return (
-            <span>
-              <b>2FA</b>: Updated
-            </span>
-          );
-          // More detailed audit message when before & after values provided
-        } else {
-          return (
-            <span>
-              <b>2FA</b>: {change.details[0] ? 'Disabled' : 'Enabled'}
-            </span>
-          );
-        }
+        return (
+          <span>
+            <b>2FA</b>
+            <br></br>
+            {!change.details || !Array.isArray(change.details) || !change.details.length ? ' Updated' : change.details[0] ? 'Disabled' : 'Enabled'}
+          </span>
+        );
       case 'force_password_change':
         return (
           <span>
@@ -259,24 +217,20 @@ class AuditModal extends React.Component {
           </span>
         );
       case 'manual_lock_reason':
-        // Generic audit message in case before & after values not provided
-        if (!change.details || !Array.isArray(change.details) || !change.details.length) {
-          return (
-            <span>
-              <b>Manually set Status</b>
-              <InfoTooltip tooltipTextKey={'manualLockReasonAudit'} location="right"></InfoTooltip>: Updated
-            </span>
-          );
-          // More detailed audit message when before & after values provided
-        } else {
-          return (
-            <span>
-              <b>Manually set Status</b>
-              <InfoTooltip tooltipTextKey={'manualLockReasonAudit'} location="right"></InfoTooltip>: Changed from &quot;{change.details[0]}&quot; to &quot;
-              {change.details[1]}&quot;
-            </span>
-          );
-        }
+        return (
+          <span>
+            <b>Manually Set Status</b>
+            <InfoTooltip tooltipTextKey={'manualLockReasonAudit'} location="right"></InfoTooltip>
+            <br></br>
+            {!change.details || !Array.isArray(change.details) || change.details.length < 2
+              ? ' Updated'
+              : ' Changed from "' +
+                (change.details[0] == null ? '' : change.details[0]) +
+                '" to "' +
+                (change.details[1] == null ? '' : change.details[1]) +
+                '"'}
+          </span>
+        );
     }
   };
 

--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -363,6 +363,11 @@ const TOOLTIP_TEXT = {
       Current Date - Date of Birth
     </div>
   ),
+
+  /* ADMIN */
+  manualLockReasonAudit: (
+    <div>A manual change to Status by a user. The Audit log does not track system generated Statuses such as &quot;Active&quot; and &quot;Inactive.&quot;</div>
+  ),
 };
 
 class InfoTooltip extends React.Component {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@
 # User: user model
 class User < ApplicationRecord
   audited only: %i[locked_at jurisdiction_id created_at api_enabled role email authy_enabled
-                   force_password_change last_sign_in_with_authy notes], max_audits: 1000
+                   force_password_change last_sign_in_with_authy notes, manual_lock_reason], max_audits: 1000
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@
 # User: user model
 class User < ApplicationRecord
   audited only: %i[locked_at jurisdiction_id created_at api_enabled role email authy_enabled
-                   force_password_change last_sign_in_with_authy notes, manual_lock_reason], max_audits: 1000
+                   force_password_change last_sign_in_with_authy notes manual_lock_reason], max_audits: 1000
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1678](https://tracker.codev.mitre.org/browse/SARAALERT-1678)

All manually set Status changes in the Admin view for a given user will be logged in that user's Audit log. This does not include Statuses set by the system such as "Inactive," "Active," and the auto-lock reason. 

## Screenshot
![image](https://user-images.githubusercontent.com/42656458/155554276-eb0c7922-6216-4d7b-842f-5d70bebe9791.png)

## Important Changes
`app/javascript/components/admin/AuditModal.js`
- Displays new audits for `manual_lock_reason` data element

`app/javascript/components/util/InfoTooltip.js`
- New Info tooltip for Manually set Status audits (to clarify that system-set Statuses are not audited)

`app/models/user.rb`
- Included `manual_lock_reason` as an auditable data element

## Testing Recommendations
As an Admin user, attempt to change the Status of a user and validate the Audit log displayes the changes properly. Only manually set Statuses will be displayed in the Audit log. Note that when a system-set Status is applied, the manually set status at that time will be blank.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@sgober :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@deastman :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
