### PR TITLE
SARAALERT-1222: Disable Submit Assessment Button Bugfixes

### DIFF
--- a/app/javascript/components/patient/assessment/steps/SymptomsAssessment.js
+++ b/app/javascript/components/patient/assessment/steps/SymptomsAssessment.js
@@ -50,25 +50,33 @@ class SymptomsAssessment extends React.Component {
 
   handleIntChange = event => {
     const validInputs = ['', '-'];
-    const value = event?.target?.value;
+    let value = event?.target?.value;
     // Ensure (1) the value is defined or an empty string && meets the condintions of (2) or (3)
     //        (2.a) the value is a number & the user is prevented from inputting non-numerical characters after inputting a number (ex. '43test')
     //        (2.b) the value can be parsed as an integer
     //        (2.c) the user is prevented from inputting '.' characters (since parseInt() would allow that as an input)
     //        (3) if the value is not a valid number, check if it is an acceptable character input
     if (!_.isNil(value) && ((!isNaN(value) && !isNaN(parseInt(value)) && !String(value).includes('.')) || validInputs.includes(value))) {
+      // Value conversion necessary to determine if any changes have been made to the assessement
+      // If value is empty, convert it to null
+      // If value is not empty, convert the string to an integer
+      value = value === '' ? null : parseInt(value);
       this.handleChange(event, value);
     }
   };
 
   handleFloatChange = event => {
     const validInputs = ['', '.', '-', '-.'];
-    const value = event?.target?.value;
+    let value = event?.target?.value;
     // Ensure (1) the value is defined or an empty string && meets the condintions of (2) or (3)
     //        (2.a) the value is a number & the user is prevented from inputting non-numerical characters after inputting a number (ex. '4.3test')
     //        (2.b) the value can be parsed as an float
     //        (3) if the value is not a valid number, check if it is an acceptable character input
     if (!_.isNil(value) && ((!isNaN(value) && !isNaN(parseFloat(value))) || validInputs.includes(value))) {
+      // Value conversion necessary to determine if any changes have been made to the assessement
+      // If value is empty, convert it to null
+      // If value is not empty, convert the string to a float
+      value = value === '' ? null : value.endsWith('.') ? value : parseFloat(value).toFixed(value.split('.')[1].length);
       this.handleChange(event, value);
     }
   };
@@ -315,7 +323,7 @@ class SymptomsAssessment extends React.Component {
             </Form.Group>
           </Form.Row>
           <span data-for="disabled-assessment-submit" data-tip="">
-            <Form.Row className="pt-3">
+            <Form.Row className="mt-2">
               <Button
                 variant="primary"
                 block

--- a/app/javascript/components/patient/assessment/steps/SymptomsAssessment.js
+++ b/app/javascript/components/patient/assessment/steps/SymptomsAssessment.js
@@ -14,7 +14,7 @@ class SymptomsAssessment extends React.Component {
     this.state = {
       ...this.props,
       reportState: {
-        symptoms: _.cloneDeep(this.props.symptoms),
+        symptoms: this.stringifyNumberValues(_.cloneDeep(this.props.symptoms)),
         reported_at: props.assessment?.reported_at
           ? moment(props.assessment.reported_at).format('YYYY-MM-DD HH:mm Z')
           : moment.utc(moment()).tz(moment.tz.guess()).format('YYYY-MM-DD HH:mm Z'),
@@ -50,33 +50,25 @@ class SymptomsAssessment extends React.Component {
 
   handleIntChange = event => {
     const validInputs = ['', '-'];
-    let value = event?.target?.value;
+    const value = event?.target?.value;
     // Ensure (1) the value is defined or an empty string && meets the condintions of (2) or (3)
     //        (2.a) the value is a number & the user is prevented from inputting non-numerical characters after inputting a number (ex. '43test')
     //        (2.b) the value can be parsed as an integer
     //        (2.c) the user is prevented from inputting '.' characters (since parseInt() would allow that as an input)
     //        (3) if the value is not a valid number, check if it is an acceptable character input
     if (!_.isNil(value) && ((!isNaN(value) && !isNaN(parseInt(value)) && !String(value).includes('.')) || validInputs.includes(value))) {
-      // Value conversion necessary to determine if any changes have been made to the assessement
-      // If value is empty, convert it to null
-      // If value is not empty, convert the string to an integer
-      value = value === '' ? null : parseInt(value);
       this.handleChange(event, value);
     }
   };
 
   handleFloatChange = event => {
     const validInputs = ['', '.', '-', '-.'];
-    let value = event?.target?.value;
+    const value = event?.target?.value;
     // Ensure (1) the value is defined or an empty string && meets the condintions of (2) or (3)
     //        (2.a) the value is a number & the user is prevented from inputting non-numerical characters after inputting a number (ex. '4.3test')
     //        (2.b) the value can be parsed as an float
     //        (3) if the value is not a valid number, check if it is an acceptable character input
     if (!_.isNil(value) && ((!isNaN(value) && !isNaN(parseFloat(value))) || validInputs.includes(value))) {
-      // Value conversion necessary to determine if any changes have been made to the assessement
-      // If value is empty, convert it to null
-      // If value is not empty, convert the string to a float
-      value = value === '' ? null : _.endsWith(value, '.') ? value : parseFloat(value).toFixed(_.includes(value, '.') ? value.split('.')[1].length : 0);
       this.handleChange(event, value);
     }
   };
@@ -104,9 +96,18 @@ class SymptomsAssessment extends React.Component {
     this.setState({ selectedBoolSymptomCount: trueBoolSymptoms.length });
   };
 
+  stringifyNumberValues = symptoms => {
+    return symptoms.map(symp => {
+      if (symp.type === 'IntegerSymptom' || symp.type === 'FloatSymptom') {
+        symp.value = symp.value === null ? '' : String(symp.value);
+      }
+      return symp;
+    });
+  };
+
   hasChanges = () => {
     return (
-      !_.isEqual(this.state.reportState.symptoms, this.props.symptoms) ||
+      !_.isEqual(this.state.reportState.symptoms, this.stringifyNumberValues(this.props.symptoms)) ||
       moment(this.props.assessment?.reported_at).format('YYYY-MM-DD HH:mm Z') !== this.state.reportState.reported_at
     );
   };

--- a/app/javascript/components/patient/assessment/steps/SymptomsAssessment.js
+++ b/app/javascript/components/patient/assessment/steps/SymptomsAssessment.js
@@ -76,7 +76,7 @@ class SymptomsAssessment extends React.Component {
       // Value conversion necessary to determine if any changes have been made to the assessement
       // If value is empty, convert it to null
       // If value is not empty, convert the string to a float
-      value = value === '' ? null : value.endsWith('.') ? value : parseFloat(value).toFixed(value.split('.')[1].length);
+      value = value === '' ? null : _.endsWith(value, '.') ? value : parseFloat(value).toFixed(_.includes(value, '.') ? value.split('.')[1].length : 0);
       this.handleChange(event, value);
     }
   };

--- a/app/javascript/components/patient/assessment/steps/SymptomsAssessment.js
+++ b/app/javascript/components/patient/assessment/steps/SymptomsAssessment.js
@@ -106,6 +106,7 @@ class SymptomsAssessment extends React.Component {
   };
 
   hasChanges = () => {
+    // Stringify the numbers for comparison with existing values to avoid errors with non-numeric input
     return (
       !_.isEqual(this.state.reportState.symptoms, this.stringifyNumberValues(this.props.symptoms)) ||
       moment(this.props.assessment?.reported_at).format('YYYY-MM-DD HH:mm Z') !== this.state.reportState.reported_at

--- a/app/javascript/tests/patient/assessment/steps/SymptomsAssessment.test.js
+++ b/app/javascript/tests/patient/assessment/steps/SymptomsAssessment.test.js
@@ -39,6 +39,14 @@ function getSymptomsByType(symptoms, type) {
     });
 }
 
+function getIntValue(intString) {
+  return intString === '' ? null : parseInt(intString);
+}
+
+function getFloatValue(floatString) {
+  return floatString === '' ? null : _.endsWith(floatString, '.') ? floatString : parseFloat(floatString).toFixed(_.includes(floatString, '.') ? floatString.split('.')[1].length : 0);
+}
+
 afterEach(() => {
   jest.clearAllMocks();
 });
@@ -225,12 +233,12 @@ describe('SymptomsAssessment', () => {
     const intSymptoms = getSymptomsByType(newProps.symptoms, 'IntegerSymptom');
     const randomSympIndex = _.random(0, intSymptoms.length - 1);
     const matchingSympIndex = wrapper.state('reportState').symptoms.findIndex(s => s.name === intSymptoms[parseInt(randomSympIndex)].name);
-    const validValues = ['', 0, _.random(1, 1000), _.random(-1000, -1)];
-    const testValues = validValues.concat(_.random(0, 10, true), _.random(-10, 0, true), false, '45test', 'some string');
+    const validValues = ['', String(0), String(_.random(1, 1000)), String(_.random(-1000, -1))];
+    const testValues = validValues.concat(String(_.random(0, 10, true)), String(_.random(-10, 0, true)), false, '45test', 'some string');
 
     let current = null;
     _.shuffle(testValues).forEach(value => {
-      current = validValues.includes(value) ? value : current;
+      current = validValues.includes(value) ? getIntValue(value) : current;
       wrapper
         .find(Form.Control)
         .at(randomSympIndex)
@@ -246,12 +254,12 @@ describe('SymptomsAssessment', () => {
     const floatSymptoms = getSymptomsByType(newProps.symptoms, 'FloatSymptom');
     const randomSympIndex = _.random(0, floatSymptoms.length - 1);
     const matchingSympIndex = wrapper.state('reportState').symptoms.findIndex(s => s.name === floatSymptoms[parseInt(randomSympIndex)].name);
-    const validValues = ['', 0, _.random(1, 1000), _.random(-1000, -1), _.random(0, 10, true), _.random(-10, 0, true)];
+    const validValues = ['', String(0), String(_.random(1, 1000)), String(_.random(-1000, -1)), String(_.random(0, 10, true)), String(_.random(-10, 0, true))];
     const testValues = validValues.concat(false, '45test', 'some string');
 
     let current = null;
     _.shuffle(testValues).forEach(value => {
-      current = validValues.includes(value) ? value : current;
+      current = validValues.includes(value) ? getFloatValue(value) : current;
       wrapper
         .find(Form.Control)
         .at(intSymptoms.length + randomSympIndex)
@@ -274,12 +282,12 @@ describe('SymptomsAssessment', () => {
 
     numberSymptoms.forEach((numSymp, n_index) => {
       if (_.sample([true, false])) {
-        const random = numSymp.type === 'IntegerSymptom' ? _.random(-100000, 100000) : _.random(-10, 10, true);
+        const random = numSymp.type === 'IntegerSymptom' ? String(_.random(-100000, 100000)) : String(_.random(-10, 10, true));
         wrapper
           .find(Form.Control)
           .at(n_index)
           .simulate('change', { target: { id: `${numSymp.name}_idpre${newProps.idPre}`, value: random } });
-        numSymp.value = random;
+        numSymp.value = numSymp.type === 'IntegerSymptom' ? getIntValue(random) : getFloatValue(random);
       }
       wrapper
         .state('reportState')
@@ -297,7 +305,7 @@ describe('SymptomsAssessment', () => {
           .find(Form.Control)
           .at(n_index)
           .simulate('change', { target: { id: `${numSymp.name}_idpre${newProps.idPre}`, value: '' } });
-        numSymp.value = '';
+        numSymp.value = null;
       }
       wrapper
         .state('reportState')

--- a/app/javascript/tests/patient/assessment/steps/SymptomsAssessment.test.js
+++ b/app/javascript/tests/patient/assessment/steps/SymptomsAssessment.test.js
@@ -39,12 +39,11 @@ function getSymptomsByType(symptoms, type) {
     });
 }
 
-function getIntValue(intString) {
-  return intString === '' ? null : parseInt(intString);
-}
-
-function getFloatValue(floatString) {
-  return floatString === '' ? null : _.endsWith(floatString, '.') ? floatString : parseFloat(floatString).toFixed(_.includes(floatString, '.') ? floatString.split('.')[1].length : 0);
+function stringifyValue(value) {
+  if (_.isBoolean(value)) {
+    return value;
+  }
+  return value === null ? '' : String(value);
 }
 
 afterEach(() => {
@@ -233,16 +232,17 @@ describe('SymptomsAssessment', () => {
     const intSymptoms = getSymptomsByType(newProps.symptoms, 'IntegerSymptom');
     const randomSympIndex = _.random(0, intSymptoms.length - 1);
     const matchingSympIndex = wrapper.state('reportState').symptoms.findIndex(s => s.name === intSymptoms[parseInt(randomSympIndex)].name);
-    const validValues = ['', String(0), String(_.random(1, 1000)), String(_.random(-1000, -1))];
-    const testValues = validValues.concat(String(_.random(0, 10, true)), String(_.random(-10, 0, true)), false, '45test', 'some string');
+    const validValues = ['', 0, _.random(1, 1000), _.random(-1000, -1)];
+    const testValues = validValues.concat(_.random(0, 10, true), _.random(-10, 0, true), false, '45test', 'some string');
 
-    let current = null;
+    let current = '';
     _.shuffle(testValues).forEach(value => {
-      current = validValues.includes(value) ? getIntValue(value) : current;
+      let stringValue = stringifyValue(value);
+      current = validValues.includes(value) ? stringValue : current;
       wrapper
         .find(Form.Control)
         .at(randomSympIndex)
-        .simulate('change', { target: { id: `${intSymptoms[parseInt(randomSympIndex)].name}_idpre${newProps.idPre}`, value: value } });
+        .simulate('change', { target: { id: `${intSymptoms[parseInt(randomSympIndex)].name}_idpre${newProps.idPre}`, value: stringValue } });
       expect(wrapper.state('reportState').symptoms[parseInt(matchingSympIndex)].value).toEqual(current);
       expect(wrapper.find(Form.Control).at(randomSympIndex).prop('value')).toEqual(current || '');
     });
@@ -254,16 +254,17 @@ describe('SymptomsAssessment', () => {
     const floatSymptoms = getSymptomsByType(newProps.symptoms, 'FloatSymptom');
     const randomSympIndex = _.random(0, floatSymptoms.length - 1);
     const matchingSympIndex = wrapper.state('reportState').symptoms.findIndex(s => s.name === floatSymptoms[parseInt(randomSympIndex)].name);
-    const validValues = ['', String(0), String(_.random(1, 1000)), String(_.random(-1000, -1)), String(_.random(0, 10, true)), String(_.random(-10, 0, true))];
+    const validValues = ['', 0, _.random(1, 1000), _.random(-1000, -1), _.random(0, 10, true), _.random(-10, 0, true)];
     const testValues = validValues.concat(false, '45test', 'some string');
 
-    let current = null;
+    let current = '';
     _.shuffle(testValues).forEach(value => {
-      current = validValues.includes(value) ? getFloatValue(value) : current;
+      let stringValue = stringifyValue(value);
+      current = validValues.includes(value) ? stringValue : current;
       wrapper
         .find(Form.Control)
         .at(intSymptoms.length + randomSympIndex)
-        .simulate('change', { target: { id: `${floatSymptoms[parseInt(randomSympIndex)].name}_idpre${newProps.idPre}`, value: value } });
+        .simulate('change', { target: { id: `${floatSymptoms[parseInt(randomSympIndex)].name}_idpre${newProps.idPre}`, value: stringValue } });
       expect(wrapper.state('reportState').symptoms[parseInt(matchingSympIndex)].value).toEqual(current);
       expect(
         wrapper
@@ -282,12 +283,12 @@ describe('SymptomsAssessment', () => {
 
     numberSymptoms.forEach((numSymp, n_index) => {
       if (_.sample([true, false])) {
-        const random = numSymp.type === 'IntegerSymptom' ? String(_.random(-100000, 100000)) : String(_.random(-10, 10, true));
+        const random = stringifyValue(numSymp.type === 'IntegerSymptom' ? _.random(-100000, 100000) : _.random(-10, 10, true));
         wrapper
           .find(Form.Control)
           .at(n_index)
           .simulate('change', { target: { id: `${numSymp.name}_idpre${newProps.idPre}`, value: random } });
-        numSymp.value = numSymp.type === 'IntegerSymptom' ? getIntValue(random) : getFloatValue(random);
+        numSymp.value = random;
       }
       wrapper
         .state('reportState')
@@ -301,11 +302,12 @@ describe('SymptomsAssessment', () => {
 
     numberSymptoms.forEach((numSymp, n_index) => {
       if (_.sample([true, false])) {
+        const value = '';
         wrapper
           .find(Form.Control)
           .at(n_index)
-          .simulate('change', { target: { id: `${numSymp.name}_idpre${newProps.idPre}`, value: '' } });
-        numSymp.value = null;
+          .simulate('change', { target: { id: `${numSymp.name}_idpre${newProps.idPre}`, value: value } });
+        numSymp.value = value;
       }
       wrapper
         .state('reportState')


### PR DESCRIPTION
# Description
Jira Ticket: [SARAALERT-1222](https://tracker.codev.mitre.org/browse/SARAALERT-1222)

Introduced in #1248 

Fixes weird floating tooltip when submit button is disabled, as well as not accurately detecting changes for int/float symptoms (empty or otherwise).  This is due to all inputs being cast to a string in the on change, so added a line to prevent that from happening.

## Testing Recommendations
Please list any recommendations regarding what reviewers should test and if there is any specific guidance on how to test certain aspects of the PR. Be sure to mention edge cases that should be tried, particularly in the UI.

# Checklists

**Submitter:**
- [x] This PR describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] This PR includes the correct JIRA ticket reference.
- [x] Comment added to the relevant JIRA ticket(s) with a link to this PR
- [x] Code diff has been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, Chrome Dev Tools Lighthouse accessibility test has been executed to ensure no 508 issues were introduced.
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [ ] Test fixtures updated and documented as necessary


@tstrass :
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@deastman :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [ ] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.


@hackrm :
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
- [ ] If applicable, you have tested changes against a large database, and considered possible performance regressions
- [x] Tested all recommendations listed in the "Testing Recommendations" section. The application behaves as expected with this PR.
