### PR TITLE
SARAALERT-1685: Display sticky value for the Dashboard Jurisdiction Filter

### DIFF
--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -277,10 +277,16 @@ class PatientsTable extends React.Component {
 
   handleJurisdictionChange = jurisdiction => {
     if (jurisdiction !== this.state.query.jurisdiction) {
+      if (jurisdiction) {
+        this.setLocalStorage(`SaraJurisdiction`, jurisdiction);
+      } else {
+        this.removeLocalStorage(`SaraJurisdiction`);
+        // Default back to current_user.jurisdiction_id when jurisdiction is null
+        jurisdiction = this.props.jurisdiction.id;
+      }
       this.updateAssignedUsers({ ...this.state.query, jurisdiction });
       this.updateTable({ ...this.state.query, jurisdiction, page: 0 });
       this.removeLocalStorage(`SaraPage`);
-      this.setLocalStorage(`SaraJurisdiction`, jurisdiction);
     }
   };
 

--- a/app/javascript/components/public_health/PatientsTable.js
+++ b/app/javascript/components/public_health/PatientsTable.js
@@ -277,16 +277,10 @@ class PatientsTable extends React.Component {
 
   handleJurisdictionChange = jurisdiction => {
     if (jurisdiction !== this.state.query.jurisdiction) {
-      if (jurisdiction) {
-        this.setLocalStorage(`SaraJurisdiction`, jurisdiction);
-      } else {
-        this.removeLocalStorage(`SaraJurisdiction`);
-        // Default back to current_user.jurisdiction_id when jurisdiction is null
-        jurisdiction = this.props.jurisdiction.id;
-      }
       this.updateAssignedUsers({ ...this.state.query, jurisdiction });
       this.updateTable({ ...this.state.query, jurisdiction, page: 0 });
       this.removeLocalStorage(`SaraPage`);
+      this.setLocalStorage(`SaraJurisdiction`, jurisdiction);
     }
   };
 

--- a/app/javascript/components/public_health/query/JurisdictionFilter.js
+++ b/app/javascript/components/public_health/query/JurisdictionFilter.js
@@ -25,6 +25,8 @@ class JurisdictionFilter extends React.Component {
       const jurisdiction = Object.keys(this.props.jurisdiction_paths).find(id => this.props.jurisdiction_paths[parseInt(id)] === jurisdiction_path);
       if (jurisdiction) {
         this.props.onJurisdictionChange(parseInt(jurisdiction));
+      } else {
+        this.props.onJurisdictionChange(null);
       }
     });
   };
@@ -48,16 +50,12 @@ class JurisdictionFilter extends React.Component {
           type="text"
           autoComplete="off"
           list="jurisdiction_paths"
-          defaultValue={this.props.jurisdiction_paths[this.props.jurisdiction] || ''}
+          value={this.props.jurisdiction_paths[this.props.jurisdiction] || '' || ''}
           onChange={event => this.handleJurisdictionChange(event?.target?.value)}
         />
         <datalist id="jurisdiction_paths">
           {this.state.sorted_jurisdiction_paths.map((jurisdiction, index) => {
-            return (
-              <option value={jurisdiction} key={index}>
-                {jurisdiction}
-              </option>
-            );
+            return <option value={jurisdiction} key={index} />;
           })}
         </datalist>
         <React.Fragment>

--- a/app/javascript/components/public_health/query/JurisdictionFilter.js
+++ b/app/javascript/components/public_health/query/JurisdictionFilter.js
@@ -29,7 +29,7 @@ class JurisdictionFilter extends React.Component {
     }
   }
 
