### PR TITLE
SARAALERT-1232: Remove Reset button from Advanced Filter Modal

### DIFF
--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -11,7 +11,6 @@ import Select, { components } from 'react-select';
 import { bootstrapSelectTheme, cursorPointerStyle } from '../../../packs/stylesheets/ReactSelectStyling';
 
 import DateInput from '../../util/DateInput';
-import confirmDialog from '../../util/ConfirmDialog';
 import { advancedFilterOptions } from '../../../data/advancedFilterOptions';
 import { getAllLanguageDisplayNames } from '../../../utils/Languages';
 
@@ -337,15 +336,6 @@ class AdvancedFilter extends React.Component {
           }
         );
       });
-  };
-
-  /**
-   * Resets modal to initial state
-   */
-  reset = async () => {
-    if (await confirmDialog('Are you sure you want to reset this filter? Anything currently configured will be lost.')) {
-      this.newFilter();
-    }
   };
 
   /**
@@ -1479,11 +1469,6 @@ class AdvancedFilter extends React.Component {
                   <span className="ml-1">Delete</span>
                 </Button>
               )}
-              <div className="float-right">
-                <Button id="advanced-filter-reset" variant="danger" onClick={this.reset}>
-                  Reset
-                </Button>
-              </div>
             </Col>
           </Row>
           <Row>
@@ -1517,7 +1502,7 @@ class AdvancedFilter extends React.Component {
           </Row>
         </Modal.Body>
         <Modal.Footer className="justify-unset">
-          <p className="lead mr-auto">Filter will be applied to all line lists in the current dashboard until reset.</p>
+          <p className="lead mr-auto">Filter will be applied to all line lists until cleared by the user.</p>
           <Button id="advanced-filter-cancel" variant="secondary btn-square" onClick={this.cancel}>
             Cancel
           </Button>

--- a/app/javascript/tests/public_health/query/AdvancedFilter.test.js
+++ b/app/javascript/tests/public_health/query/AdvancedFilter.test.js
@@ -126,20 +126,18 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find(Modal.Header).exists()).toBe(true);
     expect(wrapper.find(Modal.Header).text()).toEqual('Advanced Filter: untitled');
     expect(wrapper.find(Modal.Body).exists()).toBe(true);
-    expect(wrapper.find(Modal.Body).find(Button).length).toEqual(4);
+    expect(wrapper.find(Modal.Body).find(Button).length).toEqual(3);
     expect(wrapper.find(Modal.Body).find('#advanced-filter-save').exists()).toBe(true);
     expect(wrapper.find(Modal.Body).find('#advanced-filter-save').text()).toEqual('Save');
     expect(wrapper.find(Modal.Body).find('#advanced-filter-save').find('i').hasClass('fa-save')).toBe(true);
     expect(wrapper.find(Modal.Body).find('#advanced-filter-update').exists()).toBe(false);
     expect(wrapper.find(Modal.Body).find('#advanced-filter-delete').exists()).toBe(false);
-    expect(wrapper.find(Modal.Body).find('#advanced-filter-reset').exists()).toBe(true);
-    expect(wrapper.find(Modal.Body).find('#advanced-filter-reset').text()).toEqual('Reset');
     expect(wrapper.find(Modal.Body).find('.advanced-filter-statement').exists()).toBe(true);
     expect(wrapper.find(Modal.Body).find('.advanced-filter-statement').length).toEqual(1);
     expect(wrapper.find(Modal.Body).find('.remove-filter-row').exists()).toBe(true);
     expect(wrapper.find(Modal.Body).find('#add-filter-row').exists()).toBe(true);
     expect(wrapper.find(Modal.Footer).exists()).toBe(true);
-    expect(wrapper.find(Modal.Footer).find('p').text()).toEqual('Filter will be applied to all line lists in the current dashboard until reset.');
+    expect(wrapper.find(Modal.Footer).find('p').text()).toEqual('Filter will be applied to all line lists until cleared by the user.');
     expect(wrapper.find(Modal.Footer).find(Button).length).toEqual(2);
     expect(wrapper.find(Modal.Footer).find('#advanced-filter-cancel').exists()).toBe(true);
     expect(wrapper.find(Modal.Footer).find('#advanced-filter-cancel').text()).toEqual('Cancel');
@@ -172,7 +170,7 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find(Modal.Header).exists()).toBe(true);
     expect(wrapper.find(Modal.Header).text()).toEqual(`Advanced Filter: ${mockFilter1.name}`);
     expect(wrapper.find(Modal.Body).exists()).toBe(true);
-    expect(wrapper.find(Modal.Body).find(Button).length).toEqual(5);
+    expect(wrapper.find(Modal.Body).find(Button).length).toEqual(4);
     expect(wrapper.find(Modal.Body).find('#advanced-filter-save').exists()).toBe(false);
     expect(wrapper.find(Modal.Body).find('#advanced-filter-update').exists()).toBe(true);
     expect(wrapper.find(Modal.Body).find('#advanced-filter-update').text()).toEqual('Update');
@@ -180,14 +178,12 @@ describe('AdvancedFilter', () => {
     expect(wrapper.find(Modal.Body).find('#advanced-filter-delete').exists()).toBe(true);
     expect(wrapper.find(Modal.Body).find('#advanced-filter-delete').text()).toEqual('Delete');
     expect(wrapper.find(Modal.Body).find('#advanced-filter-delete').find('i').hasClass('fa-trash')).toBe(true);
-    expect(wrapper.find(Modal.Body).find('#advanced-filter-reset').exists()).toBe(true);
-    expect(wrapper.find(Modal.Body).find('#advanced-filter-reset').text()).toEqual('Reset');
     expect(wrapper.find(Modal.Body).find('.advanced-filter-statement').exists()).toBe(true);
     expect(wrapper.find(Modal.Body).find('.advanced-filter-statement').length).toEqual(1);
     expect(wrapper.find(Modal.Body).find('.remove-filter-row').exists()).toBe(true);
     expect(wrapper.find(Modal.Body).find('#add-filter-row').exists()).toBe(true);
     expect(wrapper.find(Modal.Footer).exists()).toBe(true);
-    expect(wrapper.find(Modal.Footer).find('p').text()).toEqual('Filter will be applied to all line lists in the current dashboard until reset.');
+    expect(wrapper.find(Modal.Footer).find('p').text()).toEqual('Filter will be applied to all line lists until cleared by the user.');
     expect(wrapper.find(Modal.Footer).find(Button).length).toEqual(2);
     expect(wrapper.find(Modal.Footer).find('#advanced-filter-cancel').exists()).toBe(true);
     expect(wrapper.find(Modal.Footer).find('#advanced-filter-cancel').text()).toEqual('Cancel');
@@ -1357,15 +1353,6 @@ describe('AdvancedFilter', () => {
     expect(deleteSpy).not.toHaveBeenCalled();
     wrapper.find('#advanced-filter-delete').simulate('click');
     expect(deleteSpy).toHaveBeenCalled();
-  });
-
-  it('Clicking "Reset" button calls reset method', () => {
-    const wrapper = getWrapper();
-    const resetSpy = jest.spyOn(wrapper.instance(), 'reset');
-    wrapper.find(Button).simulate('click');
-    expect(resetSpy).not.toHaveBeenCalled();
-    wrapper.find('#advanced-filter-reset').simulate('click');
-    expect(resetSpy).toHaveBeenCalled();
   });
 
   it('Clicking "Apply" button calls props.advancedFilterUpdate', () => {


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1232](https://tracker.codev.mitre.org/browse/SARAALERT-1232)

Given the existing erroneous behavior of the Reset button (detailed in the Jira ticket) and that this feature is likely not commonly used if used at all, it is being removed from the Filter modal. Additionally, the descriptive line at the bottom of the Filter modal has been revised to reflect the current state of how sticky the filters are. 

## Screenshots
![image](https://user-images.githubusercontent.com/42656458/156386235-56d87ecb-88d9-4c58-a4d0-d7da49046e4a.png)

## Important Changes
`app/javascript/components/public_health/query/AdvancedFilter.js`
- Removed the Rest button and reset function
- Revised the descriptive line displayed at the bottom of the modal

`app/javascript/tests/public_health/query/AdvancedFilter.test.js`
- Revised Filter tests appropriately

## Testing Recommendations
Open the Advanced Filter modal and observe that once a filter has been applied, there is no Reset button displayed. Additionally observe that the descriptive line at the bottom of the modal now says: "Filter will be applied to all line lists until cleared by the user."

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@deastman :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@sgober  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
