### PR TITLE
SARAALERT-1699: Adv filter should display patients with unpopulated value when blank

### DIFF
--- a/app/javascript/components/public_health/query/AdvancedFilter.js
+++ b/app/javascript/components/public_health/query/AdvancedFilter.js
@@ -424,14 +424,15 @@ class AdvancedFilter extends React.Component {
    * @param {String} value - Value of the current number type statement
    * @param {String} additionalFilterOption - Current additionalFilterOption value
    */
-  // Change an index filter option for type number
   changeFilterNumberOption = (index, prevNumberOption, newNumberOption, value, additionalFilterOption) => {
     let activeFilterOptions = [...this.state.activeFilterOptions];
     let newValue = value;
-    if (prevNumberOption === 'between' && newNumberOption !== 'between') {
-      newValue = 0;
-    } else if (prevNumberOption !== 'between' && newNumberOption === 'between') {
+    if (newNumberOption === '') {
+      newValue = null;
+    } else if (newNumberOption === 'between') {
       newValue = { firstBound: 0, secondBound: 0 };
+    } else if ((prevNumberOption === 'between' || prevNumberOption === '') && newNumberOption !== 'between') {
+      newValue = 0;
     }
     activeFilterOptions[parseInt(index)] = {
       filterOption: activeFilterOptions[parseInt(index)].filterOption,
@@ -936,7 +937,15 @@ class AdvancedFilter extends React.Component {
    * @param {String} additionalFilterOption - Selected option from additional list of options (if provided)
    */
   renderNumberStatement = (filter, index, value, numberOption, additionalFilterOption) => {
-    const betweenTooltipText = '"Between" is inclusive and will filter for values within the user-entered range, including the start and end values.';
+    let tooltipText;
+    if (numberOption === '') {
+      tooltipText = 'Leaving the operator blank will return monitorees with a blank value for this field.';
+    } else if (numberOption === 'between') {
+      tooltipText =
+        '"Between" is inclusive and will filter for values within the user-entered range, including the start and end values. Leaving either or both number fields blank will result in no monitorees being filtered out.';
+    } else {
+      tooltipText = 'Leaving the number field blank will result in no monitorees being filtered out.';
+    }
     return (
       <React.Fragment>
         <Form.Group className="form-group-inline py-0 my-0">
@@ -952,8 +961,9 @@ class AdvancedFilter extends React.Component {
             <option value="greater-than-equal">greater than or equal to</option>
             <option value="greater-than">greater than</option>
             {filter.allow_range && <option value="between">between</option>}
+            {filter.support_blank && <option></option>}
           </Form.Control>
-          {numberOption !== 'between' && (
+          {numberOption !== 'between' && numberOption !== '' && (
             <Form.Control
               className="advanced-filter-number-input"
               aria-label="Advanced Filter Number Input"
@@ -987,7 +997,7 @@ class AdvancedFilter extends React.Component {
             </React.Fragment>
           )}
         </Form.Group>
-        {numberOption === 'between' && this.renderStatementTooltip(filter.name, index, betweenTooltipText)}
+        {this.renderStatementTooltip(filter.name, index, tooltipText)}
       </React.Fragment>
     );
   };

--- a/app/javascript/tests/mocks/mockFilters.js
+++ b/app/javascript/tests/mocks/mockFilters.js
@@ -29,9 +29,8 @@ const mockFilterOptions = [
   {
     name: 'water-consumption',
     title: 'Water Consumption (Number)',
-    description: 'All records with the specified number of water consumption',
+    description: 'All records with the specified number of water consumption per day',
     type: 'number',
-    allow_range: true,
   },
   {
     name: 'writing-utensil',

--- a/app/lib/advanced_filter_options.rb
+++ b/app/lib/advanced_filter_options.rb
@@ -243,7 +243,8 @@ module AdvancedFilterOptions
         title: 'Age (Number)',
         description: 'Current Monitoree Age',
         type: 'number',
-        allow_range: true
+        allow_range: true,
+        support_blank: true
       },
       {
         name: 'manual-contact-attempts',
@@ -319,6 +320,7 @@ module AdvancedFilterOptions
         title: 'Address (Combination)',
         description: 'Monitorees with specified address',
         type: 'combination',
+        tooltip: 'Leaving this field blank will return monitorees with blank address fields.',
         fields: [
           {
             name: 'address-usa',


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1699](https://tracker.codev.mitre.org/browse/SARAALERT-1699)

- Address (blank)
- Age 
  - Add a blank option to the drop down list
  - When a non-blank drop down option is selected and the numerical input ( s) are left blank , the filter option should not filter out _any_ monitorees. 
  - When a non-blank drop down option is selected, display the following tooltip
    - "Leaving number field(s ) blank will not filter out any monitorees" 
- Manual Contact Attempts 
  - *Do not* add a blank option to the drop down list 
  - If the numerical input ( s) are left blank , the filter option should not filter out _any_ monitorees. 
  - Display the following tooltip
    - "Leaving number field(s ) blank will not filter out any monitorees"

## Important Changes
Please list important files (meaning substantial or integral to the PR) along with a list of the general changes that should be highlighted for reviewers.

`example_file.js`
- Example change (ex: refactored import function)

## Testing Recommendations

- address
  - try different combinations of blank/populated usa/foreign addresses
- age
  - blank age should return patients with no dob
  - all other non-blank values should behave the same as before
- contact attempts
  - blank values should return patients who have no contact attempts

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [ ] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Test fixtures updated and documented as necessary


@deastman :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@sgober :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@hackrm :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
