### PR TITLE
SARAALERT-1108: Deactivate the "Continuous Exposure" Toggle for cases in the Isolation Workflow

### DIFF
--- a/app/javascript/components/enrollment/steps/ExposureInformation.js
+++ b/app/javascript/components/enrollment/steps/ExposureInformation.js
@@ -51,6 +51,21 @@ class ExposureInformation extends React.Component {
   componentDidUpdate(prevProps) {
     if (prevProps.currentState.isolation !== this.props.currentState.isolation) {
       this.updateStaticValidations(this.props.currentState.isolation);
+
+      // If workflow is changed to isolation and CE is true, set it to false
+      if (this.props.currentState.isolation && this.state.current.patient.continuous_exposure) {
+        this.setState(
+          state => {
+            return {
+              current: { ...state.current, patient: { ...state.current.patient, continuous_exposure: false } },
+              modified: { ...state.modified, patient: { ...state.modified.patient, continuous_exposure: false } },
+            };
+          },
+          () => {
+            this.props.setEnrollmentState({ ...this.state.modified });
+          }
+        );
+      }
     }
   }
 

--- a/app/javascript/components/enrollment/steps/ExposureInformation.js
+++ b/app/javascript/components/enrollment/steps/ExposureInformation.js
@@ -420,22 +420,27 @@ class ExposureInformation extends React.Component {
               {this.state.errors['potential_exposure_country']}
             </Form.Control.Feedback>
           </Form.Group>
-          <Form.Group as={Col} lg={{ span: 8, order: 4 }} md={{ span: 12, order: 3 }} xs={{ span: 24, order: 2 }} className="pl-1">
+          <Form.Group
+            as={Col}
+            lg={{ span: 8, order: 4 }}
+            md={{ span: 12, order: 3 }}
+            xs={{ span: 24, order: 2 }}
+            controlId="continuous_exposure"
+            className="pl-1">
             <span data-for="disabled-continuous-exposure" data-tip="">
               <Form.Check
                 size="lg"
-                id="continuous_exposure"
                 className="ml-1 d-inline"
                 checked={!!this.state.current.patient.continuous_exposure}
                 onChange={this.handleChange}
                 disabled={this.state.current.patient.isolation}
               />
-              <Form.Label className="input-label ml-2">
-                CONTINUOUS EXPOSURE{schema?.fields?.continuous_exposure?._whitelist?.list?.has(true) ? ' *' : ''}
-              </Form.Label>
             </span>
+            <Form.Label className="input-label ml-2">
+              CONTINUOUS EXPOSURE{schema?.fields?.continuous_exposure?._whitelist?.list?.has(true) ? ' *' : ''}
+            </Form.Label>
             {this.state.current.patient.isolation ? (
-              <ReactTooltip id="disabled-continuous-exposure" multiline={true} type="dark" effect="solid" place="bottom" className="tooltip-container">
+              <ReactTooltip id="disabled-continuous-exposure" multiline={true} type="dark" effect="solid" place="right" className="tooltip-container">
                 <div>Continuous exposure is not relevant for cases in the isolation workflow.</div>
               </ReactTooltip>
             ) : (

--- a/app/javascript/components/enrollment/steps/ExposureInformation.js
+++ b/app/javascript/components/enrollment/steps/ExposureInformation.js
@@ -433,13 +433,13 @@ class ExposureInformation extends React.Component {
                 className="ml-1 d-inline"
                 checked={!!this.state.current.patient.continuous_exposure}
                 onChange={this.handleChange}
-                disabled={this.state.current.patient.isolation}
+                disabled={this.props.currentState.isolation}
               />
             </span>
             <Form.Label className="input-label ml-2">
               CONTINUOUS EXPOSURE{schema?.fields?.continuous_exposure?._whitelist?.list?.has(true) ? ' *' : ''}
             </Form.Label>
-            {this.state.current.patient.isolation ? (
+            {this.props.currentState.isolation ? (
               <ReactTooltip id="disabled-continuous-exposure" multiline={true} type="dark" effect="solid" place="right" className="tooltip-container">
                 <div>Continuous exposure is not relevant for cases in the isolation workflow.</div>
               </ReactTooltip>

--- a/app/javascript/components/enrollment/steps/ExposureInformation.js
+++ b/app/javascript/components/enrollment/steps/ExposureInformation.js
@@ -428,8 +428,9 @@ class ExposureInformation extends React.Component {
               className="ml-1 d-inline"
               checked={!!this.state.current.patient.continuous_exposure}
               onChange={this.handleChange}
+              disabled={this.state.current.patient.isolation}
             />
-            <InfoTooltip tooltipTextKey="continuousExposure" location="right"></InfoTooltip>
+            <InfoTooltip tooltipTextKey={this.state.current.patient.isolation ? 'continuousExposureDisabled' : 'continuousExposure'} location="right" />
           </Form.Group>
         </Form.Row>
         <Form.Label className="input-label pb-1">EXPOSURE RISK FACTORS (USE COMMAS TO SEPARATE MULTIPLE SPECIFIED VALUES)</Form.Label>

--- a/app/javascript/components/enrollment/steps/ExposureInformation.js
+++ b/app/javascript/components/enrollment/steps/ExposureInformation.js
@@ -421,16 +421,26 @@ class ExposureInformation extends React.Component {
             </Form.Control.Feedback>
           </Form.Group>
           <Form.Group as={Col} lg={{ span: 8, order: 4 }} md={{ span: 12, order: 3 }} xs={{ span: 24, order: 2 }} className="pl-1">
-            <Form.Check
-              size="lg"
-              label={`CONTINUOUS EXPOSURE${schema?.fields?.continuous_exposure?._whitelist?.list?.has(true) ? ' *' : ''}`}
-              id="continuous_exposure"
-              className="ml-1 d-inline"
-              checked={!!this.state.current.patient.continuous_exposure}
-              onChange={this.handleChange}
-              disabled={this.state.current.patient.isolation}
-            />
-            <InfoTooltip tooltipTextKey={this.state.current.patient.isolation ? 'continuousExposureDisabled' : 'continuousExposure'} location="right" />
+            <span data-for="disabled-continuous-exposure" data-tip="">
+              <Form.Check
+                size="lg"
+                id="continuous_exposure"
+                className="ml-1 d-inline"
+                checked={!!this.state.current.patient.continuous_exposure}
+                onChange={this.handleChange}
+                disabled={this.state.current.patient.isolation}
+              />
+              <Form.Label className="input-label ml-2">
+                CONTINUOUS EXPOSURE{schema?.fields?.continuous_exposure?._whitelist?.list?.has(true) ? ' *' : ''}
+              </Form.Label>
+            </span>
+            {this.state.current.patient.isolation ? (
+              <ReactTooltip id="disabled-continuous-exposure" multiline={true} type="dark" effect="solid" place="bottom" className="tooltip-container">
+                <div>Continuous exposure is not relevant for cases in the isolation workflow.</div>
+              </ReactTooltip>
+            ) : (
+              <InfoTooltip tooltipTextKey="continuousExposure" location="right" />
+            )}
           </Form.Group>
         </Form.Row>
         <Form.Label className="input-label pb-1">EXPOSURE RISK FACTORS (USE COMMAS TO SEPARATE MULTIPLE SPECIFIED VALUES)</Form.Label>

--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -180,8 +180,6 @@ const TOOLTIP_TEXT = {
     </div>
   ),
 
-  continuousExposureDisabled: <div>Continuous exposure is not relevant for cases in the isolation workflow.</div>,
-
   /* REPORTS */
   exposureNeedsReviewColumn: (
     <div>

--- a/app/javascript/components/util/InfoTooltip.js
+++ b/app/javascript/components/util/InfoTooltip.js
@@ -180,6 +180,8 @@ const TOOLTIP_TEXT = {
     </div>
   ),
 
+  continuousExposureDisabled: <div>Continuous exposure is not relevant for cases in the isolation workflow.</div>,
+
   /* REPORTS */
   exposureNeedsReviewColumn: (
     <div>

--- a/app/javascript/tests/enrollment/steps/ExposureInformation.test.js
+++ b/app/javascript/tests/enrollment/steps/ExposureInformation.test.js
@@ -10,6 +10,7 @@ import { mockJurisdictionPaths } from '../../mocks/mockJurisdiction';
 import { mockCommonExposureCohort1, mockCommonExposureCohort2 } from '../../mocks/mockCommonExposureCohorts';
 import CommonExposureCohortsTable from '../../../components/patient/common_exposure_cohorts/CommonExposureCohortsTable';
 import CommonExposureCohortModal from '../../../components/patient/common_exposure_cohorts/CommonExposureCohortModal';
+import InfoTooltip from '../../../components/util/InfoTooltip';
 
 const previousMock = jest.fn();
 const nextMock = jest.fn();
@@ -51,6 +52,7 @@ describe('ExposureInformation', () => {
     expect(wrapper.find(Card.Body).exists()).toBe(true);
     expect(wrapper.find(Form).exists()).toBe(true);
     expect(wrapper.find('#continuous_exposure').at(0).prop('disabled')).toBe(false);
+    expect(wrapper.find(InfoTooltip).exists()).toBe(true);
     expect(wrapper.find('#exposure_notes').exists()).toBe(true);
     expect(wrapper.find(PublicHealthManagement).exists()).toBe(true);
     expect(wrapper.find('#add-new-cohort-button').exists()).toBe(true);
@@ -69,6 +71,7 @@ describe('ExposureInformation', () => {
     expect(wrapper.find(Card.Body).exists()).toBe(true);
     expect(wrapper.find(Form).exists()).toBe(true);
     expect(wrapper.find('#continuous_exposure').at(0).prop('disabled')).toBe(true);
+    expect(wrapper.find('#disabled-continuous-exposure').exists()).toBe(true);
     expect(wrapper.find('#exposure_notes').exists()).toBe(false);
     expect(wrapper.find(PublicHealthManagement).exists()).toBe(false);
     expect(wrapper.find('#add-new-cohort-button').exists()).toBe(true);

--- a/app/javascript/tests/enrollment/steps/ExposureInformation.test.js
+++ b/app/javascript/tests/enrollment/steps/ExposureInformation.test.js
@@ -51,7 +51,8 @@ describe('ExposureInformation', () => {
     expect(wrapper.find(Card.Header).text()).toEqual('Monitoree Potential Exposure Information');
     expect(wrapper.find(Card.Body).exists()).toBe(true);
     expect(wrapper.find(Form).exists()).toBe(true);
-    expect(wrapper.find('#continuous_exposure').hostNodes().prop('disabled')).toBe(false);
+    expect(wrapper.find('#continuous_exposure').exists()).toBe(true);
+    expect(wrapper.find('#continuous_exposure').prop('disabled')).toBe(false);
     expect(wrapper.find(InfoTooltip).exists()).toBe(true);
     expect(wrapper.find('#exposure_notes').exists()).toBe(true);
     expect(wrapper.find(PublicHealthManagement).exists()).toBe(true);
@@ -70,7 +71,8 @@ describe('ExposureInformation', () => {
     expect(wrapper.find(Card.Header).text()).toEqual('Monitoree Potential Exposure Information');
     expect(wrapper.find(Card.Body).exists()).toBe(true);
     expect(wrapper.find(Form).exists()).toBe(true);
-    expect(wrapper.find('#continuous_exposure').hostNodes().prop('disabled')).toBe(true);
+    expect(wrapper.find('#continuous_exposure').exists()).toBe(true);
+    expect(wrapper.find('#continuous_exposure').prop('disabled')).toBe(true);
     expect(wrapper.find('#disabled-continuous-exposure').exists()).toBe(true);
     expect(wrapper.find('#exposure_notes').exists()).toBe(false);
     expect(wrapper.find(PublicHealthManagement).exists()).toBe(false);
@@ -195,7 +197,7 @@ describe('ExposureInformation', () => {
     expect(wrapper.state('current').patient.continuous_exposure).toBe(false);
     expect(wrapper.state('modified')).toEqual({});
     expect(wrapper.find(DateInput).prop('date')).toBeNull();
-    expect(wrapper.find('#continuous_exposure').prop('checked')).toBe(false);
+    expect(wrapper.find({ controlId: 'continuous_exposure' }).find(Form.Check).prop('checked')).toBe(false);
 
     wrapper.find(DateInput).simulate('change', '2021-04-18');
     expect(setEnrollmentStateMock).toHaveBeenCalledTimes(1);
@@ -204,16 +206,19 @@ describe('ExposureInformation', () => {
     expect(wrapper.state('modified').patient.last_date_of_exposure).toEqual('2021-04-18');
     expect(wrapper.state('current').patient.continuous_exposure).toBe(false);
     expect(wrapper.find(DateInput).prop('date')).toEqual('2021-04-18');
-    expect(wrapper.find('#continuous_exposure').prop('checked')).toBe(false);
+    expect(wrapper.find({ controlId: 'continuous_exposure' }).find(Form.Check).prop('checked')).toBe(false);
 
-    wrapper.find('#continuous_exposure').simulate('change', { target: { id: 'continuous_exposure', value: true } });
+    wrapper
+      .find({ controlId: 'continuous_exposure' })
+      .find(Form.Check)
+      .simulate('change', { target: { id: 'continuous_exposure', value: true } });
     expect(setEnrollmentStateMock).toHaveBeenCalledTimes(2);
     expect(wrapper.state('current').patient.last_date_of_exposure).toBeNull();
     expect(wrapper.state('current').patient.continuous_exposure).toBe(true);
     expect(wrapper.state('modified').patient.last_date_of_exposure).toBeNull();
     expect(wrapper.state('current').patient.continuous_exposure).toBe(true);
     expect(wrapper.find(DateInput).prop('date')).toBeNull();
-    expect(wrapper.find('#continuous_exposure').prop('checked')).toBe(true);
+    expect(wrapper.find({ controlId: 'continuous_exposure' }).find(Form.Check).prop('checked')).toBe(true);
 
     wrapper.find(DateInput).simulate('change', '2021-07-04');
     expect(setEnrollmentStateMock).toHaveBeenCalledTimes(3);
@@ -222,7 +227,7 @@ describe('ExposureInformation', () => {
     expect(wrapper.state('modified').patient.last_date_of_exposure).toEqual('2021-07-04');
     expect(wrapper.state('current').patient.continuous_exposure).toBe(false);
     expect(wrapper.find(DateInput).prop('date')).toEqual('2021-07-04');
-    expect(wrapper.find('#continuous_exposure').prop('checked')).toBe(false);
+    expect(wrapper.find({ controlId: 'continuous_exposure' }).find(Form.Check).prop('checked')).toBe(false);
 
     wrapper.find(DateInput).simulate('change', null);
     expect(setEnrollmentStateMock).toHaveBeenCalledTimes(4);
@@ -231,7 +236,7 @@ describe('ExposureInformation', () => {
     expect(wrapper.state('modified').patient.last_date_of_exposure).toBeNull();
     expect(wrapper.state('current').patient.continuous_exposure).toBe(false);
     expect(wrapper.find(DateInput).prop('date')).toBeNull();
-    expect(wrapper.find('#continuous_exposure').prop('checked')).toBe(false);
+    expect(wrapper.find({ controlId: 'continuous_exposure' }).find(Form.Check).prop('checked')).toBe(false);
   });
 
   it('Changing Exposure Location properly updates state and calls props.setEnrollmentState', () => {

--- a/app/javascript/tests/enrollment/steps/ExposureInformation.test.js
+++ b/app/javascript/tests/enrollment/steps/ExposureInformation.test.js
@@ -50,6 +50,7 @@ describe('ExposureInformation', () => {
     expect(wrapper.find(Card.Header).text()).toEqual('Monitoree Potential Exposure Information');
     expect(wrapper.find(Card.Body).exists()).toBe(true);
     expect(wrapper.find(Form).exists()).toBe(true);
+    expect(wrapper.find('#continuous_exposure').at(0).prop('disabled')).toBe(false);
     expect(wrapper.find('#exposure_notes').exists()).toBe(true);
     expect(wrapper.find(PublicHealthManagement).exists()).toBe(true);
     expect(wrapper.find('#add-new-cohort-button').exists()).toBe(true);
@@ -67,6 +68,7 @@ describe('ExposureInformation', () => {
     expect(wrapper.find(Card.Header).text()).toEqual('Monitoree Potential Exposure Information');
     expect(wrapper.find(Card.Body).exists()).toBe(true);
     expect(wrapper.find(Form).exists()).toBe(true);
+    expect(wrapper.find('#continuous_exposure').at(0).prop('disabled')).toBe(true);
     expect(wrapper.find('#exposure_notes').exists()).toBe(false);
     expect(wrapper.find(PublicHealthManagement).exists()).toBe(false);
     expect(wrapper.find('#add-new-cohort-button').exists()).toBe(true);

--- a/app/javascript/tests/enrollment/steps/ExposureInformation.test.js
+++ b/app/javascript/tests/enrollment/steps/ExposureInformation.test.js
@@ -51,7 +51,7 @@ describe('ExposureInformation', () => {
     expect(wrapper.find(Card.Header).text()).toEqual('Monitoree Potential Exposure Information');
     expect(wrapper.find(Card.Body).exists()).toBe(true);
     expect(wrapper.find(Form).exists()).toBe(true);
-    expect(wrapper.find('#continuous_exposure').at(0).prop('disabled')).toBe(false);
+    expect(wrapper.find('#continuous_exposure').hostNodes().prop('disabled')).toBe(false);
     expect(wrapper.find(InfoTooltip).exists()).toBe(true);
     expect(wrapper.find('#exposure_notes').exists()).toBe(true);
     expect(wrapper.find(PublicHealthManagement).exists()).toBe(true);
@@ -70,7 +70,7 @@ describe('ExposureInformation', () => {
     expect(wrapper.find(Card.Header).text()).toEqual('Monitoree Potential Exposure Information');
     expect(wrapper.find(Card.Body).exists()).toBe(true);
     expect(wrapper.find(Form).exists()).toBe(true);
-    expect(wrapper.find('#continuous_exposure').at(0).prop('disabled')).toBe(true);
+    expect(wrapper.find('#continuous_exposure').hostNodes().prop('disabled')).toBe(true);
     expect(wrapper.find('#disabled-continuous-exposure').exists()).toBe(true);
     expect(wrapper.find('#exposure_notes').exists()).toBe(false);
     expect(wrapper.find(PublicHealthManagement).exists()).toBe(false);

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -1477,7 +1477,7 @@ class Patient < ApplicationRecord
     isolation_change if isolation_changed?
     case_status_change if case_status_changed?
     symptom_onset_change if symptom_onset_changed?
-    continuous_exposure_change if continuous_exposure_changed?
+    continuous_exposure_change if continuous_exposure_changed? || isolation_changed?
   end
 
   # Handle side effects to monitoring being set to false.
@@ -1531,7 +1531,7 @@ class Patient < ApplicationRecord
   # Handle side effects to continuous_exposure being set while not monitoring
   # * continuous_exposure should alwasy remain false when not monitoring
   def continuous_exposure_change
-    self.continuous_exposure = false if continuous_exposure && !monitoring
+    self.continuous_exposure = false if (continuous_exposure && !monitoring) || isolation
   end
 
   # Create History items corresponding to updates to monitoring fields.

--- a/test/api_controller_test_case.rb
+++ b/test/api_controller_test_case.rb
@@ -310,7 +310,6 @@ class ApiControllerTestCase < ActionDispatch::IntegrationTest
       secondary_telephone_type: 'Landline',
       black_or_african_american: true,
       asian: true,
-      continuous_exposure: true,
       last_date_of_exposure: nil
     )
     @patient_2 = Patient.find_by(id: 2).as_fhir
@@ -319,6 +318,14 @@ class ApiControllerTestCase < ActionDispatch::IntegrationTest
     Patient.find_by(id: 2).update!(
       primary_telephone: '+15555559998'
     )
+
+    # Update Patient 3 before created FHIR resource from it
+    Patient.find_by(id: 3).update!(
+      isolation: false,
+      last_date_of_exposure: nil,
+      continuous_exposure: true
+    )
+    @patient_3 = Patient.find_by(id: 3).as_fhir
   end
 
   private

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -3031,11 +3031,13 @@ class PatientTest < ActiveSupport::TestCase
                      symptom_onset: DateTime.now - 1.day)
     earliest_symptomatic_assessment_timestamp = DateTime.now - 2.days
     create(:assessment, patient_id: patient.id, symptomatic: true, created_at: earliest_symptomatic_assessment_timestamp)
-    patient.update({ isolation: false })
+    patient.update({ isolation: false, continuous_exposure: true })
     assert_not patient.isolation
     assert_nil patient.extended_isolation
     assert_not patient.user_defined_symptom_onset
     assert_equal earliest_symptomatic_assessment_timestamp.to_date, patient.symptom_onset
+    patient.update({ isolation: true })
+    assert_not patient.continuous_exposure
   end
 
   test 'update handles case_status change' do


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1108](https://tracker.codev.mitre.org/browse/SARAALERT-1108)

Since this toggle has no impact of the monitoree's behavior in the isolation workflow, it would be best to have this toggle inactive.

Script to be executed along with these changes:
```
ActiveRecord::Base.connection.execute(Arel.sql("UPDATE patients SET continuous_exposure = false WHERE purged = false AND monitoring = true AND isolation = true AND continuous_exposure = true"))
```

## (Feature) Demo/Screenshots
![Screen Shot 2022-03-15 at 10 05 47 AM](https://user-images.githubusercontent.com/9956561/158395507-fc3cacb3-bd3d-457a-824a-10b00d49c68b.png)

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`example_file.js`
- Example change (ex: refactored import function)

## Testing Recommendations
- Ensure CE is disabled and proper tooltip message is displayed for isolation cases
- Ensure CE is still working and proper tooltip message is displayed for exposure monitorees
- Ensure CE is toggled off when moving a monitoree from exposure to isolation

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@hackrm :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@sgober :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@deastman :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