-  // Handle changes to jurisdiction_path and jurisdiction_input so that the user can backspace into the form input
+  // Handle changes to jurisdiction_path and jurisdiction_input separately so that the user can backspace into the form input
   handleJurisdictionChange = event => {
     const value = event.target.value;
     const jurisdiction = Object.keys(this.props.jurisdiction_paths).find(id => this.props.jurisdiction_paths[parseInt(id)] === event.target.value);

--- a/app/javascript/components/public_health/query/JurisdictionFilter.js
+++ b/app/javascript/components/public_health/query/JurisdictionFilter.js
@@ -11,6 +11,7 @@ class JurisdictionFilter extends React.Component {
     this.state = {
       sorted_jurisdiction_paths: [],
       jurisdiction_path: props.jurisdiction_paths[props.jurisdiction] || '',
+      jurisdiction_input: props.jurisdiction_paths[props.jurisdiction] || '',
     };
   }
 
@@ -20,15 +21,26 @@ class JurisdictionFilter extends React.Component {
     };
   }
 
-  handleJurisdictionChange = jurisdiction_path => {
-    this.setState({ jurisdiction_path }, () => {
-      const jurisdiction = Object.keys(this.props.jurisdiction_paths).find(id => this.props.jurisdiction_paths[parseInt(id)] === jurisdiction_path);
-      if (jurisdiction) {
+  // This update is necessary since sticky settings are loaded after this component is constructed
+  componentDidUpdate() {
+    if (this.state.jurisdiction_path !== this.props.jurisdiction_paths[this.props.jurisdiction]) {
+      this.setState({ jurisdiction_path: this.props.jurisdiction_paths[this.props.jurisdiction] });
+      this.setState({ jurisdiction_input: this.props.jurisdiction_paths[this.props.jurisdiction] });
+    }
+  }
+
+  // Handle changes to jurisdiction_path and jurisdiction_input so that the user can backspace into the form input
+  handleJurisdictionChange = event => {
+    const value = event.target.value;
+    const jurisdiction = Object.keys(this.props.jurisdiction_paths).find(id => this.props.jurisdiction_paths[parseInt(id)] === event.target.value);
+
+    this.setState({ jurisdiction_input: value });
+
+    if (jurisdiction) {
+      this.setState({ jurisdiction_path: value }, () => {
         this.props.onJurisdictionChange(parseInt(jurisdiction));
-      } else {
-        this.props.onJurisdictionChange(null);
-      }
-    });
+      });
+    }
   };
 
   handleScopeChange = scope => {
@@ -50,12 +62,16 @@ class JurisdictionFilter extends React.Component {
           type="text"
           autoComplete="off"
           list="jurisdiction_paths"
-          value={this.props.jurisdiction_paths[this.props.jurisdiction] || '' || ''}
-          onChange={event => this.handleJurisdictionChange(event?.target?.value)}
+          value={this.state.jurisdiction_input}
+          onChange={this.handleJurisdictionChange}
         />
         <datalist id="jurisdiction_paths">
           {this.state.sorted_jurisdiction_paths.map((jurisdiction, index) => {
-            return <option value={jurisdiction} key={index} />;
+            return (
+              <option value={jurisdiction} key={index}>
+                {jurisdiction}
+              </option>
+            );
           })}
         </datalist>
         <React.Fragment>

--- a/app/javascript/components/public_health/query/JurisdictionFilter.js
+++ b/app/javascript/components/public_health/query/JurisdictionFilter.js
@@ -10,8 +10,8 @@ class JurisdictionFilter extends React.Component {
     super(props);
     this.state = {
       sorted_jurisdiction_paths: [],
+      jurisdiction_id: props.jurisdiction,
       jurisdiction_path: props.jurisdiction_paths[props.jurisdiction] || '',
-      jurisdiction_input: props.jurisdiction_paths[props.jurisdiction] || '',
     };
   }
 
@@ -23,24 +23,21 @@ class JurisdictionFilter extends React.Component {
 
   // This update is necessary since sticky settings are loaded after this component is constructed
   componentDidUpdate() {
-    if (this.state.jurisdiction_path !== this.props.jurisdiction_paths[this.props.jurisdiction]) {
-      this.setState({ jurisdiction_path: this.props.jurisdiction_paths[this.props.jurisdiction] });
-      this.setState({ jurisdiction_input: this.props.jurisdiction_paths[this.props.jurisdiction] });
+    if (this.state.jurisdiction_id !== this.props.jurisdiction) {
+      this.setState({ jurisdiction_id: this.props.jurisdiction, jurisdiction_path: this.props.jurisdiction_paths[this.props.jurisdiction] });
     }
   }
 
   // Handle changes to jurisdiction_path and jurisdiction_input separately so that the user can backspace into the form input
   handleJurisdictionChange = event => {
     const value = event.target.value;
-    const jurisdiction = Object.keys(this.props.jurisdiction_paths).find(id => this.props.jurisdiction_paths[parseInt(id)] === event.target.value);
+    const jurisdiction = Object.keys(this.props.jurisdiction_paths).find(id => this.props.jurisdiction_paths[parseInt(id)] === value);
 
-    this.setState({ jurisdiction_input: value });
-
-    if (jurisdiction) {
-      this.setState({ jurisdiction_path: value }, () => {
+    this.setState({ jurisdiction_path: value }, () => {
+      if (jurisdiction) {
         this.props.onJurisdictionChange(parseInt(jurisdiction));
-      });
-    }
+      }
+    });
   };
 
   handleScopeChange = scope => {
@@ -62,7 +59,7 @@ class JurisdictionFilter extends React.Component {
           type="text"
           autoComplete="off"
           list="jurisdiction_paths"
-          value={this.state.jurisdiction_input}
+          value={this.state.jurisdiction_path}
           onChange={this.handleJurisdictionChange}
         />
         <datalist id="jurisdiction_paths">


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1685](https://tracker.codev.mitre.org/browse/SARAALERT-1685)

When the Dashboard page is refreshed or when the user switches between workflows, the Jurisdiction Filter remains sticky in terms of filtering the displayed monitorees, but the sticky value doesn't appear in the UI for the Filter. This pull request ensures that the Jurisdiction value that is being used to filter the Dashboard monitorees is shown in the user interface within the Jurisdiction filter input control.

## (Bugfix) How to Replicate

1. Filter the Patient Dashboard by a specific jurisdiction (E.g., USA, State 1, County 2)
2. Click on a different Workflow (E.g., if you were initially in the Exposure Monitoring Workflow, choose the Isolation Workflow) or refresh the page
3. Confirm that the monitorees in the table are still being filtered by the jurisdiction you chose in Step 1, but the filter has reverted back to the default value

Choose **USA, State 1, County 2**
<img width="1687" alt="Screen Shot 2022-03-02 at 2 24 26 PM" src="https://user-images.githubusercontent.com/2328582/156434274-2d94fdfa-8a8a-4729-aa24-339a6b4c8f17.png">

Filter input reverts back to **USA** when the Workflow is changed 
<img width="1704" alt="Screen Shot 2022-03-02 at 2 24 38 PM" src="https://user-images.githubusercontent.com/2328582/156434349-1dfbd068-2586-4ae9-9552-84c31dcc98c3.png">

## (Bugfix) Solution

- This PR adds state variable `jurisdiction_input` to allow the input field to change as the user types. `onJurisdictionChange` is only called when `jurisdiction_input` is a valid `jurisdiction_path`
- It updates the Jurisdiction Filter input field to use `value` rather than `defaultValue` and sets `value = this.state.jurisdiction_input`
- It adds `componentDidUpdate()` since sticky settings are loaded after this component is constructed, similar to `https://github.com/SaraAlert/SaraAlert/blob/1.43.0/app/javascript/components/public_health/query/AssignedUserFilter.js#L15`

## Important Changes

Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`app/javascript/components/public_health/query/JurisdictionFilter.js`
- Adds state variable `jurisdiction_input`
- Adds `componentDidUpdate()`
- Updates Jurisdiction Filter input to use `value` rather than `defaultValue.` 

## Testing Recommendations

1. Filter the Patient Dashboard by a specific jurisdiction (E.g., USA, State 1, County 1)
2. Click on a different Workflow (E.g., if you were initially in the Isolation Workflow, click on the Exposure Monitoring Workflow) or refresh the page
3. Confirm that the monitorees in the table are still being filtered by the jurisdiction you chose in Step 1, and that the filter is still shown in the user interface as the filter you chose in Step 1.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@hackrm  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@sgober  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@timwongj  :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
